### PR TITLE
Preserve chat drafts while offline

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -76,25 +76,26 @@ describe("proxy", () => {
     mockNextResponseRedirect.mockClear();
   });
 
-  it.each(["/api/health/core", "/api/health/trigger-agent-mode"])(
-    "bypasses AuthKit for the health endpoint %s",
-    async (pathname) => {
-      const { default: proxy } = await import("../proxy");
+  it.each([
+    "/api/health/connectivity",
+    "/api/health/core",
+    "/api/health/trigger-agent-mode",
+  ])("bypasses AuthKit for the health endpoint %s", async (pathname) => {
+    const { default: proxy } = await import("../proxy");
 
-      const response = await proxy(
-        createRequest({
-          pathname,
-          hasSession: true,
-        }),
-      );
+    const response = await proxy(
+      createRequest({
+        pathname,
+        hasSession: true,
+      }),
+    );
 
-      expect(response).toMatchObject({ kind: "next" });
-      expect(mockAuthkit).not.toHaveBeenCalled();
-      expect(mockNextResponseNext).toHaveBeenCalledWith();
-      expect(mockNextResponseJson).not.toHaveBeenCalled();
-      expect(mockNextResponseRedirect).not.toHaveBeenCalled();
-    },
-  );
+    expect(response).toMatchObject({ kind: "next" });
+    expect(mockAuthkit).not.toHaveBeenCalled();
+    expect(mockNextResponseNext).toHaveBeenCalledWith();
+    expect(mockNextResponseJson).not.toHaveBeenCalled();
+    expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+  });
 
   it.each(["/robots.txt", "/sitemap.xml"])(
     "bypasses AuthKit for the public SEO route %s",

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -101,6 +101,7 @@ const UnauthenticatedContent = () => {
               placeholder={animatedPlaceholder}
               autoFocus={false}
               restoreDraftAttachments={false}
+              offlineProtection={false}
             />
           </div>
         </div>

--- a/app/api/health/connectivity/__tests__/route.test.ts
+++ b/app/api/health/connectivity/__tests__/route.test.ts
@@ -1,0 +1,44 @@
+import { HEAD } from "../route";
+import { afterAll, beforeAll } from "@jest/globals";
+
+const originalResponse = globalThis.Response;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "Response", {
+    configurable: true,
+    value: class TestResponse {
+      status: number;
+      headers: Headers;
+
+      constructor(_body: BodyInit | null, init?: ResponseInit) {
+        this.status = init?.status ?? 200;
+        this.headers = new Headers(init?.headers);
+      }
+
+      async text() {
+        return "";
+      }
+    },
+  });
+});
+
+afterAll(() => {
+  if (originalResponse) {
+    Object.defineProperty(globalThis, "Response", {
+      configurable: true,
+      value: originalResponse,
+    });
+  } else {
+    Reflect.deleteProperty(globalThis, "Response");
+  }
+});
+
+describe("HEAD /api/health/connectivity", () => {
+  it("returns a non-cacheable empty success response", async () => {
+    const response = await HEAD();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.text()).toBe("");
+  });
+});

--- a/app/api/health/connectivity/route.ts
+++ b/app/api/health/connectivity/route.ts
@@ -1,0 +1,11 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function HEAD() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -41,6 +41,8 @@ import {
   useAgentApproval,
 } from "@/app/contexts/AgentApprovalContext";
 import { PASTED_TEXT_INLINE_RESTORE_MAX_CHARS } from "@/lib/utils/pasted-text-attachments";
