### PR TITLE
Drop stale desktop relay publishes

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -775,6 +775,65 @@ describe("forwardChunk", () => {
       publishCountAfterStop,
     );
   });
+
+  it("drops a queued stream chunk when the bridge stops before publishing it", async () => {
+    let releaseFirstPublish!: () => void;
+    const firstPublishBlocked = new Promise<void>((resolve) => {
+      releaseFirstPublish = resolve;
+    });
+    let firstPublishStarted!: () => void;
+    const firstPublishStartedPromise = new Promise<void>((resolve) => {
+      firstPublishStarted = resolve;
+    });
+    mockSubscription.publish.mockImplementationOnce(async () => {
+      firstPublishStarted();
+      await firstPublishBlocked;
+    });
+
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const bridge = new DesktopSandboxBridge(buildConfig());
+      await bridge.start();
+      const handler = getPublicationHandler();
+
+      mockInvokeHandler = async () => undefined;
+      handler({
+        data: {
+          type: "command",
+          commandId: "cmd-queued-stop",
+          command: "test",
+          targetConnectionId: "conn-123",
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const firstChunk = capturedChannel!.onmessage!({
+        type: "stdout",
+        data: "first",
+      }) as unknown as Promise<void>;
+      await firstPublishStartedPromise;
+      const queuedChunk = capturedChannel!.onmessage!({
+        type: "stderr",
+        data: "queued",
+      }) as unknown as Promise<void>;
+
+      await bridge.stop();
+      releaseFirstPublish();
+
+      await expect(Promise.all([firstChunk, queuedChunk])).resolves.toEqual([
+        undefined,
+        undefined,
+      ]);
+      expect(mockSubscription.publish).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        "[DesktopSandboxBridge] Failed to publish result:",
+        expect.anything(),
+      );
+    } finally {
+      releaseFirstPublish();
+      errorSpy.mockRestore();
+    }
+  });
 });
 
 // ── pty_data publish ordering ─────────────────────────────────────────

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -252,14 +252,14 @@ export class DesktopSandboxBridge {
 
     const userId = this.extractUserIdFromToken(centrifugoToken);
     const channel = sandboxConnectionChannel(userId, connectionId);
-    this.subscription = this.client.newSubscription(channel);
+    const subscription = this.client.newSubscription(channel);
+    this.subscription = subscription;
     this.publishQueue = new CentrifugoPublishQueue(async (message) => {
-      if (this.isStoppingOrStopped || !this.subscription) {
-        throw new Error(
-          "[DesktopSandboxBridge] Cannot publish result: subscription is null",
-        );
-      }
-      await this.subscription.publish(message);
+      // Queued work can outlive stop() or a reconnect; never publish it on a
+      // replacement subscription.
+      if (this.isStoppingOrStopped || this.subscription !== subscription)
+        return;
+      await subscription.publish(message);
     });
 
     this.subscription.on("publication", (ctx) => {


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-08-01T20:01:50Z` to `2026-08-02T20:01:50Z`.

PostHog recorded three unhandled `[DesktopSandboxBridge] Cannot publish result: subscription is null` exceptions within four milliseconds for one user after PR #1018 reached production. The errors are app-attributed to `app/services/desktop-sandbox-bridge.ts`.

## Root cause

PR #1018 serialized Centrifugo publishes through a queue. A publish can be accepted while the desktop bridge is active but execute after `stop()` or a reconnect has cleared/replaced the subscription. The queued callback treated that intentional lifecycle change as an error and could also target the replacement subscription if an old queue drained after reconnect.

## Change

- bind each publish queue to the exact subscription instance created with it
- drop queued work after stop or subscription replacement
- keep active-session Centrifugo publish failures visible
- add a regression test that blocks one publish, queues another, stops the bridge, and verifies the stale item is neither published nor reported as an error

No error suppression, transport limit, fragmentation shape, retry policy, or server protocol changed.

## Validation

- `pnpm jest packages/local/src/__tests__/centrifugo-transport.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts app/services/__tests__/desktop-sandbox-bridge.test.ts --runInBand` — 3 suites / 89 tests passed
- `pnpm typecheck`
- changed-file ESLint and Prettier checks
- `git diff --check`
- full commit hooks — 317 suites / 3,167 tests passed
- the first full hook attempt had one unrelated Jest worker `SIGSEGV`; that exact 6-test suite passed independently, then the normal unbypassed hook passed in full

## Adversarial review

Reviewed command, file, and PTY publish entry points; stop and server-termination paths; queued fragments and partial progress; reconnect/subscription replacement; ordering; deploy skew; and log privacy. Stale work is scoped to its originating subscription, while active-session failures still propagate.

## Manual verification

1. Connect the desktop sandbox through Remote Control and start a streamed command with enough output to queue publishes.
2. Disconnect while output is still queued. Confirm no `subscription is null` exception appears and no stale output reaches a later connection.
3. Reconnect and run another command. Confirm output and exit arrive in order on the new connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of queued messages when the desktop bridge stops or its connection is replaced.
  * Prevented discarded queued messages from triggering errors or failed-publish logs.
  * Ensured any message already being published can complete normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->