### PR TITLE
Switch HackerAI Max to Kimi K3

### DIFF
--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -89,4 +89,15 @@ describe("ModelSelector tier ↔ provider drift", () => {
         ?.poweredBy,
     ).toBe("xAI Grok 4.5");
   });
+
+  it("discloses Kimi K3 for HackerAI Max", () => {
+    expect(
+      ASK_MODEL_OPTIONS.find((option) => option.id === "hackerai-max")
+        ?.poweredBy,
+    ).toBe("Moonshot Kimi K3");
+    expect(
+      AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-max")
+        ?.poweredBy,
+    ).toBe("Moonshot Kimi K3");
+  });
 });

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -28,7 +28,7 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-max",
     label: "HackerAI Max",
     description: "Maximum intelligence for complex work",
-    poweredBy: "Claude Opus 4.6",
+    poweredBy: "Moonshot Kimi K3",
   },
 ];
 
@@ -51,7 +51,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-max",
     label: "HackerAI Max",
     description: "Maximum intelligence for complex work",
-    poweredBy: "Claude Opus 4.6",
+    poweredBy: "Moonshot Kimi K3",
     thinking: true,
   },
 ];

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -1,6 +1,8 @@
 import {
   getModelCutoffDate,
   getModelDisplayName,
+  isAnthropicModel,
+  isKimiModel,
   myProvider,
   sanitizeOpenRouterRequestForXai,
   supportsMultimodalToolResults,
@@ -39,6 +41,10 @@ describe("provider registry", () => {
         .modelId,
     ).toBe("moonshotai/kimi-k3");
     expect(
+      (myProvider.languageModel("model-opus-4.6") as { modelId: string })
+        .modelId,
+    ).toBe("moonshotai/kimi-k3");
+    expect(
       (myProvider.languageModel("fallback-agent-model") as { modelId: string })
         .modelId,
     ).toBe("x-ai/grok-4.5");
@@ -56,9 +62,17 @@ describe("provider registry", () => {
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
     expect(getModelDisplayName("model-kimi-k3")).toBe("Moonshot Kimi K3");
+    expect(getModelCutoffDate("model-opus-4.6")).toBe("July 2026");
+    expect(getModelDisplayName("model-opus-4.6")).toBe("Moonshot Kimi K3");
     expect(getModelDisplayName("title-generator-model")).toBe(
       "DeepSeek V4 Flash",
     );
+  });
+
+  it("applies Kimi rather than Anthropic provider behavior to HackerAI Max", () => {
+    expect(isKimiModel("model-opus-4.6")).toBe(true);
+    expect(isAnthropicModel("model-opus-4.6")).toBe(false);
+    expect(isAnthropicModel("anthropic/claude-opus-4.6")).toBe(true);
   });
 
   it.each([

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -196,7 +196,9 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     // changing Standard media fallback behavior.
     "model-grok-4.5-pro": or(GROK_4_5_SLUG),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
-    "model-opus-4.6": or("anthropic/claude-opus-4.6"),
+    // Keep the persisted Max compatibility key while routing new requests to
+    // Kimi K3. Renaming the key would invalidate existing stored selections.
+    "model-opus-4.6": or(KIMI_K3_SLUG),
     "model-glm-5.2": or(GLM_5_2_SLUG),
     "model-kimi-k3": or(KIMI_K3_SLUG),
     "fallback-agent-model": or(GROK_4_5_SLUG),
@@ -216,7 +218,7 @@ export const modelCutoffDates: Partial<Record<ModelName, string>> &
   "model-grok-4.5": "July 2026",
   "model-grok-4.5-pro": "July 2026",
   "model-deepseek-v4-pro": "May 2025",
-  "model-opus-4.6": "May 2025",
+  "model-opus-4.6": "July 2026",
   "model-glm-5.2": "June 2026",
   "fallback-agent-model": "July 2026",
   "fallback-ask-model": "July 2026",
@@ -232,7 +234,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-grok-4.5": "xAI Grok 4.5",
   "model-grok-4.5-pro": "xAI Grok 4.5",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
-  "model-opus-4.6": "Anthropic Claude Opus 4.6",
+  "model-opus-4.6": "Moonshot Kimi K3",
   "model-glm-5.2": "Z.ai GLM 5.2",
   "model-kimi-k3": "Moonshot Kimi K3",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
@@ -251,7 +253,8 @@ export const getModelCutoffDate = (
 };
 
 export function isAnthropicModel(modelName: string): boolean {
-  return modelName.includes("opus");
+  const normalized = modelName.toLowerCase();
+  return normalized.startsWith("anthropic/") || normalized.includes("claude");
 }
 
 export function isDeepSeekModel(modelName: string): boolean {
@@ -265,7 +268,9 @@ export function isDeepSeekModel(modelName: string): boolean {
 export function isKimiModel(modelName: string): boolean {
   const normalized = modelName.toLowerCase();
   return (
-    normalized === "model-kimi-k3" || normalized.includes("moonshotai/kimi")
+    normalized === "model-kimi-k3" ||
+    normalized === "model-opus-4.6" ||
+    normalized.includes("moonshotai/kimi")
   );
 }
 
@@ -305,7 +310,7 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
 /**
  * Map a HackerAI tier id to the underlying provider key for a given mode.
  * Returns `null` for `"auto"` (the caller routes to the auto-router model
- * key instead). Standard maps to DeepSeek, Pro to Grok, and Max to Opus in
+ * key instead). Standard maps to DeepSeek, Pro to Grok, and Max to Kimi K3 in
  * both modes; media-aware promotion happens in `selectModel`.
  */
 export function resolveTierToProviderKey(

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -76,15 +76,15 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it("resolves Opus 4.6 ask chain to Kimi K3 then Grok", () => {
+  it("resolves the Max Kimi K3 ask route to Grok fallback", () => {
     const opts = buildProviderOptions(false, "user-1", "model-opus-4.6", "ask");
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_K3_SLUG, GROK_SLUG],
+      models: [GROK_SLUG],
       user: "user-1",
     });
   });
 
-  it("resolves Opus 4.6 text-only agent chain to Kimi K3 then Grok", () => {
+  it("resolves the Max Kimi K3 text-only agent route to Grok fallback", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -92,12 +92,12 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_K3_SLUG, GROK_SLUG],
+      models: [GROK_SLUG],
       user: "user-1",
     });
   });
 
-  it("resolves Opus 4.6 multimodal agent chain to Kimi K3 then Grok", () => {
+  it("resolves the Max Kimi K3 multimodal agent route to Grok fallback", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -106,7 +106,7 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_K3_SLUG, GROK_SLUG],
+      models: [GROK_SLUG],
       user: "user-1",
     });
   });
@@ -339,7 +339,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(reasoning.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [KIMI_K3_SLUG, GROK_SLUG],
+      models: [GROK_SLUG],
     });
 
     const grokReasoning = buildProviderOptions(
@@ -362,7 +362,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(multimodal.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [KIMI_K3_SLUG, GROK_SLUG],
+      models: [GROK_SLUG],
     });
   });
 });
