### PR TITLE
Test manual-stop continuation guards

### DIFF
--- a/app/hooks/__tests__/useAutoContinue.test.ts
+++ b/app/hooks/__tests__/useAutoContinue.test.ts
@@ -221,6 +221,36 @@ describe("useAutoContinue", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("suppresses a delayed auto-continue signal after manual stop", () => {
+    const sendMessage = jest.fn();
+    const hasManuallyStoppedRef = { current: false };
+    let params = buildParams({
+      status: "streaming",
+      sendMessage,
+      hasManuallyStoppedRef,
+    });
+
+    const { result, rerender } = renderHook(
+      (p: UseAutoContinueParams) => useTestHarness(p),
+      { initialProps: params, wrapper: createWrapper() },
+    );
+
+    act(() => {
+      hasManuallyStoppedRef.current = true;
+    });
+    pushAutoContinue(result);
+
+    params = { ...params, status: "ready" };
+    rerender(params);
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.isAutoResuming).toBe(false);
+    expect(result.current.isAutoContinuing).toBe(false);
+  });
+
   it("stops firing after MAX_AUTO_CONTINUES and resets isAutoResuming", () => {
     const sendMessage = jest.fn();
     let params = buildParams({ status: "streaming", sendMessage });
@@ -342,6 +372,27 @@ describe("useAutoContinue", () => {
 
     expect(sendMessage).not.toHaveBeenCalled();
     expect(result.current.isAutoContinuing).toBe(false);
+  });
+
+  it("cancels a scheduled continuation when the chat unmounts", () => {
+    const sendMessage = jest.fn();
+    let params = buildParams({ status: "streaming", sendMessage });
+
+    const { result, rerender, unmount } = renderHook(
+      (p: UseAutoContinueParams) => useTestHarness(p),
+      { initialProps: params, wrapper: createWrapper() },
+    );
+
+    pushAutoContinue(result);
+    params = { ...params, status: "ready" };
+    rerender(params);
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("keeps automatic continuation active until the follow-up run settles", () => {


### PR DESCRIPTION
## What changed

- Add a regression test for a delayed `data-auto-continue` signal arriving after the user has manually stopped a run.
- Add a regression test proving an already scheduled continuation is canceled when the chat unmounts.

## Why

Customer-history investigation found two historical output-limit continuations, but no evidence that the customer pressed Stop in either run. The current implementation already sets the manual-stop flag before cancellation, checks it before scheduling a continuation, scopes stream signals to the active chat, clears stream data during navigation, and cancels scheduled timers during cleanup. These tests lock down the two timing-sensitive guard paths without changing product behavior.

The misleading historical tool error text was separately fixed in #994 by reporting output-limit interruption distinctly from a user stop.

## Validation

- `pnpm exec jest app/hooks/__tests__/useAutoContinue.test.ts --runInBand` (15 tests passed)
- `pnpm typecheck` (commit hook)
- `pnpm test` (319 suites, 3201 tests passed; commit hook)

## Manual verification

Automated validation is sufficient because this PR only adds regression coverage and does not change runtime behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring delayed auto-continue is suppressed after a manual stop.
  * Added coverage verifying scheduled continuation is canceled when the chat closes or unmounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->