### PR TITLE
Make branch icons horizontal

### DIFF
--- a/app/components/ChatHeader.tsx
+++ b/app/components/ChatHeader.tsx
@@ -252,7 +252,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
                         <TooltipProvider delayDuration={300}>
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <Split className="size-4 flex-shrink-0 text-muted-foreground" />
+                              <Split className="size-4 rotate-90 flex-shrink-0 text-muted-foreground" />
                             </TooltipTrigger>
                             <TooltipContent>
                               <p className="text-xs">

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -478,7 +478,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
             <TooltipProvider delayDuration={300}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Split className="size-3 flex-shrink-0 text-muted-foreground" />
+                  <Split className="size-3 rotate-90 flex-shrink-0 text-muted-foreground" />
                 </TooltipTrigger>
                 <TooltipContent side="right">
                   <p className="text-xs">

--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -361,7 +361,7 @@ export const MessageActions = ({
                     className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
                     aria-label="Branch in new task"
                   >
-                    <Split size={16} />
+                    <Split className="rotate-90" size={16} />
                   </button>
                 }
                 side="bottom"

--- a/app/components/__tests__/MessageActions.edit.test.tsx
+++ b/app/components/__tests__/MessageActions.edit.test.tsx
@@ -86,3 +86,29 @@ describe("MessageActions regeneration", () => {
     await waitFor(() => expect(onRegenerate).toHaveBeenCalledTimes(1));
   });
 });
+
+describe("MessageActions branching", () => {
+  it("shows the branch icon horizontally", () => {
+    render(
+      <MessageActions
+        messageText="Answer"
+        isUser={false}
+        isLastAssistantMessage
+        canRegenerate={false}
+        onRegenerate={jest.fn()}
+        onEdit={jest.fn()}
+        canEdit={false}
+        onBranch={jest.fn()}
+        isHovered
+        isEditing={false}
+        status="ready"
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Branch in new task" })
+        .querySelector("svg"),
+    ).toHaveClass("rotate-90");
+  });
+});


### PR DESCRIPTION
## Summary

- rotate the branch action icon horizontally to match the Codex-style left-to-right branch shape
- use the same orientation in branched-task headers and sidebar rows
- add a focused regression assertion for the message action icon

## Why

The existing Lucide `Split` glyph rendered vertically, while the intended branching affordance is horizontal.

## Impact

This is a visual-only change. Branching behavior, labels, and navigation are unchanged.

## Validation

- `pnpm test -- app/components/__tests__/MessageActions.edit.test.tsx app/components/__tests__/MessageActions.visibility.test.ts --runInBand` (10 tests)
- `pnpm typecheck`
- scoped ESLint and Prettier checks
- commit hook full test suite (324 suites, 3,229 tests)
- visual check confirmed the compiled icon renders with a 90-degree rotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the branched-chat icons so they display with the intended horizontal orientation across chat headers, chat items, and message actions.
* **Tests**
  * Added coverage verifying the updated orientation for the “Branch in new task” action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->