@@ -428,10 +428,10 @@ describe("getRetryFallbackModel", () => {
   });
 
   it.each(["ask", "agent"] as const)(
-    "retries Opus 4.6 with Kimi K3 in %s mode",
+    "retries the Max Kimi K3 route with Grok in %s mode",
     (mode) => {
       expect(getRetryFallbackModel("model-opus-4.6", mode)).toBe(
-        "model-kimi-k3",
+        "model-grok-4.5",
       );
     },
   );
@@ -587,6 +587,16 @@ describe("resolveServedModelForCostAccounting", () => {
       resolveServedModelForCostAccounting({
         modelName: "model-opus-4.6",
         responseModel: "anthropic/claude-4.6-opus-20261231",
+        mode: "agent",
+      }),
+    ).toBe("model-opus-4.6");
+  });
+
+  it("maps the Max Kimi K3 primary response to the persisted Max cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-opus-4.6",
+        responseModel: KIMI_K3_SLUG,
         mode: "agent",
       }),
     ).toBe("model-opus-4.6");

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -519,8 +519,8 @@ export class SummarizationTracker {
  * stream, OpenRouter rolls forward through this list and bills at the served
  * model's rate (response.modelId reflects what actually ran).
  *
- * Claude chats are repaired for Anthropic-compatible message shapes before
- * this fallback can fire. Opus 4.6 uses Kimi K3 then Grok 4.5 in every mode.
+ * The persisted Max key now resolves to Kimi K3 and falls back to Grok 4.5 in
+ * every mode. Historical Opus response ids remain recognized for accounting.
  *
  * Keys and values are registry names (see lib/ai/providers.ts) — the actual
  * OpenRouter slugs are resolved at request-build time so this stays in sync
@@ -556,6 +556,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "agent-model": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5-pro": HACKERAI_PRO_FALLBACK_CHAIN,
+  "model-opus-4.6": ["model-grok-4.5"],
   "model-glm-5.2": KIMI_K3_THEN_GROK_FALLBACK_CHAIN,
   "fallback-agent-model": GROK_4_5_FALLBACK_CHAIN,
   "fallback-ask-model": GROK_4_5_FALLBACK_CHAIN,
@@ -608,9 +609,6 @@ const getFallbackKeys = (
   modelName?: string,
 ): readonly ModelName[] | undefined => {
   if (!modelName) return undefined;
-  if (modelName === "model-opus-4.6") {
-    return KIMI_K3_THEN_GROK_FALLBACK_CHAIN;
-  }
   return MODEL_FALLBACK_CHAIN[modelName as ModelName];
 };
 
@@ -622,7 +620,7 @@ export function getRetryFallbackModel(
     return "model-glm-5.2";
   }
   if (modelName === "model-opus-4.6") {
-    return "model-kimi-k3";
+    return "model-grok-4.5";
   }
   if (
     modelName === "ask-model-free" ||

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -275,7 +275,7 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6 for Ultra", () => {
+    it("should map HackerAI Max to its Kimi K3 compatibility route for Ultra", () => {
       expect(selectModel("ask", "ultra", "hackerai-max")).toBe(
         "model-opus-4.6",
       );
@@ -293,7 +293,7 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6 for paid users with extra usage", () => {
+    it("should map HackerAI Max to its Kimi K3 compatibility route for paid users with extra usage", () => {
       expect(
         selectModel("ask", "pro", "hackerai-max", false, false, {
           extraUsageAvailable: true,
@@ -340,7 +340,7 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6 in agent mode for Ultra", () => {
+    it("should map HackerAI Max to its Kimi K3 compatibility route in agent mode for Ultra", () => {
       expect(selectModel("agent", "ultra", "hackerai-max")).toBe(
         "model-opus-4.6",
       );
@@ -358,7 +358,7 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6 in agent mode for paid users with extra usage", () => {
+    it("should map HackerAI Max to its Kimi K3 compatibility route in agent mode for paid users with extra usage", () => {
       expect(
         selectModel("agent", "pro-plus", "hackerai-max", false, false, {
           extraUsageAvailable: true,

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -481,14 +481,13 @@ describe("token-bucket", () => {
       );
     });
 
-    it("should use Kimi K3 pricing ($3.00/$15.00)", () => {
-      expect(calculateTokenCost(1_000_000, "input", "model-kimi-k3")).toBe(
-        45000,
-      );
-      expect(calculateTokenCost(1_000_000, "output", "model-kimi-k3")).toBe(
-        225000,
-      );
-    });
+    it.each(["model-kimi-k3", "model-opus-4.6"])(
+      "should use Kimi K3 pricing for %s ($3.00/$15.00)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(45000);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(225000);
+      },
+    );
 
     it.each([
       "ask-model-free",

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -97,7 +97,8 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
-  "model-opus-4.6": OPUS_4_6_PRICING,
+  // Persisted Max compatibility key; the active provider route is Kimi K3.
+  "model-opus-4.6": KIMI_K3_PRICING,
   // Baseline OpenRouter rates: $0.76 in / $2.42 out per 1M tokens.
   "model-glm-5.2": GLM_5_2_PRICING,
   // OpenRouter rates: $3.00 in / $15.00 out / $0.30 cached input per 1M tokens.


### PR DESCRIPTION
## Summary

- route HackerAI Max through OpenRouter's `moonshotai/kimi-k3` instead of Claude Opus 4.6 in both Ask and Agent modes
- preserve the persisted `model-opus-4.6` compatibility key so existing chats and stored selections keep working
- use Grok 4.5 as Max's provider and app-side fallback, and apply Kimi rather than Anthropic request shaping
- update the Max provider label, knowledge cutoff, response-model accounting, and estimated token pricing
- add drift, routing, fallback, provider-behavior, selection, and billing coverage

## Why

HackerAI Max should now use Kimi K3 as its primary model. The internal Max key is persisted in client and chat state, so this changes the upstream target without renaming that compatibility identifier.

## Impact

Ultra users, and paid users with Extra Usage available, who explicitly select HackerAI Max will use Kimi K3 for new Ask and Agent requests. Max keeps high reasoning and falls back to Grok 4.5 if Kimi fails before streaming. Standard, Pro, Auto, and Free routes are unchanged. Historical Opus response IDs remain recognized for usage accounting.

The token-estimate fallback now uses the existing Kimi K3 rate table instead of Opus pricing. Authoritative OpenRouter cost metadata still takes precedence when available.

## Validation

- pre-commit full suite: 318 test suites / 3,190 tests passed
- `pnpm typecheck`
- targeted ESLint and Prettier
- focused routing validation: 5 suites / 241 tests passed
- Google Chrome rendered the local model selector and Max entry; the provider hover detail could not finish loading because this worktree's configured local Convex deployment requires initialization
- no live billable provider request was made

## Manual verification

1. In a preview or staging environment with an Ultra account or Extra Usage enabled, open the model selector in Ask and Agent modes and confirm Max says `Powered by Moonshot Kimi K3`.
2. Select Max and send a harmless text request in each mode. Confirm OpenRouter reports requested/selected model `moonshotai/kimi-k3` with high reasoning.
3. Exercise a controlled pre-stream provider failure and confirm Max falls back to `x-ai/grok-4.5` without retrying Kimi as its own fallback.
4. Confirm Standard, Pro, Auto, and Free selections keep their existing routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HackerAI Max now correctly displays Moonshot Kimi K3 as its provider in Ask and Agent model lists.
  * Updated model routing, pricing, attribution, and fallback behavior to reflect the Kimi K3 configuration.
  * Preserved compatibility for existing Max model selections and historical responses.
* **Tests**
  * Added regression coverage for provider labels, routing, fallback behavior, cost accounting, and model classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->