### PR TITLE
Guard cross-origin ErrorEvent access

### DIFF
--- a/app/components/ChunkLoadRecovery.tsx
+++ b/app/components/ChunkLoadRecovery.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from "react";
 
+import { getSafeErrorEventCause } from "@/lib/utils/error-event";
+
 const CHUNK_LOAD_RELOAD_STORAGE_KEY = "hackerai:chunk-load-reload-at";
 const CHUNK_LOAD_RELOAD_COOLDOWN_MS = 5 * 60 * 1_000;
 
@@ -128,7 +130,7 @@ export function ChunkLoadRecovery() {
       });
 
     const onError = (event: ErrorEvent) => {
-      if (recover(event.error ?? event.message)) {
+      if (recover(getSafeErrorEventCause(event))) {
         event.preventDefault();
       }
     };

--- a/app/components/__tests__/ChunkLoadRecovery.test.ts
+++ b/app/components/__tests__/ChunkLoadRecovery.test.ts
@@ -181,4 +181,37 @@ describe("ChunkLoadRecovery", () => {
     addEventListener.mockRestore();
     removeEventListener.mockRestore();
   });
+
+  it("does not mask errors whose ErrorEvent fields are inaccessible", () => {
+    let errorListener: ((event: ErrorEvent) => void) | undefined;
+    const addEventListener = jest
+      .spyOn(window, "addEventListener")
+      .mockImplementation((type, listener) => {
+        if (type === "error" && typeof listener === "function") {
+          errorListener = listener as (event: ErrorEvent) => void;
+        }
+      });
+    const preventDefault = jest.fn();
+    const event = { preventDefault } as unknown as ErrorEvent;
+    Object.defineProperties(event, {
+      error: {
+        get: () => {
+          throw new Error('Permission denied to access property "error"');
+        },
+      },
+      message: {
+        get: () => {
+          throw new Error('Permission denied to access property "message"');
+        },
+      },
+    });
+
+    const { unmount } = render(createElement(ChunkLoadRecovery));
+
+    expect(() => errorListener?.(event)).not.toThrow();
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    unmount();
+    addEventListener.mockRestore();
+  });
 });

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -43,6 +43,7 @@ import {
   convertToUIMessages,
   type MessageRecord,
 } from "@/lib/utils";
