### PR TITLE
Clarify terminal process status

### DIFF
--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -252,13 +252,61 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
 
     await expect(
       getModelOutput(tool, {
-        result: { exitCode: 1, output: "compile passed\n", error: "killed" },
+        result: {
+          processStarted: true,
+          exitCode: 1,
+          output: "compile passed\n",
+          error: "killed",
+        },
       }),
     ).resolves.toEqual({
       type: "text",
       value:
-        'Process exited with code 1\n{"result":{"exitCode":1,"output":"compile passed\\n","error":"killed"}}',
+        'Process exited with code 1\n{"result":{"processStarted":true,"exitCode":1,"output":"compile passed\\n","error":"killed"}}',
     });
+  });
+
+  test("does not report approval denial as a process exit", async () => {
+    const requestToolApproval = jest.fn(async () => ({
+      approved: false as const,
+      reason: "User denied this command",
+    }));
+    const { context } = makeContext({ sandbox: null, requestToolApproval });
+    const tool = createRunTerminalCmd(context);
+    const result = await runTool(tool, {
+      command: "echo should-not-run",
+      is_background: false,
+      interactive: false,
+    });
+
+    const modelOutput = (await getModelOutput(tool, result)) as {
+      value: string;
+    };
+    expect(modelOutput.value).not.toContain("Process exited with code");
+    expect(modelOutput.value).toContain("User denied this command");
+  });
+
+  test("does not report unsupported PTY setup as a process exit", async () => {
+    const unsupportedPtySandbox = {
+      sandboxKind: "centrifugo" as const,
+      supportsPty: () => false,
+      commands: { run: jest.fn() },
+    };
+    const { context } = makeContext({ sandbox: unsupportedPtySandbox });
+    const tool = createRunTerminalCmd(context);
+    const result = await runTool(tool, {
+      command: "python3",
+      is_background: false,
+      interactive: true,
+    });
+
+    const modelOutput = (await getModelOutput(tool, result)) as {
+      value: string;
+    };
+    expect(modelOutput.value).not.toContain("Process exited with code");
+    expect(modelOutput.value).toContain(
+      "Interactive terminal sessions are unavailable",
+    );
   });
 
   test("makes running session status explicit in model output", async () => {
@@ -505,6 +553,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     })) as {
       result: {
         output: string;
+        processStarted?: boolean;
         exitCode: number | null;
         session?: string;
         pid?: number;
@@ -514,6 +563,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     expect(result).toHaveProperty("result");
     expect(typeof result.result.output).toBe("string");
     expect(result.result.output).toContain("hi");
+    expect(result.result.processStarted).toBe(true);
     // Foreground non-background returns an exitCode (may be null on timeout paths,
     // but here the mock resolves with 0).
     expect(result.result.exitCode).toBe(0);
@@ -717,7 +767,8 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
         onSandboxResourceMetrics,
       });
 
