### PR TITLE
Fix first message navigator jump

### DIFF
--- a/__mocks__/@legendapp/list-react.tsx
+++ b/__mocks__/@legendapp/list-react.tsx
@@ -55,6 +55,7 @@ export const LegendList = forwardRef(function MockLegendList<
 >(
   {
     data,
+    dataKey,
     extraData,
     renderItem,
     keyExtractor,
@@ -65,6 +66,7 @@ export const LegendList = forwardRef(function MockLegendList<
     "data-testid": dataTestId,
   }: {
     data: Item[];
+    dataKey?: string | number;
     extraData?: unknown;
     renderItem: (info: {
       data: readonly Item[];
@@ -99,6 +101,7 @@ export const LegendList = forwardRef(function MockLegendList<
       className={className}
       style={style}
       data-testid={dataTestId}
+      data-list-key={dataKey}
     >
       <div className="legend-list-content-container">
         {renderOptionalComponent(ListHeaderComponent)}

--- a/__mocks__/@legendapp/list-react.tsx
+++ b/__mocks__/@legendapp/list-react.tsx
@@ -11,6 +11,13 @@ import {
 
 type OptionalComponent = ReactNode | ComponentType;
 
+export const mockLegendListGetState = jest.fn(() => ({
+  data: [] as unknown[],
+  end: -1,
+  start: 0,
+}));
+export const mockLegendListScrollToIndex = jest.fn(async () => {});
+
 const renderOptionalComponent = (component: OptionalComponent) => {
   if (typeof component === "function") {
     const Component = component;
@@ -82,7 +89,9 @@ export const LegendList = forwardRef(function MockLegendList<
     "data-testid"?: string;
   },
   forwardedRef: ForwardedRef<{
+    getState: typeof mockLegendListGetState;
     getScrollableNode: () => HTMLDivElement | null;
+    scrollToIndex: typeof mockLegendListScrollToIndex;
   }>,
 ) {
   const scrollElementRef = useRef<HTMLDivElement>(null);
@@ -90,7 +99,9 @@ export const LegendList = forwardRef(function MockLegendList<
   useImperativeHandle(
     forwardedRef,
     () => ({
+      getState: mockLegendListGetState,
       getScrollableNode: () => scrollElementRef.current,
+      scrollToIndex: mockLegendListScrollToIndex,
     }),
     [],
   );

--- a/__mocks__/@legendapp/list-react.tsx
+++ b/__mocks__/@legendapp/list-react.tsx
@@ -11,11 +11,6 @@ import {
 
 type OptionalComponent = ReactNode | ComponentType;
 
-export const mockLegendListGetState = jest.fn(() => ({
-  data: [] as unknown[],
-  end: -1,
-  start: 0,
-}));
 export const mockLegendListScrollToIndex = jest.fn(async () => {});
 
 const renderOptionalComponent = (component: OptionalComponent) => {
@@ -89,7 +84,6 @@ export const LegendList = forwardRef(function MockLegendList<
     "data-testid"?: string;
   },
   forwardedRef: ForwardedRef<{
-    getState: typeof mockLegendListGetState;
     getScrollableNode: () => HTMLDivElement | null;
     scrollToIndex: typeof mockLegendListScrollToIndex;
   }>,
@@ -99,7 +93,6 @@ export const LegendList = forwardRef(function MockLegendList<
   useImperativeHandle(
     forwardedRef,
     () => ({
-      getState: mockLegendListGetState,
       getScrollableNode: () => scrollElementRef.current,
       scrollToIndex: mockLegendListScrollToIndex,
     }),

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -439,34 +439,11 @@ export const Messages = ({
   const handleNavigatorSelect = useCallback(
     (item: (typeof navigatorItems)[number]) => {
       window.dispatchEvent(new Event(STICKY_BOTTOM_ESCAPE_EVENT));
-      const instance = timelineInstance;
-      if (!instance) {
-        return;
-      }
-
-      const scrollOptions = {
+      void timelineInstance?.scrollToIndex({
         index: item.rowIndex,
-        animated: true,
+        animated: false,
         viewOffset: 24,
-      } as const;
-      const scrollToTarget = async () => {
-        await instance.scrollToIndex(scrollOptions);
-
-        const state = instance.getState();
-        const currentTarget = state.data[item.rowIndex] as
-          ChatTimelineRow | undefined;
-        const targetStillCurrent =
-          currentTarget?.kind === "message" &&
-          currentTarget.message.id === item.id;
-        const targetIsOutsideVisibleRange =
-          item.rowIndex < state.start || item.rowIndex > state.end;
-
-        if (targetStillCurrent && targetIsOutsideVisibleRange) {
-          await instance.scrollToIndex(scrollOptions);
-        }
-      };
-
-      void scrollToTarget();
+      });
     },
     [timelineInstance],
   );

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -439,11 +439,34 @@ export const Messages = ({
   const handleNavigatorSelect = useCallback(
     (item: (typeof navigatorItems)[number]) => {
       window.dispatchEvent(new Event(STICKY_BOTTOM_ESCAPE_EVENT));
-      void timelineInstance?.scrollToIndex({
+      const instance = timelineInstance;
+      if (!instance) {
+        return;
+      }
+
+      const scrollOptions = {
         index: item.rowIndex,
         animated: true,
         viewOffset: 24,
-      });
+      } as const;
+      const scrollToTarget = async () => {
+        await instance.scrollToIndex(scrollOptions);
+
+        const state = instance.getState();
+        const currentTarget = state.data[item.rowIndex] as
+          ChatTimelineRow | undefined;
+        const targetStillCurrent =
+          currentTarget?.kind === "message" &&
+          currentTarget.message.id === item.id;
+        const targetIsOutsideVisibleRange =
+          item.rowIndex < state.start || item.rowIndex > state.end;
+
+        if (targetStillCurrent && targetIsOutsideVisibleRange) {
+          await instance.scrollToIndex(scrollOptions);
+        }
+      };
+
+      void scrollToTarget();
     },
     [timelineInstance],
   );

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -83,6 +83,7 @@ const setElementRef = (ref: StickyElementRef, element: HTMLElement | null) => {
 };
 
 interface MessagesProps {
+  chatId: string;
   messages: ChatMessage[];
   setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   onRegenerate: () => void | Promise<void>;
@@ -121,6 +122,7 @@ interface MessagesProps {
 }
 
 export const Messages = ({
+  chatId,
   messages,
   setMessages,
   onRegenerate,
@@ -640,6 +642,7 @@ export const Messages = ({
         <LegendList<ChatTimelineRow>
           ref={setTimelineInstance}
           data={timelineRows}
+          dataKey={chatId}
           extraData={editingMessageId}
           keyExtractor={getTimelineRowKey}
           getItemType={getChatTimelineRowType}

--- a/app/components/__tests__/Messages.edit.test.tsx
+++ b/app/components/__tests__/Messages.edit.test.tsx
@@ -3,10 +3,7 @@ import { createRef } from "react";
 import { DataStreamProvider } from "../DataStreamProvider";
 import { Messages } from "../Messages";
 import type { ChatMessage } from "@/types";
-import {
-  mockLegendListGetState,
-  mockLegendListScrollToIndex,
-} from "../../../__mocks__/@legendapp/list-react";
+import { mockLegendListScrollToIndex } from "../../../__mocks__/@legendapp/list-react";
 
 jest.mock("../MessageItem", () => ({
   MessageItem: ({
@@ -91,8 +88,6 @@ const navigatorMessages = [
 
 describe("Messages virtualized row invalidation", () => {
   beforeEach(() => {
-    mockLegendListGetState.mockReset();
-    mockLegendListGetState.mockReturnValue({ data: [], end: -1, start: 0 });
     mockLegendListScrollToIndex.mockReset();
     mockLegendListScrollToIndex.mockResolvedValue(undefined);
   });
@@ -196,18 +191,7 @@ describe("Messages virtualized row invalidation", () => {
     );
   });
 
-  it("retries once when the first navigator scroll misses its target", async () => {
-    mockLegendListGetState.mockReturnValue({
-      data: [
-        {
-          kind: "message",
-          message: navigatorMessages[0],
-        },
-      ],
-      start: 2,
-      end: 3,
-    });
-
+  it("jumps to a navigator target without animation", async () => {
     render(
       <DataStreamProvider>
         <Messages
@@ -233,15 +217,10 @@ describe("Messages virtualized row invalidation", () => {
     fireEvent.keyDown(navigator, { key: "Enter" });
 
     await waitFor(() => {
-      expect(mockLegendListScrollToIndex).toHaveBeenCalledTimes(2);
+      expect(mockLegendListScrollToIndex).toHaveBeenCalledTimes(1);
     });
-    expect(mockLegendListScrollToIndex).toHaveBeenNthCalledWith(1, {
-      animated: true,
-      index: 0,
-      viewOffset: 24,
-    });
-    expect(mockLegendListScrollToIndex).toHaveBeenNthCalledWith(2, {
-      animated: true,
+    expect(mockLegendListScrollToIndex).toHaveBeenCalledWith({
+      animated: false,
       index: 0,
       viewOffset: 24,
     });

--- a/app/components/__tests__/Messages.edit.test.tsx
+++ b/app/components/__tests__/Messages.edit.test.tsx
@@ -74,6 +74,7 @@ describe("Messages editing", () => {
     render(
       <DataStreamProvider>
         <Messages
+          chatId="chat-1"
           messages={messages}
           setMessages={jest.fn()}
           onRegenerate={jest.fn()}
@@ -94,6 +95,42 @@ describe("Messages editing", () => {
 
     expect(screen.getByTestId("message-editor")).toHaveTextContent(
       "Editing user-1",
+    );
+  });
+
+  it("updates the virtualized dataset identity when the task changes", () => {
+    const props = {
+      messages,
+      setMessages: jest.fn(),
+      onRegenerate: jest.fn(),
+      onRetry: jest.fn(),
+      onEditMessage: jest.fn(),
+      status: "ready" as const,
+      error: null,
+      scrollRef: createRef<HTMLElement>(),
+      contentRef: createRef<HTMLElement>(),
+      isMobile: true,
+    };
+    const { rerender } = render(
+      <DataStreamProvider>
+        <Messages chatId="chat-1" {...props} />
+      </DataStreamProvider>,
+    );
+
+    expect(screen.getByTestId("messages-container")).toHaveAttribute(
+      "data-list-key",
+      "chat-1",
+    );
+
+    rerender(
+      <DataStreamProvider>
+        <Messages chatId="chat-2" {...props} />
+      </DataStreamProvider>,
+    );
+
+    expect(screen.getByTestId("messages-container")).toHaveAttribute(
+      "data-list-key",
+      "chat-2",
     );
   });
 });

--- a/app/components/__tests__/Messages.edit.test.tsx
+++ b/app/components/__tests__/Messages.edit.test.tsx
@@ -1,8 +1,12 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import { DataStreamProvider } from "../DataStreamProvider";
 import { Messages } from "../Messages";
 import type { ChatMessage } from "@/types";
+import {
+  mockLegendListGetState,
+  mockLegendListScrollToIndex,
+} from "../../../__mocks__/@legendapp/list-react";
 
 jest.mock("../MessageItem", () => ({
   MessageItem: ({
@@ -69,7 +73,28 @@ const messages = [
   },
 ] as ChatMessage[];
 
+const navigatorMessages = [
+  ...messages,
+  {
+    id: "user-2",
+    role: "user",
+    parts: [{ type: "text", text: "Follow-up question" }],
+  },
+  {
+    id: "assistant-2",
+    role: "assistant",
+    parts: [{ type: "text", text: "Follow-up answer" }],
+  },
+] as ChatMessage[];
+
 describe("Messages editing", () => {
+  beforeEach(() => {
+    mockLegendListGetState.mockReset();
+    mockLegendListGetState.mockReturnValue({ data: [], end: -1, start: 0 });
+    mockLegendListScrollToIndex.mockReset();
+    mockLegendListScrollToIndex.mockResolvedValue(undefined);
+  });
+
   it("invalidates the virtualized row when editing starts", () => {
     render(
       <DataStreamProvider>
@@ -132,5 +157,56 @@ describe("Messages editing", () => {
       "data-list-key",
       "chat-2",
     );
+  });
+
+  it("retries once when the first navigator scroll misses its target", async () => {
+    mockLegendListGetState.mockReturnValue({
+      data: [
+        {
+          kind: "message",
+          message: navigatorMessages[0],
+        },
+      ],
+      start: 2,
+      end: 3,
+    });
+
+    render(
+      <DataStreamProvider>
+        <Messages
+          chatId="chat-1"
+          messages={navigatorMessages}
+          setMessages={jest.fn()}
+          onRegenerate={jest.fn()}
+          onRetry={jest.fn()}
+          onEditMessage={jest.fn()}
+          status="ready"
+          error={null}
+          scrollRef={createRef<HTMLElement>()}
+          contentRef={createRef<HTMLElement>()}
+          isMobile={false}
+        />
+      </DataStreamProvider>,
+    );
+
+    const navigator = screen.getByRole("button", {
+      name: "Jump to message: User message",
+    });
+    fireEvent.focus(navigator);
+    fireEvent.keyDown(navigator, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockLegendListScrollToIndex).toHaveBeenCalledTimes(2);
+    });
+    expect(mockLegendListScrollToIndex).toHaveBeenNthCalledWith(1, {
+      animated: true,
+      index: 0,
+      viewOffset: 24,
+    });
+    expect(mockLegendListScrollToIndex).toHaveBeenNthCalledWith(2, {
+      animated: true,
+      index: 0,
+      viewOffset: 24,
+    });
   });
 });

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1889,6 +1889,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                 </div>
               ) : showChatLayout ? (
                 <Messages
+                  chatId={chatId}
                   scrollRef={scrollRef}
                   contentRef={contentRef}
                   messages={messages}


### PR DESCRIPTION
## Summary
- key the virtualized message timeline by chat so a newly opened conversation does not reuse stale list measurements
- make message navigator selections use one immediate LegendList jump instead of browser smooth scrolling
- remove the fallback retry that caused a visible stop-and-continue motion
- cover the chat data key and single non-animated navigator call with regression tests

## Root cause
On the first navigator use after opening a chat, dynamic row remeasurement changes the list's content height while the browser's smooth scroll is running. The animation can stop before reaching the target. Retrying it reaches the message, but creates the visible two-phase motion reported during QA.

The final fix follows the requested immediate-jump behavior: one `scrollToIndex()` call with `animated: false`. It does not use timers, retries, or modify timeline anchoring.

## Validation
- `corepack pnpm exec eslint app/components/Messages.tsx __mocks__/@legendapp/list-react.tsx app/components/__tests__/Messages.edit.test.tsx`
- `corepack pnpm exec prettier --check app/components/Messages.tsx __mocks__/@legendapp/list-react.tsx app/components/__tests__/Messages.edit.test.tsx`
- `corepack pnpm typecheck`
- `corepack pnpm jest --runInBand` — 324 suites, 3,228 tests passed
- Real Chrome, fresh local long chat, direct click on the top navigator marker:
  - immediately after click: `scrollTop 268`, target top `66`
  - 50 ms: `scrollTop 268`, target top `66`
  - 350 ms: `scrollTop 268`, target top `66`
  - 850 ms: `scrollTop 268`, target top `66`
  - no follow-up movement, pause, or restart observed

## Manual verification
1. Open a long conversation in a fresh page load.
2. Click the top message marker in the navigator once.
3. Confirm the target appears immediately and remains stationary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message list handling when switching between chats.
  * Messages now correctly refresh and remain associated with the active chat.
  * Improved navigation to messages, including reliable scrolling to selected messages without animation.

* **Tests**
  * Added coverage to verify the message container updates when the chat changes.
  * Added coverage for navigation to messages outside the initially visible range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->