+import { getSafeErrorEventMessage } from "@/lib/utils/error-event";
 import {
   cancelAgentLongRealtimeStreams,
   fetchAgentLongStream,
@@ -1144,7 +1145,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         message.includes("Cannot close a stream that is already closed"));
 
     const suppressAgentLongDoubleCloseNoise = (event: ErrorEvent) => {
-      if (isAgentLongDoubleCloseNoise(event.message)) {
+      if (isAgentLongDoubleCloseNoise(getSafeErrorEventMessage(event))) {
         event.preventDefault();
         event.stopImmediatePropagation();
       }

--- a/lib/utils/__tests__/error-event.test.ts
+++ b/lib/utils/__tests__/error-event.test.ts
@@ -1,0 +1,83 @@
+import {
+  getSafeErrorEventCause,
+  getSafeErrorEventMessage,
+} from "../error-event";
+
+const blockedAccessor = (property: "error" | "message") => {
+  const event = {} as ErrorEvent;
+  Object.defineProperty(event, property, {
+    get: () => {
+      throw new Error(`Permission denied to access property "${property}"`);
+    },
+  });
+  return event;
+};
+
+describe("safe ErrorEvent access", () => {
+  it("reads accessible messages", () => {
+    expect(getSafeErrorEventMessage({ message: "ChunkLoadError" })).toBe(
+      "ChunkLoadError",
+    );
+  });
+
+  it("reads each message accessor only once", () => {
+    const message = jest
+      .fn<() => string>()
+      .mockReturnValueOnce("ChunkLoadError")
+      .mockImplementation(() => {
+        throw new Error("message read twice");
+      });
+    const event = {} as ErrorEvent;
+    Object.defineProperty(event, "message", { get: message });
+
+    expect(getSafeErrorEventMessage(event)).toBe("ChunkLoadError");
+    expect(message).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores blocked message access", () => {
+    expect(
+      getSafeErrorEventMessage(blockedAccessor("message")),
+    ).toBeUndefined();
+  });
+
+  it("prefers an accessible error value", () => {
+    const error = new Error("ChunkLoadError");
+
+    expect(getSafeErrorEventCause({ error, message: "fallback message" })).toBe(
+      error,
+    );
+  });
+
+  it("reads each error accessor only once", () => {
+    const expected = new Error("ChunkLoadError");
+    const error = jest
+      .fn<() => Error>()
+      .mockReturnValueOnce(expected)
+      .mockImplementation(() => {
+        throw new Error("error read twice");
+      });
+    const event = { message: "fallback message" } as ErrorEvent;
+    Object.defineProperty(event, "error", { get: error });
+
+    expect(getSafeErrorEventCause(event)).toBe(expected);
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a separately guarded message", () => {
+    const event = blockedAccessor("error");
+    Object.defineProperty(event, "message", { value: "ChunkLoadError" });
+
+    expect(getSafeErrorEventCause(event)).toBe("ChunkLoadError");
+  });
+
+  it("ignores ErrorEvents whose error and message accessors are blocked", () => {
+    const event = blockedAccessor("error");
+    Object.defineProperty(event, "message", {
+      get: () => {
+        throw new Error('Permission denied to access property "message"');
+      },
+    });
+
+    expect(getSafeErrorEventCause(event)).toBeUndefined();
+  });
+});

--- a/lib/utils/error-event.ts
+++ b/lib/utils/error-event.ts
@@ -1,0 +1,24 @@
+export function getSafeErrorEventMessage(
+  event: Pick<ErrorEvent, "message">,
+): string | undefined {
+  try {
+    const message = event.message;
+    return typeof message === "string" ? message : undefined;
+  } catch {
+    // Firefox can block access to properties on cross-origin ErrorEvents.
+    return undefined;
+  }
+}
+
+export function getSafeErrorEventCause(
+  event: Pick<ErrorEvent, "error" | "message">,
+): unknown {
+  try {
+    const error = event.error;
+    if (error != null) return error;
+  } catch {
+    // Fall back to the separately guarded message accessor.
+  }
+
+  return getSafeErrorEventMessage(event);
+}


### PR DESCRIPTION
## Summary
- guard Firefox/cross-realm `ErrorEvent.error` and `ErrorEvent.message` access in both global client error listeners
- preserve existing chunk/stale-deployment recovery and Agent stream-close suppression when fields are readable
- leave the original event visible when protected fields cannot be inspected instead of masking it with a new permission exception

## Production evidence
Frozen audit window: `2026-08-03T20:01:53.418Z`–`2026-08-04T20:01:53.418Z`.

PostHog recorded six new app-framed exceptions in one Firefox Android session: three `Permission denied to access property "error"` and three `Permission denied to access property "message"`. The affected entry points directly read those properties inside capture-phase/global error listeners, so a protected cross-realm event can throw from the listener and obscure the originating browser error.

No Vercel or Trigger.dev signature contradicted this diagnosis. This PR does not add a suppression rule.

## Change
- add a small client-safe accessor that reads each protected property at most once
- fall back from an inaccessible `error` getter to a separately guarded `message` getter
- opt out of recovery/suppression when neither property is readable, allowing the original event to continue to error tracking
- cover readable, blocked, fallback, both-blocked, and once-only accessor behavior plus the live chunk-recovery listener

## Validation
- `corepack pnpm jest lib/utils/__tests__/error-event.test.ts app/components/__tests__/ChunkLoadRecovery.test.ts --runInBand` (2 suites / 16 tests)
- `corepack pnpm typecheck`
- changed-file ESLint (0 errors; 3 pre-existing `chat.tsx` hook warnings)
- changed-file Prettier and `git diff --check`
- commit hooks: 319 suites / 3,194 tests

## Manual verification
1. In a Firefox preview session, dispatch a synthetic `ErrorEvent` whose `error` and `message` getters throw permission errors.
2. Confirm neither HackerAI global listener throws or calls `preventDefault`.
3. Dispatch normal chunk-load and Agent stream double-close errors and confirm existing reload/suppression behavior is unchanged.
4. After production deploy, confirm the two permission-denied signatures stop recurring while original unknown errors remain visible.

Visual QA is not applicable because this changes non-visual global error handling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from chunk-loading errors, including error events with inaccessible properties.
  * Improved handling of agent-long stream errors to prevent unnecessary interruptions.
  * Error messages and causes are now extracted more safely, with graceful fallbacks when details cannot be read.

* **Tests**
  * Added coverage for readable, inaccessible, and fallback error-event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->