### PR TITLE
Add chat message navigator

### DIFF
--- a/app/components/MessageNavigator.tsx
+++ b/app/components/MessageNavigator.tsx
@@ -251,11 +251,11 @@ export const MessageNavigator = memo(function MessageNavigator({
                 className={cn(
                   "pointer-events-none absolute left-0 h-0.5 -translate-y-1/2 rounded-full bg-muted-foreground/35 transition-[background-color,width] duration-150 data-[in-view=true]:bg-foreground/90",
                   activeDistance === 0
-                    ? "w-6 bg-muted-foreground/75"
+                    ? "w-7 bg-muted-foreground/75"
                     : activeDistance === 1
-                      ? "w-4"
+                      ? "w-[22px]"
                       : activeDistance === 2
-                        ? "w-2.5"
+                        ? "w-3.5"
                         : "w-2",
                 )}
                 data-in-view="false"

--- a/app/components/MessageNavigator.tsx
+++ b/app/components/MessageNavigator.tsx
@@ -17,7 +17,6 @@ import {
   resolveMessageNavigatorHeightStyle,
   resolveMessageNavigatorHitStripWidth,
   resolveMessageNavigatorIndexFromPointer,
-  resolveMessageNavigatorInteractiveWidth,
   resolveMessageNavigatorTopPercent,
   type MessageNavigatorItem,
 } from "./message-navigator";
@@ -27,10 +26,6 @@ interface MessageNavigatorProps {
   scrollElement: HTMLElement | null;
   onSelect: (item: MessageNavigatorItem) => void;
 }
-
-const eventTargetsPreview = (target: EventTarget) =>
-  target instanceof Element &&
-  target.closest("[data-message-navigator-preview]") !== null;
 
 export const MessageNavigator = memo(function MessageNavigator({
   items,
@@ -207,10 +202,6 @@ export const MessageNavigator = memo(function MessageNavigator({
           )}
           onBlur={() => setActiveIndex(null)}
           onClick={(event) => {
-            if (eventTargetsPreview(event.target)) {
-              return;
-            }
-
             const nextIndex = resolveActiveIndexFromPointer(event);
             const nextItem =
               nextIndex === null ? null : (items[nextIndex] ?? null);
@@ -222,9 +213,7 @@ export const MessageNavigator = memo(function MessageNavigator({
           onFocus={() => setActiveIndex((current) => current ?? 0)}
           onKeyDown={handleKeyDown}
           onMouseDown={(event) => {
-            if (!eventTargetsPreview(event.target)) {
-              event.preventDefault();
-            }
+            event.preventDefault();
           }}
           onMouseLeave={() => setActiveIndex(null)}
           onMouseMove={(event) => {
@@ -232,10 +221,7 @@ export const MessageNavigator = memo(function MessageNavigator({
           }}
           style={{
             height: resolveMessageNavigatorHeightStyle(items.length),
-            width: resolveMessageNavigatorInteractiveWidth(
-              hitStripWidth,
-              activeItem !== null,
-            ),
+            width: hitStripWidth,
           }}
         >
           {items.map((item, index) => {
@@ -276,10 +262,9 @@ export const MessageNavigator = memo(function MessageNavigator({
 
           {activeItem ? (
             <span
-              className="pointer-events-auto absolute left-8 w-80 cursor-text select-text"
+              className="pointer-events-none absolute left-8 w-80"
               data-message-navigator-preview
               data-testid="message-navigator-preview"
-              onMouseMove={(event) => event.stopPropagation()}
               style={{
                 top: `${activeTopPercent}%`,
                 transform: `translateY(${activePreviewTranslate})`,

--- a/app/components/MessageNavigator.tsx
+++ b/app/components/MessageNavigator.tsx
@@ -189,7 +189,7 @@ export const MessageNavigator = memo(function MessageNavigator({
   return (
     <div
       className={cn(
-        "group/message-navigator pointer-events-none absolute inset-y-0 left-0 z-30 hidden w-[72px] [@media(pointer:fine)]:block",
+        "group/message-navigator pointer-events-none absolute inset-y-0 left-0 z-40 hidden w-[72px] [@media(pointer:fine)]:block",
         hasPersistentGutter
           ? "opacity-100"
           : "opacity-0 transition-opacity duration-150 hover:opacity-100 focus-within:opacity-100",
@@ -238,7 +238,7 @@ export const MessageNavigator = memo(function MessageNavigator({
             ),
           }}
         >
-          <span className="absolute top-0 left-3 h-full w-px bg-border/20" />
+          <span className="absolute top-0 left-3 h-full w-px bg-border/15" />
           {items.map((item, index) => {
             const activeDistance =
               resolvedActiveIndex === null
@@ -286,7 +286,7 @@ export const MessageNavigator = memo(function MessageNavigator({
                 transform: `translateY(${activePreviewTranslate})`,
               }}
             >
-              <span className="block rounded-xl border border-border/60 bg-popover/95 p-3 text-left text-popover-foreground shadow-xl shadow-black/25 backdrop-blur-md">
+              <span className="message-navigator-preview-glass block rounded-xl p-3 text-left text-popover-foreground">
                 <span className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium leading-5">
                   {activeItem.userText ?? "User message"}
                 </span>

--- a/app/components/MessageNavigator.tsx
+++ b/app/components/MessageNavigator.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import { cn } from "@/lib/utils";
+import {
+  MESSAGE_NAVIGATOR_MIN_ITEMS,
+  resolveMessageNavigatorHasPersistentGutter,
+  resolveMessageNavigatorHeightStyle,
+  resolveMessageNavigatorHitStripWidth,
+  resolveMessageNavigatorIndexFromPointer,
+  resolveMessageNavigatorInteractiveWidth,
+  resolveMessageNavigatorTopPercent,
+  type MessageNavigatorItem,
+} from "./message-navigator";
+
+interface MessageNavigatorProps {
+  items: ReadonlyArray<MessageNavigatorItem>;
+  scrollElement: HTMLElement | null;
+  onSelect: (item: MessageNavigatorItem) => void;
+}
+
+const eventTargetsPreview = (target: EventTarget) =>
+  target instanceof Element &&
+  target.closest("[data-message-navigator-preview]") !== null;
+
+export const MessageNavigator = memo(function MessageNavigator({
+  items,
+  scrollElement,
+  onSelect,
+}: MessageNavigatorProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const stripMapRef = useRef(new Map<string, HTMLSpanElement>());
+
+  const itemIds = useMemo(() => new Set(items.map((item) => item.id)), [items]);
+  const resolvedActiveIndex =
+    activeIndex !== null && activeIndex < items.length ? activeIndex : null;
+  const activeItem =
+    resolvedActiveIndex === null ? null : (items[resolvedActiveIndex] ?? null);
+  const hasPersistentGutter =
+    resolveMessageNavigatorHasPersistentGutter(viewportWidth);
+  const hitStripWidth = resolveMessageNavigatorHitStripWidth(viewportWidth);
+
+  useEffect(() => {
+    if (!scrollElement) {
+      return;
+    }
+
+    const measure = () => {
+      const nextWidth = scrollElement.getBoundingClientRect().width;
+      setViewportWidth((current) =>
+        current === nextWidth ? current : nextWidth,
+      );
+    };
+
+    const frame = requestAnimationFrame(measure);
+    if (typeof ResizeObserver === "undefined") {
+      return () => cancelAnimationFrame(frame);
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(scrollElement);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [scrollElement]);
+
+  const updateInViewMarkers = useCallback(() => {
+    if (!scrollElement) {
+      return;
+    }
+
+    const viewportRect = scrollElement.getBoundingClientRect();
+    const inViewIds = new Set<string>();
+    const messageRows =
+      scrollElement.querySelectorAll<HTMLElement>("[data-message-id]");
+
+    for (const row of messageRows) {
+      const messageId = row.dataset.messageId;
+      if (!messageId || !itemIds.has(messageId)) {
+        continue;
+      }
+
+      const rowRect = row.getBoundingClientRect();
+      if (
+        rowRect.top < viewportRect.bottom &&
+        rowRect.bottom > viewportRect.top
+      ) {
+        inViewIds.add(messageId);
+      }
+    }
+
+    for (const item of items) {
+      const strip = stripMapRef.current.get(item.id);
+      if (strip) {
+        strip.dataset.inView = inViewIds.has(item.id) ? "true" : "false";
+      }
+    }
+  }, [itemIds, items, scrollElement]);
+
+  useEffect(() => {
+    if (!scrollElement) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(updateInViewMarkers);
+    scrollElement.addEventListener("scroll", updateInViewMarkers, {
+      passive: true,
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      scrollElement.removeEventListener("scroll", updateInViewMarkers);
+    };
+  }, [scrollElement, updateInViewMarkers]);
+
+  const resolveActiveIndexFromPointer = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      return resolveMessageNavigatorIndexFromPointer({
+        itemCount: items.length,
+        railTop: rect.top,
+        railHeight: rect.height,
+        pointerY: event.clientY,
+      });
+    },
+    [items.length],
+  );
+
+  const moveActiveIndex = useCallback(
+    (delta: number) => {
+      setActiveIndex((current) => {
+        const base = current ?? 0;
+        return Math.max(0, Math.min(items.length - 1, base + delta));
+      });
+    },
+    [items.length],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        moveActiveIndex(1);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        moveActiveIndex(-1);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setActiveIndex(0);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setActiveIndex(items.length - 1);
+      } else if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        if (activeItem) {
+          onSelect(activeItem);
+        }
+      }
+    },
+    [activeItem, items.length, moveActiveIndex, onSelect],
+  );
+
+  if (items.length < MESSAGE_NAVIGATOR_MIN_ITEMS) {
+    return null;
+  }
+
+  const activeTopPercent =
+    resolvedActiveIndex === null
+      ? 0
+      : resolveMessageNavigatorTopPercent(resolvedActiveIndex, items.length);
+  const activePreviewTranslate =
+    resolvedActiveIndex === 0
+      ? "0%"
+      : resolvedActiveIndex === items.length - 1
+        ? "-100%"
+        : "-50%";
+
+  return (
+    <div
+      className={cn(
+        "group/message-navigator pointer-events-none absolute inset-y-0 left-0 z-30 hidden w-[72px] [@media(pointer:fine)]:block",
+        hasPersistentGutter
+          ? "opacity-100"
+          : "opacity-0 transition-opacity duration-150 hover:opacity-100 focus-within:opacity-100",
+      )}
+      data-persistent-gutter={hasPersistentGutter ? "true" : "false"}
+      data-testid="message-navigator"
+    >
+      <div className="relative h-full w-full select-none">
+        <button
+          type="button"
+          aria-label={`Jump to message: ${activeItem?.userText ?? "User message"}`}
+          className={cn(
+            "absolute top-1/2 left-3 -translate-y-1/2 cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+            hitStripWidth > 0 ? "pointer-events-auto" : "pointer-events-none",
+          )}
+          onBlur={() => setActiveIndex(null)}
+          onClick={(event) => {
+            if (eventTargetsPreview(event.target)) {
+              return;
+            }
+
+            const nextIndex = resolveActiveIndexFromPointer(event);
+            const nextItem =
+              nextIndex === null ? null : (items[nextIndex] ?? null);
+            if (nextItem) {
+              onSelect(nextItem);
+            }
+            event.currentTarget.blur();
+          }}
+          onFocus={() => setActiveIndex((current) => current ?? 0)}
+          onKeyDown={handleKeyDown}
+          onMouseDown={(event) => {
+            if (!eventTargetsPreview(event.target)) {
+              event.preventDefault();
+            }
+          }}
+          onMouseLeave={() => setActiveIndex(null)}
+          onMouseMove={(event) => {
+            setActiveIndex(resolveActiveIndexFromPointer(event));
+          }}
+          style={{
+            height: resolveMessageNavigatorHeightStyle(items.length),
+            width: resolveMessageNavigatorInteractiveWidth(
+              hitStripWidth,
+              activeItem !== null,
+            ),
+          }}
+        >
+          <span className="absolute top-0 left-3 h-full w-px bg-border/20" />
+          {items.map((item, index) => {
+            const activeDistance =
+              resolvedActiveIndex === null
+                ? null
+                : Math.abs(index - resolvedActiveIndex);
+
+            return (
+              <span
+                key={item.id}
+                aria-hidden="true"
+                className={cn(
+                  "pointer-events-none absolute left-0 h-0.5 -translate-y-1/2 rounded-full bg-muted-foreground/35 transition-[background-color,width] duration-150 data-[in-view=true]:bg-foreground/90",
+                  activeDistance === 0
+                    ? "w-6 bg-muted-foreground/75"
+                    : activeDistance === 1
+                      ? "w-4"
+                      : activeDistance === 2
+                        ? "w-2.5"
+                        : "w-2",
+                )}
+                data-in-view="false"
+                data-message-navigator-strip
+                ref={(node) => {
+                  if (node) {
+                    stripMapRef.current.set(item.id, node);
+                  } else {
+                    stripMapRef.current.delete(item.id);
+                  }
+                }}
+                style={{
+                  top: `${resolveMessageNavigatorTopPercent(index, items.length)}%`,
+                }}
+              />
+            );
+          })}
+
+          {activeItem ? (
+            <span
+              className="pointer-events-auto absolute left-8 w-80 cursor-text select-text"
+              data-message-navigator-preview
+              data-testid="message-navigator-preview"
+              onMouseMove={(event) => event.stopPropagation()}
+              style={{
+                top: `${activeTopPercent}%`,
+                transform: `translateY(${activePreviewTranslate})`,
+              }}
+            >
+              <span className="block rounded-xl border border-border/60 bg-popover/95 p-3 text-left text-popover-foreground shadow-xl shadow-black/25 backdrop-blur-md">
+                <span className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium leading-5">
+                  {activeItem.userText ?? "User message"}
+                </span>
+                {activeItem.assistantText ? (
+                  <span
+                    className="mt-1 max-h-[3.75rem] overflow-hidden text-sm leading-5 text-muted-foreground"
+                    style={{
+                      display: "-webkit-box",
+                      WebkitBoxOrient: "vertical",
+                      WebkitLineClamp: 3,
+                    }}
+                  >
+                    {activeItem.assistantText}
+                  </span>
+                ) : null}
+              </span>
+            </span>
+          ) : null}
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/app/components/MessageNavigator.tsx
+++ b/app/components/MessageNavigator.tsx
@@ -50,31 +50,6 @@ export const MessageNavigator = memo(function MessageNavigator({
     resolveMessageNavigatorHasPersistentGutter(viewportWidth);
   const hitStripWidth = resolveMessageNavigatorHitStripWidth(viewportWidth);
 
-  useEffect(() => {
-    if (!scrollElement) {
-      return;
-    }
-
-    const measure = () => {
-      const nextWidth = scrollElement.getBoundingClientRect().width;
-      setViewportWidth((current) =>
-        current === nextWidth ? current : nextWidth,
-      );
-    };
-
-    const frame = requestAnimationFrame(measure);
-    if (typeof ResizeObserver === "undefined") {
-      return () => cancelAnimationFrame(frame);
-    }
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(scrollElement);
-    return () => {
-      cancelAnimationFrame(frame);
-      observer.disconnect();
-    };
-  }, [scrollElement]);
-
   const updateInViewMarkers = useCallback(() => {
     if (!scrollElement) {
       return;
@@ -107,6 +82,32 @@ export const MessageNavigator = memo(function MessageNavigator({
       }
     }
   }, [itemIds, items, scrollElement]);
+
+  useEffect(() => {
+    if (!scrollElement) {
+      return;
+    }
+
+    const measure = () => {
+      const nextWidth = scrollElement.getBoundingClientRect().width;
+      setViewportWidth((current) =>
+        current === nextWidth ? current : nextWidth,
+      );
+      updateInViewMarkers();
+    };
+
+    const frame = requestAnimationFrame(measure);
+    if (typeof ResizeObserver === "undefined") {
+      return () => cancelAnimationFrame(frame);
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(scrollElement);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [scrollElement, updateInViewMarkers]);
 
   useEffect(() => {
     if (!scrollElement) {

--- a/app/components/MessageNavigator.tsx
+++ b/app/components/MessageNavigator.tsx
@@ -238,7 +238,6 @@ export const MessageNavigator = memo(function MessageNavigator({
             ),
           }}
         >
-          <span className="absolute top-0 left-3 h-full w-px bg-border/15" />
           {items.map((item, index) => {
             const activeDistance =
               resolvedActiveIndex === null

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -36,6 +36,9 @@ import { hasTextContent } from "@/lib/utils/message-utils";
 import { useDataStreamState } from "./DataStreamProvider";
 import type { RateLimitWarningData } from "./RateLimitWarning";
 import type { SelectedModel } from "@/types";
+import { STICKY_BOTTOM_ESCAPE_EVENT } from "@/lib/utils/scroll-events";
+import { MessageNavigator } from "./MessageNavigator";
+import { deriveMessageNavigatorItems } from "./message-navigator";
 import {
   createStableChatTimelineRowsState,
   deriveChatTimelineRows,
@@ -252,6 +255,10 @@ export const Messages = ({
     stableTimelineRowsRef.current = stableTimelineRowsState;
   }, [stableTimelineRowsState]);
   const timelineRows = stableTimelineRowsState.result;
+  const navigatorItems = useMemo(
+    () => deriveMessageNavigatorItems(visibleMessages, timelineRows),
+    [timelineRows, visibleMessages],
+  );
   // Track edit state for messages
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
 
@@ -427,6 +434,18 @@ export const Messages = ({
     return () => scrollElement.removeEventListener("scroll", handleScroll);
   }, [handleScroll, timelineElements.scroll]);
 
+  const handleNavigatorSelect = useCallback(
+    (item: (typeof navigatorItems)[number]) => {
+      window.dispatchEvent(new Event(STICKY_BOTTOM_ESCAPE_EVENT));
+      void timelineInstance?.scrollToIndex({
+        index: item.rowIndex,
+        animated: true,
+        viewOffset: 24,
+      });
+    },
+    [timelineInstance],
+  );
+
   const showingLoadingIndicator =
     summarizationStatus?.status === "started" ||
     uploadStatus?.isUploading ||
@@ -526,6 +545,10 @@ export const Messages = ({
       return (
         <div
           className={`mx-auto w-full max-w-full sm:max-w-[768px] sm:min-w-[390px] ${rowClassName}`}
+          data-message-id={row.kind === "message" ? row.message.id : undefined}
+          data-message-role={
+            row.kind === "message" ? row.message.role : undefined
+          }
           data-timeline-row-kind={row.kind}
         >
           {content}
@@ -637,6 +660,14 @@ export const Messages = ({
           ListFooterComponent={timelineFooter}
           data-testid="messages-container"
         />
+
+        {!isMobile ? (
+          <MessageNavigator
+            items={navigatorItems}
+            scrollElement={timelineElements.scroll}
+            onSelect={handleNavigatorSelect}
+          />
+        ) : null}
 
         {/* All Files Dialog */}
         {hasOpenedAllFilesDialog && (

--- a/app/components/__tests__/MessageNavigator.test.tsx
+++ b/app/components/__tests__/MessageNavigator.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { MessageNavigator } from "../MessageNavigator";
 import type { MessageNavigatorItem } from "../message-navigator";
 
@@ -117,5 +117,85 @@ describe("MessageNavigator", () => {
     expect(strips[0]).toHaveAttribute("data-in-view", "false");
     expect(strips[1]).toHaveAttribute("data-in-view", "true");
     expect(strips[2]).toHaveAttribute("data-in-view", "false");
+  });
+
+  it("refreshes visible destinations after resize without a scroll event", () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let resizeCallback: ResizeObserverCallback | null = null;
+    let observerInstance!: ResizeObserver;
+
+    class ResizeObserverMock implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+        observerInstance = this;
+      }
+
+      observe = jest.fn();
+      unobserve = jest.fn();
+      disconnect = jest.fn();
+    }
+
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+
+    try {
+      const scrollElement = document.createElement("div");
+      const resizedRow = document.createElement("div");
+      resizedRow.dataset.messageId = "user-2";
+      scrollElement.append(resizedRow);
+      let rowTop = 700;
+
+      scrollElement.getBoundingClientRect = () =>
+        ({
+          top: 0,
+          right: 900,
+          bottom: 600,
+          left: 0,
+          width: 900,
+          height: 600,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      resizedRow.getBoundingClientRect = () =>
+        ({
+          top: rowTop,
+          right: 700,
+          bottom: rowTop + 80,
+          left: 100,
+          width: 600,
+          height: 80,
+          x: 100,
+          y: rowTop,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      render(
+        <MessageNavigator
+          items={items}
+          scrollElement={scrollElement}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      const strips = document.querySelectorAll(
+        "[data-message-navigator-strip]",
+      );
+      expect(strips[1]).toHaveAttribute("data-in-view", "false");
+
+      rowTop = 100;
+      act(() => {
+        resizeCallback?.([], observerInstance);
+      });
+
+      expect(strips[1]).toHaveAttribute("data-in-view", "true");
+    } finally {
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        configurable: true,
+        value: originalResizeObserver,
+      });
+    }
   });
 });

--- a/app/components/__tests__/MessageNavigator.test.tsx
+++ b/app/components/__tests__/MessageNavigator.test.tsx
@@ -120,7 +120,10 @@ describe("MessageNavigator", () => {
   });
 
   it("refreshes visible destinations after resize without a scroll event", () => {
-    const originalResizeObserver = globalThis.ResizeObserver;
+    const originalResizeObserverDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "ResizeObserver",
+    );
     let resizeCallback: ResizeObserverCallback | null = null;
     let observerInstance!: ResizeObserver;
 
@@ -137,6 +140,7 @@ describe("MessageNavigator", () => {
 
     Object.defineProperty(globalThis, "ResizeObserver", {
       configurable: true,
+      writable: true,
       value: ResizeObserverMock,
     });
 
@@ -192,10 +196,15 @@ describe("MessageNavigator", () => {
 
       expect(strips[1]).toHaveAttribute("data-in-view", "true");
     } finally {
-      Object.defineProperty(globalThis, "ResizeObserver", {
-        configurable: true,
-        value: originalResizeObserver,
-      });
+      if (originalResizeObserverDescriptor) {
+        Object.defineProperty(
+          globalThis,
+          "ResizeObserver",
+          originalResizeObserverDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(globalThis, "ResizeObserver");
+      }
     }
   });
 });

--- a/app/components/__tests__/MessageNavigator.test.tsx
+++ b/app/components/__tests__/MessageNavigator.test.tsx
@@ -80,6 +80,42 @@ describe("MessageNavigator", () => {
     expect(onSelect).toHaveBeenCalledWith(items[1]);
   });
 
+  it("keeps the preview open while the pointer moves onto it", () => {
+    render(
+      <MessageNavigator
+        items={items}
+        scrollElement={null}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Jump to message: User message",
+    });
+    button.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        right: 40,
+        bottom: 122,
+        left: 0,
+        width: 40,
+        height: 22,
+        x: 0,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    fireEvent.mouseMove(button, { clientY: 111 });
+    const preview = screen.getByTestId("message-navigator-preview");
+    expect(preview).toHaveTextContent("Second question");
+    expect(button).toHaveStyle({ width: "22rem" });
+
+    fireEvent.mouseMove(preview);
+    expect(screen.getByTestId("message-navigator-preview")).toHaveTextContent(
+      "Second question",
+    );
+  });
+
   it("marks destinations whose user rows are in the viewport", () => {
     const scrollElement = document.createElement("div");
     const visibleRow = document.createElement("div");

--- a/app/components/__tests__/MessageNavigator.test.tsx
+++ b/app/components/__tests__/MessageNavigator.test.tsx
@@ -63,11 +63,18 @@ describe("MessageNavigator", () => {
     expect(screen.getByTestId("message-navigator-preview")).toHaveTextContent(
       "First question",
     );
+    const strips = document.querySelectorAll("[data-message-navigator-strip]");
+    expect(strips[0]).toHaveClass("w-7");
+    expect(strips[1]).toHaveClass("w-[22px]");
+    expect(strips[2]).toHaveClass("w-3.5");
 
     fireEvent.keyDown(button, { key: "ArrowDown" });
     expect(screen.getByTestId("message-navigator-preview")).toHaveTextContent(
       "Second question",
     );
+    expect(strips[0]).toHaveClass("w-[22px]");
+    expect(strips[1]).toHaveClass("w-7");
+    expect(strips[2]).toHaveClass("w-[22px]");
 
     fireEvent.keyDown(button, { key: "Enter" });
     expect(onSelect).toHaveBeenCalledWith(items[1]);

--- a/app/components/__tests__/MessageNavigator.test.tsx
+++ b/app/components/__tests__/MessageNavigator.test.tsx
@@ -80,7 +80,7 @@ describe("MessageNavigator", () => {
     expect(onSelect).toHaveBeenCalledWith(items[1]);
   });
 
-  it("keeps the preview open while the pointer moves onto it", () => {
+  it("dismisses the preview when the pointer leaves the marker strip", () => {
     render(
       <MessageNavigator
         items={items}
@@ -108,12 +108,12 @@ describe("MessageNavigator", () => {
     fireEvent.mouseMove(button, { clientY: 111 });
     const preview = screen.getByTestId("message-navigator-preview");
     expect(preview).toHaveTextContent("Second question");
-    expect(button).toHaveStyle({ width: "22rem" });
+    expect(preview).toHaveClass("pointer-events-none");
 
-    fireEvent.mouseMove(preview);
-    expect(screen.getByTestId("message-navigator-preview")).toHaveTextContent(
-      "Second question",
-    );
+    fireEvent.mouseLeave(button);
+    expect(
+      screen.queryByTestId("message-navigator-preview"),
+    ).not.toBeInTheDocument();
   });
 
   it("marks destinations whose user rows are in the viewport", () => {

--- a/app/components/__tests__/MessageNavigator.test.tsx
+++ b/app/components/__tests__/MessageNavigator.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MessageNavigator } from "../MessageNavigator";
+import type { MessageNavigatorItem } from "../message-navigator";
+
+const items: MessageNavigatorItem[] = [
+  {
+    id: "user-1",
+    rowIndex: 0,
+    userText: "First question",
+    assistantText: "First answer",
+  },
+  {
+    id: "user-2",
+    rowIndex: 2,
+    userText: "Second question",
+    assistantText: "Second answer",
+  },
+  {
+    id: "user-3",
+    rowIndex: 4,
+    userText: "Third question",
+    assistantText: null,
+  },
+];
+
+describe("MessageNavigator", () => {
+  it("stays hidden until a chat has multiple user turns", () => {
+    const { rerender } = render(
+      <MessageNavigator
+        items={items.slice(0, 1)}
+        scrollElement={null}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("message-navigator")).not.toBeInTheDocument();
+
+    rerender(
+      <MessageNavigator
+        items={items.slice(0, 2)}
+        scrollElement={null}
+        onSelect={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("message-navigator")).toBeInTheDocument();
+  });
+
+  it("previews and selects a destination with the keyboard", () => {
+    const onSelect = jest.fn();
+    render(
+      <MessageNavigator
+        items={items}
+        scrollElement={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Jump to message: User message",
+    });
+    fireEvent.focus(button);
+
+    expect(screen.getByTestId("message-navigator-preview")).toHaveTextContent(
+      "First question",
+    );
+
+    fireEvent.keyDown(button, { key: "ArrowDown" });
+    expect(screen.getByTestId("message-navigator-preview")).toHaveTextContent(
+      "Second question",
+    );
+
+    fireEvent.keyDown(button, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith(items[1]);
+  });
+
+  it("marks destinations whose user rows are in the viewport", () => {
+    const scrollElement = document.createElement("div");
+    const visibleRow = document.createElement("div");
+    visibleRow.dataset.messageId = "user-2";
+    scrollElement.append(visibleRow);
+
+    scrollElement.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        right: 900,
+        bottom: 600,
+        left: 0,
+        width: 900,
+        height: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    visibleRow.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        right: 700,
+        bottom: 180,
+        left: 100,
+        width: 600,
+        height: 80,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    render(
+      <MessageNavigator
+        items={items}
+        scrollElement={scrollElement}
+        onSelect={jest.fn()}
+      />,
+    );
+    fireEvent.scroll(scrollElement);
+
+    const strips = document.querySelectorAll("[data-message-navigator-strip]");
+    expect(strips[0]).toHaveAttribute("data-in-view", "false");
+    expect(strips[1]).toHaveAttribute("data-in-view", "true");
+    expect(strips[2]).toHaveAttribute("data-in-view", "false");
+  });
+});

--- a/app/components/__tests__/message-navigator.test.ts
+++ b/app/components/__tests__/message-navigator.test.ts
@@ -1,0 +1,112 @@
+import type { ChatMessage } from "@/types";
+import {
+  deriveChatTimelineRows,
+  type ChatTimelineRow,
+} from "../message-timeline-rows";
+import {
+  deriveMessageNavigatorItems,
+  resolveMessageNavigatorHasPersistentGutter,
+  resolveMessageNavigatorHeightStyle,
+  resolveMessageNavigatorHitStripWidth,
+  resolveMessageNavigatorIndexFromPointer,
+  resolveMessageNavigatorInteractiveWidth,
+  resolveMessageNavigatorTopPercent,
+} from "../message-navigator";
+
+const message = (
+  id: string,
+  role: ChatMessage["role"],
+  text: string,
+): ChatMessage =>
+  ({
+    id,
+    role,
+    parts: [{ type: "text", text }],
+  }) as ChatMessage;
+
+const deriveRows = (messages: ChatMessage[]): ChatTimelineRow[] =>
+  deriveChatTimelineRows({
+    messages,
+    status: "ready",
+    lastAssistantMessageIndex: undefined,
+    expandedAgentMessageIds: new Set(),
+  });
+
+describe("message navigator logic", () => {
+  it("builds one destination per user turn with compact previews", () => {
+    const messages = [
+      message("user-1", "user", "  First\n\nquestion  "),
+      message("assistant-1", "assistant", "First answer"),
+      message("assistant-2", "assistant", "Final\nanswer for turn one"),
+      message("user-2", "user", "Second question"),
+      message("assistant-3", "assistant", "Second answer"),
+    ];
+
+    expect(deriveMessageNavigatorItems(messages, deriveRows(messages))).toEqual(
+      [
+        {
+          id: "user-1",
+          rowIndex: 0,
+          userText: "First question",
+          assistantText: "Final answer for turn one",
+        },
+        {
+          id: "user-2",
+          rowIndex: 3,
+          userText: "Second question",
+          assistantText: "Second answer",
+        },
+      ],
+    );
+  });
+
+  it("omits user messages without a rendered timeline destination", () => {
+    const messages = [
+      message("user-1", "user", "First"),
+      message("assistant-1", "assistant", "Answer"),
+      message("user-2", "user", "Second"),
+    ];
+    const rows = deriveRows(messages).filter(
+      (row) => row.kind !== "message" || row.message.id !== "user-1",
+    );
+
+    expect(deriveMessageNavigatorItems(messages, rows)).toEqual([
+      {
+        id: "user-2",
+        rowIndex: 1,
+        userText: "Second",
+        assistantText: null,
+      },
+    ]);
+  });
+
+  it("resolves rail geometry and bounded pointer destinations", () => {
+    expect(resolveMessageNavigatorHeightStyle(5)).toBe(
+      "min(32px, calc(100vh - 18rem))",
+    );
+    expect(resolveMessageNavigatorTopPercent(2, 5)).toBe(50);
+    expect(
+      resolveMessageNavigatorIndexFromPointer({
+        itemCount: 5,
+        railTop: 100,
+        railHeight: 200,
+        pointerY: 250,
+      }),
+    ).toBe(3);
+    expect(
+      resolveMessageNavigatorIndexFromPointer({
+        itemCount: 5,
+        railTop: 100,
+        railHeight: 200,
+        pointerY: 999,
+      }),
+    ).toBe(4);
+    expect(resolveMessageNavigatorHasPersistentGutter(863)).toBe(false);
+    expect(resolveMessageNavigatorHasPersistentGutter(864)).toBe(true);
+    expect(resolveMessageNavigatorHitStripWidth(768)).toBe(0);
+    expect(resolveMessageNavigatorHitStripWidth(820)).toBe(14);
+    expect(resolveMessageNavigatorHitStripWidth(872)).toBe(40);
+    expect(resolveMessageNavigatorInteractiveWidth(14, false)).toBe(14);
+    expect(resolveMessageNavigatorInteractiveWidth(14, true)).toBe("22rem");
+  });
+});

--- a/app/components/__tests__/message-navigator.test.ts
+++ b/app/components/__tests__/message-navigator.test.ts
@@ -9,7 +9,6 @@ import {
   resolveMessageNavigatorHeightStyle,
   resolveMessageNavigatorHitStripWidth,
   resolveMessageNavigatorIndexFromPointer,
-  resolveMessageNavigatorInteractiveWidth,
   resolveMessageNavigatorTopPercent,
 } from "../message-navigator";
 
@@ -106,7 +105,5 @@ describe("message navigator logic", () => {
     expect(resolveMessageNavigatorHitStripWidth(768)).toBe(0);
     expect(resolveMessageNavigatorHitStripWidth(820)).toBe(14);
     expect(resolveMessageNavigatorHitStripWidth(872)).toBe(40);
-    expect(resolveMessageNavigatorInteractiveWidth(14, false)).toBe(14);
-    expect(resolveMessageNavigatorInteractiveWidth(14, true)).toBe("22rem");
   });
 });

--- a/app/components/__tests__/message-navigator.test.ts
+++ b/app/components/__tests__/message-navigator.test.ts
@@ -82,7 +82,7 @@ describe("message navigator logic", () => {
 
   it("resolves rail geometry and bounded pointer destinations", () => {
     expect(resolveMessageNavigatorHeightStyle(5)).toBe(
-      "min(32px, calc(100vh - 18rem))",
+      "min(44px, calc(100vh - 18rem))",
     );
     expect(resolveMessageNavigatorTopPercent(2, 5)).toBe(50);
     expect(

--- a/app/components/message-navigator.ts
+++ b/app/components/message-navigator.ts
@@ -3,7 +3,7 @@ import { extractMessageText } from "@/lib/utils/message-utils";
 import type { ChatTimelineRow } from "./message-timeline-rows";
 
 export const MESSAGE_NAVIGATOR_MIN_ITEMS = 2;
-export const MESSAGE_NAVIGATOR_ITEM_SPACING = 8;
+export const MESSAGE_NAVIGATOR_ITEM_SPACING = 11;
 export const MESSAGE_NAVIGATOR_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
 export const MESSAGE_NAVIGATOR_CONTENT_MAX_WIDTH = 768;
 export const MESSAGE_NAVIGATOR_PERSISTENT_GUTTER = 48;

--- a/app/components/message-navigator.ts
+++ b/app/components/message-navigator.ts
@@ -9,7 +9,6 @@ export const MESSAGE_NAVIGATOR_CONTENT_MAX_WIDTH = 768;
 export const MESSAGE_NAVIGATOR_PERSISTENT_GUTTER = 48;
 export const MESSAGE_NAVIGATOR_HIT_STRIP_LEFT = 12;
 export const MESSAGE_NAVIGATOR_HIT_STRIP_MAX_WIDTH = 40;
-export const MESSAGE_NAVIGATOR_EXPANDED_WIDTH = "22rem";
 
 export interface MessageNavigatorItem {
   id: string;
@@ -154,11 +153,4 @@ export function resolveMessageNavigatorHitStripWidth(
       Math.floor(sideGutter) - MESSAGE_NAVIGATOR_HIT_STRIP_LEFT,
     ),
   );
-}
-
-export function resolveMessageNavigatorInteractiveWidth(
-  collapsedWidth: number,
-  expanded: boolean,
-): number | string {
-  return expanded ? MESSAGE_NAVIGATOR_EXPANDED_WIDTH : collapsedWidth;
 }

--- a/app/components/message-navigator.ts
+++ b/app/components/message-navigator.ts
@@ -1,0 +1,164 @@
+import type { ChatMessage } from "@/types";
+import { extractMessageText } from "@/lib/utils/message-utils";
+import type { ChatTimelineRow } from "./message-timeline-rows";
+
+export const MESSAGE_NAVIGATOR_MIN_ITEMS = 2;
+export const MESSAGE_NAVIGATOR_ITEM_SPACING = 8;
+export const MESSAGE_NAVIGATOR_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
+export const MESSAGE_NAVIGATOR_CONTENT_MAX_WIDTH = 768;
+export const MESSAGE_NAVIGATOR_PERSISTENT_GUTTER = 48;
+export const MESSAGE_NAVIGATOR_HIT_STRIP_LEFT = 12;
+export const MESSAGE_NAVIGATOR_HIT_STRIP_MAX_WIDTH = 40;
+export const MESSAGE_NAVIGATOR_EXPANDED_WIDTH = "22rem";
+
+export interface MessageNavigatorItem {
+  id: string;
+  rowIndex: number;
+  userText: string | null;
+  assistantText: string | null;
+}
+
+const compactPreview = (text: string | null | undefined) => {
+  const compact = text?.replace(/\s+/g, " ").trim() ?? "";
+  return compact.length > 0 ? compact : null;
+};
+
+export function deriveMessageNavigatorItems(
+  messages: ReadonlyArray<ChatMessage>,
+  timelineRows: ReadonlyArray<ChatTimelineRow>,
+): MessageNavigatorItem[] {
+  const rowIndexByMessageId = new Map<string, number>();
+  for (let index = 0; index < timelineRows.length; index += 1) {
+    const row = timelineRows[index];
+    if (row?.kind === "message") {
+      rowIndexByMessageId.set(row.message.id, index);
+    }
+  }
+
+  const items: MessageNavigatorItem[] = [];
+  for (
+    let messageIndex = 0;
+    messageIndex < messages.length;
+    messageIndex += 1
+  ) {
+    const message = messages[messageIndex];
+    if (message?.role !== "user") {
+      continue;
+    }
+
+    const rowIndex = rowIndexByMessageId.get(message.id);
+    if (rowIndex === undefined) {
+      continue;
+    }
+
+    let assistantText: string | null = null;
+    for (
+      let responseIndex = messageIndex + 1;
+      responseIndex < messages.length;
+      responseIndex += 1
+    ) {
+      const response = messages[responseIndex];
+      if (!response || response.role === "user") {
+        break;
+      }
+      if (response.role === "assistant") {
+        assistantText = compactPreview(extractMessageText(response.parts));
+      }
+    }
+
+    items.push({
+      id: message.id,
+      rowIndex,
+      userText: compactPreview(extractMessageText(message.parts)),
+      assistantText,
+    });
+  }
+
+  return items;
+}
+
+export function resolveMessageNavigatorHeightStyle(itemCount: number): string {
+  const naturalHeight = Math.max(
+    1,
+    (itemCount - 1) * MESSAGE_NAVIGATOR_ITEM_SPACING,
+  );
+  return `min(${naturalHeight}px, ${MESSAGE_NAVIGATOR_MAX_HEIGHT_CSS})`;
+}
+
+export function resolveMessageNavigatorTopPercent(
+  index: number,
+  itemCount: number,
+): number {
+  if (itemCount <= 1) {
+    return 0;
+  }
+
+  const boundedIndex = Math.max(0, Math.min(index, itemCount - 1));
+  return (boundedIndex / (itemCount - 1)) * 100;
+}
+
+export function resolveMessageNavigatorIndexFromPointer(input: {
+  itemCount: number;
+  railTop: number;
+  railHeight: number;
+  pointerY: number;
+}): number | null {
+  if (input.itemCount <= 0 || input.railHeight <= 0) {
+    return null;
+  }
+  if (input.itemCount === 1) {
+    return 0;
+  }
+
+  const progress = Math.max(
+    0,
+    Math.min(1, (input.pointerY - input.railTop) / input.railHeight),
+  );
+  return Math.max(
+    0,
+    Math.min(input.itemCount - 1, Math.round(progress * (input.itemCount - 1))),
+  );
+}
+
+export function resolveMessageNavigatorHasPersistentGutter(
+  viewportWidth: number,
+): boolean {
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
+    return false;
+  }
+
+  const contentWidth = Math.min(
+    viewportWidth,
+    MESSAGE_NAVIGATOR_CONTENT_MAX_WIDTH,
+  );
+  const sideGutter = Math.max(0, (viewportWidth - contentWidth) / 2);
+  return sideGutter >= MESSAGE_NAVIGATOR_PERSISTENT_GUTTER;
+}
+
+export function resolveMessageNavigatorHitStripWidth(
+  viewportWidth: number,
+): number {
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
+    return 0;
+  }
+
+  const contentWidth = Math.min(
+    viewportWidth,
+    MESSAGE_NAVIGATOR_CONTENT_MAX_WIDTH,
+  );
+  const sideGutter = Math.max(0, (viewportWidth - contentWidth) / 2);
+  return Math.max(
+    0,
+    Math.min(
+      MESSAGE_NAVIGATOR_HIT_STRIP_MAX_WIDTH,
+      Math.floor(sideGutter) - MESSAGE_NAVIGATOR_HIT_STRIP_LEFT,
+    ),
+  );
+}
+
+export function resolveMessageNavigatorInteractiveWidth(
+  collapsedWidth: number,
+  expanded: boolean,
+): number | string {
+  return expanded ? MESSAGE_NAVIGATOR_EXPANDED_WIDTH : collapsedWidth;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -161,6 +161,24 @@
   }
 }
 
+.message-navigator-preview-glass {
+  background: color-mix(
+    in srgb,
+    var(--popover) 18%,
+    color-mix(in srgb, var(--popover) 80%, transparent)
+  );
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  box-shadow: 0 16px 40px -18px rgb(0 0 0 / 55%);
+}
+
+.dark .message-navigator-preview-glass {
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 18px 44px -18px rgb(0 0 0 / 80%);
+}
+
 @keyframes shimmer {
   0% {
     background-position: 200% 0;


### PR DESCRIPTION
## Summary
- add a compact desktop message navigator beside the task sidebar for chats with multiple user turns
- preview the selected user prompt and final assistant response on hover or keyboard focus
- jump to exact virtualized message rows while preserving narrow-pane and mobile usability
- highlight user turns currently visible in the chat viewport

## Why
Long chats are slow to navigate using the scrollbar alone. The navigator provides a low-profile overview and direct access to earlier conversational turns without replacing the existing LegendList timeline or bottom-follow behavior.

## Validation
- commit hook: 323 test suites / 3,218 tests passed
- `corepack pnpm typecheck`
- focused ESLint and Prettier checks
- `git diff --check`
- Google Chrome verification against current `main` and `@legendapp/list@3.3.3`

## Manual verification
1. Open a desktop task containing at least two user turns.
2. Hover the rail beside the task sidebar and confirm the prompt plus three-line assistant preview follows the pointer.
3. Click a marker and confirm the matching user message is positioned 24px below the chat viewport top.
4. Focus the rail with the keyboard, use Arrow Up/Down or Home/End, and press Enter or Space to jump.
5. Narrow the chat pane or use mobile and confirm the navigator does not cover message content.

Chrome verification used an isolated eight-turn synthetic fixture. Pointer and keyboard jumps passed, visible markers updated correctly, the preview stayed at 110px, and the browser console remained clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a message navigator for quickly locating messages and responses.
  * Supports pointer, mouse, keyboard, focus, and click interactions with previews.
  * Adapts to viewport size and hides when navigation is unnecessary.
  * Selecting an item scrolls directly to the corresponding message.
  * Available on non-mobile layouts with enhanced preview styling.

* **Tests**
  * Added coverage for visibility, keyboard controls, previews, responsive layout, and message selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->