### PR TITLE
Harden retired temporary chat data handling

### DIFF
--- a/convex/__tests__/tempStreams.test.ts
+++ b/convex/__tests__/tempStreams.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockValidateServiceKey = jest.fn();
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config) => config),
+  query: jest.fn((config) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: new Proxy(
+    {},
+    {
+      get: () => jest.fn(() => "validator"),
+    },
+  ),
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: mockValidateServiceKey,
+}));
+
+describe("legacy temp stream cleanup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("inspects legacy rows through bounded pagination", async () => {
+    const paginate = jest.fn().mockResolvedValue({
+      page: [{ _id: "temp-1" }, { _id: "temp-2" }],
+      isDone: false,
+      continueCursor: "next-cursor",
+    });
+    const order = jest.fn(() => ({ paginate }));
+    const query = jest.fn(() => ({ order }));
+    const { inspectLegacyTempStreams } = await import("../tempStreams");
+
+    await expect(
+      inspectLegacyTempStreams.handler({ db: { query } } as any, {
+        serviceKey: "service-key",
+        cursor: null,
+        numItems: 25,
+      }),
+    ).resolves.toEqual({
+      rowCount: 2,
+      isDone: false,
+      continueCursor: "next-cursor",
+    });
+
+    expect(mockValidateServiceKey).toHaveBeenCalledWith("service-key");
+    expect(query).toHaveBeenCalledWith("temp_streams");
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 25 });
+  });
+
+  it("purges only one bounded batch and reports remaining rows", async () => {
+    const rows = [{ _id: "temp-1" }, { _id: "temp-2" }, { _id: "temp-3" }];
+    const take = jest.fn().mockResolvedValue(rows);
+    const order = jest.fn(() => ({ take }));
+    const query = jest.fn(() => ({ order }));
+    const deleteRow = jest.fn().mockResolvedValue(undefined);
+    const { purgeLegacyTempStreams } = await import("../tempStreams");
+
+    await expect(
+      purgeLegacyTempStreams.handler(
+        { db: { query, delete: deleteRow } } as any,
+        { serviceKey: "service-key", limit: 2 },
+      ),
+    ).resolves.toEqual({ deletedCount: 2, hasMore: true });
+
+    expect(mockValidateServiceKey).toHaveBeenCalledWith("service-key");
+    expect(take).toHaveBeenCalledWith(3);
+    expect(deleteRow.mock.calls).toEqual([["temp-1"], ["temp-2"]]);
+  });
+});

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -263,6 +263,14 @@ function seedTables(userId = "user_123", otherUserId = "user_other"): Tables {
       { _id: "custom-user", user_id: userId, updated_at: 1 },
       { _id: "custom-other", user_id: otherUserId, updated_at: 1 },
     ],
