### PR TITLE
Hide regenerate for Agent responses

### DIFF
--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -330,8 +330,8 @@ export const MessageActions = ({
               </>
             )}
 
-            {/* Show regenerate only for the last assistant message */}
-            {!isUser && isLastAssistantMessage && (
+            {/* Show regenerate only for eligible last assistant messages. */}
+            {!isUser && isLastAssistantMessage && canRegenerate && (
               <WithTooltip
                 display={"Regenerate response"}
                 trigger={

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -189,7 +189,9 @@ export const MessageItem = memo(function MessageItem({
     message.role === "assistant" &&
     lastAssistantMessageIndex !== undefined &&
     index === lastAssistantMessageIndex;
-  const canRegenerate = status === "ready" || status === "error";
+  const canRegenerate =
+    message.metadata?.mode !== "agent" &&
+    (status === "ready" || status === "error");
   const isLastMessage = index === messagesLength - 1;
 
   // Only the last assistant message should propagate "streaming" status to its

--- a/app/components/__tests__/MessageActions.edit.test.tsx
+++ b/app/components/__tests__/MessageActions.edit.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, jest } from "@jest/globals";
 
 jest.mock("@/components/ui/with-tooltip", () => ({
@@ -27,6 +27,28 @@ const renderUserActions = (canEdit: boolean, onEdit = jest.fn()) => {
   return onEdit;
 };
 
+const renderAssistantActions = (
+  canRegenerate: boolean,
+  onRegenerate = jest.fn(),
+) => {
+  render(
+    <MessageActions
+      messageText="Answer"
+      isUser={false}
+      isLastAssistantMessage
+      canRegenerate={canRegenerate}
+      onRegenerate={onRegenerate}
+      onEdit={jest.fn()}
+      canEdit={false}
+      isHovered
+      isEditing={false}
+      status="ready"
+    />,
+  );
+
+  return onRegenerate;
+};
+
 describe("MessageActions editing", () => {
   it("does not offer editing for an older user message", () => {
     renderUserActions(false);
@@ -42,5 +64,25 @@ describe("MessageActions editing", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
 
     expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MessageActions regeneration", () => {
+  it("does not show regeneration when it is unavailable", () => {
+    renderAssistantActions(false);
+
+    expect(
+      screen.queryByRole("button", { name: "Regenerate response" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows regeneration when it is available", async () => {
+    const onRegenerate = renderAssistantActions(true);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Regenerate response" }),
+    );
+
+    await waitFor(() => expect(onRegenerate).toHaveBeenCalledTimes(1));
   });
 });

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -27,7 +27,12 @@ jest.mock("../MessagePartHandler", () => ({
 }));
 
 jest.mock("../MessageActions", () => ({
-  MessageActions: () => <div data-testid="message-actions" />,
+  MessageActions: ({ canRegenerate }: { canRegenerate: boolean }) => (
+    <div
+      data-testid="message-actions"
+      data-can-regenerate={String(canRegenerate)}
+    />
+  ),
 }));
 
 jest.mock("../FilePartRenderer", () => ({
@@ -122,6 +127,33 @@ const renderMessageItem = ({
   );
 
 describe("MessageItem WorkedFor rendering", () => {
+  it("disables regeneration for an Agent response after switching to Ask", () => {
+    renderMessageItem({ mode: "ask" });
+
+    expect(screen.getByTestId("message-actions")).toHaveAttribute(
+      "data-can-regenerate",
+      "false",
+    );
+  });
+
+  it("allows regeneration for an Ask response after switching to Agent", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        metadata: {
+          mode: "ask",
+          generationTimeMs: 1_500,
+        },
+      } as ChatMessage,
+    });
+
+    expect(screen.getByTestId("message-actions")).toHaveAttribute(
+      "data-can-regenerate",
+      "true",
+    );
+  });
+
   it("renders work inline for messages generated in ask mode", () => {
     renderMessageItem({
       mode: "agent",


### PR DESCRIPTION
## Summary

- hide the regenerate action for assistant messages generated in Agent mode
- keep regenerate available for Ask responses, including after the composer mode changes
- add regression coverage for action visibility and message-mode eligibility

## Why

Agent runs can perform tool calls and other side effects that regeneration cannot rewind. The existing branch action remains available for exploring another path without presenting regeneration as a safe replay.

## Validation

- `pnpm typecheck`
- full pre-commit Jest suite: 321 suites, 3,216 tests passed
- scoped ESLint and Prettier checks
- targeted MessageActions and MessageItem tests: 22 passed

## Manual verification

1. Open a completed Agent task and hover the final assistant response. Confirm **Regenerate response** is absent and **Branch in new task** remains available.
2. Open a completed Ask task and hover the final assistant response. Confirm **Regenerate response** is visible and starts a replacement response.
3. Switch the composer mode after either response and confirm the action remains based on the mode that generated the response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Regeneration controls now appear only for eligible last assistant messages when regeneration is available.
  * Regeneration is disabled for messages created in agent mode.
  * Regeneration remains available for other messages in ready or error states.

* **Tests**
  * Added coverage for regeneration availability and callback behavior across supported message modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->