### PR TITLE
Measure explicit Agent step-limit stops

### DIFF
--- a/lib/ai/tools/__tests__/todo-write.test.ts
+++ b/lib/ai/tools/__tests__/todo-write.test.ts
@@ -30,7 +30,8 @@ async function runTool(
 
 describe("todo_write", () => {
   it("creates a full todo list and returns currentTodos", async () => {
-    const result = await runTool(createTodoWrite(makeContext()), {
+    const context = makeContext();
+    const result = await runTool(createTodoWrite(context), {
       merge: false,
       todos: [
         { id: "1", content: "Plan test", status: "in_progress" },
@@ -55,22 +56,106 @@ describe("todo_write", () => {
         },
       ],
     });
+    expect(context.todoManager.getRunMetrics()).toEqual({
+      initialTodoCount: 0,
+      initialUnfinishedTodoCount: 0,
+      finalTodoCount: 2,
+      finalUnfinishedTodoCount: 2,
+      todoWriteCount: 1,
+      todoCreatedThisRunCount: 2,
+      todoUpdatedThisRunCount: 0,
+      todoRemovedThisRunCount: 0,
+      currentRunTodoCount: 2,
+      currentRunUnfinishedTodoCount: 2,
+    });
   });
 
   it("allows partial merge updates for existing todos", async () => {
-    const result = await runTool(
-      createTodoWrite(
-        makeContext([{ id: "1", content: "Plan test", status: "in_progress" }]),
-      ),
-      {
-        merge: true,
-        todos: [{ id: "1", status: "completed" }],
-      },
-    );
+    const context = makeContext([
+      { id: "1", content: "Plan test", status: "in_progress" },
+    ]);
+    const result = await runTool(createTodoWrite(context), {
+      merge: true,
+      todos: [{ id: "1", status: "completed" }],
+    });
 
     expect(result).toMatchObject({
       counts: { completed: 1, total: 1 },
       currentTodos: [{ id: "1", content: "Plan test", status: "completed" }],
+    });
+    expect(context.todoManager.getRunMetrics()).toEqual({
+      initialTodoCount: 1,
+      initialUnfinishedTodoCount: 1,
+      finalTodoCount: 1,
+      finalUnfinishedTodoCount: 0,
+      todoWriteCount: 1,
+      todoCreatedThisRunCount: 0,
+      todoUpdatedThisRunCount: 1,
+      todoRemovedThisRunCount: 0,
+      currentRunTodoCount: 1,
+      currentRunUnfinishedTodoCount: 0,
+    });
+  });
+
+  it("tracks unique todo changes without treating inherited todos as current-run work", async () => {
+    const context = makeContext([
+      { id: "stale", content: "Old work", status: "pending" },
+      { id: "active", content: "Current work", status: "in_progress" },
+    ]);
+    const tool = createTodoWrite(context);
+
+    await runTool(tool, {
+      merge: true,
+      todos: [
+        { id: "active", status: "completed" },
+        { id: "new", content: "New work", status: "pending" },
+      ],
+    });
+    await runTool(tool, {
+      merge: true,
+      todos: [{ id: "new", status: "in_progress" }],
+    });
+
+    expect(context.todoManager.getRunMetrics()).toEqual({
+      initialTodoCount: 2,
+      initialUnfinishedTodoCount: 2,
+      finalTodoCount: 3,
+      finalUnfinishedTodoCount: 2,
+      todoWriteCount: 2,
+      todoCreatedThisRunCount: 1,
+      todoUpdatedThisRunCount: 2,
+      todoRemovedThisRunCount: 0,
+      currentRunTodoCount: 2,
+      currentRunUnfinishedTodoCount: 1,
+    });
+  });
+
+  it("tracks assistant todos removed by a replacement plan", async () => {
+    const context = makeContext([
+      {
+        id: "old",
+        content: "Old plan",
+        status: "pending",
+        sourceMessageId: "assistant-old",
+      },
+    ]);
+
+    await runTool(createTodoWrite(context), {
+      merge: false,
+      todos: [{ id: "new", content: "New plan", status: "in_progress" }],
+    });
+
+    expect(context.todoManager.getRunMetrics()).toEqual({
+      initialTodoCount: 1,
+      initialUnfinishedTodoCount: 1,
+      finalTodoCount: 1,
+      finalUnfinishedTodoCount: 1,
+      todoWriteCount: 1,
+      todoCreatedThisRunCount: 1,
+      todoUpdatedThisRunCount: 0,
+      todoRemovedThisRunCount: 1,
+      currentRunTodoCount: 1,
+      currentRunUnfinishedTodoCount: 1,
     });
   });
 

--- a/lib/ai/tools/utils/todo-manager.ts
+++ b/lib/ai/tools/utils/todo-manager.ts
@@ -7,6 +7,22 @@ export interface TodoUpdate {
   status?: "pending" | "in_progress" | "completed" | "cancelled";
 }
 
+export type TodoRunMetrics = {
+  initialTodoCount: number;
+  initialUnfinishedTodoCount: number;
+  finalTodoCount: number;
+  finalUnfinishedTodoCount: number;
+  todoWriteCount: number;
+  todoCreatedThisRunCount: number;
+  todoUpdatedThisRunCount: number;
+  todoRemovedThisRunCount: number;
+  currentRunTodoCount: number;
+  currentRunUnfinishedTodoCount: number;
+};
+
+const isUnfinishedTodo = (todo: Todo): boolean =>
+  todo.status === "pending" || todo.status === "in_progress";
+
 /**
  * TodoManager handles backend state management for todos during tool execution.
  * It maintains the current state of todos in memory for the duration of the conversation.
@@ -14,11 +30,20 @@ export interface TodoUpdate {
 export class TodoManager {
   private todos: Todo[] = [];
   private hasCreatedPlanThisRun: boolean = false;
+  private readonly initialTodoCount: number;
+  private readonly initialUnfinishedTodoCount: number;
+  private todoWriteCount = 0;
+  private readonly createdTodoIds = new Set<string>();
+  private readonly updatedTodoIds = new Set<string>();
+  private readonly removedTodoIds = new Set<string>();
 
   constructor(initialTodos?: Todo[]) {
     if (initialTodos) {
       this.todos = [...initialTodos];
     }
+    this.initialTodoCount = this.todos.length;
+    this.initialUnfinishedTodoCount =
+      this.todos.filter(isUnfinishedTodo).length;
   }
 
   /**
@@ -35,13 +60,40 @@ export class TodoManager {
     newTodos: (Partial<Todo> & { id: string })[],
     merge: boolean = false,
   ): Todo[] {
+    const previousTodos = this.todos;
     const result = applyTodoWriteUpdate({
-      currentTodos: this.todos,
+      currentTodos: previousTodos,
       incomingTodos: newTodos,
       merge,
     });
 
     this.todos = result.todos;
+    this.todoWriteCount += 1;
+
+    const previousById = new Map(
+      previousTodos.map((todo) => [todo.id, todo] as const),
+    );
+    const currentById = new Map(
+      this.todos.map((todo) => [todo.id, todo] as const),
+    );
+
+    for (const todo of this.todos) {
+      const previous = previousById.get(todo.id);
+      if (!previous) {
+        this.createdTodoIds.add(todo.id);
+      } else if (
+        previous.content !== todo.content ||
+        previous.status !== todo.status
+      ) {
+        this.updatedTodoIds.add(todo.id);
+      }
+    }
+
+    for (const todo of previousTodos) {
+      if (!currentById.has(todo.id)) {
+        this.removedTodoIds.add(todo.id);
+      }
+    }
 
     if (!merge) {
       this.hasCreatedPlanThisRun = true;
@@ -66,6 +118,31 @@ export class TodoManager {
       cancelled: cancelled,
       // Count both completed and cancelled as "done" for progress tracking
       done: completed + cancelled,
+    };
+  }
+
+  /** Return privacy-safe counts describing todo changes during this run. */
+  getRunMetrics(): TodoRunMetrics {
+    const currentRunTodoIds = new Set([
+      ...this.createdTodoIds,
+      ...this.updatedTodoIds,
+    ]);
+    const currentRunTodos = this.todos.filter((todo) =>
+      currentRunTodoIds.has(todo.id),
+    );
+
+    return {
+      initialTodoCount: this.initialTodoCount,
+      initialUnfinishedTodoCount: this.initialUnfinishedTodoCount,
+      finalTodoCount: this.todos.length,
+      finalUnfinishedTodoCount: this.todos.filter(isUnfinishedTodo).length,
+      todoWriteCount: this.todoWriteCount,
+      todoCreatedThisRunCount: this.createdTodoIds.size,
+      todoUpdatedThisRunCount: this.updatedTodoIds.size,
+      todoRemovedThisRunCount: this.removedTodoIds.size,
+      currentRunTodoCount: currentRunTodos.length,
+      currentRunUnfinishedTodoCount:
+        currentRunTodos.filter(isUnfinishedTodo).length,
     };
   }
 

--- a/lib/analytics/__tests__/agent-step-limit-telemetry.test.ts
+++ b/lib/analytics/__tests__/agent-step-limit-telemetry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { buildAgentStepLimitTelemetry } from "../agent-step-limit-telemetry";
+
+describe("agent step-limit telemetry", () => {
+  it("builds a content-free snapshot from explicit stop and todo-run state", () => {
+    expect(
+      buildAgentStepLimitTelemetry({
+        configuredMaxSteps: 300,
+        stepCount: 300,
+        stepLimitReached: true,
+        todoRunMetrics: {
+          initialTodoCount: 4,
+          initialUnfinishedTodoCount: 2,
+          finalTodoCount: 5,
+          finalUnfinishedTodoCount: 2,
+          todoWriteCount: 3,
+          todoCreatedThisRunCount: 2,
+          todoUpdatedThisRunCount: 1,
+          todoRemovedThisRunCount: 1,
+          currentRunTodoCount: 3,
+          currentRunUnfinishedTodoCount: 1,
+        },
+      }),
+    ).toEqual({
+      version: 1,
+      configuredMaxSteps: 300,
+      stepCount: 300,
+      stepLimitReached: true,
+      initialTodoCount: 4,
+      initialUnfinishedTodoCount: 2,
+      finalTodoCount: 5,
+      finalUnfinishedTodoCount: 2,
+      todoWriteCount: 3,
+      todoCreatedThisRunCount: 2,
+      todoUpdatedThisRunCount: 1,
+      todoRemovedThisRunCount: 1,
+      currentRunTodoCount: 3,
+      currentRunUnfinishedTodoCount: 1,
+    });
+  });
+});

--- a/lib/analytics/agent-step-limit-telemetry.ts
+++ b/lib/analytics/agent-step-limit-telemetry.ts
@@ -1,0 +1,29 @@
+import type { TodoRunMetrics } from "@/lib/ai/tools/utils/todo-manager";
+
+export const AGENT_STEP_LIMIT_TELEMETRY_VERSION = 1;
+
+export type AgentStepLimitTelemetry = TodoRunMetrics & {
+  version: typeof AGENT_STEP_LIMIT_TELEMETRY_VERSION;
+  configuredMaxSteps: number;
+  stepCount: number;
+  stepLimitReached: boolean;
+};
+
+/** Build content-free measurements for deciding whether the Agent step cap is too low. */
+export const buildAgentStepLimitTelemetry = ({
+  configuredMaxSteps,
+  stepCount,
+  stepLimitReached,
+  todoRunMetrics,
+}: {
+  configuredMaxSteps: number;
+  stepCount: number;
+  stepLimitReached: boolean;
+  todoRunMetrics: TodoRunMetrics;
+}): AgentStepLimitTelemetry => ({
+  version: AGENT_STEP_LIMIT_TELEMETRY_VERSION,
+  configuredMaxSteps,
+  stepCount,
+  stepLimitReached,
+  ...todoRunMetrics,
+});

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -72,6 +72,7 @@ describe("captureAgentRun", () => {
     captureAgentRun({
       posthog: { capture } as any,
       userId: "user_123",
+      chatId: "chat_123",
       mode: "agent",
       subscription: "pro",
       sandboxInfo: { type: "remote-connection", name: "Work laptop" },
@@ -98,6 +99,7 @@ describe("captureAgentRun", () => {
         mode: "agent",
         subscription: "pro",
         subscription_tier: "pro",
+        chat_id: "chat_123",
         outcome: "success",
         selected_model: "agent-model",
         configured_model: "deepseek/deepseek-v4-pro",
@@ -123,6 +125,7 @@ describe("captureAgentRun", () => {
     captureAgentRun({
       posthog: { capture } as any,
       userId: "user_123",
+      chatId: "chat_123",
       mode: "agent",
       subscription: "pro",
       sandboxInfo: null,
@@ -153,12 +156,69 @@ describe("captureAgentRun", () => {
     );
   });
 
+  it("captures explicit step-limit and current-run todo measurements", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      mode: "agent",
+      subscription: "pro",
+      sandboxInfo: null,
+      outcome: "success",
+      selectedModel: "agent-model",
+      configuredModelId: "deepseek/deepseek-v4-pro",
+      finishReason: "tool-calls",
+      isAutoContinue: true,
+      stepLimitTelemetry: {
+        version: 1,
+        configuredMaxSteps: 300,
+        stepCount: 300,
+        stepLimitReached: true,
+        initialTodoCount: 8,
+        initialUnfinishedTodoCount: 5,
+        finalTodoCount: 9,
+        finalUnfinishedTodoCount: 4,
+        todoWriteCount: 3,
+        todoCreatedThisRunCount: 2,
+        todoUpdatedThisRunCount: 3,
+        todoRemovedThisRunCount: 1,
+        currentRunTodoCount: 4,
+        currentRunUnfinishedTodoCount: 2,
+      },
+    });
+
+    expect(capture.mock.calls[0][0].properties).toEqual(
+      expect.objectContaining({
+        chat_id: "chat_123",
+        finish_reason: "tool-calls",
+        is_auto_continue: true,
+        step_limit_telemetry_version: 1,
+        configured_max_steps: 300,
+        agent_step_count: 300,
+        step_limit_reached: true,
+        initial_todo_count: 8,
+        initial_unfinished_todo_count: 5,
+        final_todo_count: 9,
+        final_unfinished_todo_count: 4,
+        todo_write_count: 3,
+        todo_created_this_run_count: 2,
+        todo_updated_this_run_count: 3,
+        todo_removed_this_run_count: 1,
+        current_run_todo_count: 4,
+        current_run_unfinished_todo_count: 2,
+      }),
+    );
+  });
+
   it("attributes a served fallback without inferring it from model names", () => {
     const capture = jest.fn();
 
     captureAgentRun({
       posthog: { capture } as any,
       userId: "user_123",
+      chatId: "chat_123",
       mode: "agent",
       subscription: "free",
       sandboxInfo: { type: "e2b" },
@@ -187,6 +247,7 @@ describe("captureAgentRun", () => {
     captureAgentRun({
       posthog: { capture } as any,
       userId: "user_123",
+      chatId: "chat_123",
       mode: "agent",
       subscription: "pro",
       sandboxInfo: null,
@@ -211,6 +272,7 @@ describe("captureAgentRun", () => {
     captureAgentRun({
       posthog: { capture } as any,
       userId: "user_123",
+      chatId: "chat_123",
       mode: "ask",
       subscription: "pro",
       sandboxInfo: { type: "e2b" },
@@ -314,6 +376,7 @@ describe("captureAgentCompletionAnalytics", () => {
         mode: "agent",
         subscription: "free",
         subscription_tier: "free",
+        chat_id: "chat_123",
         outcome: "success",
         selected_model: "agent-model-free",
         configured_model: "deepseek/deepseek-v4-flash-0731",
@@ -359,6 +422,7 @@ describe("captureAgentCompletionAnalytics", () => {
         mode: "agent",
         subscription: "pro",
         subscription_tier: "pro",
+        chat_id: "chat_123",
         outcome: "success",
         selected_model: "agent-model",
         configured_model: "deepseek/deepseek-v4-pro",

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -15,7 +15,6 @@
 
 import {
   convertToModelMessages,
-  stepCountIs,
   streamText,
   type LanguageModel,
   type ModelMessage,
@@ -38,6 +37,7 @@ import {
   elapsedTimeExceeds,
   tokenExhaustedAfterSummarization,
   doomLoopDetected,
+  stepLimitReached,
   PREEMPTIVE_TIMEOUT_FINISH_REASON,
   TOKEN_EXHAUSTION_FINISH_REASON,
   DOOM_LOOP_FINISH_REASON,
@@ -200,6 +200,11 @@ export type AgentStreamState = {
   /** True when a provider rejected an image-bearing tool result. */
   providerRejectedMultimodalToolResults: boolean;
   /** Stop-condition flags set by the respective onFired callbacks. */
+  configuredMaxSteps: number;
+  /** Total completed model steps across provider attempts in this request. */
+  agentStepCount: number;
+  /** True only when the final provider attempt stopped at the step condition. */
+  stoppedDueToStepLimit: boolean;
   stoppedDueToTokenExhaustion: boolean;
   /** Maps to stoppedDueToPreemptiveTimeout in chat-handler, stoppedDueToElapsedTimeout in agent-long. */
   stoppedDueToElapsedTimeout: boolean;
@@ -229,6 +234,9 @@ export function initAgentStreamState(
     fallbackServed: undefined,
     providerError: undefined,
     providerRejectedMultimodalToolResults: false,
+    configuredMaxSteps: 0,
+    agentStepCount: 0,
+    stoppedDueToStepLimit: false,
     stoppedDueToTokenExhaustion: false,
     stoppedDueToElapsedTimeout: false,
     stoppedDueToDoomLoop: false,
@@ -502,6 +510,8 @@ export async function createAgentStream(
   ctx: AgentStreamContext,
   state: AgentStreamState,
 ) {
+  const configuredMaxSteps = getMaxStepsForUser(ctx.mode);
+  state.configuredMaxSteps = configuredMaxSteps;
   const toolCallRunNamespace = randomUUID().replaceAll("-", "").slice(0, 8);
   const stepUsageCostIndexes: Array<number | undefined> = [];
   const getActiveToolsWithExclusions = async (
@@ -1176,7 +1186,12 @@ export async function createAgentStream(
     },
 
     stopWhen: [
-      stepCountIs(getMaxStepsForUser(ctx.mode)),
+      stepLimitReached({
+        maxSteps: configuredMaxSteps,
+        onFired: () => {
+          state.stoppedDueToStepLimit = true;
+        },
+      }),
       tokenExhaustedAfterSummarization({
         threshold: summarizationThreshold,
         getLastStepInputTokens: () => state.lastStepInputTokens,
@@ -1249,6 +1264,7 @@ export async function createAgentStream(
 
     onStepFinish: async ({ usage, response, providerMetadata }) => {
       ctx.onModelStreamFinish?.();
+      state.agentStepCount += 1;
       let stepUsageCostIndex: number | undefined;
       if (usage) {
         const stepAccountingModel = resolveServedModelForCostAccounting({

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -138,6 +138,7 @@ import { Id } from "@/convex/_generated/dataModel";
 import { phLogger } from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import { readAnalyticsRequestContext } from "@/lib/analytics/request-context";
+import { buildAgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
 import {
   capturePaidDailyFreeAllowanceServerEvent,
   createPaidDailyFreeAllowanceBudgetSnapshot,
@@ -1310,6 +1311,7 @@ export const createChatHandler = () => {
                 );
                 resetServedModelTelemetryForRetry(state);
                 state.lastStepInputTokens = 0;
+                state.stoppedDueToStepLimit = false;
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
                 state.stoppedDueToDoomLoop = false;
@@ -1463,6 +1465,7 @@ export const createChatHandler = () => {
                       ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
+                        state.stoppedDueToStepLimit = false;
                         state.streamFinishReason = undefined;
                         state.providerError = undefined;
                         state.providerRejectedMultimodalToolResults = false;
@@ -1593,6 +1596,17 @@ export const createChatHandler = () => {
                                       : state.fallbackServed,
                                   finishReason: state.streamFinishReason,
                                   budgetAbortDetails: state.budgetAbortDetails,
+                                  isAutoContinue: !!isAutoContinue,
+                                  stepLimitTelemetry:
+                                    buildAgentStepLimitTelemetry({
+                                      configuredMaxSteps:
+                                        state.configuredMaxSteps,
+                                      stepCount: state.agentStepCount,
+                                      stepLimitReached:
+                                        state.stoppedDueToStepLimit,
+                                      todoRunMetrics:
+                                        getTodoManager().getRunMetrics(),
+                                    }),
                                 });
                                 chatLogger!.emitSuccess({
                                   finishReason: state.streamFinishReason,
@@ -1872,6 +1886,13 @@ export const createChatHandler = () => {
                           : state.fallbackServed,
                       finishReason: state.streamFinishReason,
                       budgetAbortDetails: state.budgetAbortDetails,
+                      isAutoContinue: !!isAutoContinue,
+                      stepLimitTelemetry: buildAgentStepLimitTelemetry({
+                        configuredMaxSteps: state.configuredMaxSteps,
+                        stepCount: state.agentStepCount,
+                        stepLimitReached: state.stoppedDueToStepLimit,
+                        todoRunMetrics: getTodoManager().getRunMetrics(),
+                      }),
                     });
                     chatLogger!.emitSuccess({
                       finishReason: state.streamFinishReason,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -30,6 +30,7 @@ import {
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
 import type { AnalyticsRequestContext } from "@/lib/analytics/request-context";
+import type { AgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
 import { extraUsagePointsToDollars } from "@/convex/lib/extraUsagePricing";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
 import type { UsageDeductionResult } from "@/lib/rate-limit";
@@ -1177,11 +1178,14 @@ type AgentCompletionAnalyticsArgs = {
   activeModelStreamDurationMs?: number;
   activeTerminalWaitDurationMs?: number;
   activeSandboxRecoveryDurationMs?: number;
+  isAutoContinue?: boolean;
+  stepLimitTelemetry?: AgentStepLimitTelemetry;
 };
 
 export function captureAgentRun({
   posthog,
   userId,
+  chatId,
   mode,
   subscription,
   sandboxInfo,
@@ -1201,9 +1205,12 @@ export function captureAgentRun({
   activeModelStreamDurationMs,
   activeTerminalWaitDurationMs,
   activeSandboxRecoveryDurationMs,
+  isAutoContinue,
+  stepLimitTelemetry,
 }: {
   posthog: PostHog | null;
   userId: string;
+  chatId: string;
   mode: ChatMode;
   subscription: string;
   sandboxInfo: SandboxInfo | null;
@@ -1223,6 +1230,8 @@ export function captureAgentRun({
   activeModelStreamDurationMs?: number;
   activeTerminalWaitDurationMs?: number;
   activeSandboxRecoveryDurationMs?: number;
+  isAutoContinue?: boolean;
+  stepLimitTelemetry?: AgentStepLimitTelemetry;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1232,6 +1241,7 @@ export function captureAgentRun({
       mode,
       subscription,
       subscription_tier: subscription,
+      chat_id: chatId,
       outcome,
       selected_model: selectedModel,
       configured_model: configuredModelId,
@@ -1260,6 +1270,9 @@ export function captureAgentRun({
       ...(activeSandboxRecoveryDurationMs !== undefined && {
         active_sandbox_recovery_duration_ms: activeSandboxRecoveryDurationMs,
       }),
+      ...(isAutoContinue !== undefined && {
+        is_auto_continue: isAutoContinue,
+      }),
       ...(responseModel && { response_model: responseModel }),
       ...(responseModel &&
         fallbackServed !== undefined && { fallback_served: fallbackServed }),
@@ -1267,6 +1280,25 @@ export function captureAgentRun({
         sandbox_type: sandboxInfo.type,
       }),
       ...(finishReason && { finish_reason: finishReason }),
+      ...(stepLimitTelemetry && {
+        step_limit_telemetry_version: stepLimitTelemetry.version,
+        configured_max_steps: stepLimitTelemetry.configuredMaxSteps,
+        agent_step_count: stepLimitTelemetry.stepCount,
+        step_limit_reached: stepLimitTelemetry.stepLimitReached,
+        initial_todo_count: stepLimitTelemetry.initialTodoCount,
+        initial_unfinished_todo_count:
+          stepLimitTelemetry.initialUnfinishedTodoCount,
+        final_todo_count: stepLimitTelemetry.finalTodoCount,
+        final_unfinished_todo_count:
+          stepLimitTelemetry.finalUnfinishedTodoCount,
+        todo_write_count: stepLimitTelemetry.todoWriteCount,
+        todo_created_this_run_count: stepLimitTelemetry.todoCreatedThisRunCount,
+        todo_updated_this_run_count: stepLimitTelemetry.todoUpdatedThisRunCount,
+        todo_removed_this_run_count: stepLimitTelemetry.todoRemovedThisRunCount,
+        current_run_todo_count: stepLimitTelemetry.currentRunTodoCount,
+        current_run_unfinished_todo_count:
+          stepLimitTelemetry.currentRunUnfinishedTodoCount,
+      }),
       ...(budgetAbortDetails && {
         budget_abort_cap_reason: budgetAbortDetails.capReason,
         budget_abort_billing_stop_reason: budgetAbortDetails.billingStopReason,
@@ -1283,6 +1315,7 @@ export function captureAgentCompletionAnalytics(
   captureAgentRun({
     posthog,
     userId,
+    chatId: args.chatId,
     mode,
     subscription,
     sandboxInfo,
@@ -1302,6 +1335,8 @@ export function captureAgentCompletionAnalytics(
     activeModelStreamDurationMs: args.activeModelStreamDurationMs,
     activeTerminalWaitDurationMs: args.activeTerminalWaitDurationMs,
     activeSandboxRecoveryDurationMs: args.activeSandboxRecoveryDurationMs,
+    isAutoContinue: args.isAutoContinue,
+    stepLimitTelemetry: args.stepLimitTelemetry,
   });
 }
 

--- a/lib/chat/__tests__/stop-conditions.test.ts
+++ b/lib/chat/__tests__/stop-conditions.test.ts
@@ -10,7 +10,21 @@ import {
   tokenExhaustedAfterSummarization,
   elapsedTimeExceeds,
   getAgentAutoContinueStopSource,
+  stepLimitReached,
 } from "../stop-conditions";
+
+describe("stepLimitReached", () => {
+  it("fires only when the configured step limit is reached", () => {
+    const onFired = jest.fn();
+    const condition = stepLimitReached({ maxSteps: 3, onFired });
+
+    expect(condition({ steps: [{}, {}] } as never)).toBe(false);
+    expect(onFired).not.toHaveBeenCalled();
+
+    expect(condition({ steps: [{}, {}, {}] } as never)).toBe(true);
+    expect(onFired).toHaveBeenCalledTimes(1);
+  });
+});
 
 function makeState(overrides: {
   threshold: number;

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -11,6 +11,17 @@ export const OUTPUT_LIMIT_FINISH_REASON = "length";
 
 export const BUDGET_EXHAUSTION_FINISH_REASON = "budget-exhausted";
 
+export function stepLimitReached(state: {
+  maxSteps: number;
+  onFired: () => void;
+}): StopCondition<any> {
+  return ({ steps }) => {
+    const shouldStop = steps.length >= state.maxSteps;
+    if (shouldStop) state.onFired();
+    return shouldStop;
+  };
+}
+
 export type AgentAutoContinueStopSource =
   | "post_summarization_token_exhaustion"
   | "elapsed_timeout"

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -119,6 +119,7 @@ import {
 import { phLogger } from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import type { AnalyticsRequestContext } from "@/lib/analytics/request-context";
+import { buildAgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
 import {
   capturePaidDailyFreeAllowanceServerEvent,
   createPaidDailyFreeAllowanceBudgetSnapshot,
@@ -2914,6 +2915,7 @@ export const agentLongTask = task({
                 );
                 resetServedModelTelemetryForRetry(state);
                 state.lastStepInputTokens = 0;
+                state.stoppedDueToStepLimit = false;
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
                 state.stoppedDueToDoomLoop = false;
@@ -3055,6 +3057,7 @@ export const agentLongTask = task({
                         );
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
+                        state.stoppedDueToStepLimit = false;
                         state.streamFinishReason = undefined;
                         state.providerError = undefined;
                         state.providerRejectedMultimodalToolResults = false;
@@ -3188,6 +3191,17 @@ export const agentLongTask = task({
                                     budgetAbortDetails:
                                       state.budgetAbortDetails,
                                     agentPermissionMode,
+                                    isAutoContinue: !!isAutoContinue,
+                                    stepLimitTelemetry:
+                                      buildAgentStepLimitTelemetry({
+                                        configuredMaxSteps:
+                                          state.configuredMaxSteps,
+                                        stepCount: state.agentStepCount,
+                                        stepLimitReached:
+                                          state.stoppedDueToStepLimit,
+                                        todoRunMetrics:
+                                          getTodoManager().getRunMetrics(),
+                                      }),
                                     ...getTriggerRunTelemetry(),
                                   });
                                   if (!isTerminalProviderStreamError(state)) {
@@ -3339,6 +3353,13 @@ export const agentLongTask = task({
                         finishReason: state.streamFinishReason,
                         budgetAbortDetails: state.budgetAbortDetails,
                         agentPermissionMode,
+                        isAutoContinue: !!isAutoContinue,
+                        stepLimitTelemetry: buildAgentStepLimitTelemetry({
+                          configuredMaxSteps: state.configuredMaxSteps,
+                          stepCount: state.agentStepCount,
+                          stepLimitReached: state.stoppedDueToStepLimit,
+                          todoRunMetrics: getTodoManager().getRunMetrics(),
+                        }),
                         ...getTriggerRunTelemetry(),
                       });
                       if (!isTerminalProviderStreamError(state)) {


### PR DESCRIPTION
## Summary

- replace the generic Agent step-count stop condition with an equivalent instrumented condition that records when the loop actually stops at its configured cap
- track initial/final todo state plus unique todos created, updated, removed, and still unfinished from the current run
- attach versioned, privacy-safe fields to the existing `hackerai-agent_run` event in both Next.js and Trigger.dev paths
- add the opaque `chat_id` correlation key and explicit `is_auto_continue` value so cap-hit continuation outcomes can be followed without capturing user content

## Why

The prior `has_unfinished_todos` result was technically correct but mixed current work with inherited or stale chat todos. PR #1015 removed that temporary broad completion telemetry after the HAC-52 no-go decision.

This narrower replacement measures the decision boundary directly:

- `step_limit_reached` is set by the real stop condition, rather than inferred from `finish_reason`
- `configured_max_steps` records the cap used by that request
- initial/final todo counts expose inherited state
- `current_run_unfinished_todo_count` includes only todos created or meaningfully changed during this request

No step limit or Agent stopping behavior changes. No new PostHog event, model call, tool call, or network request is added. Only counts, booleans, versions, and opaque IDs are captured; no prompt, todo text, tool name, input/output, error, code, target, or finding is sent.

## Validation

- full Jest suite: 316 suites / 3,156 tests passed
- focused telemetry, todo, stop-condition, logger, and Agent contract tests: 5 suites / 155 tests passed
- `pnpm typecheck`
- scoped ESLint on all touched files
- `pnpm lint`: zero errors, five pre-existing warnings
- Prettier check and `git diff --check`

## Manual verification

1. Deploy to a staging or preview environment that sends Agent analytics.
2. Run a short Agent request that creates or updates todos.
3. Confirm one `hackerai-agent_run` event contains `step_limit_telemetry_version = 1`, `configured_max_steps = 300`, `step_limit_reached = false`, the initial/final todo counts, current-run todo counts, `chat_id`, and `is_auto_continue`.
4. Confirm no todo content or other user content appears in the event.

The 300-step cap path is covered by the instrumented stop-condition unit test; manually consuming a cap-length run is not required for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Agent runs now reliably stop when configured step limits are reached.
  - Completion analytics capture configured and observed step counts, whether a limit was reached, auto-continuation status, and chat context.
  - Todo activity is summarized with privacy-safe metrics, including counts and changes made during a run.
  - Step-limit and todo metrics are preserved across fallback and retry flows.
- **Bug Fixes**
  - Improved consistency when resetting agent state during retries and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->