+    temp_streams: [
+      { _id: "temp-stream-user", chat_id: "chat-1", user_id: userId },
+      {
+        _id: "temp-stream-other",
+        chat_id: "chat-other-id",
+        user_id: otherUserId,
+      },
+    ],
     extra_usage: [
       {
         _id: "extra-user",
@@ -545,6 +553,8 @@ describe("userDeletion", () => {
     expect(row(tables, "chats", "chat-other")).toBeTruthy();
     expect(row(tables, "feedback", "feedback-other")).toBeTruthy();
     expect(row(tables, "files", "file-other")).toBeTruthy();
+    expect(row(tables, "temp_streams", "temp-stream-user")).toBeUndefined();
+    expect(row(tables, "temp_streams", "temp-stream-other")).toBeTruthy();
 
     expect(row(tables, "cancellation_reasons", "cancel-user")).toMatchObject({
       user_id: DELETED_USER_ID,

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -40,6 +40,7 @@ import type * as s3Utils from "../s3Utils.js";
 import type * as sharedChats from "../sharedChats.js";
 import type * as teamExtraUsage from "../teamExtraUsage.js";
 import type * as teamExtraUsageActions from "../teamExtraUsageActions.js";
+import type * as tempStreams from "../tempStreams.js";
 import type * as unitEconomics from "../unitEconomics.js";
 import type * as unitEconomicsLib from "../unitEconomicsLib.js";
 import type * as usageLogs from "../usageLogs.js";
@@ -86,6 +87,7 @@ declare const fullApi: ApiFromModules<{
   sharedChats: typeof sharedChats;
   teamExtraUsage: typeof teamExtraUsage;
   teamExtraUsageActions: typeof teamExtraUsageActions;
+  tempStreams: typeof tempStreams;
   unitEconomics: typeof unitEconomics;
   unitEconomicsLib: typeof unitEconomicsLib;
   usageLogs: typeof usageLogs;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -618,6 +618,15 @@ export default defineSchema({
       filterFields: ["user_id", "category"],
     }),
 
+  // Legacy cleanup surface only. Do not add new writers. Remove this table
+  // after production inspection and purge confirm that no rows remain.
+  temp_streams: defineTable({
+    chat_id: v.string(),
+    user_id: v.string(),
+  })
+    .index("by_chat_id", ["chat_id"])
+    .index("by_user_id", ["user_id"]),
+
   // Local Sandbox Tables
   local_sandbox_tokens: defineTable({
     user_id: v.string(),

--- a/convex/tempStreams.ts
+++ b/convex/tempStreams.ts
@@ -1,0 +1,83 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { validateServiceKey } from "./lib/utils";
+
+const DEFAULT_BATCH_SIZE = 100;
+const MAX_BATCH_SIZE = 200;
+
+const normalizeBatchSize = (requested?: number): number => {
+  if (requested === undefined || !Number.isFinite(requested)) {
+    return DEFAULT_BATCH_SIZE;
+  }
+
+  return Math.min(MAX_BATCH_SIZE, Math.max(1, Math.floor(requested)));
+};
+
+/**
+ * Inspect one bounded page of the retired temp_streams table. Callers should
+ * follow continueCursor until isDone and sum rowCount before purging.
+ */
+export const inspectLegacyTempStreams = query({
+  args: {
+    serviceKey: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.optional(v.number()),
+  },
+  returns: v.object({
+    rowCount: v.number(),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const result = await ctx.db
+      .query("temp_streams")
+      .order("asc")
+      .paginate({
+        cursor: args.cursor,
+        numItems: normalizeBatchSize(args.numItems),
+      });
+
+    return {
+      rowCount: result.page.length,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+/**
+ * Delete one bounded batch from the retired temp_streams table. Repeat while
+ * hasMore is true, then inspect again and remove this migration surface only
+ * after the production table is verified empty.
+ */
+export const purgeLegacyTempStreams = mutation({
+  args: {
+    serviceKey: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({
+    deletedCount: v.number(),
+    hasMore: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const limit = normalizeBatchSize(args.limit);
+    const rows = await ctx.db
+      .query("temp_streams")
+      .order("asc")
+      .take(limit + 1);
+    const rowsToDelete = rows.slice(0, limit);
+
+    for (const row of rowsToDelete) {
+      await ctx.db.delete(row._id);
+    }
+
+    return {
+      deletedCount: rowsToDelete.length,
+      hasMore: rows.length > limit,
+    };
+  },
+});

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -19,6 +19,7 @@ export const USER_DELETION_TABLE_POLICY = {
     "user_customization",
     "extra_usage",
     "team_member_usage",
+    "temp_streams",
     "local_sandbox_tokens",
     "local_sandbox_connections",
     "cancellation_reason_details",
@@ -374,6 +375,13 @@ async function cleanupUserDataForUser(
   >(ctx, budget, "user_customization", "by_user_id", (q) =>
     q.eq("user_id", userId),
   );
+  const tempStreamsBatch = await collectByIndexBatch<Doc<"temp_streams">>(
+    ctx,
+    budget,
+    "temp_streams",
+    "by_user_id",
+    (q) => q.eq("user_id", userId),
+  );
   const localSandboxTokensBatch = await collectByIndexBatch<
     Doc<"local_sandbox_tokens">
   >(ctx, budget, "local_sandbox_tokens", "by_user_id", (q) =>
@@ -413,6 +421,7 @@ async function cleanupUserDataForUser(
     notesBatch,
     customizationBatch,
     messagesBatch,
+    tempStreamsBatch,
     localSandboxTokensBatch,
     localSandboxConnectionsBatch,
     extraUsageBatch,
@@ -425,6 +434,7 @@ async function cleanupUserDataForUser(
   const files = filesBatch.docs;
   const notes = notesBatch.docs;
   const customization = customizationBatch.docs;
+  const tempStreams = tempStreamsBatch.docs;
   const localSandboxTokens = localSandboxTokensBatch.docs;
   const localSandboxConnections = localSandboxConnectionsBatch.docs;
   const extraUsage = extraUsageBatch.docs;
@@ -446,6 +456,7 @@ async function cleanupUserDataForUser(
   await deleteFiles(ctx, stats, files, mode);
   await deleteDocs(ctx, stats, "notes", notes, mode);
   await deleteDocs(ctx, stats, "user_customization", customization, mode);
+  await deleteDocs(ctx, stats, "temp_streams", tempStreams, mode);
   await deleteDocs(
     ctx,
     stats,

--- a/lib/api/__tests__/agent-trigger-route.test.ts
+++ b/lib/api/__tests__/agent-trigger-route.test.ts
@@ -1,7 +1,31 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
+class MockResponse {
+  readonly status: number;
+  private readonly body: unknown;
+
+  constructor(body: unknown, init?: { status?: number }) {
+    this.body = body;
+    this.status = init?.status ?? 200;
+  }
+
+  static json(body: unknown, init?: { status?: number }) {
+    return new MockResponse(body, init);
+  }
+
+  async json() {
+    return this.body;
+  }
+}
+
+Object.defineProperty(globalThis, "Response", {
+  configurable: true,
+  value: MockResponse,
+});
+
 const mockCreatePublicToken = jest.fn<any>();
 const mockSetActiveTriggerRun = jest.fn<any>();
+const mockHandleInitialChatAndUserMessage = jest.fn<any>();
 const mockCancelAgentTriggerRun = jest.fn<any>();
 const mockCloseAgentApprovalSession = jest.fn<any>();
 
@@ -20,7 +44,7 @@ jest.mock("@trigger.dev/sdk", () => ({
 jest.mock("@/lib/db/actions", () => ({
   getChatById: jest.fn(),
   getUserCustomization: jest.fn(),
-  handleInitialChatAndUserMessage: jest.fn(),
+  handleInitialChatAndUserMessage: mockHandleInitialChatAndUserMessage,
   setActiveTriggerRun: mockSetActiveTriggerRun,
 }));
 
@@ -53,6 +77,7 @@ jest.mock("@/lib/utils/sandbox-file-utils", () => ({
 const {
   buildAgentApprovalSessionId,
   buildAgentRunDedupeKeyParts,
+  createAgentTriggerPost,
   finalizeStartedAgentRun,
   shouldRequireAgentApprovalWorkerVersion,
 } =
@@ -67,6 +92,32 @@ describe("Agent trigger route lifecycle", () => {
     mockCancelAgentTriggerRun.mockResolvedValue(true);
     mockCloseAgentApprovalSession.mockResolvedValue(true);
   });
+
+  it.each([true, false])(
+    "rejects retired temporary=%s before persistence",
+    async (temporary) => {
+      const post = createAgentTriggerPost({ endpoint: "/api/agent" });
+      const response = await post({
+        headers: new Headers(),
+        json: jest.fn().mockResolvedValue({
+          chatId: "chat-1",
+          messages: [],
+          temporary,
+        }),
+      } as any);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        code: "bad_request:api",
+        cause: "Invalid chat request: temporary is no longer supported.",
+        metadata: {
+          invalid_request_field: "temporary",
+          invalid_request_field_reason: "retired_field",
+        },
+      });
+      expect(mockHandleInitialChatAndUserMessage).not.toHaveBeenCalled();
+    },
+  );
 
   it("closes and cancels a run that cannot be associated after deletion", async () => {
     mockSetActiveTriggerRun.mockResolvedValue("deleting");

--- a/lib/api/__tests__/chat-handler-request-validation.test.ts
+++ b/lib/api/__tests__/chat-handler-request-validation.test.ts
@@ -1,6 +1,41 @@
-import { requireChatMessagesArray } from "@/lib/api/chat-request-validation";
+import {
+  requireChatMessagesArray,
+  requireRetiredTemporaryFieldAbsent,
+} from "@/lib/api/chat-request-validation";
 
 describe("chat-handler request validation", () => {
+  it.each([true, false])(
+    "rejects retired temporary=%s before persistence",
+    (temporary) => {
+      const persist = jest.fn();
+
+      expect(() => {
+        const body = { messages: [], temporary };
+        requireRetiredTemporaryFieldAbsent(body);
+        persist(body);
+      }).toThrow(
+        expect.objectContaining({
+          type: "bad_request",
+          surface: "api",
+          statusCode: 400,
+          cause: "Invalid chat request: temporary is no longer supported.",
+          metadata: expect.objectContaining({
+            invalid_request_field: "temporary",
+            invalid_request_field_reason: "retired_field",
+          }),
+        }),
+      );
+
+      expect(persist).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts requests that omit the retired temporary field", () => {
+    expect(() =>
+      requireRetiredTemporaryFieldAbsent({ messages: [] }),
+    ).not.toThrow();
+  });
+
   it("rejects non-array messages as a bad request", () => {
     expect(() => requireChatMessagesArray({ id: "not-array" })).toThrow(
       expect.objectContaining({

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -29,7 +29,10 @@ import {
   normalizeSelectedModelOverrideForSubscription,
 } from "@/types";
 import { ChatSDKError } from "@/lib/errors";
-import { requireOptionalIdentifier } from "@/lib/api/chat-request-validation";
+import {
+  requireOptionalIdentifier,
+  requireRetiredTemporaryFieldAbsent,
+} from "@/lib/api/chat-request-validation";
 import { readAnalyticsRequestContext } from "@/lib/analytics/request-context";
 import { resolveProjectExecutionContext } from "@/lib/chat/project-context";
 import type {
@@ -124,6 +127,8 @@ const parseAgentTriggerRequestBody = async (
       response: new NextResponse("Invalid JSON body", { status: 400 }),
     };
   }
+
+  requireRetiredTemporaryFieldAbsent(rawBody);
 
   const body = rawBody as Record<string, unknown>;
   if (typeof body.chatId !== "string" || body.chatId.length === 0) {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -157,6 +157,7 @@ import {
 import {
   requireChatMessagesArray,
   requireOptionalIdentifier,
+  requireRetiredTemporaryFieldAbsent,
 } from "@/lib/api/chat-request-validation";
 import { resolveProjectExecutionContext } from "@/lib/chat/project-context";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
@@ -216,6 +217,9 @@ export const createChatHandler = () => {
     };
 
     try {
+      const rawRequestBody: unknown = await req.json();
+      requireRetiredTemporaryFieldAbsent(rawRequestBody);
+
       const {
         messages,
         mode,
@@ -228,7 +232,7 @@ export const createChatHandler = () => {
         useClientMessagesForRegenerate,
         limitRescue: rawLimitRescue,
         projectId: rawProjectId,
-      }: {
+      } = rawRequestBody as {
         messages: unknown;
         mode: ChatMode;
         chatId: string;
@@ -240,7 +244,7 @@ export const createChatHandler = () => {
         useClientMessagesForRegenerate?: boolean;
         limitRescue?: unknown;
         projectId?: unknown;
-      } = await req.json();
+      };
       const analyticsRequestContext = readAnalyticsRequestContext(req.headers);
       const requestedProjectId = requireOptionalIdentifier(
         "projectId",

--- a/lib/api/chat-request-validation.ts
+++ b/lib/api/chat-request-validation.ts
@@ -9,6 +9,24 @@ const getValueKind = (value: unknown): string =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+export const requireRetiredTemporaryFieldAbsent = (
+  requestBody: unknown,
+): void => {
+  if (
+    isRecord(requestBody) &&
+    Object.prototype.hasOwnProperty.call(requestBody, "temporary")
+  ) {
+    throw new ChatSDKError(
+      "bad_request:api",
+      "Invalid chat request: temporary is no longer supported.",
+      {
+        invalid_request_field: "temporary",
+        invalid_request_field_reason: "retired_field",
+      },
+    );
+  }
+};
+
 const invalidMessagesError = (
   field: string,
   value: unknown,


### PR DESCRIPTION
## Summary
- reject the retired `temporary` request field with HTTP 400 in both chat and Agent entry points before authentication or persistence
- restore `temp_streams` only as a legacy cleanup surface, including account-deletion coverage
- add service-key-protected, bounded inspection and purge operations without restoring any legacy creation, cancellation, or status paths

## Security closure
- **CAND-ABF-01:** hardened. Requests containing `temporary` (including `false`) are rejected before `handleInitialChatAndUserMessage`; regression coverage asserts a 400 response and zero persistence calls.
- **CAND-AAU-01:** migration path added. Historical rows can be counted page-by-page, purged in capped batches, and remain covered by user deletion until production is verified empty.
- These remain privacy hardening for previously ignored Low candidates; this patch does not claim an attacker-controlled cross-tenant exploit.

## Validation
- `corepack pnpm jest --runInBand` — 327 suites / 3,248 tests passed
- `corepack pnpm typecheck`
- targeted ESLint on all changed TypeScript files
- targeted Prettier check on all changed files
- `git diff --check`
- `convex dev --once` could not load a deployment config in this worktree; schema/function typing and generated API typing pass locally

## Manual verification
1. Deploy to the intended Convex environment.
2. Call `tempStreams:inspectLegacyTempStreams` with the service key, beginning with a null cursor; follow cursors until done and record the summed row count.
3. If the count is non-zero, call `tempStreams:purgeLegacyTempStreams` in bounded batches until `hasMore` is false, then repeat inspection and confirm zero rows.
4. Retain the schema and user-deletion cleanup until production inspection is recorded as zero.
5. POST otherwise-valid requests containing `temporary: true` to `/api/chat` and `/api/agent`; each should return HTTP 400 and create no chat/message rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled inspection and batch cleanup for legacy temporary stream records.
  * Included temporary stream data in user deletion cleanup.

* **Bug Fixes**
  * Requests containing the retired `temporary` field now return a validation error and are not saved.
  * Requests without the retired field continue to pass validation.

* **Tests**
  * Added coverage for cleanup pagination, deletion limits, service-key validation, and user-specific data removal.
  * Added API validation coverage for rejected legacy request fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->