+import { useOnlineStatus } from "@/app/hooks/useOnlineStatus";
+import { WifiOff } from "lucide-react";
 
 interface ChatInputProps {
   onSubmit: (e: React.FormEvent) => void | boolean | Promise<void | boolean>;
@@ -218,6 +220,7 @@ export const ChatInput = ({
   } = useGlobalState();
   const input = useComposerInput();
   const { setInput } = useComposerActions();
+  const isOnline = useOnlineStatus();
   const {
     fileInputRef,
     handleFileUploadEvent,
@@ -565,6 +568,8 @@ export const ChatInput = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isOnline) return;
+
     const canSubmit =
       (status === "ready" || status === "streaming") &&
       !isUploadingFiles &&
@@ -599,6 +604,24 @@ export const ChatInput = ({
   return (
     <div className={`relative px-4 min-w-0 ${isCentered ? "" : "pb-3"}`}>
       <div className="mx-auto w-full max-w-full min-w-0 sm:max-w-[768px] sm:min-w-[390px] flex flex-col flex-1">
+        {!isOnline && (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="offline-status"
+            className="mb-2 flex items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
+          >
+            <WifiOff
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+            />
+            <p>
+              You&apos;re offline. Keep typing—this draft will stay on this
+              device, and Send will be available when you reconnect.
+            </p>
+          </div>
+        )}
+
         {rateLimitWarning && onDismissRateLimitWarning && (
           <RateLimitWarning
             data={rateLimitWarning}
@@ -673,6 +696,7 @@ export const ChatInput = ({
               input={input}
               uploadedFiles={uploadedFiles}
               chatMode={chatMode}
+              isOnline={isOnline}
             />
           </div>
         )}

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -64,6 +64,7 @@ interface ChatInputProps {
   autoFocus?: boolean;
   restoreDraftAttachments?: boolean;
   storedApprovalRequest?: ActiveAgentToolApprovalRequest | null;
+  offlineProtection?: boolean;
 }
 
 const isBrowserFile = (file: UploadedFileState["file"]): file is File =>
@@ -196,6 +197,7 @@ export const ChatInput = ({
   autoFocus,
   restoreDraftAttachments = true,
   storedApprovalRequest,
+  offlineProtection = true,
 }: ChatInputProps) => {
   const {
     chatMode,
@@ -221,6 +223,7 @@ export const ChatInput = ({
   const input = useComposerInput();
   const { setInput } = useComposerActions();
   const isOnline = useOnlineStatus();
+  const isOffline = offlineProtection && !isOnline;
   const {
     fileInputRef,
     handleFileUploadEvent,
@@ -568,7 +571,7 @@ export const ChatInput = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!isOnline) return;
+    if (isOffline) return;
 
     const canSubmit =
       (status === "ready" || status === "streaming") &&
@@ -604,7 +607,7 @@ export const ChatInput = ({
   return (
     <div className={`relative px-4 min-w-0 ${isCentered ? "" : "pb-3"}`}>
       <div className="mx-auto w-full max-w-full min-w-0 sm:max-w-[768px] sm:min-w-[390px] flex flex-col flex-1">
-        {!isOnline && (
+        {isOffline && (
           <div
             role="status"
             aria-live="polite"
@@ -696,7 +699,7 @@ export const ChatInput = ({
               input={input}
               uploadedFiles={uploadedFiles}
               chatMode={chatMode}
-              isOnline={isOnline}
+              isOnline={!isOffline}
             />
           </div>
         )}

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -41,13 +41,17 @@ import {
   useAgentApproval,
 } from "@/app/contexts/AgentApprovalContext";
 import { PASTED_TEXT_INLINE_RESTORE_MAX_CHARS } from "@/lib/utils/pasted-text-attachments";
-import { useOnlineStatus } from "@/app/hooks/useOnlineStatus";
+import {
+  reconnectOnlineStatus,
+  useOnlineStatus,
+} from "@/app/hooks/useOnlineStatus";
 import { WifiOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface ChatInputProps {
   onSubmit: (e: React.FormEvent) => void | boolean | Promise<void | boolean>;
   onStop: () => void | boolean | Promise<void | boolean>;
-  onReconnect?: () => void;
+  onReconnect?: () => void | Promise<void>;
   onSendNow: (messageId: string) => void;
   status: ChatStatus;
   isCentered?: boolean;
@@ -237,6 +241,7 @@ export const ChatInput = ({
   const isAgent = isAgentMode(chatMode);
   const approvalRequest = activeToolApprovalRequest ?? storedApprovalRequest;
   const [isStoppingAgent, setIsStoppingAgent] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const showAgentApprovalPrompt = !!approvalRequest && !isStoppingAgent;
 
   useEffect(() => {
@@ -587,6 +592,28 @@ export const ChatInput = ({
     }
   };
 
+  const handleOfflineReconnect = async () => {
+    if (isReconnecting) return;
+
+    setIsReconnecting(true);
+    try {
+      const reconnected = await reconnectOnlineStatus();
+      if (!reconnected) {
+        toast.info("Still offline", {
+          description: "Check your connection, then try reconnecting again.",
+        });
+        return;
+      }
+      await onReconnect?.();
+    } catch {
+      toast.error("Could not reconnect the chat", {
+        description: "Your draft is still saved. Please try again.",
+      });
+    } finally {
+      setIsReconnecting(false);
+    }
+  };
+
   const handleShowGeneratedTextInField = async (
     index: number,
     content: string,
@@ -612,16 +639,28 @@ export const ChatInput = ({
             role="status"
             aria-live="polite"
             data-testid="offline-status"
-            className="mb-2 flex items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
+            className="mb-2 flex flex-col gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-foreground sm:flex-row sm:items-center"
           >
-            <WifiOff
-              aria-hidden="true"
-              className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
-            />
-            <p>
-              You&apos;re offline. Keep typing—this draft will stay on this
-              device, and Send will be available when you reconnect.
-            </p>
+            <div className="flex min-w-0 flex-1 items-start gap-2">
+              <WifiOff
+                aria-hidden="true"
+                className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+              />
+              <p>
+                You&apos;re offline. Keep typing—this draft will stay on this
+                device.
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full shrink-0 sm:w-auto"
+              disabled={isReconnecting}
+              onClick={() => void handleOfflineReconnect()}
+            >
+              {isReconnecting ? "Reconnecting..." : "Reconnect"}
+            </Button>
           </div>
         )}
 

--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -19,6 +19,7 @@ export interface ChatInputToolbarProps extends SubmitStopButtonProps {
 export function ChatInputToolbar({
   onAttachClick,
   chatMode,
+  isOnline = true,
   ...submitStopProps
 }: ChatInputToolbarProps) {
   const {
@@ -33,7 +34,7 @@ export function ChatInputToolbar({
   return (
     <div className="px-3 flex gap-2 items-center min-w-0">
       <div className="shrink-0">
-        <AttachmentButton onAttachClick={onAttachClick} />
+        <AttachmentButton onAttachClick={onAttachClick} disabled={!isOnline} />
       </div>
       {chatModeAccessResolved && !paidAgentOnlyActive ? (
         <ChatModeSelector />
@@ -55,6 +56,7 @@ export function ChatInputToolbar({
           {...submitStopProps}
           chatMode={chatMode}
           isPaid={subscription !== "free"}
+          isOnline={isOnline}
         />
       </div>
     </div>

--- a/app/components/ChatInput/SubmitStopButton.tsx
+++ b/app/components/ChatInput/SubmitStopButton.tsx
@@ -43,9 +43,11 @@ function getSubmitButtonVariantClasses(
 }
 
 function getSendButtonTooltip(
+  isOnline: boolean,
   hasFileErrors: boolean,
   isUploading: boolean,
 ): string {
+  if (!isOnline) return "Reconnect to send";
   if (hasFileErrors) return "Remove failed files to send";
   if (isUploading) return "File upload pending";
   return "Send (⏎)";
@@ -62,6 +64,7 @@ export interface SubmitStopButtonProps {
   uploadedFiles: UploadedFileState[];
   chatMode: ChatMode;
   isPaid?: boolean;
+  isOnline?: boolean;
 }
 
 export function SubmitStopButton({
@@ -75,6 +78,7 @@ export function SubmitStopButton({
   uploadedFiles,
   chatMode,
   isPaid = false,
+  isOnline = true,
 }: SubmitStopButtonProps) {
   useHotkeys(
     "ctrl+c",
@@ -126,6 +130,7 @@ export function SubmitStopButton({
               <Button
                 type="submit"
                 disabled={
+                  !isOnline ||
                   status !== "ready" ||
                   isUploadingFiles ||
                   (!input.trim() && uploadedFiles.length === 0)
@@ -142,6 +147,7 @@ export function SubmitStopButton({
           <TooltipContent>
             <p>
               {getSendButtonTooltip(
+                isOnline,
                 uploadedFiles.some((f) => f.error),
                 isUploadingFiles,
               )}

--- a/app/components/ChatInput/__tests__/SubmitStopButton.test.tsx
+++ b/app/components/ChatInput/__tests__/SubmitStopButton.test.tsx
@@ -36,6 +36,16 @@ function renderButton(
 }
 
 describe("SubmitStopButton paid mode colors", () => {
+  it("disables sending while offline without hiding the composer action", () => {
+    render(
+      <TooltipProvider>
+        <SubmitStopButton {...defaultProps} chatMode="ask" isOnline={false} />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByLabelText("Send message")).toBeDisabled();
+  });
+
   it("uses the default submit treatment for paid Agent mode", () => {
     const button = renderButton("agent", true);
 

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -233,6 +233,27 @@ describe("ChatInput - Integration Tests", () => {
       expect(screen.getByLabelText("Send message")).toBeEnabled();
     });
 
+    it("does not show authenticated-chat offline UI when protection is disabled", () => {
+      setNavigatorOnline(false);
+
+      render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            offlineProtection={false}
+          />
+        </TestWrapper>,
+      );
+
+      const input = screen.getByPlaceholderText("Ask, learn, brainstorm");
+      fireEvent.change(input, { target: { value: "Start from landing page" } });
+
+      expect(screen.queryByTestId("offline-status")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Send message")).toBeEnabled();
+    });
+
     it("restores an unavailable pasted-text attachment into the Ask field", async () => {
       const pastedContent = "Source material restored from the attachment";
       const uploadedFile: UploadedFileState = {

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -19,6 +19,7 @@ import type { UploadedFileState } from "@/types/file";
 const mockUseQuery = jest.fn(() => undefined);
 const mockReadGeneratedTextAttachment = jest.fn();
 const mockHandleRemoveFile = jest.fn();
+const mockFetch = jest.fn();
 
 const setNavigatorOnline = (isOnline: boolean) => {
   Object.defineProperty(navigator, "onLine", {
@@ -143,6 +144,13 @@ describe("ChatInput - Integration Tests", () => {
     mockUseQuery.mockReset();
     mockUseQuery.mockReturnValue(undefined);
     mockReadGeneratedTextAttachment.mockReset();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: mockFetch,
+    });
     window.localStorage.clear();
     setNavigatorOnline(true);
   });
@@ -198,6 +206,7 @@ describe("ChatInput - Integration Tests", () => {
           <ChatInput
             onSubmit={mockOnSubmit}
             onStop={mockOnStop}
+            onReconnect={mockOnReconnect}
             status="ready"
             isNewChat
           />
@@ -224,13 +233,49 @@ describe("ChatInput - Integration Tests", () => {
         expect(getDraftAttachmentsById("new")).toHaveLength(1);
       });
 
-      act(() => {
-        setNavigatorOnline(true);
-        window.dispatchEvent(new Event("online"));
-      });
+      fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
 
-      expect(screen.queryByTestId("offline-status")).not.toBeInTheDocument();
-      expect(screen.getByLabelText("Send message")).toBeEnabled();
+      await waitFor(() => {
+        expect(screen.queryByTestId("offline-status")).not.toBeInTheDocument();
+        expect(screen.getByLabelText("Send message")).toBeEnabled();
+      });
+      expect(mockFetch).toHaveBeenCalledWith("/api/health/connectivity", {
+        method: "HEAD",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+      expect(mockOnReconnect).toHaveBeenCalledTimes(1);
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+      expect(input).toHaveValue("Preserve this draft");
+    });
+
+    it("keeps the draft blocked when reconnect cannot reach HackerAI", async () => {
+      setNavigatorOnline(false);
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            onReconnect={mockOnReconnect}
+            status="ready"
+            isNewChat
+          />
+        </TestWrapper>,
+      );
+
+      const input = screen.getByPlaceholderText("Ask, learn, brainstorm");
+      fireEvent.change(input, { target: { value: "Keep this safe" } });
+      fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("offline-status")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Reconnect" })).toBeEnabled();
+      });
+      expect(screen.getByLabelText("Send message")).toBeDisabled();
+      expect(input).toHaveValue("Keep this safe");
+      expect(mockOnReconnect).not.toHaveBeenCalled();
     });
 
     it("does not show authenticated-chat offline UI when protection is disabled", () => {

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -252,6 +252,9 @@ describe("ChatInput - Integration Tests", () => {
 
       expect(screen.queryByTestId("offline-status")).not.toBeInTheDocument();
       expect(screen.getByLabelText("Send message")).toBeEnabled();
+
+      fireEvent.click(screen.getByLabelText("Send message"));
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
     });
 
     it("restores an unavailable pasted-text attachment into the Ask field", async () => {

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -9,12 +9,23 @@ import {
 } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ReactNode, useEffect } from "react";
-import { CONVERSATION_DRAFTS_STORAGE_KEY } from "@/lib/utils/client-storage";
+import {
+  CONVERSATION_DRAFTS_STORAGE_KEY,
+  getDraftAttachmentsById,
+  getDraftContentById,
+} from "@/lib/utils/client-storage";
 import type { UploadedFileState } from "@/types/file";
 
 const mockUseQuery = jest.fn(() => undefined);
 const mockReadGeneratedTextAttachment = jest.fn();
 const mockHandleRemoveFile = jest.fn();
+
+const setNavigatorOnline = (isOnline: boolean) => {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value: isOnline,
+  });
+};
 
 // Mock only external dependencies, not contexts
 jest.mock("react-hotkeys-hook", () => ({
@@ -133,6 +144,7 @@ describe("ChatInput - Integration Tests", () => {
     mockUseQuery.mockReturnValue(undefined);
     mockReadGeneratedTextAttachment.mockReset();
     window.localStorage.clear();
+    setNavigatorOnline(true);
   });
 
   describe("Ask Mode Integration", () => {
@@ -168,6 +180,57 @@ describe("ChatInput - Integration Tests", () => {
       expect(
         screen.queryByLabelText("Stop generation"),
       ).not.toBeInTheDocument();
+    });
+
+    it("keeps the draft and attachments while offline, then enables send after reconnect", async () => {
+      const uploadedFile: UploadedFileState = {
+        file: new File(["evidence"], "evidence.txt", { type: "text/plain" }),
+        uploading: false,
+        uploaded: true,
+        storage: "s3",
+        fileId: "file_evidence",
+      };
+      setNavigatorOnline(false);
+
+      render(
+        <TestWrapper>
+          <UploadedFilesSetter files={[uploadedFile]} label="Add evidence" />
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            isNewChat
+          />
+        </TestWrapper>,
+      );
+
+      fireEvent.click(screen.getByText("Add evidence"));
+      const input = screen.getByPlaceholderText("Ask, learn, brainstorm");
+      fireEvent.change(input, { target: { value: "Preserve this draft" } });
+
+      expect(screen.getByTestId("offline-status")).toHaveTextContent(
+        "You're offline",
+      );
+      expect(screen.getByLabelText("Send message")).toBeDisabled();
+      expect(screen.getByText("evidence.txt")).toBeInTheDocument();
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+      expect(input).toHaveValue("Preserve this draft");
+      expect(screen.getByText("evidence.txt")).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(getDraftContentById("new")).toBe("Preserve this draft");
+        expect(getDraftAttachmentsById("new")).toHaveLength(1);
+      });
+
+      act(() => {
+        setNavigatorOnline(true);
+        window.dispatchEvent(new Event("online"));
+      });
+
+      expect(screen.queryByTestId("offline-status")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Send message")).toBeEnabled();
     });
 
     it("restores an unavailable pasted-text attachment into the Ask field", async () => {

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -243,6 +243,7 @@ describe("ChatInput - Integration Tests", () => {
         method: "HEAD",
         cache: "no-store",
         credentials: "same-origin",
+        signal: expect.any(AbortSignal),
       });
       expect(mockOnReconnect).toHaveBeenCalledTimes(1);
       expect(mockOnSubmit).not.toHaveBeenCalled();

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -12,6 +12,8 @@ const mockSendMessage = jest.fn(async () => undefined);
 const mockStop = jest.fn();
 const mockSetMessages = jest.fn();
 const mockSetTodos = jest.fn();
+const mockClearInput = jest.fn();
+const mockClearUploadedFiles = jest.fn();
 let mockInput = "";
 
 const todos: Todo[] = [
@@ -56,8 +58,8 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     getInput: () => mockInput,
     uploadedFiles: [],
     chatMode: "agent",
-    clearInput: jest.fn(),
-    clearUploadedFiles: jest.fn(),
+    clearInput: mockClearInput,
+    clearUploadedFiles: mockClearUploadedFiles,
     todos,
     setTodos: mockSetTodos,
     isUploadingFiles: false,
@@ -119,6 +121,10 @@ describe("useChatHandlers steer todo handoff", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockInput = "";
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(globalThis, "fetch", {
       configurable: true,
       value: jest.fn(async () => ({ ok: true, status: 200 }) as Response),
@@ -240,6 +246,40 @@ describe("useChatHandlers steer todo handoff", () => {
     expect(mockQueueMessage).toHaveBeenCalledWith("Use the latest result", []);
     expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not send or clear the composer when connectivity drops before submission", async () => {
+    mockInput = "Keep this unsent draft";
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate: jest.fn(),
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+      }),
+    );
+
+    let accepted: boolean | undefined;
+    await act(async () => {
+      accepted = await result.current.handleSubmit({
+        preventDefault: jest.fn(),
+      } as unknown as React.FormEvent);
+    });
+
+    expect(accepted).toBe(false);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockClearInput).not.toHaveBeenCalled();
+    expect(mockClearUploadedFiles).not.toHaveBeenCalled();
   });
 
   it("sends a queued message after the stream has already stopped", async () => {

--- a/app/hooks/__tests__/useOnlineStatus.test.ts
+++ b/app/hooks/__tests__/useOnlineStatus.test.ts
@@ -25,6 +25,7 @@ describe("useOnlineStatus", () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     act(() => {
       setNavigatorOnline(true);
       window.dispatchEvent(new Event("online"));
@@ -76,6 +77,7 @@ describe("useOnlineStatus", () => {
       method: "HEAD",
       cache: "no-store",
       credentials: "same-origin",
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -93,5 +95,40 @@ describe("useOnlineStatus", () => {
 
     expect(reconnected).toBe(false);
     expect(result.current).toBe(false);
+  });
+
+  it("times out a hung probe and allows a later reconnect", async () => {
+    jest.useFakeTimers();
+    setNavigatorOnline(false);
+    (globalThis.fetch as jest.Mock).mockImplementationOnce(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    const { result } = renderHook(() => useOnlineStatus());
+
+    let timedOutReconnect: Promise<boolean>;
+    act(() => {
+      timedOutReconnect = reconnectOnlineStatus();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+      expect(await timedOutReconnect).toBe(false);
+    });
+
+    expect(result.current).toBe(false);
+    expect(
+      (globalThis.fetch as jest.Mock).mock.calls[0]?.[1]?.signal.aborted,
+    ).toBe(true);
+
+    (globalThis.fetch as jest.Mock).mockResolvedValueOnce({ ok: true });
+    await act(async () => {
+      await expect(reconnectOnlineStatus()).resolves.toBe(true);
+    });
+
+    expect(result.current).toBe(true);
   });
 });

--- a/app/hooks/__tests__/useOnlineStatus.test.ts
+++ b/app/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
-import { useOnlineStatus } from "../useOnlineStatus";
+import { afterEach, beforeEach, jest } from "@jest/globals";
+import { reconnectOnlineStatus, useOnlineStatus } from "../useOnlineStatus";
 
 const setNavigatorOnline = (isOnline: boolean) => {
   Object.defineProperty(navigator, "onLine", {
@@ -13,13 +14,31 @@ describe("useOnlineStatus", () => {
     navigator,
     "onLine",
   );
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+  });
 
   afterEach(() => {
+    act(() => {
+      setNavigatorOnline(true);
+      window.dispatchEvent(new Event("online"));
+    });
     if (originalOnlineDescriptor) {
       Object.defineProperty(navigator, "onLine", originalOnlineDescriptor);
     } else {
       Reflect.deleteProperty(navigator, "onLine");
     }
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
   });
 
   it("tracks browser offline and online events", () => {
@@ -39,5 +58,40 @@ describe("useOnlineStatus", () => {
       window.dispatchEvent(new Event("online"));
     });
     expect(result.current).toBe(true);
+  });
+
+  it("marks the browser online after the reconnect probe succeeds", async () => {
+    setNavigatorOnline(false);
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const { result } = renderHook(() => useOnlineStatus());
+
+    let reconnected = false;
+    await act(async () => {
+      reconnected = await reconnectOnlineStatus();
+    });
+
+    expect(reconnected).toBe(true);
+    expect(result.current).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/health/connectivity", {
+      method: "HEAD",
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+  });
+
+  it("stays offline when the reconnect probe fails", async () => {
+    setNavigatorOnline(false);
+    (globalThis.fetch as jest.Mock).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+    const { result } = renderHook(() => useOnlineStatus());
+
+    let reconnected = true;
+    await act(async () => {
+      reconnected = await reconnectOnlineStatus();
+    });
+
+    expect(reconnected).toBe(false);
+    expect(result.current).toBe(false);
   });
 });

--- a/app/hooks/__tests__/useOnlineStatus.test.ts
+++ b/app/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,43 @@
+import { act, renderHook } from "@testing-library/react";
+import { useOnlineStatus } from "../useOnlineStatus";
+
+const setNavigatorOnline = (isOnline: boolean) => {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value: isOnline,
+  });
+};
+
+describe("useOnlineStatus", () => {
+  const originalOnlineDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "onLine",
+  );
+
+  afterEach(() => {
+    if (originalOnlineDescriptor) {
+      Object.defineProperty(navigator, "onLine", originalOnlineDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "onLine");
+    }
+  });
+
+  it("tracks browser offline and online events", () => {
+    setNavigatorOnline(true);
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(true);
+
+    act(() => {
+      setNavigatorOnline(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setNavigatorOnline(true);
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -323,6 +323,15 @@ export const useChatHandlers = ({
     // value out of this hook prevents each keystroke from rerendering Chat.
     const input = getInput();
 
+    // The visible composer normally blocks this path while offline. Check the
+    // browser snapshot again here so a connectivity race cannot clear a draft.
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      toast.info("You're offline", {
+        description: "Your draft is saved. Reconnect before sending.",
+      });
+      return false;
+    }
+
     setIsAutoResuming(false);
 
     // Reset manual stop flag when user submits a new message

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -23,6 +23,7 @@ import { getInputTokenLimitStatus } from "@/lib/utils/client-token-validation";
 import { toast } from "sonner";
 import { removeTodosBySourceMessages } from "@/lib/utils/todo-utils";
 import { useDataStreamDispatch } from "@/app/components/DataStreamProvider";
+import { getOnlineStatusSnapshot } from "@/app/hooks/useOnlineStatus";
 import { AUTO_CONTINUE_PROMPT } from "@/app/hooks/useAutoContinue";
 import { normalizeMessages } from "@/lib/utils/message-processor";
 import {
@@ -325,7 +326,7 @@ export const useChatHandlers = ({
 
     // The visible composer normally blocks this path while offline. Check the
     // browser snapshot again here so a connectivity race cannot clear a draft.
-    if (typeof navigator !== "undefined" && !navigator.onLine) {
+    if (!getOnlineStatusSnapshot()) {
       toast.info("You're offline", {
         description: "Your draft is saved. Reconnect before sending.",
       });

--- a/app/hooks/useOnlineStatus.ts
+++ b/app/hooks/useOnlineStatus.ts
@@ -2,23 +2,61 @@
 
 import { useSyncExternalStore } from "react";
 
-const getOnlineSnapshot = () =>
+const listeners = new Set<() => void>();
+let verifiedOnlineOverride: boolean | null = null;
+
+const getBrowserOnlineSnapshot = () =>
   typeof navigator === "undefined" ? true : navigator.onLine;
 
+export const getOnlineStatusSnapshot = () =>
+  verifiedOnlineOverride ?? getBrowserOnlineSnapshot();
+
+const emitOnlineStatusChange = () => {
+  listeners.forEach((listener) => listener());
+};
+
+const handleBrowserOnlineStatusChange = () => {
+  verifiedOnlineOverride = null;
+  emitOnlineStatusChange();
+};
+
 const subscribeToOnlineStatus = (onStoreChange: () => void) => {
-  window.addEventListener("online", onStoreChange);
-  window.addEventListener("offline", onStoreChange);
+  listeners.add(onStoreChange);
+  if (listeners.size === 1) {
+    window.addEventListener("online", handleBrowserOnlineStatusChange);
+    window.addEventListener("offline", handleBrowserOnlineStatusChange);
+  }
 
   return () => {
-    window.removeEventListener("online", onStoreChange);
-    window.removeEventListener("offline", onStoreChange);
+    listeners.delete(onStoreChange);
+    if (listeners.size === 0) {
+      window.removeEventListener("online", handleBrowserOnlineStatusChange);
+      window.removeEventListener("offline", handleBrowserOnlineStatusChange);
+      verifiedOnlineOverride = null;
+    }
   };
 };
+
+export async function reconnectOnlineStatus(): Promise<boolean> {
+  try {
+    const response = await fetch("/api/health/connectivity", {
+      method: "HEAD",
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    verifiedOnlineOverride = response.ok;
+  } catch {
+    verifiedOnlineOverride = false;
+  }
+
+  emitOnlineStatusChange();
+  return verifiedOnlineOverride;
+}
 
 export function useOnlineStatus(): boolean {
   return useSyncExternalStore(
     subscribeToOnlineStatus,
-    getOnlineSnapshot,
+    getOnlineStatusSnapshot,
     () => true,
   );
 }

--- a/app/hooks/useOnlineStatus.ts
+++ b/app/hooks/useOnlineStatus.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const getOnlineSnapshot = () =>
+  typeof navigator === "undefined" ? true : navigator.onLine;
+
+const subscribeToOnlineStatus = (onStoreChange: () => void) => {
+  window.addEventListener("online", onStoreChange);
+  window.addEventListener("offline", onStoreChange);
+
+  return () => {
+    window.removeEventListener("online", onStoreChange);
+    window.removeEventListener("offline", onStoreChange);
+  };
+};
+
+export function useOnlineStatus(): boolean {
+  return useSyncExternalStore(
+    subscribeToOnlineStatus,
+    getOnlineSnapshot,
+    () => true,
+  );
+}

--- a/app/hooks/useOnlineStatus.ts
+++ b/app/hooks/useOnlineStatus.ts
@@ -4,6 +4,7 @@ import { useSyncExternalStore } from "react";
 
 const listeners = new Set<() => void>();
 let verifiedOnlineOverride: boolean | null = null;
+const CONNECTIVITY_PROBE_TIMEOUT_MS = 5_000;
 
 const getBrowserOnlineSnapshot = () =>
   typeof navigator === "undefined" ? true : navigator.onLine;
@@ -38,15 +39,24 @@ const subscribeToOnlineStatus = (onStoreChange: () => void) => {
 };
 
 export async function reconnectOnlineStatus(): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    CONNECTIVITY_PROBE_TIMEOUT_MS,
+  );
+
   try {
     const response = await fetch("/api/health/connectivity", {
       method: "HEAD",
       cache: "no-store",
       credentials: "same-origin",
+      signal: controller.signal,
     });
     verifiedOnlineOverride = response.ok;
   } catch {
     verifiedOnlineOverride = false;
+  } finally {
+    clearTimeout(timeout);
   }
 
   emitOnlineStatusChange();

--- a/proxy.ts
+++ b/proxy.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/referrals/config";
 
 const AUTHKIT_BYPASS_PATHS = new Set([
+  "/api/health/connectivity",
   "/api/health/core",
   "/api/health/trigger-agent-mode",
   "/robots.txt",


### PR DESCRIPTION
## What changed

- Track browser connectivity with a shared `useSyncExternalStore` hook.
- Show a persistent offline state above the composer while keeping the textarea editable.
- Disable Send and new file uploads while offline.
- Re-check the shared connectivity snapshot at the submission boundary so a connectivity race cannot clear text or attachments.
- Add an explicit **Reconnect** action that performs a non-cacheable same-origin HEAD probe, then re-enables Send and attaches to any existing stream only after the probe succeeds.
- Abort a hung reconnect probe after five seconds so the action always becomes available again.
- Keep the logged-out landing composer unchanged; offline protection is enabled only for authenticated chat surfaces.
- Keep paid-run retries explicit; reconnect never submits the draft or starts a replacement run.

## Why

Customer-specific telemetry contained 18 frontend `TypeError: Failed to fetch` exceptions: 16 reported `navigator.onLine=false`, while the other two reported online state from hidden tabs. This distinguishes the dominant failure mode as browser connectivity and does not establish a server outage.

Before this change, the composer remained sendable offline and cleared text and attachments immediately after launching the send action. Blocking known-offline submissions keeps drafts safe. The reconnect probe is safe and idempotent: it checks only HackerAI's web origin and uses the existing GET-based stream resume path. Automatic replacement runs remain intentionally excluded because they cannot be guaranteed duplicate-free.

## Validation

- Focused Jest coverage for connectivity events, successful, failed, and timed-out reconnect probes, timeout recovery, offline text/attachment preservation, disabled Send, the no-submit guarantee, the health endpoint/AuthKit bypass, and the submission-boundary race (58 tests passed).
- `pnpm typecheck`.
- Targeted ESLint for all changed files.
- Full `pnpm test` (321 suites, 3210 tests passed).
- Playwright browser verification at 1440×900 and 390×844 using the production `ChatInput` under the authenticated-chat offline configuration: the banner and responsive Reconnect action rendered, Send stayed disabled, the draft persisted in local storage, and a successful probe removed the banner without clearing or submitting the draft.

## Manual verification

1. Open a new task and type a message; attach an already-uploaded file if available.
2. In browser DevTools, set Network to **Offline**.
3. Confirm the persistent offline notice and **Reconnect** action appear, the textarea remains editable, Send and Attach are disabled, and pressing Enter does not clear or submit the draft.
4. Click **Reconnect** while still offline. Confirm the notice remains and the draft is unchanged.
5. Restore Network to **Online**.
6. Confirm the notice disappears, Send re-enables, and the original text and attachment remain ready to send.
7. For a successful explicit-probe check, force `navigator.onLine` to remain false while leaving requests enabled, dispatch an `offline` event, then click **Reconnect**. Confirm the notice disappears and no message is submitted.
8. For an interrupted response, confirm **Reconnect** attaches to the existing stream and **Retry** remains an explicit user action.
9. Sign out, toggle DevTools Network to **Offline**, and confirm the landing composer does not show the authenticated-chat offline notice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added online/offline status detection for chat composition.
  * Displays accessible offline status, reconnect guidance, and feedback.
  * Preserves drafts and uploaded attachments while offline.
  * Automatically re-enables sending after connectivity is restored.
  * Added configurable offline protection for chat input.

* **Bug Fixes**
  * Prevented message submission and attachment uploads while offline.
  * Offline attempts no longer clear drafts or uploaded files.
  * Unprotected chat experiences continue to allow offline composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->