### PR TITLE
Fix oversized Centrifugo relay messages

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -1,4 +1,8 @@
 import { DesktopSandboxBridge } from "../desktop-sandbox-bridge";
+import {
+  CentrifugoMessageReassembler,
+  isCentrifugoTransportFragment,
+} from "@/packages/local/src/centrifugo-transport";
 
 // ── Mocks ─────────────────────────────────────────────────────────────
 
@@ -433,6 +437,71 @@ describe("native desktop file relay", () => {
       sizeBytes: 12,
       totalLines: 1,
       content: "hello world\n",
+      startLine: 1,
+    });
+  });
+
+  it("fragments oversized file_read responses below the relay limit", async () => {
+    mockSubscription.publish.mockResolvedValue(undefined);
+    const bridge = new DesktopSandboxBridge(buildConfig());
+    await bridge.start();
+    const handler = getPublicationHandler();
+    const content = "large file line\n".repeat(6_000);
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "get_cmd_server_info") {
+        return { port: 49152, token: "file-token" };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        path: "C:\\repo\\large.txt",
+        sizeBytes: content.length,
+        totalLines: 6_000,
+        content,
+        startLine: 1,
+        truncated: false,
+      }),
+    } as Response);
+
+    handler({
+      data: {
+        type: "file_read",
+        requestId: "file-req-large",
+        path: "C:\\repo\\large.txt",
+        maxFullBytes: 1024 * 1024,
+        maxResultBytes: 1024 * 1024,
+        targetConnectionId: "conn-123",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const fragments = mockSubscription.publish.mock.calls
+      .map(([message]: [unknown]) => message)
+      .filter(isCentrifugoTransportFragment);
+    expect(fragments.length).toBeGreaterThan(1);
+    expect(
+      fragments.every(
+        (fragment) =>
+          new TextEncoder().encode(JSON.stringify(fragment)).byteLength <
+          64 * 1024,
+      ),
+    ).toBe(true);
+
+    const reassembler = new CentrifugoMessageReassembler();
+    let reassembled: unknown = null;
+    for (const fragment of fragments) {
+      reassembled = reassembler.accept(fragment) ?? reassembled;
+    }
+    expect(reassembled).toEqual({
+      type: "file_read_result",
+      requestId: "file-req-large",
+      path: "C:\\repo\\large.txt",
+      sizeBytes: content.length,
+      totalLines: 6_000,
+      content,
       startLine: 1,
     });
   });

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_PTY_COLS,
   DEFAULT_PTY_ROWS,
 } from "@/lib/ai/tools/utils/pty-session-manager";
+import { CentrifugoPublishQueue } from "@/packages/local/src/centrifugo-transport";
 
 type RefreshTokenResult =
   | { ok: true; centrifugoToken: string }
