### PR TITLE
Reduce chat composer and timeline rerenders

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -13,6 +13,7 @@ import MigratePentestgptDialog from "../components/MigratePentestgptDialog";
 import { ExtraUsagePurchaseToast } from "../components/extra-usage";
 import { usePricingDialog } from "../hooks/usePricingDialog";
 import { useGlobalState } from "../contexts/GlobalState";
+import { useComposerInput } from "../contexts/ComposerState";
 import { usePentestgptMigration } from "../hooks/usePentestgptMigration";
 import { navigateToAuth } from "../hooks/useTauri";
 import { useTypingAnimation } from "../hooks/useTypingAnimation";
@@ -32,7 +33,7 @@ const LOGIN_TYPING_TAILS = [
 
 // Simple unauthenticated content that redirects to signup on message send
 const UnauthenticatedContent = () => {
-  const { input } = useGlobalState();
+  const input = useComposerInput();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useGlobalState } from "@/app/contexts/GlobalState";
+import {
+  useComposerActions,
+  useComposerInput,
+} from "@/app/contexts/ComposerState";
 import { TodoPanel } from "../TodoPanel";
 import type { ChatStatus } from "@/types";
 import { FileUploadPreview } from "../FileUploadPreview";
@@ -192,8 +196,6 @@ export const ChatInput = ({
   storedApprovalRequest,
 }: ChatInputProps) => {
   const {
-    input,
-    setInput,
     chatMode,
     setChatMode,
     uploadedFiles,
@@ -214,6 +216,8 @@ export const ChatInput = ({
     hasLocalSandbox,
     defaultLocalSandboxPreference,
   } = useGlobalState();
+  const input = useComposerInput();
+  const { setInput } = useComposerActions();
   const {
     fileInputRef,
     handleFileUploadEvent,

--- a/app/components/ChatInput/ChatInputTextarea.tsx
+++ b/app/components/ChatInput/ChatInputTextarea.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useRef } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { useGlobalState } from "@/app/contexts/GlobalState";
+import {
+  useComposerActions,
+  useComposerInput,
+} from "@/app/contexts/ComposerState";
 import { useFileUpload } from "@/app/hooks/useFileUpload";
 import {
   getDraftContentById,
@@ -38,7 +42,9 @@ export function ChatInputTextarea({
   placeholder,
   autoFocus = true,
 }: ChatInputTextareaProps) {
-  const { input, setInput, subscription } = useGlobalState();
+  const input = useComposerInput();
+  const { setInput } = useComposerActions();
+  const { subscription } = useGlobalState();
   const { handlePasteEvent, handlePastedTextAttachment } =
     useFileUpload(chatMode);
   const textareaRef = useRef<HTMLTextAreaElement>(null);

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useMemo,
   useCallback,
+  useRef,
   Dispatch,
   MutableRefObject,
   RefCallback,
@@ -36,9 +37,12 @@ import { useDataStreamState } from "./DataStreamProvider";
 import type { RateLimitWarningData } from "./RateLimitWarning";
 import type { SelectedModel } from "@/types";
 import {
+  createStableChatTimelineRowsState,
   deriveChatTimelineRows,
   getChatTimelineRowType,
+  stabilizeChatTimelineRows,
   type ChatTimelineRow,
+  type StableChatTimelineRowsState,
 } from "./message-timeline-rows";
 
 const AllFilesDialog = dynamic(
@@ -218,7 +222,7 @@ export const Messages = ({
   const [expandedAgentMessageIds, setExpandedAgentMessageIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
-  const timelineRows = useMemo(
+  const rawTimelineRows = useMemo(
     () =>
       deriveChatTimelineRows({
         messages: visibleMessages,
@@ -233,6 +237,21 @@ export const Messages = ({
       visibleMessages,
     ],
   );
+  const stableTimelineRowsRef = useRef<StableChatTimelineRowsState | null>(
+    null,
+  );
+  const stableTimelineRowsState = useMemo(
+    () =>
+      stabilizeChatTimelineRows(
+        rawTimelineRows,
+        stableTimelineRowsRef.current ?? createStableChatTimelineRowsState(),
+      ),
+    [rawTimelineRows],
+  );
+  useLayoutEffect(() => {
+    stableTimelineRowsRef.current = stableTimelineRowsState;
+  }, [stableTimelineRowsState]);
+  const timelineRows = stableTimelineRowsState.result;
   // Track edit state for messages
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
 

--- a/app/components/__tests__/message-timeline-rows.test.ts
+++ b/app/components/__tests__/message-timeline-rows.test.ts
@@ -1,5 +1,7 @@
 import {
+  createStableChatTimelineRowsState,
   deriveChatTimelineRows,
+  stabilizeChatTimelineRows,
   type AgentActivityTimelineRow,
 } from "../message-timeline-rows";
 import type { ChatMessage } from "@/types";
@@ -190,5 +192,65 @@ describe("deriveChatTimelineRows", () => {
     });
 
     expect(rows.filter((row) => row.kind === "agent-activity")).toHaveLength(2);
+  });
+
+  it("reuses every row when derivation produces equivalent data", () => {
+    const message = agentMessage([
+      {
+        type: "tool-shell",
+        toolCallId: "tool-1",
+        input: { command: "pwd" },
+        state: "output-available",
+      },
+    ] as ChatMessage["parts"]);
+    const options = {
+      messages: [message],
+      status: "ready" as const,
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set<string>(),
+    };
+
+    const first = stabilizeChatTimelineRows(
+      deriveChatTimelineRows(options),
+      createStableChatTimelineRowsState(),
+    );
+    const second = stabilizeChatTimelineRows(
+      deriveChatTimelineRows(options),
+      first,
+    );
+
+    expect(second).toBe(first);
+    expect(second.result).toBe(first.result);
+  });
+
+  it("keeps settled rows stable while the active message changes", () => {
+    const userMessage = {
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "question" }],
+    } as ChatMessage;
+    const firstAssistant = agentMessage([
+      { type: "text", text: "first chunk" },
+    ] as ChatMessage["parts"]);
+    const nextAssistant = {
+      ...firstAssistant,
+      parts: [{ type: "text", text: "first chunk plus more" }],
+    } as ChatMessage;
+    const derive = (assistant: ChatMessage) =>
+      deriveChatTimelineRows({
+        messages: [userMessage, assistant],
+        status: "streaming",
+        lastAssistantMessageIndex: 1,
+        expandedAgentMessageIds: new Set(),
+      });
+
+    const first = stabilizeChatTimelineRows(
+      derive(firstAssistant),
+      createStableChatTimelineRowsState(),
+    );
+    const second = stabilizeChatTimelineRows(derive(nextAssistant), first);
+
+    expect(second.result[0]).toBe(first.result[0]);
+    expect(second.result.at(-1)).not.toBe(first.result.at(-1));
   });
 });

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -28,6 +28,7 @@ import Footer from "./Footer";
 import { useMessageScroll } from "../hooks/useMessageScroll";
 import { useChatHandlers } from "../hooks/useChatHandlers";
 import { useGlobalState } from "../contexts/GlobalState";
+import { useComposerInput } from "../contexts/ComposerState";
 import {
   type ActiveAgentToolApprovalRequest,
   useAgentApproval,
@@ -440,6 +441,44 @@ function StreamEffects({
   return null;
 }
 
+// Keep the live composer subscription below Chat. This effect needs to react
+// when a shared-task draft is restored, but the rest of the chat shell does
+// not need to rerender for every character the user types.
+function ForkAutoSendEffect({
+  chatId,
+  status,
+  isExistingChat,
+  messageCount,
+  onSubmit,
+}: {
+  chatId: string;
+  status: UseChatHelpers<ChatMessage>["status"];
+  isExistingChat: boolean;
+  messageCount: number;
+  onSubmit: (event: React.FormEvent) => void | Promise<boolean>;
+}) {
+  const input = useComposerInput();
+  const autoSendFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (autoSendFiredRef.current) return;
+    try {
+      const pendingChatId = sessionStorage.getItem("autoSendChatId");
+      if (pendingChatId !== chatId) return;
+    } catch {
+      return;
+    }
+    if (status !== "ready" || !input.trim()) return;
+    if (!isExistingChat || messageCount === 0) return;
+
+    autoSendFiredRef.current = true;
+    sessionStorage.removeItem("autoSendChatId");
+    void onSubmit(new Event("submit") as unknown as React.FormEvent);
+  }, [chatId, input, isExistingChat, messageCount, onSubmit, status]);
+
+  return null;
+}
+
 export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const params = useParams();
   const routeChatId = params?.id as string | undefined;
@@ -458,7 +497,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     streamingState;
 
   const {
-    input,
     chatMode,
     setChatMode,
     sidebarOpen,
@@ -1753,27 +1791,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     [branchChatMutation, initializeChat, router],
   );
 
-  // Auto-send message after forking a shared chat
-  const autoSendFiredRef = useRef(false);
-  useEffect(() => {
-    if (autoSendFiredRef.current) return;
-    try {
-      const pendingChatId = sessionStorage.getItem("autoSendChatId");
-      if (pendingChatId !== chatId) return;
-    } catch {
-      return;
-    }
-    // Wait for chat to be ready with draft input loaded
-    if (status !== "ready" || !input.trim()) return;
-    // Wait for server messages to be loaded (forked chat has messages)
-    if (!isExistingChat || messages.length === 0) return;
-
-    autoSendFiredRef.current = true;
-    sessionStorage.removeItem("autoSendChatId");
-    // Trigger submit with a synthetic event
-    handleSubmit(new Event("submit") as unknown as React.FormEvent);
-  }, [chatId, status, input, isExistingChat, messages.length, handleSubmit]);
-
   const hasMessages = messages.length > 0;
   const showChatLayout = hasMessages || isExistingChat;
   const { isInitialExistingChatLoad, isChatNotFound } =
@@ -1822,6 +1839,14 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
             : !!chatDataForCurrentChat?.active_stream_id ||
               !!chatDataForCurrentChat?.active_trigger_run_id
         }
+      />
+      <ForkAutoSendEffect
+        key={`fork-auto-send:${chatId}`}
+        chatId={chatId}
+        status={status}
+        isExistingChat={isExistingChat}
+        messageCount={messages.length}
+        onSubmit={handleSubmit}
       />
       <div className="flex min-h-0 flex-1 w-full flex-col bg-background overflow-hidden">
         <div className="flex min-h-0 flex-1 min-w-0 relative">

--- a/app/components/message-timeline-rows.ts
+++ b/app/components/message-timeline-rows.ts
@@ -37,6 +37,11 @@ export type AgentActivityTimelineRow = BaseTimelineRow &
 export type ChatTimelineRow =
   MessageTimelineRow | AgentWorkHeaderTimelineRow | AgentActivityTimelineRow;
 
+export type StableChatTimelineRowsState = {
+  byId: ReadonlyMap<string, ChatTimelineRow>;
+  result: ChatTimelineRow[];
+};
+
 export type DeriveChatTimelineRowsOptions = {
   messages: readonly ChatMessage[];
   status: ChatStatus;
@@ -137,6 +142,90 @@ export function deriveChatTimelineRows({
   }
 
   return rows;
+}
+
+export function createStableChatTimelineRowsState(): StableChatTimelineRowsState {
+  return { byId: new Map(), result: [] };
+}
+
+/**
+ * Reuses row objects whose rendered inputs did not change. LegendList can then
+ * skip settled rows while the active assistant message continues streaming.
+ */
+export function stabilizeChatTimelineRows(
+  rows: ChatTimelineRow[],
+  previous: StableChatTimelineRowsState,
+): StableChatTimelineRowsState {
+  const byId = new Map<string, ChatTimelineRow>();
+  let anyChanged = rows.length !== previous.result.length;
+
+  const result = rows.map((row, index) => {
+    const previousRow = previous.byId.get(row.id);
+    const stableRow =
+      previousRow && isChatTimelineRowUnchanged(previousRow, row)
+        ? previousRow
+        : row;
+
+    byId.set(row.id, stableRow);
+    if (!anyChanged && previous.result[index] !== stableRow) {
+      anyChanged = true;
+    }
+    return stableRow;
+  });
+
+  return anyChanged ? { byId, result } : previous;
+}
+
+function isChatTimelineRowUnchanged(
+  previous: ChatTimelineRow,
+  next: ChatTimelineRow,
+): boolean {
+  if (
+    previous.kind !== next.kind ||
+    previous.id !== next.id ||
+    previous.messageIndex !== next.messageIndex
+  ) {
+    return false;
+  }
+
+  if (previous.kind === "message" && next.kind === "message") {
+    return (
+      previous.message === next.message &&
+      previous.workPresentation === next.workPresentation
+    );
+  }
+
+  if (
+    previous.kind === "agent-work-header" &&
+    next.kind === "agent-work-header"
+  ) {
+    return (
+      previous.message === next.message &&
+      previous.canToggle === next.canToggle &&
+      previous.durationMs === next.durationMs &&
+      previous.expanded === next.expanded &&
+      previous.isTiming === next.isTiming &&
+      previous.startedAt === next.startedAt
+    );
+  }
+
+  if (previous.kind === "agent-activity" && next.kind === "agent-activity") {
+    // terminalChunksByToolCallId is derived from message.parts. When the
+    // immutable message reference is unchanged, the derived terminal data is
+    // unchanged too even though the Map instance was rebuilt.
+    return (
+      previous.message === next.message &&
+      previous.part === next.part &&
+      previous.partIndex === next.partIndex &&
+      previous.isLastMessage === next.isLastMessage &&
+      previous.keepLatestReasoningOpenDuringStreaming ===
+        next.keepLatestReasoningOpenDuringStreaming &&
+      previous.deferReasoningCollapseUntilParent ===
+        next.deferReasoningCollapseUntilParent
+    );
+  }
+
+  return false;
 }
 
 export function getChatTimelineRowType(row: ChatTimelineRow) {

--- a/app/contexts/ComposerState.tsx
+++ b/app/contexts/ComposerState.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+type ComposerActions = {
+  clearInput: () => void;
+  getInput: () => string;
+  setInput: (value: string) => void;
+};
+
+const ComposerInputContext = createContext<string | undefined>(undefined);
+const ComposerActionsContext = createContext<ComposerActions | undefined>(
+  undefined,
+);
+
+export function ComposerStateProvider({ children }: { children: ReactNode }) {
+  const [input, setInputState] = useState("");
+  const inputRef = useRef(input);
+
+  const setInput = useCallback((value: string) => {
+    inputRef.current = value;
+    setInputState(value);
+  }, []);
+
+  const clearInput = useCallback(() => {
+    inputRef.current = "";
+    setInputState("");
+  }, []);
+
+  const getInput = useCallback(() => inputRef.current, []);
+  const actions = useMemo(
+    () => ({ clearInput, getInput, setInput }),
+    [clearInput, getInput, setInput],
+  );
+
+  return (
+    <ComposerActionsContext.Provider value={actions}>
+      <ComposerInputContext.Provider value={input}>
+        {children}
+      </ComposerInputContext.Provider>
+    </ComposerActionsContext.Provider>
+  );
+}
+
+export function useComposerInput(): string {
+  const input = useContext(ComposerInputContext);
+  if (input === undefined) {
+    throw new Error(
+      "useComposerInput must be used within a ComposerStateProvider",
+    );
+  }
+  return input;
+}
+
+export function useComposerActions(): ComposerActions {
+  const actions = useContext(ComposerActionsContext);
+  if (actions === undefined) {
+    throw new Error(
+      "useComposerActions must be used within a ComposerStateProvider",
+    );
+  }
+  return actions;
+}

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -59,15 +59,15 @@ import {
   getAgentFirstDefaultDecision,
   normalizeAgentFirstSandboxType,
 } from "@/lib/activation/agent-first-default";
+import {
+  ComposerStateProvider,
+  useComposerActions,
+} from "@/app/contexts/ComposerState";
 
 const ENTITLEMENT_REFRESH_TIMEOUT_MS = 5_000;
 const ENTITLEMENT_REFRESH_RETRY_DELAYS_MS = [1_000, 3_000] as const;
 
 interface GlobalStateType {
-  // Input state
-  input: string;
-  setInput: (value: string) => void;
-
   // File upload state
   uploadedFiles: UploadedFileState[];
   setUploadedFiles: (files: UploadedFileState[]) => void;
@@ -162,6 +162,7 @@ interface GlobalStateType {
   setSelectedModel: (model: SelectedModel) => void;
 
   // Utility methods
+  getInput: () => string;
   clearInput: () => void;
   clearUploadedFiles: () => void;
   openSidebar: (content: SidebarContent) => void;
@@ -213,9 +214,10 @@ interface LocalSandboxConnection {
   };
 }
 
-export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
+const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
   children,
 }) => {
+  const { clearInput, getInput } = useComposerActions();
   const {
     user,
     entitlements,
@@ -230,7 +232,6 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const initialSavedChatModeRef = useRef<ChatMode | null>(null);
   const hasUserSelectedModeThisSessionRef = useRef(false);
   const agentFirstDefaultAppliedRef = useRef(false);
-  const [input, setInput] = useState("");
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFileState[]>([]);
   const [chatMode, setChatModeState] = useState<ChatMode>(() => {
     const saved = readChatMode();
@@ -951,10 +952,6 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     };
   }, [migrateFromPentestgptDialogOpen]);
 
-  const clearInput = () => {
-    setInput("");
-  };
-
   const clearUploadedFiles = () => {
     setUploadedFiles([]);
   };
@@ -1114,8 +1111,6 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   );
 
   const value: GlobalStateType = {
-    input,
-    setInput,
     uploadedFiles,
     setUploadedFiles,
     addUploadedFile,
@@ -1148,6 +1143,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     subscription,
     isCheckingProPlan,
 
+    getInput,
     clearInput,
     clearUploadedFiles,
     openSidebar,
@@ -1204,6 +1200,14 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     </GlobalStateContext.Provider>
   );
 };
+
+export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
+  children,
+}) => (
+  <ComposerStateProvider>
+    <GlobalStateProviderInner>{children}</GlobalStateProviderInner>
+  </ComposerStateProvider>
+);
 
 export const useGlobalState = (): GlobalStateType => {
   const context = useContext(GlobalStateContext);

--- a/app/contexts/__tests__/ComposerState.test.tsx
+++ b/app/contexts/__tests__/ComposerState.test.tsx
@@ -1,0 +1,84 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  ComposerStateProvider,
+  useComposerActions,
+  useComposerInput,
+} from "../ComposerState";
+
+describe("ComposerStateProvider", () => {
+  it("updates input subscribers without rerendering action-only consumers", () => {
+    const actionConsumerRendered = jest.fn();
+    const inputConsumerRendered = jest.fn();
+
+    function ActionConsumer() {
+      actionConsumerRendered();
+      const { getInput, setInput } = useComposerActions();
+
+      return (
+        <>
+          <button type="button" onClick={() => setInput("updated prompt")}>
+            Update prompt
+          </button>
+          <button type="button" onClick={() => getInput()}>
+            Read prompt
+          </button>
+        </>
+      );
+    }
+
+    function InputConsumer() {
+      inputConsumerRendered();
+      const input = useComposerInput();
+      return <div data-testid="composer-input">{input}</div>;
+    }
+
+    render(
+      <ComposerStateProvider>
+        <ActionConsumer />
+        <InputConsumer />
+      </ComposerStateProvider>,
+    );
+
+    expect(actionConsumerRendered).toHaveBeenCalledTimes(1);
+    expect(inputConsumerRendered).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Update prompt" }));
+
+    expect(screen.getByTestId("composer-input")).toHaveTextContent(
+      "updated prompt",
+    );
+    expect(actionConsumerRendered).toHaveBeenCalledTimes(1);
+    expect(inputConsumerRendered).toHaveBeenCalledTimes(2);
+  });
+
+  it("exposes the latest input to event handlers without a value subscription", () => {
+    let latestInput = "";
+
+    function ActionConsumer() {
+      const { getInput, setInput } = useComposerActions();
+      return (
+        <>
+          <button type="button" onClick={() => setInput("send this")}>
+            Update prompt
+          </button>
+          <button type="button" onClick={() => (latestInput = getInput())}>
+            Read prompt
+          </button>
+        </>
+      );
+    }
+
+    render(
+      <ComposerStateProvider>
+        <ActionConsumer />
+      </ComposerStateProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Update prompt" }));
+    fireEvent.click(screen.getByRole("button", { name: "Read prompt" }));
+
+    expect(latestInput).toBe("send this");
+  });
+});

--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -14,7 +14,7 @@ jest.mock("convex/react", () => ({
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
-    input: "",
+    getInput: () => "",
     uploadedFiles: [],
     chatMode: "ask",
     clearInput: jest.fn(),

--- a/app/hooks/__tests__/useChatHandlers.regenerate-sidebar.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-sidebar.test.tsx
@@ -15,7 +15,7 @@ jest.mock("convex/react", () => ({
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
-    input: "",
+    getInput: () => "",
     uploadedFiles: [],
     chatMode: "ask",
     clearInput: jest.fn(),

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -53,7 +53,7 @@ jest.mock("convex/react", () => ({
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
-    input: mockInput,
+    getInput: () => mockInput,
     uploadedFiles: [],
     chatMode: "agent",
     clearInput: jest.fn(),

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -96,7 +96,7 @@ export const useChatHandlers = ({
 }: UseChatHandlersProps) => {
   const { setIsAutoResuming } = useDataStreamDispatch();
   const {
-    input,
+    getInput,
     uploadedFiles,
     chatMode,
     clearInput,
@@ -318,6 +318,10 @@ export const useChatHandlers = ({
 
   const handleSubmit = async (e: React.FormEvent): Promise<boolean> => {
     e.preventDefault();
+
+    // Read the prompt only when the user submits. Keeping the live composer
+    // value out of this hook prevents each keystroke from rerendering Chat.
+    const input = getInput();
 
     setIsAutoResuming(false);
 

--- a/app/share/[shareId]/SharedChatView.tsx
+++ b/app/share/[shareId]/SharedChatView.tsx
@@ -13,6 +13,7 @@ import ChatHeader from "@/app/components/ChatHeader";
 import MainSidebar from "@/app/components/Sidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useGlobalState } from "@/app/contexts/GlobalState";
+import { useComposerInput } from "@/app/contexts/ComposerState";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChatInput } from "@/app/components/ChatInput";
@@ -98,7 +99,8 @@ type SharedSnapshot = {
 export function SharedChatView({ shareId }: SharedChatViewProps) {
   const isMobile = useIsMobile();
   const { user, loading: authLoading } = useAuth();
-  const { chatSidebarOpen, setChatSidebarOpen, input } = useGlobalState();
+  const { chatSidebarOpen, setChatSidebarOpen } = useGlobalState();
+  const input = useComposerInput();
   const router = useRouter();
   const convex = useConvex();
   const forkSharedChatMutation = useMutation(api.sharedChats.forkSharedChat);


### PR DESCRIPTION
## Summary

- move live composer text into a dedicated state provider with separate value and stable action contexts
- read the latest prompt only when submitting, keeping keystrokes out of the main `Chat` render path
- isolate shared-task fork auto-send into a small input-subscribing effect
- structurally share unchanged LegendList timeline rows so settled messages and Agent activities retain object identity during streaming
- add regression coverage for composer subscription boundaries and timeline row reuse

## Why

The monolithic global context previously included the live prompt, so every keystroke invalidated `Chat` and other global-state consumers. Timeline derivation also returned fresh row objects whenever the active message changed, preventing LegendList from recognizing unchanged rows.

This ports the useful parts of t3code's chat-performance architecture while preserving HackerAI's existing LegendList, pagination, and scroll behavior.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes; existing repository warnings remain)
- full commit-hook suite: 318 test suites, 3,170 tests passed
- focused chat suite: composer state, chat integration, GlobalState, ChatInput, Messages editing, timeline rows, and chat handlers
- Prettier and `git diff --check`

## Manual verification

1. Open a long Agent task and type continuously while a response is streaming. The composer should remain responsive and the transcript should not jump.
2. Send a normal message and queue a message during an active run. The latest prompt should send once and clear afterward.
3. Continue a shared task with text entered before forking. The restored draft should auto-send once after the forked task loads.
4. Expand and collapse completed Agent work and load older messages. Existing scroll-preservation behavior should remain unchanged.

No visual design changes are expected, so automated validation is the primary verification surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved chat composer state handling for more responsive typing and submission across regular, unauthenticated, and shared chats.
  - Preserved draft-saving and forked-chat auto-send behavior.
  - Reduced unnecessary message timeline updates to support smoother rendering while conversations change.

- **Bug Fixes**
  - Improved consistency when reading the latest composer content during chat actions, including regeneration and steering workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->