### PR TITLE
Recover wrapped sandbox acquisition timeouts

### DIFF
--- a/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
@@ -113,6 +113,12 @@ describe("sandbox health resource observations", () => {
     ],
     [new Error("fetch failed: ECONNRESET"), "connection_error"],
     [new Error("operation timed out"), "operation_timeout"],
+    [
+      new Error(
+        "Failed creating persistent sandbox: The operation was aborted due to timeout",
+      ),
+      "operation_timeout",
+    ],
     [new Error("500: Failed to place sandbox"), "placement_failure"],
   ])(
     "classifies readiness failures without exposing raw errors",

--- a/lib/ai/tools/utils/sandbox-readiness-failure.ts
+++ b/lib/ai/tools/utils/sandbox-readiness-failure.ts
@@ -34,7 +34,11 @@ export function classifySandboxReadinessFailureSignal(
   ) {
     return "connection_error";
   }
-  if (name.includes("timeout") || message.includes("timed out")) {
+  if (
+    name.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("aborted due to timeout")
+  ) {
     return "operation_timeout";
   }
 

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -686,7 +686,7 @@ describe("token-bucket async functions", () => {
 
       expect(mockDeductFromBalance).toHaveBeenCalledWith(
         "user-123",
-        42,
+        45,
         undefined,
       );
     });
@@ -719,7 +719,7 @@ describe("token-bucket async functions", () => {
 
       expect(mockDeductFromBalance).toHaveBeenCalledWith(
         "user-123",
-        42,
+        45,
         "settlement-123",
       );
     });
@@ -736,11 +736,11 @@ describe("token-bucket async functions", () => {
       const { deductUsage, calculateTokenCost, billableCostDollarsToPoints } =
         getIsolatedModule();
 
-      // Estimate: 10000 input tokens = 70 billable points
+      // Estimate: 10000 input tokens = 75 billable points
       const estimatedInputTokens = 10000;
       const estimatedCost = calculateTokenCost(estimatedInputTokens, "input");
 
-      // Actual provider cost: $0.002 = 28 billable points
+      // Actual provider cost: $0.002 = 30 billable points
       const providerCostDollars = 0.002;
 
       await deductUsage(
@@ -753,7 +753,7 @@ describe("token-bucket async functions", () => {
         providerCostDollars,
       );
 
-      // Should refund the difference (70 - 28 = 42 points)
+      // Should refund the difference (75 - 30 = 45 points)
       const expectedRefund =
         estimatedCost - billableCostDollarsToPoints(providerCostDollars);
       expect(mockHincrbyFn).toHaveBeenCalledWith(
@@ -771,7 +771,7 @@ describe("token-bucket async functions", () => {
       const estimatedCost = calculateTokenCost(estimatedInputTokens, "input");
       const providerCostDollars = 0.003;
 
-      expect(estimatedCost).toBe(54);
+      expect(estimatedCost).toBe(57);
 
       const result = await deductUsage(
         "user-123",
@@ -790,11 +790,11 @@ describe("token-bucket async functions", () => {
         },
       );
 
-      expect(mockRefundToBalance).toHaveBeenCalledWith("user-123", 12);
+      expect(mockRefundToBalance).toHaveBeenCalledWith("user-123", 9);
       expect(mockHincrbyFn).not.toHaveBeenCalled();
       expect(result).toEqual({
         includedPointsDeducted: 17,
-        extraUsagePointsDeducted: 25,
+        extraUsagePointsDeducted: 28,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });
@@ -833,7 +833,7 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 37,
-        uncoveredPoints: 30,
+        uncoveredPoints: 36,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "deduction_failed",
       });
@@ -843,11 +843,11 @@ describe("token-bucket async functions", () => {
     it("should refund when token-based actual cost is less than estimated", async () => {
       const { deductUsage, calculateTokenCost } = getIsolatedModule();
 
-      // Estimate: 10000 input tokens = 70 billable points (pre-deducted)
+      // Estimate: 10000 input tokens = 75 billable points (pre-deducted)
       const estimatedInputTokens = 10000;
       const estimatedCost = calculateTokenCost(estimatedInputTokens, "input");
 
-      // Actual: 2000 input + 500 output = 14 + 21 = 35 billable points
+      // Actual: 2000 input + 500 output = 15 + 23 = 38 billable points
       const actualInputTokens = 2000;
       const actualOutputTokens = 500;
       const actualCost =
@@ -876,7 +876,7 @@ describe("token-bucket async functions", () => {
     it("should not refund or charge when actual cost equals estimated", async () => {
       const { deductUsage } = getIsolatedModule();
 
-      // Estimate: 10000 input tokens = 70 billable points
+      // Estimate: 10000 input tokens = 75 billable points
       const estimatedInputTokens = 10000;
 
       // Actual provider cost exactly matches after applying the billable multiplier.
@@ -900,10 +900,10 @@ describe("token-bucket async functions", () => {
     it("should charge additional when actual cost exceeds estimated", async () => {
       const { deductUsage } = getIsolatedModule();
 
-      // Estimate: 1000 input tokens = 7 billable points (pre-deducted)
+      // Estimate: 1000 input tokens = 8 billable points (pre-deducted)
       const estimatedInputTokens = 1000;
 
-      // Actual provider cost: $0.005 = 70 billable points (much more than 7)
+      // Actual provider cost: $0.005 = 75 billable points (much more than 8)
       const providerCostDollars = 0.005;
 
       await deductUsage(
@@ -969,7 +969,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(73_640);
+      expect(expectedAdditional).toBe(78_900);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),
@@ -1028,7 +1028,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(3_920);
+      expect(expectedAdditional).toBe(4_200);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),
@@ -1466,12 +1466,12 @@ describe("token-bucket async functions", () => {
       expect(mockLimitFn).not.toHaveBeenCalled();
       expect(mockDeductFromBalance).toHaveBeenCalledWith(
         "user-123",
-        63,
+        68,
         undefined,
       );
       expect(result).toEqual({
         includedPointsDeducted: 0,
-        extraUsagePointsDeducted: 70,
+        extraUsagePointsDeducted: 75,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });
@@ -1495,9 +1495,9 @@ describe("token-bucket async functions", () => {
         limit: 250000,
       });
 
-      // Estimated 1000 input = 7 points, actual provider cost = $0.005 = 70 billable points.
-      // Difference = 70 - 7 = 63 additional needed.
-      // Bucket has 10, so fromBucket=10, fromExtraUsage=53.
+      // Estimated 1000 input = 8 points, actual provider cost = $0.005 = 75 billable points.
+      // Difference = 75 - 8 = 67 additional needed.
+      // Bucket has 10, so fromBucket=10, fromExtraUsage=57.
       const result = await deductUsage(
         "user-123",
         "pro",
@@ -1517,15 +1517,15 @@ describe("token-bucket async functions", () => {
         expect.any(String),
         expect.objectContaining({ rate: 10 }),
       );
-      // Should deduct the overflow (53) from extra usage
+      // Should deduct the overflow (57) from extra usage
       expect(mockDeductFromBalance).toHaveBeenCalledWith(
         "user-123",
-        53,
+        57,
         undefined,
       );
       expect(result).toEqual({
-        includedPointsDeducted: 17,
-        extraUsagePointsDeducted: 53,
+        includedPointsDeducted: 18,
+        extraUsagePointsDeducted: 57,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });
@@ -1565,13 +1565,13 @@ describe("token-bucket async functions", () => {
 
       expect(mockDeductFromBalance).toHaveBeenCalledWith(
         "user-123",
-        53,
+        57,
         undefined,
       );
       expect(result).toEqual({
-        includedPointsDeducted: 17,
+        includedPointsDeducted: 18,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 53,
+        uncoveredPoints: 57,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "insufficient_funds",
       });
@@ -1611,9 +1611,9 @@ describe("token-bucket async functions", () => {
       );
 
       expect(result).toEqual({
-        includedPointsDeducted: 17,
+        includedPointsDeducted: 18,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 53,
+        uncoveredPoints: 57,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "monthly_cap_exceeded",
       });
@@ -1655,9 +1655,9 @@ describe("token-bucket async functions", () => {
       );
 
       expect(result).toEqual({
-        includedPointsDeducted: 17,
+        includedPointsDeducted: 18,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 53,
+        uncoveredPoints: 57,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "auto_reload_failed",
       });
@@ -1705,13 +1705,13 @@ describe("token-bucket async functions", () => {
       expect(mockDeductFromTeamBalance).toHaveBeenCalledWith(
         "org-123",
         "user-123",
-        53,
+        57,
         undefined,
       );
       expect(result).toEqual({
-        includedPointsDeducted: 17,
+        includedPointsDeducted: 18,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 53,
+        uncoveredPoints: 57,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "member_cap_exceeded",
       });
@@ -1979,14 +1979,14 @@ describe("token-bucket async functions", () => {
         undefined,
         0,
         undefined,
-        { pointsDeducted: 35, extraUsagePointsDeducted: 35 },
+        { pointsDeducted: 38, extraUsagePointsDeducted: 37 },
       );
 
       expect(mockLimitFn).not.toHaveBeenCalled();
       expect(mockDeductFromBalance).not.toHaveBeenCalled();
       expect(result).toEqual({
-        includedPointsDeducted: 35,
-        extraUsagePointsDeducted: 35,
+        includedPointsDeducted: 38,
+        extraUsagePointsDeducted: 37,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });
@@ -2007,7 +2007,7 @@ describe("token-bucket async functions", () => {
           if (opts.rate === 0) {
             return {
               success: true,
-              remaining: 7,
+              remaining: 8,
               reset: Date.now() + 3600000,
               limit: 250000,
             };

--- a/lib/rate-limit/__tests__/usage-settlement.test.ts
+++ b/lib/rate-limit/__tests__/usage-settlement.test.ts
@@ -34,7 +34,7 @@ describe("usage-settlement", () => {
         currentCostDollars: 0.08,
       }),
     ).toBe(true);
-    expect(getUnsettledUsagePoints(state, 0.08)).toBe(120);
+    expect(getUnsettledUsagePoints(state, 0.08)).toBe(200);
   });
 
   it("settles without trusting the remaining balance captured at run start", () => {
@@ -46,7 +46,7 @@ describe("usage-settlement", () => {
         currentCostDollars: 5,
       }),
     ).toBe(true);
-    expect(getUnsettledUsagePoints(state, 5)).toBe(69_000);
+    expect(getUnsettledUsagePoints(state, 5)).toBe(74_000);
   });
 
   it("updates cumulative settled totals after a mid-run deduction", () => {
@@ -84,8 +84,8 @@ describe("usage-settlement", () => {
         state,
         currentCostDollars: 0.25,
       }),
-    ).toBe(false);
-    expect(getUnsettledUsagePoints(state, 0.25)).toBe(0);
+    ).toBe(true);
+    expect(getUnsettledUsagePoints(state, 0.25)).toBe(250);
 
     expect(
       shouldSettleUsageMidRun({
@@ -93,6 +93,6 @@ describe("usage-settlement", () => {
         currentCostDollars: 0.3,
       }),
     ).toBe(true);
-    expect(getUnsettledUsagePoints(state, 0.3)).toBe(700);
+    expect(getUnsettledUsagePoints(state, 0.3)).toBe(1_000);
   });
 });

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -529,6 +529,10 @@ describe("desktop-local sandbox file helpers", () => {
       "operation_timeout",
     ],
     [
+      "Failed creating persistent sandbox: The operation was aborted due to timeout",
+      "operation_timeout",
+    ],
+    [
       "Failed creating persistent sandbox: 500: Failed to place sandbox",
       "placement_failure",
     ],


### PR DESCRIPTION
## Summary

- classify the exact wrapped E2B message `The operation was aborted due to timeout` as an attachment acquisition timeout
- reuse the existing one-operation fresh-sandbox retry and bounded scheduled/recovered/retry-failed telemetry
- update two stale billing test suites for the already-merged 1.5x usage multiplier; this changes test expectations only

## Production evidence

Frozen audit window: `2026-07-31T20:01:14.724Z`–`2026-08-01T20:01:14.724Z`.

PR #1008 first reached Trigger production as worker `20260731.8` / deployment `1bbs8qbb` at `2026-07-31T20:46:13Z`. In post-fix serving worker `20260801.4`, run `run_06frsdmjdg0jo5l1pr9ghgtcc1` failed attachment acquisition with:

`Failed creating persistent sandbox: The operation was aborted due to timeout`

The trace emitted no `sandbox_attachment_acquisition_*` event, did not request a fresh sandbox, and classified the failure as non-transient. The SDK wrapper had removed the original `TimeoutError` identity, while the shared classifier recognized only timeout names or the phrase `timed out`.

The other sampled post-#1008 attachment failures were transfer/relay exhaustion and remain intentionally visible. This change does not broaden transfer retries, alter file handling, or suppress errors.

## Change

The shared privacy-safe classifier now recognizes only the bounded phrase `aborted due to timeout`. Existing retry policy still permits at most one operation-wide fresh-sandbox acquisition when the caller opts in. Regression coverage verifies both shared classification and the real acquisition retry/logging path.

Current `origin/main` was already red after the 1.5x usage-markup change because two integration suites retained 1.4x expectations. The second commit mechanically updates those expectations and comments without changing billing production code.

## Validation

- `corepack pnpm jest lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/api/__tests__/agent-long-contracts.test.ts lib/ai/tools/utils/__tests__/sandbox-health.test.ts lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand` — 4 suites / 143 tests passed
- `corepack pnpm jest lib/rate-limit/__tests__ --runInBand` — 9 suites / 197 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint and Prettier — passed
- final commit hooks — 316 suites / 3,155 tests passed

## Manual verification

After deployment, force one E2B attachment sandbox create/resume failure with the wrapped timeout message. Confirm exactly one fresh-sandbox acquisition retry and one bounded scheduled/recovered or retry-failed event. Confirm transfer failures and non-timeout aborts do not gain an acquisition retry.

Visual QA is not applicable to this backend classification and test-only baseline repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox recovery by correctly identifying aborted timeout errors and triggering the appropriate refresh flow.
  * Updated usage and cost calculations to reflect revised token billing and settlement values.

* **Tests**
  * Added coverage for sandbox timeout classification and recovery.
  * Updated billing and settlement expectations for revised calculation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->