@@ -138,6 +139,7 @@ export class DesktopSandboxBridge {
   private activeCommands = new Set<string>();
   private isStoppingOrStopped = true;
   private config: DesktopBridgeConfig;
+  private publishQueue: CentrifugoPublishQueue | null = null;
 
   constructor(config: DesktopBridgeConfig) {
     this.config = config;
@@ -154,6 +156,7 @@ export class DesktopSandboxBridge {
     const subscription = this.subscription;
     this.client = null;
     this.subscription = null;
+    this.publishQueue = null;
     this.connectionId = null;
     try {
       subscription?.unsubscribe();
@@ -250,6 +253,14 @@ export class DesktopSandboxBridge {
     const userId = this.extractUserIdFromToken(centrifugoToken);
     const channel = sandboxConnectionChannel(userId, connectionId);
     this.subscription = this.client.newSubscription(channel);
+    this.publishQueue = new CentrifugoPublishQueue(async (message) => {
+      if (this.isStoppingOrStopped || !this.subscription) {
+        throw new Error(
+          "[DesktopSandboxBridge] Cannot publish result: subscription is null",
+        );
+      }
+      await this.subscription.publish(message);
+    });
 
     this.subscription.on("publication", (ctx) => {
       const message = ctx.data;
@@ -790,13 +801,15 @@ export class DesktopSandboxBridge {
 
   private async publishResult(message: SandboxMessage): Promise<void> {
     if (this.isStoppingOrStopped) return;
-    if (!this.subscription) {
+    if (!this.publishQueue) {
       throw new Error(
         "[DesktopSandboxBridge] Cannot publish result: subscription is null",
       );
     }
     try {
-      await this.subscription.publish(message);
+      await this.publishQueue.publish(
+        message as unknown as Record<string, unknown>,
+      );
     } catch (error) {
       console.error("[DesktopSandboxBridge] Failed to publish result:", error);
       throw error;
@@ -985,6 +998,7 @@ export class DesktopSandboxBridge {
 
   async stop(): Promise<void> {
     this.isStoppingOrStopped = true;
+    this.publishQueue = null;
     if (this.connectionId) {
       try {
         await this.config.disconnectDesktop({

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -10,6 +10,7 @@
 import { EventEmitter } from "events";
 import { CentrifugoSandbox, parseSandboxMessage } from "../centrifugo-sandbox";
 import type { CentrifugoConfig } from "../centrifugo-sandbox";
+import { fragmentCentrifugoMessage } from "@/packages/local/src/centrifugo-transport";
 
 // Track all created mock subscriptions and clients for assertions
 let mockSubscriptions: MockSubscription[];
@@ -252,6 +253,38 @@ describe("CentrifugoSandbox", () => {
       });
       expect(onStdout).toHaveBeenCalledWith("hello\n");
       expect(onStderr).toHaveBeenCalledWith("warn\n");
+    });
+
+    it("reassembles oversized stdout before completing the command", async () => {
+      const sandbox = createSandbox();
+      const { promise } = startCommand(sandbox, "generate output", {
+        timeoutMs: 5000,
+      });
+      const stdout = "🙂\u0000".repeat(20_000);
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      const fragments = fragmentCentrifugoMessage({
+        type: "stdout",
+        commandId: FIXED_UUID,
+        data: stdout,
+      });
+      expect(fragments.length).toBeGreaterThan(1);
+      for (const fragment of fragments) {
+        sub.emit("publication", { data: fragment });
+      }
+      sub.emit("publication", {
+        data: { type: "exit", commandId: FIXED_UUID, exitCode: 0 },
+      });
+
+      await expect(promise).resolves.toEqual({
+        stdout,
+        stderr: "",
+        exitCode: 0,
+      });
     });
   });
 
@@ -858,6 +891,36 @@ describe("CentrifugoSandbox", () => {
       });
 
       await expect(promise).resolves.toBe("hello world\n");
+    });
+
+    it("reassembles oversized native file read responses", async () => {
+      const sandbox = createDesktopSandbox();
+      const promise = sandbox.files.read("C:\\repo\\large.txt");
+      const content = "large file line\n".repeat(6_000);
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      const request = (sub.publish as jest.Mock).mock.calls[0][0] as {
+        requestId: string;
+      };
+      const fragments = fragmentCentrifugoMessage({
+        type: "file_read_result",
+        requestId: request.requestId,
+        path: "C:\\repo\\large.txt",
+        sizeBytes: content.length,
+        totalLines: 6_000,
+        content,
+        startLine: 1,
+      });
+      expect(fragments.length).toBeGreaterThan(1);
+      for (const fragment of fragments) {
+        sub.emit("publication", { data: fragment });
+      }
+
+      await expect(promise).resolves.toBe(content);
     });
 
     it("files.write publishes file_write instead of shell heredoc for desktop connections", async () => {

--- a/lib/ai/tools/utils/centrifugo-pty-adapter.ts
+++ b/lib/ai/tools/utils/centrifugo-pty-adapter.ts
@@ -19,6 +19,10 @@
 import { Centrifuge, type Subscription } from "centrifuge";
 
 import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
+import {
+  CentrifugoMessageReassembler,
+  fragmentMatchesCorrelation,
+} from "@/packages/local/src/centrifugo-transport";
 import type { PtyHandle, CreatePtyOptions } from "./e2b-pty-adapter";
 import type { CentrifugoSandbox } from "./centrifugo-sandbox";
 import { createResolvableExited } from "./pty-exited-promise";
@@ -65,10 +69,7 @@ interface PtyKillPayload {
 }
 
 type PtyOutgoingPayload =
-  | PtyCreatePayload
-  | PtyInputPayload
-  | PtyResizePayload
-  | PtyKillPayload;
+  PtyCreatePayload | PtyInputPayload | PtyResizePayload | PtyKillPayload;
 
 // ── Incoming message shapes from the local runner ──────────────────────
 
@@ -173,6 +174,7 @@ export async function createCentrifugoPtyHandle(
   let subscription: Subscription | undefined;
   let settled = false;
   let cleanedUp = false;
+  const reassembler = new CentrifugoMessageReassembler();
 
   const { exited, resolveOnce: resolveExitedOnce } = createResolvableExited();
 
@@ -309,7 +311,12 @@ export async function createCentrifugoPtyHandle(
     subscription = client.newSubscription(channel);
 
     subscription.on("publication", (ctx) => {
-      const msg = parsePtyMessage(ctx.data);
+      if (!fragmentMatchesCorrelation(ctx.data, "sessionId", sessionId)) {
+        return;
+      }
+      const reassembled = reassembler.accept(ctx.data);
+      if (!reassembled) return;
+      const msg = parsePtyMessage(reassembled);
       if (!msg || msg.sessionId !== sessionId) return;
 
       switch (msg.type) {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -14,6 +14,10 @@ import {
   type FileListResultMessage,
 } from "@/lib/centrifugo/types";
 import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
+import {
+  CentrifugoMessageReassembler,
+  fragmentMatchesCorrelation,
+} from "@/packages/local/src/centrifugo-transport";
 import { getPlatformDisplayName, escapeShellValue } from "./platform-utils";
 import type { ConnectionInfo } from "./sandbox-types";
 import { validateDownloadUrl } from "./path-validation";
@@ -366,6 +370,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       let settled = false;
       let timeoutId: NodeJS.Timeout | undefined;
       let subscription: Subscription | undefined;
+      const reassembler = new CentrifugoMessageReassembler();
 
       const cleanup = () => {
         if (timeoutId) {
@@ -409,8 +414,13 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       subscription = client.newSubscription(channel);
       subscription.on("publication", (ctx) => {
         if (settled) return;
+        if (!fragmentMatchesCorrelation(ctx.data, "requestId", requestId)) {
+          return;
+        }
 
-        const message = parseFileResponseMessage(ctx.data);
+        const reassembled = reassembler.accept(ctx.data);
+        if (!reassembled) return;
+        const message = parseFileResponseMessage(reassembled);
         if (!message || message.requestId !== requestId) return;
 
         if (message.type === "file_error") {
@@ -544,6 +554,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         let cancelTriggeredBySignal = false;
         let cancelAttemptPromise: Promise<boolean> | null = null;
         let resolveCancelAttempt: ((confirmed: boolean) => void) | null = null;
+        const reassembler = new CentrifugoMessageReassembler();
 
         const maxWaitTime = timeout + 5000; // Add 5s buffer for network
 
@@ -700,8 +711,13 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
 
         subscription.on("publication", (ctx) => {
           if (settled) return;
+          if (!fragmentMatchesCorrelation(ctx.data, "commandId", commandId)) {
+            return;
+          }
 
-          const message = parseSandboxMessage(ctx.data);
+          const reassembled = reassembler.accept(ctx.data);
+          if (!reassembled) return;
+          const message = parseSandboxMessage(reassembled);
           if (!message) return;
           if (message.commandId !== commandId) return;
           if (message.type === "command" || message.type === "command_cancel") {

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackerai/local",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "HackerAI Local Sandbox Client - Execute commands on your local machine",
   "bin": {
     "hackerai-local": "./dist/index.js"

--- a/packages/local/src/__tests__/centrifugo-transport.test.ts
+++ b/packages/local/src/__tests__/centrifugo-transport.test.ts
@@ -71,6 +71,60 @@ describe("Centrifugo transport fragmentation", () => {
     );
   });
 
+  it("rejects messages that exceed the fragment-count limit", () => {
+    expect(() =>
+      fragmentCentrifugoMessage({
+        type: "stdout",
+        commandId: "command-too-large",
+        data: "x".repeat(2_400_000),
+      }),
+    ).toThrow("maximum is 128");
+  });
+
+  it("drops new transfers after the active-transfer limit is reached", () => {
+    const reassembler = new CentrifugoMessageReassembler();
+    const firstFragments = Array.from({ length: 16 }, (_, index) => ({
+      type: "transport_fragment" as const,
+      transferId: `transfer-${index}`,
+      index: 0,
+      total: 2,
+      data: "e3",
+    }));
+
+    for (const fragment of firstFragments) {
+      expect(reassembler.accept(fragment)).toBeNull();
+    }
+
+    expect(
+      reassembler.accept({
+        type: "transport_fragment",
+        transferId: "transfer-over-limit",
+        index: 0,
+        total: 2,
+        data: "e3",
+      }),
+    ).toBeNull();
+    expect(
+      reassembler.accept({
+        type: "transport_fragment",
+        transferId: "transfer-over-limit",
+        index: 1,
+        total: 2,
+        data: "0=",
+      }),
+    ).toBeNull();
+
+    expect(
+      reassembler.accept({
+        type: "transport_fragment",
+        transferId: "transfer-0",
+        index: 1,
+        total: 2,
+        data: "0=",
+      }),
+    ).toEqual({});
+  });
+
   it("serializes fragments and later messages in FIFO order", async () => {
     let activePublishes = 0;
     let maxActivePublishes = 0;

--- a/packages/local/src/__tests__/centrifugo-transport.test.ts
+++ b/packages/local/src/__tests__/centrifugo-transport.test.ts
@@ -1,0 +1,126 @@
+import {
+  CentrifugoMessageReassembler,
+  CentrifugoPublishQueue,
+  fragmentCentrifugoMessage,
+  fragmentMatchesCorrelation,
+  isCentrifugoTransportFragment,
+} from "../centrifugo-transport";
+
+const byteLength = (value: unknown): number =>
+  new TextEncoder().encode(JSON.stringify(value)).byteLength;
+
+describe("Centrifugo transport fragmentation", () => {
+  it("keeps small messages backward compatible", () => {
+    const message = {
+      type: "stdout",
+      commandId: "command-1",
+      data: "hello",
+    };
+
+    expect(fragmentCentrifugoMessage(message)).toEqual([message]);
+  });
+
+  it("fragments and losslessly reassembles oversized UTF-8 messages", () => {
+    const message = {
+      type: "file_read_result",
+      requestId: "request-1",
+      path: "/tmp/large.txt",
+      sizeBytes: 180_000,
+      totalLines: 1,
+      content: '\u0000🙂"\\'.repeat(30_000),
+    };
+    const fragments = fragmentCentrifugoMessage(message);
+
+    expect(fragments.length).toBeGreaterThan(1);
+    expect(fragments.every(isCentrifugoTransportFragment)).toBe(true);
+    expect(
+      fragments.every((fragment) => byteLength(fragment) < 64 * 1024),
+    ).toBe(true);
+    expect(
+      fragments.every(
+        (fragment) =>
+          isCentrifugoTransportFragment(fragment) &&
+          fragment.requestId === "request-1",
+      ),
+    ).toBe(true);
+
+    const reassembler = new CentrifugoMessageReassembler();
+    let result: unknown = null;
+    for (const fragment of [...fragments].reverse()) {
+      result = reassembler.accept(fragment) ?? result;
+    }
+
+    expect(result).toEqual(message);
+  });
+
+  it("filters fragments before allocating unrelated transfers", () => {
+    const [fragment] = fragmentCentrifugoMessage({
+      type: "stdout",
+      commandId: "command-1",
+      data: "x".repeat(40 * 1024),
+    });
+
+    expect(fragmentMatchesCorrelation(fragment, "commandId", "command-1")).toBe(
+      true,
+    );
+    expect(fragmentMatchesCorrelation(fragment, "commandId", "command-2")).toBe(
+      false,
+    );
+    expect(fragmentMatchesCorrelation(fragment, "requestId", "request-1")).toBe(
+      false,
+    );
+  });
+
+  it("serializes fragments and later messages in FIFO order", async () => {
+    let activePublishes = 0;
+    let maxActivePublishes = 0;
+    const published: unknown[] = [];
+    const publish = jest.fn(async (message: unknown) => {
+      activePublishes += 1;
+      maxActivePublishes = Math.max(maxActivePublishes, activePublishes);
+      await Promise.resolve();
+      published.push(message);
+      activePublishes -= 1;
+    });
+    const queue = new CentrifugoPublishQueue(publish);
+
+    const output = queue.publish({
+      type: "stdout",
+      commandId: "command-1",
+      data: "x".repeat(80 * 1024),
+    });
+    const exit = queue.publish({
+      type: "exit",
+      commandId: "command-1",
+      exitCode: 0,
+    });
+
+    await Promise.all([output, exit]);
+
+    expect(maxActivePublishes).toBe(1);
+    expect(isCentrifugoTransportFragment(published[published.length - 1])).toBe(
+      false,
+    );
+    expect(published[published.length - 1]).toEqual({
+      type: "exit",
+      commandId: "command-1",
+      exitCode: 0,
+    });
+  });
+
+  it("recovers the queue after a publish rejection", async () => {
+    const publish = jest
+      .fn<Promise<void>, [unknown]>()
+      .mockRejectedValueOnce({ code: 11, message: "connection closed" })
+      .mockResolvedValue(undefined);
+    const queue = new CentrifugoPublishQueue(publish);
+
+    await expect(
+      queue.publish({ type: "stdout", commandId: "command-1", data: "one" }),
+    ).rejects.toThrow("connection closed");
+    await expect(
+      queue.publish({ type: "exit", commandId: "command-1", exitCode: 1 }),
+    ).resolves.toBeUndefined();
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/local/src/centrifugo-transport.ts
+++ b/packages/local/src/centrifugo-transport.ts
@@ -37,10 +37,6 @@ interface PendingTransfer {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
-function serializedByteLength(value: unknown): number {
-  return encoder.encode(JSON.stringify(value)).byteLength;
-}
-
 function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   const batchSize = 0x8000;
@@ -123,7 +119,7 @@ export function fragmentCentrifugoMessage(
   message: Record<string, unknown>,
 ): Array<Record<string, unknown> | CentrifugoTransportFragment> {
   const serialized = JSON.stringify(message);
-  if (serializedByteLength(message) <= MAX_DIRECT_MESSAGE_BYTES) {
+  if (encoder.encode(serialized).byteLength <= MAX_DIRECT_MESSAGE_BYTES) {
     return [message];
   }
 

--- a/packages/local/src/centrifugo-transport.ts
+++ b/packages/local/src/centrifugo-transport.ts
@@ -1,0 +1,248 @@
+// Centrifugo v5 accepts at most 64 KiB per WebSocket message by default.
+// Keep direct messages and fragment envelopes well below that ceiling so
+// Centrifuge's protocol/channel wrapper always has room. Small messages retain
+// their existing shape; only oversized client-to-server relay messages use the
+// transport_fragment envelope.
+const MAX_DIRECT_MESSAGE_BYTES = 32 * 1024;
+const MAX_FRAGMENT_DATA_CHARS = 24 * 1024;
+const MAX_FRAGMENT_COUNT = 128;
+const MAX_REASSEMBLED_BASE64_CHARS =
+  MAX_FRAGMENT_DATA_CHARS * MAX_FRAGMENT_COUNT;
+const MAX_ACTIVE_TRANSFERS = 16;
+const TRANSFER_TTL_MS = 2 * 60 * 1000;
+
+const CORRELATION_KEYS = ["commandId", "requestId", "sessionId"] as const;
+
+type CorrelationKey = (typeof CORRELATION_KEYS)[number];
+
+export interface CentrifugoTransportFragment {
+  type: "transport_fragment";
+  transferId: string;
+  index: number;
+  total: number;
+  data: string;
+  commandId?: string;
+  requestId?: string;
+  sessionId?: string;
+}
+
+interface PendingTransfer {
+  total: number;
+  chunks: Array<string | undefined>;
+  received: number;
+  encodedChars: number;
+  updatedAt: number;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function serializedByteLength(value: unknown): number {
+  return encoder.encode(JSON.stringify(value)).byteLength;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const batchSize = 0x8000;
+
+  for (let offset = 0; offset < bytes.length; offset += batchSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + batchSize),
+    );
+  }
+
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function getCorrelationFields(
+  message: Record<string, unknown>,
+): Partial<Record<CorrelationKey, string>> {
+  const fields: Partial<Record<CorrelationKey, string>> = {};
+  for (const key of CORRELATION_KEYS) {
+    if (typeof message[key] === "string") {
+      fields[key] = message[key];
+    }
+  }
+  return fields;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function isCentrifugoTransportFragment(
+  value: unknown,
+): value is CentrifugoTransportFragment {
+  if (typeof value !== "object" || value === null) return false;
+  const fragment = value as Record<string, unknown>;
+  return (
+    fragment.type === "transport_fragment" &&
+    typeof fragment.transferId === "string" &&
+    fragment.transferId.length > 0 &&
+    fragment.transferId.length <= 128 &&
+    Number.isInteger(fragment.index) &&
+    (fragment.index as number) >= 0 &&
+    Number.isInteger(fragment.total) &&
+    (fragment.total as number) > 0 &&
+    (fragment.total as number) <= MAX_FRAGMENT_COUNT &&
+    (fragment.index as number) < (fragment.total as number) &&
+    typeof fragment.data === "string" &&
+    fragment.data.length <= MAX_FRAGMENT_DATA_CHARS
+  );
+}
+
+export function fragmentMatchesCorrelation(
+  value: unknown,
+  key: CorrelationKey,
+  expectedId: string,
+): boolean {
+  if (!isCentrifugoTransportFragment(value)) return true;
+  const actualId = value[key];
+  if (actualId !== undefined) return actualId === expectedId;
+  return !CORRELATION_KEYS.some(
+    (correlationKey) => typeof value[correlationKey] === "string",
+  );
+}
+
+export function fragmentCentrifugoMessage(
+  message: Record<string, unknown>,
+): Array<Record<string, unknown> | CentrifugoTransportFragment> {
+  const serialized = JSON.stringify(message);
+  if (serializedByteLength(message) <= MAX_DIRECT_MESSAGE_BYTES) {
+    return [message];
+  }
+
+  const encoded = bytesToBase64(encoder.encode(serialized));
+  const total = Math.ceil(encoded.length / MAX_FRAGMENT_DATA_CHARS);
+  if (total > MAX_FRAGMENT_COUNT) {
+    throw new Error(
+      `Centrifugo message requires ${total} fragments; maximum is ${MAX_FRAGMENT_COUNT}`,
+    );
+  }
+
+  const transferId = crypto.randomUUID();
+  const correlation = getCorrelationFields(message);
+  const fragments: CentrifugoTransportFragment[] = [];
+
+  for (let index = 0; index < total; index += 1) {
+    fragments.push({
+      type: "transport_fragment",
+      transferId,
+      index,
+      total,
+      data: encoded.slice(
+        index * MAX_FRAGMENT_DATA_CHARS,
+        (index + 1) * MAX_FRAGMENT_DATA_CHARS,
+      ),
+      ...correlation,
+    });
+  }
+
+  return fragments;
+}
+
+export class CentrifugoMessageReassembler {
+  private readonly transfers = new Map<string, PendingTransfer>();
+
+  accept(value: unknown): unknown | null {
+    if (!isCentrifugoTransportFragment(value)) return value;
+
+    const now = Date.now();
+    this.removeExpired(now);
+
+    let transfer = this.transfers.get(value.transferId);
+    if (!transfer) {
+      if (this.transfers.size >= MAX_ACTIVE_TRANSFERS) return null;
+      transfer = {
+        total: value.total,
+        chunks: new Array<string | undefined>(value.total),
+        received: 0,
+        encodedChars: 0,
+        updatedAt: now,
+      };
+      this.transfers.set(value.transferId, transfer);
+    }
+
+    if (transfer.total !== value.total) {
+      this.transfers.delete(value.transferId);
+      return null;
+    }
+
+    const existing = transfer.chunks[value.index];
+    if (existing !== undefined) {
+      if (existing !== value.data) {
+        this.transfers.delete(value.transferId);
+      }
+      return null;
+    }
+
+    transfer.chunks[value.index] = value.data;
+    transfer.received += 1;
+    transfer.encodedChars += value.data.length;
+    transfer.updatedAt = now;
+
+    if (transfer.encodedChars > MAX_REASSEMBLED_BASE64_CHARS) {
+      this.transfers.delete(value.transferId);
+      return null;
+    }
+    if (transfer.received !== transfer.total) return null;
+
+    this.transfers.delete(value.transferId);
+    try {
+      const encoded = transfer.chunks.join("");
+      const serialized = decoder.decode(base64ToBytes(encoded));
+      const parsed = JSON.parse(serialized) as unknown;
+      if (isCentrifugoTransportFragment(parsed)) return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  private removeExpired(now: number): void {
+    for (const [transferId, transfer] of this.transfers) {
+      if (now - transfer.updatedAt > TRANSFER_TTL_MS) {
+        this.transfers.delete(transferId);
+      }
+    }
+  }
+}
+
+export class CentrifugoPublishQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly publishFragment: (message: unknown) => Promise<void>,
+  ) {}
+
+  publish(message: Record<string, unknown>): Promise<void> {
+    const operation = this.tail.then(async () => {
+      const fragments = fragmentCentrifugoMessage(message);
+      for (const fragment of fragments) {
+        try {
+          await this.publishFragment(fragment);
+        } catch (error) {
+          throw error instanceof Error ? error : new Error(errorMessage(error));
+        }
+      }
+    });
+
+    this.tail = operation.catch(() => undefined);
+    return operation;
+  }
+}

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -33,6 +33,7 @@ import {
   confirmProcessTermination,
   isProcessTreeTerminationConfirmed,
 } from "./command-cancellation";
+import { CentrifugoPublishQueue } from "./centrifugo-transport";
 
 const DEFAULT_SHELL = getDefaultShell(os.platform());
 
@@ -285,6 +286,7 @@ class LocalSandboxClient {
   private idleCheckInterval?: NodeJS.Timeout;
   private processRunner: ProcessRunner;
   private activeStreamCommands: Map<string, ChildProcess> = new Map();
+  private publishQueue?: CentrifugoPublishQueue;
 
   constructor(private config: Config) {
     this.convexHttp = new ConvexHttpClient(config.convexUrl);
@@ -491,6 +493,12 @@ class LocalSandboxClient {
 
     const channel = `sandbox:connection:${this.connectionId}#${this.userId}`;
     this.subscription = this.centrifuge.newSubscription(channel);
+    this.publishQueue = new CentrifugoPublishQueue(async (message) => {
+      if (!this.subscription) {
+        throw new Error("Cannot publish: no active subscription");
+      }
+      await this.subscription.publish(message);
+    });
 
     this.subscription.on("publication", (ctx: PublicationContext) => {
       if (this.isShuttingDown) return;
@@ -592,12 +600,14 @@ class LocalSandboxClient {
   private async publishToChannel(
     data: CentrifugoOutgoingMessage,
   ): Promise<void> {
-    if (!this.subscription) {
+    if (!this.publishQueue) {
       console.error(chalk.red("Cannot publish: no active subscription"));
       return;
     }
     try {
-      await this.subscription.publish(data);
+      await this.publishQueue.publish(
+        data as unknown as Record<string, unknown>,
+      );
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : JSON.stringify(err);
       console.error(chalk.red(`Publish failed: ${msg}`));
@@ -819,7 +829,7 @@ class LocalSandboxClient {
         });
       });
 
-      proc.on("close", (code) => {
+      proc.on("close", async (code) => {
         if (timeoutId) clearTimeout(timeoutId);
         this.activeStreamCommands.delete(commandId);
 
@@ -840,7 +850,7 @@ class LocalSandboxClient {
           });
         }
 
-        this.publishToChannel({
+        await this.publishToChannel({
           type: "exit",
           commandId,
           exitCode,
@@ -877,7 +887,7 @@ class LocalSandboxClient {
         resolve();
       });
 
-      proc.on("error", (error) => {
+      proc.on("error", async (error) => {
         if (timeoutId) clearTimeout(timeoutId);
         this.activeStreamCommands.delete(commandId);
         this.publishToChannel({
@@ -891,7 +901,7 @@ class LocalSandboxClient {
             ),
           );
         });
-        this.publishToChannel({
+        await this.publishToChannel({
           type: "exit",
           commandId,
           exitCode: 1,
@@ -1033,6 +1043,7 @@ class LocalSandboxClient {
       this.subscription.unsubscribe();
       this.subscription = undefined;
     }
+    this.publishQueue = undefined;
     if (this.centrifuge) {
       this.centrifuge.disconnect();
       this.centrifuge = undefined;


### PR DESCRIPTION
## Summary

- fragment oversized client-to-server Centrifugo relay messages while leaving small messages byte-for-byte compatible
- serialize publishes and reassemble command, file, and PTY responses by their correlation IDs
- cover both `@hackerai/local` and the desktop sandbox bridge
- bump `@hackerai/local` from `0.8.3` to `0.8.4`

## Root cause

Centrifugo v5 limits client messages to 64 KiB. A Node stdout chunk can already be 64 KiB before the JSON/protocol envelope is added, so large command output closes the relay connection. File reads and directory listings could exceed the same limit because they were also sent as one publish.

The new transport keeps ordinary messages unchanged, but fragments serialized messages over 32 KiB into bounded 24 KiB base64 chunks. Server-side consumers reassemble them with count, size, concurrency, expiry, duplicate, and correlation guards. Server-to-client requests remain unfragmented so already-installed local clients stay compatible.

Fixes #1012

## Validation

- `pnpm exec jest packages/local/src/__tests__/centrifugo-transport.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts app/services/__tests__/desktop-sandbox-bridge.test.ts --runInBand` — 88 tests passed
- `pnpm local-sandbox:build`
- `pnpm typecheck`
- `pnpm lint` — 0 errors; 5 pre-existing warnings in unrelated files
- Prettier check and `git diff --check`
- `npm pack --dry-run` for `@hackerai/local@0.8.4`
- full Jest run — 315 suites / 3,158 tests passed in the restricted runner; the only failures were 6 existing subprocess-output assertions across 2 script suites, and all 6 passed when re-run outside the restricted sandbox

## Manual verification

1. Install/run `@hackerai/local@0.8.4`, connect it through Remote Control, and execute a command that writes more than 64 KiB to stdout/stderr.
2. Confirm the connection remains open, all output arrives in order, and the exit result arrives after the output.
3. Through the desktop sandbox, read a text file larger than 64 KiB and confirm the response succeeds without a Centrifugo disconnect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending and receiving oversized sandbox messages by automatically splitting and reassembling payloads.
  * Preserved message order during transmission, including reliable recovery after temporary publish failures.

* **Bug Fixes**
  * Improved handling of fragmented responses, malformed data, duplicate fragments, and expired transfers.
  * Prevented responses from unrelated requests or sessions from being processed.

* **Tests**
  * Added coverage for fragmentation, reassembly, UTF-8 payload limits, ordering, filtering, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->