### PR TITLE
Use DeepSeek V4 Flash 0731 for free users

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -101,6 +101,22 @@ describe("systemPrompt security instructions", () => {
     }
   });
 
+  it("does not invent a cutoff for the free DeepSeek routes", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "ask",
+      "free",
+      "ask-model-free",
+      null,
+      null,
+    );
+
+    expect(prompt).toContain(
+      "Your reliable knowledge cutoff is not specified.",
+    );
+    expect(prompt).not.toContain("undefined");
+  });
+
   it("does not claim isolated container execution for dangerous local hosts", async () => {
     const localHostContext = `You are executing commands on macOS 15.0 (arm64) in DANGEROUS MODE.
 Commands are invoked via /bin/bash -c.

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -1,4 +1,5 @@
 import {
+  getModelCutoffDate,
   getModelDisplayName,
   myProvider,
   sanitizeOpenRouterRequestForXai,
@@ -14,9 +15,13 @@ describe("provider registry", () => {
       (myProvider.languageModel("agent-model") as { modelId: string }).modelId,
     ).toBe("x-ai/grok-4.5");
     expect(
+      (myProvider.languageModel("ask-model-free") as { modelId: string })
+        .modelId,
+    ).toBe("deepseek/deepseek-v4-flash-0731");
+    expect(
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
-    ).toBe("deepseek/deepseek-v4-flash");
+    ).toBe("deepseek/deepseek-v4-flash-0731");
     expect(
       (myProvider.languageModel("model-grok-4.5") as { modelId: string })
         .modelId,
@@ -45,6 +50,8 @@ describe("provider registry", () => {
       (myProvider.languageModel("title-generator-model") as { modelId: string })
         .modelId,
     ).toBe("deepseek/deepseek-v4-flash");
+    expect(getModelCutoffDate("ask-model-free")).toBeUndefined();
+    expect(getModelCutoffDate("agent-model-free")).toBeUndefined();
     expect(getModelDisplayName("model-grok-4.5")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -182,7 +182,8 @@ type OpenRouterInstance = typeof openrouter;
 export const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
-export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash";
+export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
+const TITLE_GENERATOR_DEEPSEEK_SLUG = "deepseek/deepseek-v4-flash";
 
 const buildProviderMap = (or: OpenRouterInstance) =>
   ({
@@ -201,19 +202,17 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "fallback-agent-model": or(GROK_4_5_SLUG),
     "fallback-ask-model": or(GROK_4_5_SLUG),
     // Titles are a short structured-output task and should never use reasoning.
-    "title-generator-model": or(DEEPSEEK_V4_FLASH_SLUG),
+    "title-generator-model": or(TITLE_GENERATOR_DEEPSEEK_SLUG),
   }) as Record<string, any>;
 
 const baseProviders = buildProviderMap(openrouter);
 
 export type ModelName = keyof typeof baseProviders;
 
-export const modelCutoffDates: Record<ModelName, string> &
-  Record<string, string> = {
+export const modelCutoffDates: Partial<Record<ModelName, string>> &
+  Record<string, string | undefined> = {
   "ask-model": "July 2026",
-  "ask-model-free": "May 2025",
   "agent-model": "July 2026",
-  "agent-model-free": "May 2025",
   "model-grok-4.5": "July 2026",
   "model-grok-4.5-pro": "July 2026",
   "model-deepseek-v4-pro": "May 2025",
@@ -245,7 +244,9 @@ export const getModelDisplayName = (modelName: ModelName): string => {
   return modelDisplayNames[modelName];
 };
 
-export const getModelCutoffDate = (modelName: ModelName): string => {
+export const getModelCutoffDate = (
+  modelName: ModelName,
+): string | undefined => {
   return modelCutoffDates[modelName];
 };
 

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -261,7 +261,7 @@ describe("retry served-model telemetry", () => {
 
   it("clears prior served-model state before a retry can abort without metadata", () => {
     const state = {
-      responseModel: "deepseek/deepseek-v4-flash",
+      responseModel: "deepseek/deepseek-v4-flash-0731",
       fallbackServed: false,
     };
 

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -214,7 +214,7 @@ describe("captureAgentRun", () => {
       sandboxInfo: { type: "e2b" },
       outcome: "success",
       selectedModel: "agent-model-free",
-      configuredModelId: "deepseek/deepseek-v4-flash",
+      configuredModelId: "deepseek/deepseek-v4-flash-0731",
       responseModel: "x-ai/grok-4.5",
       fallbackServed: true,
     });
@@ -224,7 +224,7 @@ describe("captureAgentRun", () => {
       event: "hackerai-agent_run",
       properties: expect.objectContaining({
         selected_model: "agent-model-free",
-        configured_model: "deepseek/deepseek-v4-flash",
+        configured_model: "deepseek/deepseek-v4-flash-0731",
         response_model: "x-ai/grok-4.5",
         fallback_served: true,
       }),
@@ -351,8 +351,8 @@ describe("captureAgentCompletionAnalytics", () => {
       outcome: "success",
       chatLogger: { getToolCalls: () => [{ name: "web_search" }] } as any,
       selectedModel: "agent-model-free",
-      configuredModelId: "deepseek/deepseek-v4-flash",
-      responseModel: "deepseek/deepseek-v4-flash",
+      configuredModelId: "deepseek/deepseek-v4-flash-0731",
+      responseModel: "deepseek/deepseek-v4-flash-0731",
       fallbackServed: false,
     });
 
@@ -366,8 +366,8 @@ describe("captureAgentCompletionAnalytics", () => {
         subscription_tier: "free",
         outcome: "success",
         selected_model: "agent-model-free",
-        configured_model: "deepseek/deepseek-v4-flash",
-        response_model: "deepseek/deepseek-v4-flash",
+        configured_model: "deepseek/deepseek-v4-flash-0731",
+        response_model: "deepseek/deepseek-v4-flash-0731",
         fallback_served: false,
         sandbox_type: "e2b",
       },
@@ -741,7 +741,7 @@ describe("createChatLogger provider stream termination", () => {
       chatLogger.recordProviderError(err, {
         mode: "ask",
         model: "ask-model-free",
-        requestedModelSlug: "deepseek/deepseek-v4-flash",
+        requestedModelSlug: "deepseek/deepseek-v4-flash-0731",
       });
       chatLogger.emitUnexpectedError(err);
 
@@ -755,7 +755,7 @@ describe("createChatLogger provider stream termination", () => {
       expect(errorOutput).toContain('"provider_name":"Anthropic Vertex"');
       expect(errorOutput).toContain('"configured_model":"ask-model-free"');
       expect(errorOutput).toContain(
-        '"requested_model_slug":"deepseek/deepseek-v4-flash"',
+        '"requested_model_slug":"deepseek/deepseek-v4-flash-0731"',
       );
       expect(phErrorSpy).toHaveBeenCalledWith(
         "Provider content blocked",
@@ -765,7 +765,7 @@ describe("createChatLogger provider stream termination", () => {
           provider_name: "Anthropic Vertex",
           provider_name_source: "openrouter_error_metadata",
           configured_model: "ask-model-free",
-          requested_model_slug: "deepseek/deepseek-v4-flash",
+          requested_model_slug: "deepseek/deepseek-v4-flash-0731",
           model_provider_slug: "deepseek",
           openrouter_generation_id: "gen-content-blocked",
         }),
@@ -781,7 +781,7 @@ describe("createChatLogger provider stream termination", () => {
         provider_name: "Anthropic Vertex",
         provider_name_source: "openrouter_error_metadata",
         configured_model: "ask-model-free",
-        requested_model_slug: "deepseek/deepseek-v4-flash",
+        requested_model_slug: "deepseek/deepseek-v4-flash-0731",
         model_provider_slug: "deepseek",
         openrouter_generation_id: "gen-content-blocked",
       });
@@ -1057,12 +1057,12 @@ describe("createChatLogger provider stream termination", () => {
       chatLogger.recordProviderError(err, {
         mode: "ask",
         model: "ask-model-free",
-        requestedModelSlug: "deepseek/deepseek-v4-flash",
+        requestedModelSlug: "deepseek/deepseek-v4-flash-0731",
       });
       chatLogger.emitUnexpectedError(err);
 
       const expectedFingerprint =
-        "provider_error|provider_5xx|status_502|provider_fireworks|model_deepseek/deepseek-v4-flash";
+        "provider_error|provider_5xx|status_502|provider_fireworks|model_deepseek/deepseek-v4-flash-0731";
       const structuredErrorLog = errorSpy.mock.calls
         .map((call) => call[0])
         .find(

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -26,7 +26,8 @@ jest.mock("@/lib/logger", () => ({
 const GROK_SLUG = "x-ai/grok-4.5";
 const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 const GLM_SLUG = "z-ai/glm-5.2";
-const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash";
+const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
+const DEEPSEEK_FLASH_CANONICAL_SLUG = "deepseek/deepseek-v4-flash-20260731";
 const GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "ask-model",
   "ask-model-free",
@@ -475,6 +476,16 @@ describe("resolveServedModelForCostAccounting", () => {
       resolveServedModelForCostAccounting({
         modelName: "agent-model-free",
         responseModel: DEEPSEEK_FLASH_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("agent-model-free");
+  });
+
+  it("maps OpenRouter's canonical DeepSeek Flash 0731 slug to its cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        responseModel: DEEPSEEK_FLASH_CANONICAL_SLUG,
         mode: "agent",
       }),
     ).toBe("agent-model-free");

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -676,6 +676,8 @@ export function getFallbackSlugs(
 
 const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
   "anthropic/claude-opus-4.6": "model-opus-4.6",
+  "deepseek/deepseek-v4-flash-0731": "agent-model-free",
+  "deepseek/deepseek-v4-flash-20260731": "agent-model-free",
   "x-ai/grok-4.5": "model-grok-4.5",
   "z-ai/glm-5.2": "model-glm-5.2",
   "z-ai/glm-5.2-20260616": "model-glm-5.2",

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -969,7 +969,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(74_340);
+      expect(expectedAdditional).toBe(73_639);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),
@@ -1028,7 +1028,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(4_620);
+      expect(expectedAdditional).toBe(3_919);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -969,7 +969,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(73_639);
+      expect(expectedAdditional).toBe(73_640);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),
@@ -1028,7 +1028,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(3_919);
+      expect(expectedAdditional).toBe(3_920);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -116,6 +116,17 @@ describe("token-bucket", () => {
       ).toBeCloseTo(2.34);
     });
 
+    it("prices DeepSeek V4 Flash 0731 cached input at OpenRouter's $0.0028/M rate", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          cacheReadTokens: 800_000,
+          modelName: "deepseek/deepseek-v4-flash-20260731",
+        }),
+      ).toBeCloseTo(0.05824);
+    });
+
     it("recognizes dated Anthropic response model IDs", () => {
       expect(
         calculateRawModelUsageCostDollars({
@@ -478,14 +489,18 @@ describe("token-bucket", () => {
       );
     });
 
-    it("should use DeepSeek V4 Flash pricing for free Agent ($0.09/$0.18)", () => {
-      expect(calculateTokenCost(1_000_000, "input", "agent-model-free")).toBe(
-        1260,
-      );
-      expect(calculateTokenCost(1_000_000, "output", "agent-model-free")).toBe(
-        2520,
-      );
-    });
+    it.each([
+      "ask-model-free",
+      "agent-model-free",
+      "deepseek/deepseek-v4-flash-0731",
+      "deepseek/deepseek-v4-flash-20260731",
+    ])(
+      "should use DeepSeek V4 Flash 0731 pricing for %s ($0.14/$0.28)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(1961);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(3921);
+      },
+    );
 
     it.each([
       "model-grok-4.5",

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -122,9 +122,10 @@ describe("token-bucket", () => {
           inputTokens: 1_000_000,
           outputTokens: 100_000,
           cacheReadTokens: 800_000,
+          cacheWriteTokens: 100_000,
           modelName: "deepseek/deepseek-v4-flash-20260731",
         }),
-      ).toBeCloseTo(0.05824);
+      ).toBeCloseTo(0.05824, 5);
     });
 
     it("recognizes dated Anthropic response model IDs", () => {
@@ -497,8 +498,8 @@ describe("token-bucket", () => {
     ])(
       "should use DeepSeek V4 Flash 0731 pricing for %s ($0.14/$0.28)",
       (modelName) => {
-        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(1961);
-        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(3921);
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(1960);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(3920);
       },
     );
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -51,6 +51,12 @@ const DEEPSEEK_V4_FLASH_PRICING: ModelPricing = {
   cacheRead: 0.018,
   cacheWrite: 0.09,
 };
+const DEEPSEEK_V4_FLASH_0731_PRICING: ModelPricing = {
+  input: 0.14,
+  output: 0.28,
+  cacheRead: 0.0028,
+  cacheWrite: 0.14,
+};
 const DEEPSEEK_V4_PRO_PRICING: ModelPricing = {
   input: 0.435,
   output: 0.87,
@@ -87,9 +93,9 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "agent-model": GROK_4_5_PRICING,
   "fallback-agent-model": GROK_4_5_PRICING,
   "fallback-ask-model": GROK_4_5_PRICING,
-  // Rates from OpenRouter: $0.09 in / $0.18 out per 1M tokens.
-  "ask-model-free": DEEPSEEK_V4_FLASH_PRICING,
-  "agent-model-free": DEEPSEEK_V4_FLASH_PRICING,
+  // DeepSeek V4 Flash 0731 rates from OpenRouter: $0.14 in / $0.28 out per 1M tokens.
+  "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
+  "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "model-opus-4.6": OPUS_4_6_PRICING,
   // Baseline OpenRouter rates: $0.76 in / $2.42 out per 1M tokens.
@@ -99,6 +105,8 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   // Provider response ids can reach accounting before local-key normalization.
   "x-ai/grok-4.5": GROK_4_5_PRICING,
   "deepseek/deepseek-v4-flash": DEEPSEEK_V4_FLASH_PRICING,
+  "deepseek/deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_PRICING,
+  "deepseek/deepseek-v4-flash-20260731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "deepseek/deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "anthropic/claude-opus-4.6": OPUS_4_6_PRICING,
   "z-ai/glm-5.2": GLM_5_2_PRICING,

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -396,9 +396,9 @@ export const calculateTokenCost = (
   if (tokens <= 0) return 0;
   const pricing = getModelPricing(modelName);
   const price = type === "input" ? pricing.input : pricing.output;
-  return Math.ceil(
-    (tokens / 1_000_000) * price * POINTS_PER_DOLLAR * NORMAL_USAGE_MULTIPLIER,
-  );
+  const costPoints =
+    (tokens / 1_000_000) * price * POINTS_PER_DOLLAR * NORMAL_USAGE_MULTIPLIER;
+  return Math.ceil(Number(costPoints.toFixed(6)));
 };
 
 /**

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -51,9 +51,12 @@ Own and correct mistakes honestly. Avoid excessive apology, self-critique, self-
 
 const getFreshnessAndWebSearchSection = (modelName: ModelName): string => {
   const knowledgeCutoffDate = getModelCutoffDate(modelName);
+  const knowledgeCutoffGuidance = knowledgeCutoffDate
+    ? `Your reliable knowledge cutoff is ${knowledgeCutoffDate}. Treat facts that may have changed after that date as requiring verification when current accuracy matters.`
+    : "Your reliable knowledge cutoff is not specified. Treat facts that may have changed as requiring verification when current accuracy matters.";
 
   return `<freshness_and_web_search>
-Your reliable knowledge cutoff is ${knowledgeCutoffDate}. Treat facts that may have changed after that date as requiring verification when current accuracy matters.
+${knowledgeCutoffGuidance}
 Use web_search when the user asks for current or time-sensitive information, explicitly asks to verify or look something up, or when the answer depends on a fact likely to have changed. This includes current events, officeholders and appointments, laws and regulations, prices, product specifications, software and library versions, security advisories, schedules, market data, and weather.
 Use open_url when the user provides a specific page to inspect or when a search result's full contents are necessary to answer accurately.
 Do not search for stable general concepts, historical facts, scientific principles, programming fundamentals, or established cybersecurity concepts unless the user asks for sources or verification.


### PR DESCRIPTION
## Summary

- route both free Ask and free Agent requests to `deepseek/deepseek-v4-flash-0731`
- update cost accounting to OpenRouter's published $0.14/M input, $0.28/M output, and $0.0028/M cached-input rates
- recognize OpenRouter's canonical `deepseek/deepseek-v4-flash-20260731` response slug so served-model accounting stays accurate
- keep title generation on the existing Flash model and avoid inventing a knowledge cutoff because OpenRouter does not publish one for the 0731 revision

## Why

Free users currently resolve to `deepseek/deepseek-v4-flash`. This upgrades the free Ask and Agent routes to the new DeepSeek V4 Flash 0731 release while preserving the existing Grok/Kimi fallback behavior and title-generation route.

Model metadata: https://openrouter.ai/deepseek/deepseek-v4-flash-0731

## Validation

- `pnpm test --runInBand` — 313 suites, 3,115 tests passed
- `pnpm typecheck`
- scoped ESLint on all changed TypeScript files
- scoped Prettier check
- `git diff --check`

## Manual verification

1. Open the preview as a free user.
2. Send one text prompt in Ask mode and one in Agent mode.
3. Confirm both responses complete normally and provider telemetry records `deepseek/deepseek-v4-flash-0731` as the configured model (or the existing Grok/Kimi model when a fallback is actually served).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system prompts for models without a known knowledge cutoff so they no longer display an undefined date.
  * Updated DeepSeek V4 Flash model routing, aliases, and pricing for improved request handling and cost accounting.
  * Improved token cost calculations and preserved date-specific guidance for models with configured knowledge cutoffs.

* **Tests**
  * Added regression coverage for cutoff messaging, model routing, aliases, pricing, and usage calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->