### PR TITLE
Keep Trigger tag limits from failing Agent runs

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -687,6 +687,12 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(routeSrc).toMatch(/metadata:\s*triggerMetadata/);
     expect(routeSrc).toMatch(/status:\s*"queued"/);
     expect(routeSrc).toMatch(/loginRequired:\s*false/);
+    expect(taskSrc).toMatch(
+      /getMissingAgentLongTags\(\s*ctx\.run\.tags,\s*desiredTaskStartTags,?\s*\)/,
+    );
+    expect(taskSrc).toMatch(
+      /if\s*\(missingTaskStartTags\.length\s*>\s*0\)[\s\S]*addAgentLongTags\(missingTaskStartTags/,
+    );
   });
 
   test("captures Trigger usage and active-time attribution on Agent completion", () => {

--- a/trigger/__tests__/agent-long-tag-updates.test.ts
+++ b/trigger/__tests__/agent-long-tag-updates.test.ts
@@ -1,0 +1,111 @@
+const addTagsMock = jest.fn();
+const warnMock = jest.fn();
+
+jest.mock("@trigger.dev/sdk", () => ({
+  tags: { add: (...args: unknown[]) => addTagsMock(...args) },
+  logger: { warn: (...args: unknown[]) => warnMock(...args) },
+}));
+
+import {
+  addAgentLongTags,
+  getMissingAgentLongTags,
+} from "../agent-long-tag-updates";
+
+const context = {
+  runId: "run_opaque",
+  chatId: "chat_opaque",
+  userId: "user_opaque",
+  stage: "task_start_missing" as const,
+};
+
+describe("addAgentLongTags", () => {
+  beforeEach(() => {
+    addTagsMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it("writes tags normally", async () => {
+    addTagsMock.mockResolvedValue(undefined);
+
+    await expect(
+      addAgentLongTags(["user_opaque", "chat_opaque"], context),
+    ).resolves.toBe(true);
+
+    expect(addTagsMock).toHaveBeenCalledWith(["user_opaque", "chat_opaque"]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps Agent work alive when Trigger rate-limits a tag update", async () => {
+    addTagsMock.mockRejectedValue(
+      Object.assign(new Error("Rate limit exceeded"), {
+        name: "TriggerApiError",
+        status: 429,
+        code: "rate_limit_exceeded",
+      }),
+    );
+
+    await expect(
+      addAgentLongTags(["user_opaque", "chat_opaque"], context),
+    ).resolves.toBe(false);
+
+    expect(warnMock).toHaveBeenCalledWith(
+      "[agent-long] tag update rate limited",
+      {
+        event: "agent_long_tag_update_rate_limited",
+        service: "agent-long",
+        reason: "trigger_api_rate_limited",
+        statusCode: 429,
+        stage: "task_start_missing",
+        runId: "run_opaque",
+        chatId: "chat_opaque",
+        userId: "user_opaque",
+        errorCode: "rate_limit_exceeded",
+      },
+    );
+  });
+
+  it("rethrows unknown tag failures", async () => {
+    const error = Object.assign(new Error("Trigger unavailable"), {
+      name: "TriggerApiError",
+      status: 503,
+    });
+    addTagsMock.mockRejectedValue(error);
+
+    await expect(addAgentLongTags("terminal_error", context)).rejects.toBe(
+      error,
+    );
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress unrelated 429-shaped application errors", async () => {
+    const error = Object.assign(new Error("Application rate limited"), {
+      status: 429,
+    });
+    addTagsMock.mockRejectedValue(error);
+
+    await expect(addAgentLongTags("terminal_error", context)).rejects.toBe(
+      error,
+    );
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getMissingAgentLongTags", () => {
+  it("avoids redundant task-start writes when run creation set every tag", () => {
+    expect(
+      getMissingAgentLongTags(
+        ["user_opaque", "chat_opaque", "sub_pro"],
+        ["user_opaque", "chat_opaque", "sub_pro"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("preserves one combined write for direct or admin-triggered runs", () => {
+    expect(
+      getMissingAgentLongTags(
+        ["user_opaque"],
+        ["user_opaque", "chat_opaque", "sub_pro"],
+      ),
+    ).toEqual(["chat_opaque", "sub_pro"]);
+  });
+});

--- a/trigger/agent-long-tag-updates.ts
+++ b/trigger/agent-long-tag-updates.ts
@@ -1,0 +1,65 @@
+import { logger as triggerLogger, tags } from "@trigger.dev/sdk";
+
+type AgentLongTagValue = string | string[];
+
+export type AgentLongTagUpdateStage =
+  | "task_start_missing"
+  | "terminal_error"
+  | "handled_rate_limit"
+  | "handled_tool_failure"
+  | "realtime_transport_error";
+
+type AgentLongTagUpdateContext = {
+  runId: string;
+  chatId: string;
+  userId: string;
+  stage: AgentLongTagUpdateStage;
+};
+
+const getErrorField = (error: unknown, field: string): unknown => {
+  if (!error || typeof error !== "object") return undefined;
+  return (error as Record<string, unknown>)[field];
+};
+
+const isTriggerApiRateLimitError = (error: unknown): boolean =>
+  getErrorField(error, "name") === "TriggerApiError" &&
+  getErrorField(error, "status") === 429;
+
+export const getMissingAgentLongTags = (
+  existingTags: readonly string[],
+  desiredTags: readonly string[],
+): string[] => {
+  const existing = new Set(existingTags);
+  return desiredTags.filter((tag) => !existing.has(tag));
+};
+
+/**
+ * Trigger tags are dashboard-only diagnostics. A project-level Trigger API
+ * rate-limit burst must not terminate otherwise healthy Agent work, while
+ * unknown tag failures remain visible through the task's normal error path.
+ */
+export const addAgentLongTags = async (
+  value: AgentLongTagValue,
+  context: AgentLongTagUpdateContext,
+): Promise<boolean> => {
+  try {
+    await tags.add(value);
+    return true;
+  } catch (error) {
+    if (!isTriggerApiRateLimitError(error)) throw error;
+
+    const errorCode = getErrorField(error, "code");
+    triggerLogger.warn("[agent-long] tag update rate limited", {
+      event: "agent_long_tag_update_rate_limited",
+      service: "agent-long",
+      reason: "trigger_api_rate_limited",
+      statusCode: 429,
+      stage: context.stage,
+      runId: context.runId,
+      chatId: context.chatId,
+      userId: context.userId,
+      ...(typeof errorCode === "string" ? { errorCode } : {}),
+    });
+    return false;
+  }
+};

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1,12 +1,15 @@
 import {
   task,
-  tags,
   metadata,
   logger as triggerLogger,
   usage as triggerUsage,
 } from "@trigger.dev/sdk";
 import * as triggerSdk from "@trigger.dev/sdk";
 import { agentUiStream } from "./streams";
+import {
+  addAgentLongTags,
+  getMissingAgentLongTags,
+} from "./agent-long-tag-updates";
 import {
   createUIMessageStream,
   generateId,
@@ -1388,7 +1391,12 @@ const recordAgentLongFailureForDashboard = async (
       buildTriggerTag("error_sandbox_upload_", summary.uploadFailureReason),
     );
   }
-  await tags.add(terminalTags);
+  await addAgentLongTags(terminalTags, {
+    runId: context.runId,
+    chatId: context.chatId,
+    userId: context.userId,
+    stage: "terminal_error",
+  });
 
   const { emptyAfterProcessingMetadata, ...summaryLogFields } = summary;
   const logFields = {
@@ -1438,10 +1446,18 @@ const recordAgentLongHandledRateLimitForDashboard = async (
 
   if (summary.statusCode) metadata.set("blockedStatusCode", summary.statusCode);
 
-  await tags.add([
-    "rate_limited",
-    buildTriggerTag("blocked_code_", summary.code ?? "rate_limit_chat"),
-  ]);
+  await addAgentLongTags(
+    [
+      "rate_limited",
+      buildTriggerTag("blocked_code_", summary.code ?? "rate_limit_chat"),
+    ],
+    {
+      runId: context.runId,
+      chatId: context.chatId,
+      userId: context.userId,
+      stage: "handled_rate_limit",
+    },
+  );
 
   triggerLogger.info("[agent-long] run rate limited", {
     chatId: context.chatId,
@@ -1473,14 +1489,22 @@ const recordAgentLongHandledToolFailureForDashboard = async (
     metadata.set("lastHandledToolFailureStatus", failure.status);
   }
 
-  await tags.add([
-    "handled_tool_failure",
-    buildTriggerTag("tool_", failure.tool_name),
-    buildTriggerTag("tool_provider_", failure.provider),
-    ...(failure.status != null
-      ? [buildTriggerTag("tool_status_", String(failure.status))]
-      : []),
-  ]);
+  await addAgentLongTags(
+    [
+      "handled_tool_failure",
+      buildTriggerTag("tool_", failure.tool_name),
+      buildTriggerTag("tool_provider_", failure.provider),
+      ...(failure.status != null
+        ? [buildTriggerTag("tool_status_", String(failure.status))]
+        : []),
+    ],
+    {
+      runId: context.runId,
+      chatId: context.chatId,
+      userId: context.userId,
+      stage: "handled_tool_failure",
+    },
+  );
 
   triggerLogger.warn("[agent-long] handled tool failure", {
     chatId: context.chatId,
@@ -1718,9 +1742,26 @@ export const agentLongTask = task({
       };
     };
 
-    // Tag for dashboard filtering; add subscription tier for paid-only queries.
-    await tags.add([`user_${userId}`, `chat_${chatId}`]);
-    if (subscription !== "free") await tags.add(`sub_${subscription}`);
+    // The Vercel trigger route normally supplies these tags atomically with
+    // run creation. Preserve direct/admin triggers without spending another
+    // Trigger API request when the run already has the desired tags.
+    const desiredTaskStartTags = [
+      `user_${userId}`,
+      `chat_${chatId}`,
+      ...(subscription !== "free" ? [`sub_${subscription}`] : []),
+    ];
+    const missingTaskStartTags = getMissingAgentLongTags(
+      ctx.run.tags,
+      desiredTaskStartTags,
+    );
+    if (missingTaskStartTags.length > 0) {
+      await addAgentLongTags(missingTaskStartTags, {
+        runId: ctx.run.id,
+        chatId,
+        userId,
+        stage: "task_start_missing",
+      });
+    }
 
     // Lifecycle metadata so the dashboard shows progress for long runs.
     metadata
@@ -3640,7 +3681,12 @@ export const agentLongTask = task({
           .set("realtimeStreamStatus", "transport_error")
           .set("realtimeStreamErrorMessage", errorMessage)
           .set("realtimeStreamFailedAt", new Date().toISOString());
-        await tags.add("trigger_realtime_transport_error");
+        await addAgentLongTags("trigger_realtime_transport_error", {
+          runId: ctx.run.id,
+          chatId,
+          userId,
+          stage: "realtime_transport_error",
+        });
         triggerLogger.warn("[agent-long] realtime stream transport failed", {
           chatId,
           userId,


### PR DESCRIPTION
## Summary
- avoid redundant task-start Trigger tag API calls when the run was already tagged at creation
- preserve direct/admin-triggered runs with one combined write for only missing tags
- treat only Trigger API 429s from Agent diagnostic tag updates as best-effort, with a bounded structured warning; non-429 and unrelated failures still throw
- add focused behavioral and cross-entry-point regression coverage

## Production evidence
Frozen audit window: `2026-08-04T21:03:35.786Z` through `2026-08-05T21:03:35.786Z`.

Trigger.dev recorded 11 failed `agent-long` runs across 10 opaque users/chats on worker `20260805.5` from `2026-08-05T14:30:57.610Z` through `14:33:17.371Z`. Representative run `run_06ft4ldb4f1ta41ignn3ns7fc1` failed in `tags.set` after four completed 429 waits over 36.4 seconds with `Rate limit exceeded 0/1500 requests remaining`.

The same interval had a concentrated Vercel incident: 1,255 Agent API timeout rows across 94 observed users, primarily `/api/agent/resume`, with zero error rows in the adjacent 15-minute windows. The underlying project-level Trigger control-plane incident remains visible; this PR prevents optional diagnostic tag mutations from terminating otherwise healthy Agent work and reduces standard-run tag traffic.

## Root cause
The Vercel trigger route already attaches user, chat, subscription, and permission tags atomically when creating direct runs and approval sessions. The Trigger task repeated user/chat/subscription writes at startup. During the shared Trigger API quota burst, that redundant dashboard mutation exhausted SDK retries and failed the task before Agent work began.

## Change
- Compare desired startup tags with `ctx.run.tags`; standard route-created runs perform no extra startup tag request.
- Direct/admin runs still add all missing startup tags in one request.
- Centralize Agent tag updates so only structural Trigger API 429 errors are swallowed after emitting `agent_long_tag_update_rate_limited` with a bounded stage, reason, status, and opaque run/chat/user IDs.
- Preserve failure behavior for Trigger 503/auth/unknown errors and unrelated 429-shaped application errors.

## Validation
- `corepack pnpm jest trigger/__tests__/agent-long-tag-updates.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 2 suites / 89 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint, Prettier, and `git diff --check` — passed
- commit hooks — 325 suites / 3,235 tests passed, plus typecheck and staged lint/format

Visual QA is not applicable because this changes backend Trigger task resilience and diagnostics only.

## Manual verification
After preview deployment:
1. Start an Agent run through the normal `/api/agent` route and confirm the run retains user/chat/subscription/permission tags without a redundant task-start tag update.
2. Simulate a Trigger API 429 for a diagnostic tag update and confirm `agent_long_tag_update_rate_limited` is emitted once for the bounded stage while the Agent run continues.
3. Confirm a non-429 tag failure still terminates through the existing error path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved run labeling across task starts, terminal errors, tool failures, rate limits, and connection issues.
  - Added support for subscription-related labels.
  - Prevented duplicate labels and avoided unnecessary updates.
  - Improved handling of rate limits with graceful suppression and clearer diagnostic logging.
  - Preserved visibility of unexpected errors for reliable troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->