### PR TITLE
Increase E2B sandbox memory to 4 GB

### DIFF
--- a/e2b/build.dev.ts
+++ b/e2b/build.dev.ts
@@ -8,7 +8,7 @@ config({ path: resolve(__dirname, "../.env.local") });
 async function main() {
   await Template.build(template, "terminal-agent-sandbox-dev", {
     cpuCount: 4,
-    memoryMB: 2048,
+    memoryMB: 4096,
     onBuildLogs: defaultBuildLogger(),
   });
 }

--- a/e2b/build.prod.ts
+++ b/e2b/build.prod.ts
@@ -8,7 +8,7 @@ config({ path: resolve(__dirname, "../.env.local") });
 async function main() {
   await Template.build(template, "terminal-agent-sandbox", {
     cpuCount: 4,
-    memoryMB: 2048,
+    memoryMB: 4096,
     onBuildLogs: defaultBuildLogger(),
   });
 }

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -640,7 +640,7 @@ describe("HybridSandboxManager reset cleanup", () => {
         {
           sandboxId: "sandbox-2",
           state: "running",
-          metadata: { sandboxVersion: "v11" },
+          metadata: { sandboxVersion: "v12" },
         },
       ]),
     });

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -51,7 +51,7 @@ const listSandbox = (
       {
         sandboxId: "sandbox-1",
         state: "running",
-        metadata: { sandboxVersion: "v11" },
+        metadata: { sandboxVersion: "v12" },
         ...overrides,
       },
     ]),

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -129,7 +129,8 @@ const logSandboxKillFailure = (
 // v9: added temporary HTTP interception support
 // v10: added whois, Chromium, and agent-browser browser automation
 // v11: removed preinstalled interception CLI from the sandbox image
-const SANDBOX_VERSION = "v11";
+// v12: increased sandbox memory from 2GB to 4GB
+const SANDBOX_VERSION = "v12";
 
 /**
  * Ensures a sandbox connection is established and maintained


### PR DESCRIPTION
## Summary

- increase the shared E2B development and production templates from 2 GB to 4 GB RAM while keeping 4 vCPUs
- bump the sandbox compatibility version to `v12` so paused older sandboxes are replaced safely
- update lifecycle test fixtures to represent the new current sandbox version

## Why

HAC-54 production telemetry shows memory-dominant resource pressure. Using one 4 GB template for all E2B users avoids tier-specific template routing and keeps the existing persistent-sandbox lifecycle model.

Running shared sandboxes are not killed during migration. The existing version migration defers replacement until a sandbox is paused.

## Deployment

This PR changes the template build configuration but does not deploy an E2B template.

Publish the E2B template aliases from this branch **before merging/deploying the `v12` application code**. This ensures that any sandbox created with `v12` metadata already uses the 4 GB build. After the aliases are updated, merge the PR so paused older sandboxes migrate safely on their next connection.

## Validation

- `pnpm exec jest --runInBand` — 318 suites, 3,171 tests passed
- `pnpm typecheck`
- scoped ESLint
- scoped Prettier check
- `git diff --check`

Related: [HAC-54](https://linear.app/hackerai/issue/HAC-54/review-e2b-cpu-and-memory-pressure-telemetry-and-choose-mitigation)