-      const resultPromise = runTool(createRunTerminalCmd(context), {
+      const tool = createRunTerminalCmd(context);
+      const resultPromise = runTool(tool, {
         command: "echo should-not-run",
         brief: "verify sandbox",
         is_background: false,
@@ -728,6 +779,13 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
       const result = await resultPromise;
 
       expect(result.result.error).toContain(
+        "initial health check and reconnect both failed",
+      );
+      const modelOutput = (await getModelOutput(tool, result)) as {
+        value: string;
+      };
+      expect(modelOutput.value).not.toContain("Process exited with code");
+      expect(modelOutput.value).toContain(
         "initial health check and reconnect both failed",
       );
       expect(recordHealthFailure).toHaveBeenCalledTimes(2);

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -226,11 +226,78 @@ async function runTool(
   });
 }
 
+async function getModelOutput(
+  tool: ReturnType<typeof createRunTerminalCmd>,
+  output: unknown,
+) {
+  const toModelOutput = (
+    tool as unknown as {
+      toModelOutput: (args: { output: unknown }) => unknown | Promise<unknown>;
+    }
+  ).toModelOutput;
+
+  return toModelOutput({ output });
+}
+
 describe("run_terminal_cmd — PTY action dispatch", () => {
   beforeEach(() => {
     mockCreateE2BPtyHandle.mockReset();
     mockCreateCentrifugoPtyHandle.mockReset();
     mockPhEvent.mockClear();
+  });
+
+  test("makes completed process status explicit in model output", async () => {
+    const { context } = makeContext({ sandbox: null });
+    const tool = createRunTerminalCmd(context);
+
+    await expect(
+      getModelOutput(tool, {
+        result: { exitCode: 1, output: "compile passed\n", error: "killed" },
+      }),
+    ).resolves.toEqual({
+      type: "text",
+      value:
+        'Process exited with code 1\n{"result":{"exitCode":1,"output":"compile passed\\n","error":"killed"}}',
+    });
+  });
+
+  test("makes running session status explicit in model output", async () => {
+    const { context } = makeContext({ sandbox: null });
+    const tool = createRunTerminalCmd(context);
+
+    await expect(
+      getModelOutput(tool, {
+        result: {
+          session: "session-abc",
+          pid: 4321,
+          output: "server starting\n",
+          rawSnapshot: "raw terminal bytes",
+        },
+      }),
+    ).resolves.toEqual({
+      type: "text",
+      value:
+        'Process running with session ID session-abc\n{"result":{"session":"session-abc","pid":4321,"output":"server starting\\n"}}',
+    });
+  });
+
+  test("reports an exited interactive process before its reusable session", async () => {
+    const { context } = makeContext({ sandbox: null });
+    const tool = createRunTerminalCmd(context);
+
+    await expect(
+      getModelOutput(tool, {
+        result: {
+          session: "session-finished",
+          output: "done\n",
+          exited: { exitCode: 0 },
+        },
+      }),
+    ).resolves.toEqual({
+      type: "text",
+      value:
+        'Process exited with code 0\n{"result":{"session":"session-finished","output":"done\\n","exited":{"exitCode":0}}}',
+    });
   });
 
   test("forwards the user-facing justification and reusable argv prefix", async () => {

--- a/lib/ai/tools/__tests__/schemas.test.ts
+++ b/lib/ai/tools/__tests__/schemas.test.ts
@@ -19,6 +19,12 @@ describe("agent tool schema descriptions", () => {
     expect(fullAccessDescription).toContain(
       "Use command chaining and pipes for efficiency",
     );
+    expect(fullAccessDescription).toContain(
+      "Process running with session ID X",
+    );
+    expect(fullAccessDescription).toContain(
+      "a detached PID is not a reusable terminal session",
+    );
     expect(fullAccessDescription).toContain("append ` | cat` to the command");
 
     const approvalGatedTool = createRunTerminalCmdToolSchema({

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -59,6 +59,28 @@ const NOISY_TIMEOUT_MIN_BUFFERED_CHARS = 256 * 1024;
 // ceiling. The agent can follow up with action=wait/send.
 const INTERACTIVE_QUIET_WINDOW_MS = 500;
 
+const getTerminalProcessStatus = (
+  result: Record<string, unknown>,
+): string | undefined => {
+  if (typeof result.exitCode === "number") {
+    return `Process exited with code ${result.exitCode}`;
+  }
+
+  if (
+    typeof result.exited === "object" &&
+    result.exited !== null &&
+    typeof (result.exited as { exitCode?: unknown }).exitCode === "number"
+  ) {
+    return `Process exited with code ${(result.exited as { exitCode: number }).exitCode}`;
+  }
+
+  if (typeof result.session === "string" && result.session) {
+    return `Process running with session ID ${result.session}`;
+  }
+
+  return undefined;
+};
+
 type RunTerminalCmdInput = {
   command: string;
   brief?: string;
@@ -1185,6 +1207,10 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     // fields. rawSnapshot stays in the persisted tool result so the
     // sidebar's xterm renderer can replay it. No-op for non-interactive
     // results, which never include rawSnapshot.
+    //
+    // Prepend a plain-language process state so partial stdout cannot be
+    // mistaken for a successful command when the structural result contains
+    // a non-zero exit code or a still-running session.
     toModelOutput({ output }) {
       if (typeof output !== "object" || output === null) {
         return { type: "text", value: String(output ?? "") };
@@ -1197,7 +1223,15 @@ export const createRunTerminalCmd = (context: ToolContext) => {
         string,
         unknown
       >;
-      return { type: "text", value: JSON.stringify({ result: rest }) };
+      const processStatus = getTerminalProcessStatus(rest);
+      const serializedResult = JSON.stringify({ result: rest });
+
+      return {
+        type: "text",
+        value: processStatus
+          ? `${processStatus}\n${serializedResult}`
+          : serializedResult,
+      };
     },
   });
 };

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -62,7 +62,7 @@ const INTERACTIVE_QUIET_WINDOW_MS = 500;
 const getTerminalProcessStatus = (
   result: Record<string, unknown>,
 ): string | undefined => {
-  if (typeof result.exitCode === "number") {
+  if (result.processStarted === true && typeof result.exitCode === "number") {
     return `Process exited with code ${result.exitCode}`;
   }
 
@@ -748,6 +748,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 result: {
                   output: result.output,
                   exitCode: terminated ? 130 : null,
+                  ...(terminated ? { processStarted: true } : {}),
                   error: terminated
                     ? "Command execution aborted by user"
                     : "Command cancellation could not be confirmed. The local session was retained so termination can be retried.",
@@ -884,6 +885,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     result: {
                       output: result.output,
                       exitCode: commandTerminated ? 124 : null,
+                      ...(commandTerminated ? { processStarted: true } : {}),
                       timedOut: true,
                       ...(resumableSession && {
                         session: resumableSession,
@@ -1119,6 +1121,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                           output: `Detached background process started with PID: ${processId ?? "unknown"}. No reusable terminal session was created; do not pass this PID to interact_terminal_session.\n`,
                         }
                       : {
+                          processStarted: true,
                           exitCode: exec.exitCode ?? 0,
                           output: outputWithSaveInfo,
                           error:
@@ -1178,6 +1181,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
                     resolve({
                       result: {
+                        processStarted: true,
                         exitCode: error.exitCode,
                         output: outputWithSaveInfo,
                         error: error.message,
@@ -1209,8 +1213,8 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     // results, which never include rawSnapshot.
     //
     // Prepend a plain-language process state so partial stdout cannot be
-    // mistaken for a successful command when the structural result contains
-    // a non-zero exit code or a still-running session.
+    // mistaken for a successful command when the structural result explicitly
+    // marks a completed process or a still-running session.
     toModelOutput({ output }) {
       if (typeof output !== "object" || output === null) {
         return { type: "text", value: String(output ?? "") };

--- a/lib/ai/tools/schemas.ts
+++ b/lib/ai/tools/schemas.ts
@@ -49,7 +49,7 @@ ${commandCompositionGuidance}
 2. NEVER run code directly via interpreter inline commands (like \`python3 -c "..."\` or \`node -e "..."\`). ALWAYS save code to a file first, then execute the file.
 3. For ANY commands that would require user interaction, ASSUME THE USER IS NOT AVAILABLE TO INTERACT and PASS THE NON-INTERACTIVE FLAGS (e.g. --yes for npx).
 ${pagerGuidance}
-5. For commands that are long running/expected to run indefinitely until interruption, please run them in the background. To run jobs in the background, set \`is_background\` to true rather than changing the details of the command. EXCEPTION: Never use background mode if you plan to retrieve the output file immediately afterward.
+5. For long-running commands whose output or completion you need to monitor, keep \`is_background\` false. If the result says \`Process running with session ID X\`, continue it with \`interact_terminal_session\` using that exact session ID. Use \`is_background\` true only for detached jobs whose output and completion you do not need to poll; a detached PID is not a reusable terminal session.
 6. Dont include any newlines in the command.
 ${largeOutputGuidance}
 8. Install missing tools when needed: Use \`apt install tool\` or \`pip install package\` (no sudo needed in container).


### PR DESCRIPTION
## Summary

- prepend an explicit process-state line to model-facing terminal results while preserving the existing structured result and UI payload
- report `Process exited with code X` only for confirmed completed processes, including completed interactive commands
- report `Process running with session ID X` for resumable terminal sessions
- keep approval, PTY setup, and sandbox readiness failures classified as tool errors rather than process exits
- guide agents to keep monitored long-running work in the foreground and continue it through `interact_terminal_session`

## Why

Terminal stdout can contain a successful-looking partial line even when the command later exits non-zero or is killed. Making the lifecycle state the first model-visible line reduces the chance that partial output is mistaken for command success. Long-running work that needs monitoring should use the existing reusable session contract rather than a detached PID.

## Validation

- `pnpm test -- lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/ai/tools/__tests__/schemas.test.ts --runInBand` (34 tests)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 5 existing warnings outside touched files)
- pre-commit full Jest suite (318 suites, 3182 tests)
- scoped Prettier and `git diff --check`

## Manual verification

1. In Agent mode, run a command that prints output and exits non-zero; confirm the model-facing result begins with `Process exited with code X`.
2. Run a foreground command that outlives its initial wait window; confirm the result begins with `Process running with session ID X` and the exact returned session works with `interact_terminal_session`.
3. Deny an approval-gated command or attempt an unavailable interactive PTY; confirm the model receives the tool error without a `Process exited` prefix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Terminal command results now clearly indicate whether a process completed, is still running, or exited interactively.
  - Running-session output is presented more cleanly by excluding internal snapshot details.
  - Approval denials, unsupported terminal setups, and health-check failures are reported as errors.
  - Terminal guidance explains when to keep commands in the foreground and how to monitor them using the provided session ID.
  - Documentation clarifies that detached process IDs cannot be reused as terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->