### PR TITLE
Use low reasoning for free Ask

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -30,7 +30,6 @@ const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
 const DEEPSEEK_FLASH_CANONICAL_SLUG = "deepseek/deepseek-v4-flash-20260731";
 const GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "ask-model",
-  "ask-model-free",
   "agent-model",
   "agent-model-free",
   "model-grok-4.5",
@@ -240,19 +239,38 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it("uses high reasoning when free Ask can fall back to Grok", () => {
+  it("uses low reasoning for free Ask across its fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
     expect(opts.openrouter.reasoning).toEqual({
       enabled: true,
-      effort: "high",
+      effort: "low",
     });
+    expect(opts.openrouter.models).toEqual([GROK_SLUG, KIMI_K3_SLUG]);
+  });
+
+  it("keeps free Ask reasoning low over a scoped override", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "ask-model-free",
+      "ask",
+      {
+        reasoningOverride: { enabled: true, effort: "medium" },
+      },
+    );
+
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "low",
+    });
+    expect(opts.openrouter.models).toEqual([GROK_SLUG, KIMI_K3_SLUG]);
   });
 
   it("keeps Grok fallback reasoning high over a lower scoped override", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
-      "ask-model-free",
+      "model-deepseek-v4-pro",
       "ask",
       {
         reasoningOverride: { enabled: true, effort: "medium" },

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -735,31 +735,40 @@ export function buildProviderOptions(
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
   const isGrok45 = modelId === GROK_4_5_SLUG;
+  // Free Ask uses low reasoning across the entire OpenRouter request, including
+  // its Grok/Kimi fallbacks. OpenRouter does not support per-fallback effort.
+  const isFreeAskDeepSeekV4 =
+    mode === "ask" && modelName === "ask-model-free" && isDeepSeekV4;
   // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this
   // mode-scoped for any future route that does not also include Grok.
   const isAgentDeepSeekV4 = mode === "agent" && isDeepSeekV4;
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
   // OpenRouter applies one reasoning configuration to both the primary model
-  // and every provider fallback. Force high whenever this request can resolve
-  // to Grok 4.5 so fallback execution cannot inherit a lower effort.
+  // and every provider fallback. Aside from the explicit free Ask policy,
+  // force high whenever Grok 4.5 is reachable so it cannot inherit less effort.
   const routesThroughGrok45 = isGrok45 || fallbackSlugs.includes(GROK_4_5_SLUG);
-  const reasoning = routesThroughGrok45
+  const reasoning = isFreeAskDeepSeekV4
     ? {
         enabled: true,
-        effort: "high",
+        effort: "low",
       }
-    : (options.reasoningOverride ??
-      (isHighReasoningModel(modelName) || isAgentDeepSeekV4
-        ? {
-            enabled: true,
-            effort: "high",
-          }
-        : isReasoningModel
+    : routesThroughGrok45
+      ? {
+          enabled: true,
+          effort: "high",
+        }
+      : (options.reasoningOverride ??
+        (isHighReasoningModel(modelName) || isAgentDeepSeekV4
           ? {
               enabled: true,
-              ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
+              effort: "high",
             }
-          : { enabled: false }));
+          : isReasoningModel
+            ? {
+                enabled: true,
+                ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
+              }
+            : { enabled: false }));
 
   return {
     openrouter: {


### PR DESCRIPTION
## Summary

- use low reasoning for free Ask requests routed through DeepSeek V4 Flash
- keep free Agent and other Grok-backed routes on high reasoning
- add regression coverage for the free Ask policy and its fallback chain

## Why

Free Ask should use the lower reasoning level while Agent retains deeper reasoning. OpenRouter applies reasoning configuration to the full request, so the free Ask Grok and Kimi fallbacks inherit low reasoning as well.

## Validation

- `pnpm test lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand` (70 tests)
- `pnpm typecheck`
- `pnpm exec eslint lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts`
- full pre-commit Jest suite (326 suites, 3,241 tests)

## Manual verification

1. In a free account, send a text prompt in Ask mode and confirm the OpenRouter request uses `reasoning.effort = low`.
2. Send a prompt in Agent mode and confirm it continues to use `reasoning.effort = high`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning behavior for free Ask requests across DeepSeek V4 and fallback models.
  * Ensured requests reaching Grok 4.5 consistently use high reasoning.
  * Preserved scoped reasoning overrides while applying the correct model-specific defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->