### PR TITLE
Handle desktop relay publish transients

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -28,6 +28,10 @@ jest.mock("centrifuge", () => ({
     mockClientOptions = options;
     return mockClient;
   }),
+  errorCodes: {
+    timeout: 1,
+    connectionClosed: 11,
+  },
 }));
 
 jest.mock("@/lib/analytics/client", () => ({
@@ -842,14 +846,26 @@ describe("forwardChunk", () => {
 
   it.each([
     {
-      code: 11,
-      message: "connection closed",
+      label: "structured connection closed",
+      publishError: { code: 11, message: "connection closed" },
+      directForwardFailure: undefined,
       reason: "connection_closed",
     },
-    { code: 1, message: "timeout", reason: "timeout" },
+    {
+      label: "JSON-encoded Error timeout",
+      publishError: new Error(JSON.stringify({ code: 1, message: "timeout" })),
+      directForwardFailure: undefined,
+      reason: "timeout",
+    },
+    {
+      label: "plain connection closed message",
+      publishError: undefined,
+      directForwardFailure: "connection closed",
+      reason: "connection_closed",
+    },
   ])(
-    "handles $message stream publish rejections and reports them once per command",
-    async ({ code, message, reason }) => {
+    "handles $label stream publish rejections and reports them once per command",
+    async ({ publishError, directForwardFailure, reason }) => {
       let finishCommand!: () => void;
       const commandFinished = new Promise<void>((resolve) => {
         finishCommand = resolve;
@@ -861,12 +877,28 @@ describe("forwardChunk", () => {
         }
         return undefined;
       };
-      mockSubscription.publish.mockRejectedValue({ code, message });
+      if (publishError !== undefined) {
+        mockSubscription.publish.mockRejectedValue(publishError);
+      }
       const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      let forwardChunkSpy: jest.SpyInstance | null = null;
 
       try {
         const bridge = new DesktopSandboxBridge(buildConfig());
         await bridge.start();
+        if (directForwardFailure !== undefined) {
+          forwardChunkSpy = jest
+            .spyOn(
+              bridge as unknown as {
+                forwardChunk: (
+                  commandId: string,
+                  chunk: unknown,
+                ) => Promise<void>;
+              },
+              "forwardChunk",
+            )
+            .mockRejectedValue(directForwardFailure);
+        }
         const handler = getPublicationHandler();
         handler({
           data: {
@@ -927,6 +959,7 @@ describe("forwardChunk", () => {
         );
       } finally {
         finishCommand();
+        forwardChunkSpy?.mockRestore();
         mockSubscription.publish.mockResolvedValue(undefined);
         warnSpy.mockRestore();
       }

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -3,6 +3,7 @@ import {
   CentrifugoMessageReassembler,
   isCentrifugoTransportFragment,
 } from "@/packages/local/src/centrifugo-transport";
+import { captureAuthenticatedEvent } from "@/lib/analytics/client";
 
 // ── Mocks ─────────────────────────────────────────────────────────────
 
@@ -27,6 +28,10 @@ jest.mock("centrifuge", () => ({
     mockClientOptions = options;
     return mockClient;
   }),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: jest.fn(),
 }));
 
 // Mock Tauri IPC
@@ -832,6 +837,151 @@ describe("forwardChunk", () => {
     } finally {
       releaseFirstPublish();
       errorSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    {
+      code: 11,
+      message: "connection closed",
+      reason: "connection_closed",
+    },
+    { code: 1, message: "timeout", reason: "timeout" },
+  ])(
+    "handles $message stream publish rejections and reports them once per command",
+    async ({ code, message, reason }) => {
+      let finishCommand!: () => void;
+      const commandFinished = new Promise<void>((resolve) => {
+        finishCommand = resolve;
+      });
+      mockInvokeHandler = async (cmd: string) => {
+        if (cmd === "execute_stream_command") {
+          await commandFinished;
+          return undefined;
+        }
+        return undefined;
+      };
+      mockSubscription.publish.mockRejectedValue({ code, message });
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const bridge = new DesktopSandboxBridge(buildConfig());
+        await bridge.start();
+        const handler = getPublicationHandler();
+        handler({
+          data: {
+            type: "command",
+            commandId: "cmd-publish-failure",
+            command: "test",
+            targetConnectionId: "conn-123",
+          },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const firstChunk = capturedChannel!.onmessage!({
+          type: "stdout",
+          data: "first",
+        }) as unknown as Promise<void>;
+        const secondChunk = capturedChannel!.onmessage!({
+          type: "stderr",
+          data: "second",
+        }) as unknown as Promise<void>;
+
+        await expect(Promise.all([firstChunk, secondChunk])).resolves.toEqual([
+          undefined,
+          undefined,
+        ]);
+        expect(captureAuthenticatedEvent).toHaveBeenCalledTimes(1);
+        expect(captureAuthenticatedEvent).toHaveBeenCalledWith(
+          "desktop_stream_publish_failed",
+          {
+            connectionId: "conn-123",
+            commandId: "cmd-publish-failure",
+            chunkType: "stdout",
+            reason,
+          },
+        );
+
+        const structuredLog = warnSpy.mock.calls
+          .map(([value]) => {
+            try {
+              return JSON.parse(String(value)) as Record<string, unknown>;
+            } catch {
+              return null;
+            }
+          })
+          .find((value) => value?.event === "desktop_stream_publish_failed");
+        expect(structuredLog).toEqual(
+          expect.objectContaining({
+            timestamp: expect.any(String),
+            level: "warn",
+            event: "desktop_stream_publish_failed",
+            service: "desktop_bridge",
+            environment: "test",
+            request_id: "cmd-publish-failure",
+            connection_id: "conn-123",
+            command_id: "cmd-publish-failure",
+            chunk_type: "stdout",
+            reason,
+          }),
+        );
+      } finally {
+        finishCommand();
+        mockSubscription.publish.mockResolvedValue(undefined);
+        warnSpy.mockRestore();
+      }
+    },
+  );
+
+  it("preserves unexpected publish rejections for error tracking", async () => {
+    let finishCommand!: () => void;
+    const commandFinished = new Promise<void>((resolve) => {
+      finishCommand = resolve;
+    });
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "execute_stream_command") {
+        await commandFinished;
+      }
+      return undefined;
+    };
+    mockSubscription.publish.mockRejectedValue({
+      code: 999,
+      message: "unexpected publish failure",
+    });
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const bridge = new DesktopSandboxBridge(buildConfig());
+      await bridge.start();
+      const handler = getPublicationHandler();
+      handler({
+        data: {
+          type: "command",
+          commandId: "cmd-unknown-publish-failure",
+          command: "test",
+          targetConnectionId: "conn-123",
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const firstChunk = capturedChannel!.onmessage!({
+        type: "stdout",
+        data: "first",
+      }) as unknown as Promise<void>;
+      const secondChunk = capturedChannel!.onmessage!({
+        type: "stderr",
+        data: "second",
+      }) as unknown as Promise<void>;
+      await expect(firstChunk).rejects.toThrow("unexpected publish failure");
+      await expect(secondChunk).rejects.toThrow("unexpected publish failure");
+      expect(captureAuthenticatedEvent).not.toHaveBeenCalled();
+      expect(warnSpy.mock.calls).not.toContainEqual([
+        expect.stringContaining("desktop_stream_publish_failed"),
+      ]);
+    } finally {
+      finishCommand();
+      mockSubscription.publish.mockResolvedValue(undefined);
+      warnSpy.mockRestore();
     }
   });
 });

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -52,11 +52,46 @@ type DesktopBridgeTerminationReason =
   | "ownership_mismatch"
   | "connection_inactive";
 
+type DesktopStreamPublishFailureReason = "connection_closed" | "timeout";
+
 interface StreamChunk {
   type: "stdout" | "stderr" | "exit" | "error";
   data?: string;
   exitCode?: number;
   message?: string;
+}
+
+function classifyDesktopStreamPublishFailure(
+  error: unknown,
+): DesktopStreamPublishFailureReason | null {
+  let code: unknown;
+  let message: unknown;
+
+  if (error instanceof Error) {
+    message = error.message;
+    try {
+      const parsed = JSON.parse(error.message) as unknown;
+      if (typeof parsed === "object" && parsed !== null) {
+        code = (parsed as { code?: unknown }).code;
+        message = (parsed as { message?: unknown }).message;
+      }
+    } catch {
+      // Centrifuge can also reject with a normal Error message.
+    }
+  } else if (typeof error === "object" && error !== null) {
+    code = (error as { code?: unknown }).code;
+    message = (error as { message?: unknown }).message;
+  } else {
+    message = error;
+  }
+
+  if (code === 11 || message === "connection closed") {
+    return "connection_closed";
+  }
+  if (code === 1 || message === "timeout") {
+    return "timeout";
+  }
+  return null;
 }
 
 type TargetedIncomingMessage =
@@ -451,8 +486,42 @@ export class DesktopSandboxBridge {
       const { invoke, Channel } = await import("@tauri-apps/api/core");
 
       const channel = new Channel<StreamChunk>();
+      let publishFailureReported = false;
       channel.onmessage = async (chunk) => {
-        await this.forwardChunk(commandId, chunk);
+        try {
+          await this.forwardChunk(commandId, chunk);
+        } catch (error) {
+          // Tauri does not await Channel callbacks. Handle the rejection here
+          // so one disconnected command cannot emit an unhandled exception for
+          // every subsequent stream chunk.
+          const reason = classifyDesktopStreamPublishFailure(error);
+          // Unknown failures are still actionable exceptions and must remain
+          // visible to the global error tracker.
+          if (!reason) throw error;
+          if (publishFailureReported) return;
+          publishFailureReported = true;
+
+          console.warn(
+            JSON.stringify({
+              timestamp: new Date().toISOString(),
+              level: "warn",
+              event: "desktop_stream_publish_failed",
+              service: "desktop_bridge",
+              environment: process.env.NODE_ENV ?? "unknown",
+              request_id: commandId,
+              connection_id: this.connectionId,
+              command_id: commandId,
+              chunk_type: chunk.type,
+              reason,
+            }),
+          );
+          captureAuthenticatedEvent("desktop_stream_publish_failed", {
+            connectionId: this.connectionId,
+            commandId,
+            chunkType: chunk.type,
+            reason,
+          });
+        }
       };
 
       await invoke("execute_stream_command", {

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -1,4 +1,4 @@
-import { Centrifuge, type Subscription } from "centrifuge";
+import { Centrifuge, errorCodes, type Subscription } from "centrifuge";
 import { captureAuthenticatedEvent } from "@/lib/analytics/client";
 import {
   sandboxConnectionChannel,
@@ -85,10 +85,10 @@ function classifyDesktopStreamPublishFailure(
     message = error;
   }
 
-  if (code === 11 || message === "connection closed") {
+  if (code === errorCodes.connectionClosed || message === "connection closed") {
     return "connection_closed";
   }
-  if (code === 1 || message === "timeout") {
+  if (code === errorCodes.timeout || message === "timeout") {
     return "timeout";
   }
   return null;


### PR DESCRIPTION
## Summary

- handle only the observed Centrifugo `code=11 / connection closed` and `code=1 / timeout` publish rejections inside the Tauri stream callback
- emit one bounded `desktop_stream_publish_failed` event per affected command instead of leaking an unhandled rejection for every stream chunk
- preserve unknown failures, queue ordering, fragmentation, retry, reconnect, and stop behavior

## Production evidence

In the frozen `2026-08-02T20:03:09.869Z`–`2026-08-03T20:03:09.869Z` window, PostHog grouped 578 Centrifugo transport occurrences across 113 issue-summed sessions and 111 issue-summed users, up from 54/15/16 in the previous equivalent window. Representative frames point to the app-owned desktop transport. There were zero post-#1019 `DesktopSandboxBridge subscription is null` events, so this change does not alter the subscription lifecycle fix.

The separate Vercel socket/420-second cluster was concentrated into a 21-minute incident and remains visible as an operational transient; this PR does not suppress or reclassify it.

## Root cause

Tauri's channel callback does not await the promise returned by an async `onmessage` handler. A transient publish rejection therefore escaped as an unhandled rejection once per stream chunk. This change catches only the two verified operational transport conditions at that boundary, aggregates them at command scope, and rethrows every unknown exception.

Structured telemetry includes only bounded reasons, chunk type, and opaque connection/command identifiers; it excludes chunk contents, prompts, targets, and raw error data.

## Validation

- `pnpm jest app/services/__tests__/desktop-sandbox-bridge.test.ts packages/local/src/__tests__/centrifugo-transport.test.ts --runInBand` — 2 suites, 37 tests passed
- `pnpm typecheck`
- changed-file ESLint
- Prettier check
- `git diff --check`
- commit hooks: 318 suites, 3,186 tests passed

Visual verification is not applicable because this is transport/error-handling telemetry with no UI layout or copy change.

## Manual verification

- **Where:** authenticated HackerAI desktop/local-sandbox session after deployment
- **Do:** start a streaming command and briefly interrupt/reconnect Centrifugo so a publish reports either `connection closed` or `timeout`
- **Expect:** stream/reconnect behavior is unchanged; PostHog does not receive a per-chunk unhandled rejection; exactly one `desktop_stream_publish_failed` event is emitted for the affected command with a bounded reason and opaque IDs; unknown failures remain globally error-visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expected desktop connection and timeout failures.
  * Added clearer warning messages and analytics tracking for recognized stream publishing failures.
  * Prevented duplicate reporting of the same failure while allowing unexpected errors to continue normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->