### PR TITLE
Resolve missing entitlements before mode access

### DIFF
--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -60,7 +60,7 @@ import {
   normalizeAgentFirstSandboxType,
 } from "@/lib/activation/agent-first-default";
 
-const DESKTOP_ENTITLEMENT_REFRESH_TIMEOUT_MS = 5_000;
+const ENTITLEMENT_REFRESH_TIMEOUT_MS = 5_000;
 
 interface GlobalStateType {
   // Input state
@@ -250,6 +250,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     setSubscription(tier);
   }, []);
   const [isCheckingProPlan, setIsCheckingProPlan] = useState(false);
+  const [entitlementApiResolvedUserId, setEntitlementApiResolvedUserId] =
+    useState<string | null>(null);
   const subscriptionFromEntitlements = useMemo<SubscriptionTier | null>(() => {
     if (!Array.isArray(entitlements)) return null;
     return resolveSubscriptionTier(entitlements);
@@ -416,7 +418,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     [],
   );
   const chatResetRef = useRef<(() => void) | null>(null);
-  const desktopEntitlementRefreshUserRef = useRef<string | null>(null);
+  const entitlementRefreshUserRef = useRef<string | null>(null);
 
   // Rate limit warning dismissal state (persists across chat switches)
   const [
@@ -480,19 +482,23 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     typeof window !== "undefined" &&
     new URL(window.location.href).searchParams.get("refresh") ===
       "entitlements";
-  const desktopEntitlementRefreshPending =
+  const automaticEntitlementRefreshNeeded =
     Boolean(user) &&
     !authLoading &&
-    subscriptionFromEntitlements === "free" &&
-    isTauriEnvironment() &&
-    desktopEntitlementRefreshUserRef.current !== user?.id &&
+    (subscriptionFromEntitlements === null ||
+      (subscriptionFromEntitlements === "free" && isTauriEnvironment())) &&
     !entitlementRefreshRequested;
+  const automaticEntitlementRefreshPending =
+    automaticEntitlementRefreshNeeded &&
+    entitlementApiResolvedUserId !== user?.id &&
+    entitlementRefreshUserRef.current !== user?.id;
   const subscriptionResolved =
     Boolean(user) &&
     !authLoading &&
-    subscriptionFromEntitlements !== null &&
+    (subscriptionFromEntitlements !== null ||
+      entitlementApiResolvedUserId === user?.id) &&
     !entitlementRefreshRequested &&
-    !desktopEntitlementRefreshPending;
+    !automaticEntitlementRefreshPending;
 
   // Persist queue behavior to localStorage
   useEffect(() => {
@@ -681,7 +687,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   useEffect(() => {
     if (!user) {
       setSubscription("free");
-      desktopEntitlementRefreshUserRef.current = null;
+      entitlementRefreshUserRef.current = null;
+      setEntitlementApiResolvedUserId(null);
       return;
     }
 
@@ -690,25 +697,28 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     }
   }, [user, subscriptionFromEntitlements, setSubscriptionWithNormalize]);
 
-  // Desktop sessions are created through a separate OAuth transfer flow. Older
-  // desktop sessions may be unscoped, so refresh once to pull WorkOS
-  // entitlements from the user's organization before showing them as free.
+  // AuthKit can omit entitlements on unscoped sessions, including web preview
+  // sessions. Resolve those through the authoritative API before exposing mode
+  // access. Desktop sessions also recheck token-free state because their
+  // separate OAuth transfer flow may leave paid entitlements stale.
   useEffect(() => {
     let cancelled = false;
     let requestSettled = false;
     let controller: AbortController | null = null;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-    const refreshDesktopEntitlements = async () => {
-      if (!user || typeof window === "undefined" || !isTauriEnvironment()) {
+    const refreshEntitlements = async () => {
+      if (!user || typeof window === "undefined") {
         setIsCheckingProPlan(false);
         return;
       }
 
-      const currentEntitlements = Array.isArray(entitlements)
-        ? entitlements
-        : [];
-      if (resolveSubscriptionTier(currentEntitlements) !== "free") {
+      const tokenTier = Array.isArray(entitlements)
+        ? resolveSubscriptionTier(entitlements)
+        : null;
+      const refreshNeeded =
+        tokenTier === null || (tokenTier === "free" && isTauriEnvironment());
+      if (!refreshNeeded || entitlementApiResolvedUserId === user.id) {
         setIsCheckingProPlan(false);
         return;
       }
@@ -718,16 +728,16 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
         return;
       }
 
-      if (desktopEntitlementRefreshUserRef.current === user.id) {
+      if (entitlementRefreshUserRef.current === user.id) {
         return;
       }
-      desktopEntitlementRefreshUserRef.current = user.id;
+      entitlementRefreshUserRef.current = user.id;
 
       setIsCheckingProPlan(true);
       controller = new AbortController();
       timeoutId = setTimeout(
         () => controller?.abort(),
-        DESKTOP_ENTITLEMENT_REFRESH_TIMEOUT_MS,
+        ENTITLEMENT_REFRESH_TIMEOUT_MS,
       );
       try {
         const response = await fetch("/api/entitlements", {
@@ -738,17 +748,18 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
         const data = await response.json();
         if (cancelled) return;
-        setSubscriptionWithNormalize(
-          resolveSubscriptionTier(
-            Array.isArray(data.entitlements) ? data.entitlements : [],
-          ),
+        const tier = resolveSubscriptionTier(
+          Array.isArray(data.entitlements) ? data.entitlements : [],
         );
+        setSubscriptionWithNormalize(tier);
+        setEntitlementApiResolvedUserId(user.id);
         // The API response is authoritative for the UI. Refresh AuthKit and the
         // shared access token in the background so a slow token refresh cannot
         // keep the free Ask/Agent selector hidden.
         void refreshAuthTokenAfterEntitlementRefresh();
       } catch {
-        // Keep the token-derived tier; this is only a best-effort desktop heal.
+        // Keep access unresolved when AuthKit omitted entitlements. A token-free
+        // desktop session can still safely fall back to its token-derived tier.
       } finally {
         requestSettled = true;
         if (timeoutId !== null) clearTimeout(timeoutId);
@@ -756,16 +767,16 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       }
     };
 
-    refreshDesktopEntitlements();
+    refreshEntitlements();
 
     return () => {
       cancelled = true;
       if (
         controller !== null &&
         !requestSettled &&
-        desktopEntitlementRefreshUserRef.current === user?.id
+        entitlementRefreshUserRef.current === user?.id
       ) {
-        desktopEntitlementRefreshUserRef.current = null;
+        entitlementRefreshUserRef.current = null;
       }
       controller?.abort();
       if (timeoutId !== null) clearTimeout(timeoutId);
@@ -773,6 +784,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   }, [
     user,
     entitlements,
+    entitlementApiResolvedUserId,
     refreshAuthTokenAfterEntitlementRefresh,
     setSubscriptionWithNormalize,
   ]);
@@ -816,6 +828,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
               ? tier
               : "free",
           );
+          setEntitlementApiResolvedUserId(user.id);
         } else {
           if (response.status === 401) {
             if (typeof window !== "undefined") {

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/lib/activation/agent-first-default";
 
 const ENTITLEMENT_REFRESH_TIMEOUT_MS = 5_000;
+const ENTITLEMENT_REFRESH_RETRY_DELAYS_MS = [1_000, 3_000] as const;
 
 interface GlobalStateType {
   // Input state
@@ -252,6 +253,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const [isCheckingProPlan, setIsCheckingProPlan] = useState(false);
   const [entitlementApiResolvedUserId, setEntitlementApiResolvedUserId] =
     useState<string | null>(null);
+  const [entitlementRefreshRetryNonce, setEntitlementRefreshRetryNonce] =
+    useState(0);
   const subscriptionFromEntitlements = useMemo<SubscriptionTier | null>(() => {
     if (!Array.isArray(entitlements)) return null;
     return resolveSubscriptionTier(entitlements);
@@ -419,6 +422,10 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   );
   const chatResetRef = useRef<(() => void) | null>(null);
   const entitlementRefreshUserRef = useRef<string | null>(null);
+  const entitlementRefreshFailureRef = useRef<{
+    userId: string;
+    count: number;
+  } | null>(null);
 
   // Rate limit warning dismissal state (persists across chat switches)
   const [
@@ -490,6 +497,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     !entitlementRefreshRequested;
   const automaticEntitlementRefreshPending =
     automaticEntitlementRefreshNeeded &&
+    subscriptionFromEntitlements === null &&
     entitlementApiResolvedUserId !== user?.id &&
     entitlementRefreshUserRef.current !== user?.id;
   const subscriptionResolved =
@@ -688,6 +696,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     if (!user) {
       setSubscription("free");
       entitlementRefreshUserRef.current = null;
+      entitlementRefreshFailureRef.current = null;
       setEntitlementApiResolvedUserId(null);
       return;
     }
@@ -706,6 +715,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     let requestSettled = false;
     let controller: AbortController | null = null;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const refreshEntitlements = async () => {
       if (!user || typeof window === "undefined") {
@@ -713,18 +723,11 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
         return;
       }
 
-      const tokenTier = Array.isArray(entitlements)
-        ? resolveSubscriptionTier(entitlements)
-        : null;
-      const refreshNeeded =
-        tokenTier === null || (tokenTier === "free" && isTauriEnvironment());
-      if (!refreshNeeded || entitlementApiResolvedUserId === user.id) {
+      if (
+        !automaticEntitlementRefreshNeeded ||
+        entitlementApiResolvedUserId === user.id
+      ) {
         setIsCheckingProPlan(false);
-        return;
-      }
-
-      const url = new URL(window.location.href);
-      if (url.searchParams.get("refresh") === "entitlements") {
         return;
       }
 
@@ -744,7 +747,9 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
           credentials: "include",
           signal: controller.signal,
         });
-        if (!response.ok) return;
+        if (!response.ok) {
+          throw new Error("Entitlement refresh failed");
+        }
 
         const data = await response.json();
         if (cancelled) return;
@@ -753,6 +758,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
         );
         setSubscriptionWithNormalize(tier);
         setEntitlementApiResolvedUserId(user.id);
+        entitlementRefreshFailureRef.current = null;
         // The API response is authoritative for the UI. Refresh AuthKit and the
         // shared access token in the background so a slow token refresh cannot
         // keep the free Ask/Agent selector hidden.
@@ -760,6 +766,28 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       } catch {
         // Keep access unresolved when AuthKit omitted entitlements. A token-free
         // desktop session can still safely fall back to its token-derived tier.
+        if (!cancelled) {
+          if (entitlementRefreshUserRef.current === user.id) {
+            entitlementRefreshUserRef.current = null;
+          }
+          const previousFailureCount =
+            entitlementRefreshFailureRef.current?.userId === user.id
+              ? entitlementRefreshFailureRef.current.count
+              : 0;
+          const failureCount = previousFailureCount + 1;
+          entitlementRefreshFailureRef.current = {
+            userId: user.id,
+            count: failureCount,
+          };
+          const retryDelay =
+            ENTITLEMENT_REFRESH_RETRY_DELAYS_MS[failureCount - 1];
+          if (retryDelay !== undefined) {
+            retryTimeoutId = setTimeout(
+              () => setEntitlementRefreshRetryNonce((nonce) => nonce + 1),
+              retryDelay,
+            );
+          }
+        }
       } finally {
         requestSettled = true;
         if (timeoutId !== null) clearTimeout(timeoutId);
@@ -780,11 +808,15 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       }
       controller?.abort();
       if (timeoutId !== null) clearTimeout(timeoutId);
+      if (retryTimeoutId !== null) clearTimeout(retryTimeoutId);
     };
   }, [
     user,
-    entitlements,
+    authLoading,
+    entitlementRefreshRequested,
+    automaticEntitlementRefreshNeeded,
     entitlementApiResolvedUserId,
+    entitlementRefreshRetryNonce,
     refreshAuthTokenAfterEntitlementRefresh,
     setSubscriptionWithNormalize,
   ]);

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -23,7 +23,7 @@ const { GlobalStateProvider, useGlobalState } =
   jest.requireActual<typeof import("../GlobalState")>("../GlobalState");
 
 const mockAuthUser = (
-  entitlements: string[],
+  entitlements: string[] | undefined,
   overrides: Partial<ReturnType<typeof useAuth>> = {},
 ) => {
   jest.mocked(useAuth).mockReturnValue({
@@ -94,7 +94,7 @@ describe("GlobalStateProvider agent defaults", () => {
   it("reveals free desktop mode access before token refresh finishes", async () => {
     window.__TAURI_INTERNALS__ = {};
     const refreshAuth = jest.fn(() => new Promise<void>(() => {}));
-    mockAuthUser([], { refreshAuth });
+    mockAuthUser(undefined, { refreshAuth });
     global.fetch = jest.fn((input) => {
       if (String(input) === "/api/entitlements") {
         return Promise.resolve({
@@ -122,6 +122,102 @@ describe("GlobalStateProvider agent defaults", () => {
       );
     });
     expect(screen.getByTestId("subscription")).toHaveTextContent("free");
+    expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("false");
+  });
+
+  it("reveals free web mode access when AuthKit omits entitlements", async () => {
+    const refreshAuth = jest.fn(() => new Promise<void>(() => {}));
+    mockAuthUser(undefined, { refreshAuth });
+    global.fetch = jest.fn((input) => {
+      if (String(input) === "/api/entitlements") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ entitlements: [], subscription: "free" }),
+        });
+      }
+
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+      "false",
+    );
+
+    await waitFor(() => {
+      expect(refreshAuth).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+        "true",
+      );
+    });
+    expect(screen.getByTestId("subscription")).toHaveTextContent("free");
+    expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("false");
+  });
+
+  it("keeps paid web users Agent-only when AuthKit omits entitlements", async () => {
+    const refreshAuth = jest.fn(() => new Promise<void>(() => {}));
+    mockAuthUser(undefined, { refreshAuth });
+    global.fetch = jest.fn((input) => {
+      if (String(input) === "/api/entitlements") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              entitlements: ["pro-plan"],
+              subscription: "pro",
+            }),
+        });
+      }
+
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription")).toHaveTextContent("pro");
+      expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+        "true",
+      );
+      expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("true");
+      expect(screen.getByTestId("chat-mode")).toHaveTextContent("agent");
+    });
+  });
+
+  it("keeps web mode access unresolved when missing entitlements cannot be verified", async () => {
+    mockAuthUser(undefined);
+    global.fetch = jest.fn((input) =>
+      Promise.resolve({ ok: String(input) !== "/api/entitlements" }),
+    ) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/entitlements",
+        expect.objectContaining({ credentials: "include" }),
+      );
+      expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent(
+        "false",
+      );
+    });
+    expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+      "false",
+    );
     expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("false");
   });
 

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -195,6 +195,7 @@ describe("GlobalStateProvider agent defaults", () => {
   });
 
   it("keeps web mode access unresolved when missing entitlements cannot be verified", async () => {
+    jest.useFakeTimers();
     mockAuthUser(undefined);
     global.fetch = jest.fn((input) =>
       Promise.resolve({ ok: String(input) !== "/api/entitlements" }),
@@ -219,6 +220,52 @@ describe("GlobalStateProvider agent defaults", () => {
       "false",
     );
     expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("false");
+  });
+
+  it("retries missing web entitlements after a transient verification failure", async () => {
+    jest.useFakeTimers();
+    mockAuthUser(undefined);
+    let entitlementAttempts = 0;
+    global.fetch = jest.fn((input) => {
+      if (String(input) === "/api/entitlements") {
+        entitlementAttempts += 1;
+        if (entitlementAttempts === 1) {
+          return Promise.resolve({ ok: false });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ entitlements: [], subscription: "free" }),
+        });
+      }
+
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(entitlementAttempts).toBe(1);
+      expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+        "false",
+      );
+    });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1_000);
+    });
+
+    await waitFor(() => {
+      expect(entitlementAttempts).toBe(2);
+      expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+        "true",
+      );
+    });
+    expect(screen.getByTestId("subscription")).toHaveTextContent("free");
   });
 
   it("resolves paid desktop users to Agent-only before token refresh finishes", async () => {


### PR DESCRIPTION
## Summary

- resolve missing AuthKit entitlements through the authoritative `/api/entitlements` response on web and Desktop
- preserve the existing Desktop recheck for token-free sessions and paid Agent-only behavior
- keep mode access unresolved when the fallback cannot verify the account tier
- retry transient entitlement verification failures with bounded backoff
- add regression coverage for free web, free Desktop, paid web, fallback failure, and retry recovery states

## Root cause

AuthKit can return `entitlements` as `undefined` for an authenticated session. `GlobalState` treated that as unresolved and kept the Ask/Agent selector hidden, even when `/api/entitlements` returned `200` with a valid free tier. PR #1009 covered an empty entitlement array but not the missing property.

The issue was reproduced on PR #1011's preview as a signed-in free user: the API returned `entitlements: []` and `subscription: "free"`, while the UI remained in Ask mode without the selector.

## Validation

- `corepack pnpm jest app/contexts/__tests__/GlobalState.agent-default.test.tsx --runInBand` — 14 tests passed
- `corepack pnpm test` — 313 suites / 3,113 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm exec prettier --check app/contexts/GlobalState.tsx app/contexts/__tests__/GlobalState.agent-default.test.tsx`
- scoped ESLint on both changed files
- `corepack pnpm lint` — passes with five existing warnings outside this change
- `git diff --check`

## Manual verification

1. Open the Vercel preview as a signed-in free user whose AuthKit state omits entitlements.
2. Confirm the Ask/Agent selector appears after the entitlement API resolves and Agent mode can be selected.
3. Open the preview as a paid user with the same missing AuthKit field.
4. Confirm the paid user remains Agent-only and never receives free-mode access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entitlement verification for web sessions when access information is unavailable.
  * Preserved access for free desktop sessions using token-provided access levels.
  * Added reliable retry handling for temporary verification failures.
  * Prevented unresolved checks from incorrectly granting or denying access.
  * Reset entitlement state correctly after logout.

* **Tests**
  * Added coverage for free and paid sessions, missing entitlements, failed verification, and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
