### PR TITLE
Recover transient desktop relay publishes

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -991,6 +991,72 @@ describe("forwardChunk", () => {
     },
   );
 
+  it("preserves sequence continuity after a chunk exhausts its retries", async () => {
+    jest.useFakeTimers();
+    let finishCommand!: () => void;
+    const commandFinished = new Promise<void>((resolve) => {
+      finishCommand = resolve;
+    });
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "execute_stream_command") {
+        await commandFinished;
+      }
+      return undefined;
+    };
+    const publishError = { code: 11, message: "connection closed" };
+    mockSubscription.publish
+      .mockRejectedValueOnce(publishError)
+      .mockRejectedValueOnce(publishError)
+      .mockRejectedValueOnce(publishError)
+      .mockResolvedValue(undefined);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const bridge = new DesktopSandboxBridge(buildConfig());
+      await bridge.start();
+      const handler = getPublicationHandler();
+      handler({
+        data: {
+          type: "command",
+          commandId: "cmd-sequence-after-exhaustion",
+          command: "test",
+          targetConnectionId: "conn-123",
+        },
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      const firstChunk = capturedChannel!.onmessage!({
+        type: "stdout",
+        data: "dropped",
+      }) as unknown as Promise<void>;
+      const secondChunk = capturedChannel!.onmessage!({
+        type: "stdout",
+        data: "delivered",
+      }) as unknown as Promise<void>;
+
+      await jest.advanceTimersByTimeAsync(250);
+      await jest.advanceTimersByTimeAsync(500);
+      await Promise.all([
+        expect(firstChunk).resolves.toBeUndefined(),
+        expect(secondChunk).resolves.toBeUndefined(),
+      ]);
+
+      expect(mockSubscription.publish).toHaveBeenNthCalledWith(4, {
+        type: "stdout",
+        commandId: "cmd-sequence-after-exhaustion",
+        data: "delivered",
+        sequence: 1,
+      });
+    } finally {
+      finishCommand();
+      mockSubscription.publish.mockResolvedValue(undefined);
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
   it("retries a transient publish after reconnect and reports recovery", async () => {
     jest.useFakeTimers();
     let finishCommand!: () => void;

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -13,6 +13,7 @@ const mockSubscription = {
   unsubscribe: jest.fn(),
   removeAllListeners: jest.fn(),
   publish: jest.fn().mockResolvedValue(undefined),
+  ready: jest.fn().mockResolvedValue(undefined),
 };
 
 const mockClient = {
@@ -20,6 +21,7 @@ const mockClient = {
   connect: jest.fn(),
   disconnect: jest.fn(),
   on: jest.fn(),
+  ready: jest.fn().mockResolvedValue(undefined),
 };
 let mockClientOptions: { getToken?: () => Promise<string> } | null = null;
 
@@ -703,7 +705,12 @@ describe("forwardChunk", () => {
     ]);
 
     expect(calls).toContainEqual([
-      { type: "stdout", commandId: "cmd-fwd", data: "hello world" },
+      {
+        type: "stdout",
+        commandId: "cmd-fwd",
+        data: "hello world",
+        sequence: 0,
+      },
     ]);
   });
 
@@ -722,7 +729,7 @@ describe("forwardChunk", () => {
     const calls = await startBridgeAndForwardChunks([{ type: "exit" }]);
 
     expect(calls).toContainEqual([
-      { type: "exit", commandId: "cmd-fwd", exitCode: -1 },
+      { type: "exit", commandId: "cmd-fwd", exitCode: -1, sequence: 0 },
     ]);
   });
 
@@ -732,7 +739,7 @@ describe("forwardChunk", () => {
     ]);
 
     expect(calls).toContainEqual([
-      { type: "exit", commandId: "cmd-fwd", exitCode: 42 },
+      { type: "exit", commandId: "cmd-fwd", exitCode: 42, sequence: 0 },
     ]);
   });
 
@@ -742,7 +749,7 @@ describe("forwardChunk", () => {
     ]);
 
     expect(calls).toContainEqual([
-      { type: "exit", commandId: "cmd-fwd", exitCode: 0 },
+      { type: "exit", commandId: "cmd-fwd", exitCode: 0, sequence: 0 },
     ]);
   });
 
@@ -864,8 +871,9 @@ describe("forwardChunk", () => {
       reason: "connection_closed",
     },
   ])(
-    "handles $label stream publish rejections and reports them once per command",
+    "exhausts retries for $label and reports the command once",
     async ({ publishError, directForwardFailure, reason }) => {
+      jest.useFakeTimers();
       let finishCommand!: () => void;
       const commandFinished = new Promise<void>((resolve) => {
         finishCommand = resolve;
@@ -881,6 +889,9 @@ describe("forwardChunk", () => {
         mockSubscription.publish.mockRejectedValue(publishError);
       }
       const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       let forwardChunkSpy: jest.SpyInstance | null = null;
 
       try {
@@ -908,29 +919,38 @@ describe("forwardChunk", () => {
             targetConnectionId: "conn-123",
           },
         });
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await jest.advanceTimersByTimeAsync(0);
 
         const firstChunk = capturedChannel!.onmessage!({
           type: "stdout",
           data: "first",
         }) as unknown as Promise<void>;
-        const secondChunk = capturedChannel!.onmessage!({
-          type: "stderr",
-          data: "second",
-        }) as unknown as Promise<void>;
-
-        await expect(Promise.all([firstChunk, secondChunk])).resolves.toEqual([
-          undefined,
-          undefined,
-        ]);
-        expect(captureAuthenticatedEvent).toHaveBeenCalledTimes(1);
-        expect(captureAuthenticatedEvent).toHaveBeenCalledWith(
+        await jest.advanceTimersByTimeAsync(250);
+        await jest.advanceTimersByTimeAsync(500);
+        await expect(firstChunk).resolves.toBeUndefined();
+        expect(captureAuthenticatedEvent).toHaveBeenCalledTimes(2);
+        expect(captureAuthenticatedEvent).toHaveBeenNthCalledWith(
+          1,
           "desktop_stream_publish_failed",
           {
             connectionId: "conn-123",
             commandId: "cmd-publish-failure",
             chunkType: "stdout",
             reason,
+            attempt: 1,
+            maxAttempts: 3,
+          },
+        );
+        expect(captureAuthenticatedEvent).toHaveBeenNthCalledWith(
+          2,
+          "desktop_stream_publish_recovery_exhausted",
+          {
+            connectionId: "conn-123",
+            commandId: "cmd-publish-failure",
+            chunkType: "stdout",
+            reason,
+            attempts: 3,
+            recoveryLatencyMs: 750,
           },
         );
 
@@ -955,6 +975,8 @@ describe("forwardChunk", () => {
             command_id: "cmd-publish-failure",
             chunk_type: "stdout",
             reason,
+            attempt: 1,
+            max_attempts: 3,
           }),
         );
       } finally {
@@ -962,9 +984,93 @@ describe("forwardChunk", () => {
         forwardChunkSpy?.mockRestore();
         mockSubscription.publish.mockResolvedValue(undefined);
         warnSpy.mockRestore();
+        errorSpy.mockRestore();
+        jest.useRealTimers();
       }
     },
   );
+
+  it("retries a transient publish after reconnect and reports recovery", async () => {
+    jest.useFakeTimers();
+    let finishCommand!: () => void;
+    const commandFinished = new Promise<void>((resolve) => {
+      finishCommand = resolve;
+    });
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "execute_stream_command") {
+        await commandFinished;
+      }
+      return undefined;
+    };
+    mockSubscription.publish
+      .mockRejectedValueOnce({ code: 11, message: "connection closed" })
+      .mockResolvedValue(undefined);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+
+    try {
+      const bridge = new DesktopSandboxBridge(buildConfig());
+      await bridge.start();
+      const handler = getPublicationHandler();
+      handler({
+        data: {
+          type: "command",
+          commandId: "cmd-publish-recovery",
+          command: "test",
+          targetConnectionId: "conn-123",
+        },
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      const chunk = capturedChannel!.onmessage!({
+        type: "stdout",
+        data: "recovered",
+      }) as unknown as Promise<void>;
+      await jest.advanceTimersByTimeAsync(250);
+      await expect(chunk).resolves.toBeUndefined();
+
+      expect(mockClient.ready).toHaveBeenCalledWith(5_000);
+      expect(mockSubscription.ready).toHaveBeenCalledWith(5_000);
+      expect(mockSubscription.publish).toHaveBeenNthCalledWith(1, {
+        type: "stdout",
+        commandId: "cmd-publish-recovery",
+        data: "recovered",
+        sequence: 0,
+      });
+      expect(mockSubscription.publish).toHaveBeenNthCalledWith(2, {
+        type: "stdout",
+        commandId: "cmd-publish-recovery",
+        data: "recovered",
+        sequence: 0,
+      });
+      expect(captureAuthenticatedEvent).toHaveBeenNthCalledWith(
+        1,
+        "desktop_stream_publish_failed",
+        expect.objectContaining({
+          commandId: "cmd-publish-recovery",
+          reason: "connection_closed",
+          attempt: 1,
+          maxAttempts: 3,
+        }),
+      );
+      expect(captureAuthenticatedEvent).toHaveBeenNthCalledWith(
+        2,
+        "desktop_stream_publish_recovered",
+        expect.objectContaining({
+          commandId: "cmd-publish-recovery",
+          reason: "connection_closed",
+          attempts: 2,
+          recoveryLatencyMs: 250,
+        }),
+      );
+    } finally {
+      finishCommand();
+      mockSubscription.publish.mockResolvedValue(undefined);
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
 
   it("preserves unexpected publish rejections for error tracking", async () => {
     let finishCommand!: () => void;

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -950,6 +950,7 @@ describe("forwardChunk", () => {
             chunkType: "stdout",
             reason,
             attempts: 3,
+            exhaustionReason: "attempts",
             recoveryLatencyMs: 750,
           },
         );
@@ -1068,6 +1069,78 @@ describe("forwardChunk", () => {
       mockSubscription.publish.mockResolvedValue(undefined);
       warnSpy.mockRestore();
       infoSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it("stops retrying when the command recovery deadline is reached", async () => {
+    jest.useFakeTimers();
+    let finishCommand!: () => void;
+    const commandFinished = new Promise<void>((resolve) => {
+      finishCommand = resolve;
+    });
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "execute_stream_command") {
+        await commandFinished;
+      }
+      return undefined;
+    };
+    mockSubscription.publish.mockRejectedValue({
+      code: 11,
+      message: "connection closed",
+    });
+    const rejectAtTimeout = (timeoutMs: number) =>
+      new Promise<void>((_, reject) => {
+        setTimeout(() => reject(new Error("ready timeout")), timeoutMs);
+      });
+    mockClient.ready.mockImplementationOnce(rejectAtTimeout);
+    mockSubscription.ready.mockImplementationOnce(rejectAtTimeout);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const bridge = new DesktopSandboxBridge(buildConfig());
+      await bridge.start();
+      const handler = getPublicationHandler();
+      handler({
+        data: {
+          type: "command",
+          commandId: "cmd-publish-deadline",
+          command: "test",
+          timeout: 1_000,
+          targetConnectionId: "conn-123",
+        },
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      const chunk = capturedChannel!.onmessage!({
+        type: "stdout",
+        data: "late",
+      }) as unknown as Promise<void>;
+      await jest.advanceTimersByTimeAsync(250);
+      await jest.advanceTimersByTimeAsync(3_750);
+      await expect(chunk).resolves.toBeUndefined();
+
+      expect(mockSubscription.publish).toHaveBeenCalledTimes(1);
+      expect(mockClient.ready).toHaveBeenCalledWith(3_750);
+      expect(mockSubscription.ready).toHaveBeenCalledWith(3_750);
+      expect(captureAuthenticatedEvent).toHaveBeenNthCalledWith(
+        2,
+        "desktop_stream_publish_recovery_exhausted",
+        expect.objectContaining({
+          commandId: "cmd-publish-deadline",
+          attempts: 1,
+          exhaustionReason: "deadline",
+          recoveryLatencyMs: 4_000,
+        }),
+      );
+    } finally {
+      finishCommand();
+      mockSubscription.publish.mockResolvedValue(undefined);
+      mockClient.ready.mockResolvedValue(undefined);
+      mockSubscription.ready.mockResolvedValue(undefined);
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
       jest.useRealTimers();
     }
   });

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -533,7 +533,8 @@ export class DesktopSandboxBridge {
             // Tauri does not await Channel callbacks. Exhausted known
             // transients are already reported above, so keep them from
             // becoming one unhandled rejection per subsequent stream chunk.
-            // Unknown failures remain rejected for the global error tracker.
+            // Unknown failures are logged before reaching this catch and
+            // remain rejected for callers that directly await this operation.
             if (!classifyDesktopStreamPublishFailure(error)) throw error;
           }
         });

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -54,11 +54,28 @@ type DesktopBridgeTerminationReason =
 
 type DesktopStreamPublishFailureReason = "connection_closed" | "timeout";
 
+const DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS = 3;
+const DESKTOP_STREAM_PUBLISH_RETRY_BASE_DELAY_MS = 250;
+const DESKTOP_STREAM_RECONNECT_WAIT_MS = 5_000;
+
 interface StreamChunk {
   type: "stdout" | "stderr" | "exit" | "error";
   data?: string;
   exitCode?: number;
   message?: string;
+}
+
+interface DesktopStreamPublishRecoveryState {
+  failureReported: boolean;
+  recoveryReported: boolean;
+  exhaustionReported: boolean;
+}
+
+function shouldForwardStreamChunk(chunk: StreamChunk): boolean {
+  if (chunk.type === "stdout" || chunk.type === "stderr") {
+    return Boolean(chunk.data);
+  }
+  return true;
 }
 
 function classifyDesktopStreamPublishFailure(
@@ -486,42 +503,36 @@ export class DesktopSandboxBridge {
       const { invoke, Channel } = await import("@tauri-apps/api/core");
 
       const channel = new Channel<StreamChunk>();
-      let publishFailureReported = false;
-      channel.onmessage = async (chunk) => {
-        try {
-          await this.forwardChunk(commandId, chunk);
-        } catch (error) {
-          // Tauri does not await Channel callbacks. Handle the rejection here
-          // so one disconnected command cannot emit an unhandled exception for
-          // every subsequent stream chunk.
-          const reason = classifyDesktopStreamPublishFailure(error);
-          // Unknown failures are still actionable exceptions and must remain
-          // visible to the global error tracker.
-          if (!reason) throw error;
-          if (publishFailureReported) return;
-          publishFailureReported = true;
+      const recoveryState: DesktopStreamPublishRecoveryState = {
+        failureReported: false,
+        recoveryReported: false,
+        exhaustionReported: false,
+      };
+      let nextSequence = 0;
+      let streamPublishTail: Promise<void> = Promise.resolve();
 
-          console.warn(
-            JSON.stringify({
-              timestamp: new Date().toISOString(),
-              level: "warn",
-              event: "desktop_stream_publish_failed",
-              service: "desktop_bridge",
-              environment: process.env.NODE_ENV ?? "unknown",
-              request_id: commandId,
-              connection_id: this.connectionId,
-              command_id: commandId,
-              chunk_type: chunk.type,
-              reason,
-            }),
-          );
-          captureAuthenticatedEvent("desktop_stream_publish_failed", {
-            connectionId: this.connectionId,
-            commandId,
-            chunkType: chunk.type,
-            reason,
-          });
-        }
+      channel.onmessage = (chunk) => {
+        if (!shouldForwardStreamChunk(chunk)) return;
+
+        const sequence = nextSequence++;
+        const operation = streamPublishTail.then(async () => {
+          try {
+            await this.forwardChunkWithRetry(
+              commandId,
+              chunk,
+              sequence,
+              recoveryState,
+            );
+          } catch (error) {
+            // Tauri does not await Channel callbacks. Exhausted known
+            // transients are already reported above, so keep them from
+            // becoming one unhandled rejection per subsequent stream chunk.
+            // Unknown failures remain rejected for the global error tracker.
+            if (!classifyDesktopStreamPublishFailure(error)) throw error;
+          }
+        });
+        streamPublishTail = operation.catch(() => undefined);
+        return operation;
       };
 
       await invoke("execute_stream_command", {
@@ -532,6 +543,7 @@ export class DesktopSandboxBridge {
         timeoutMs: command.timeout ?? 30000,
         onEvent: channel,
       });
+      await streamPublishTail;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(
@@ -813,7 +825,9 @@ export class DesktopSandboxBridge {
   private async forwardChunk(
     commandId: string,
     chunk: StreamChunk,
+    sequence?: number,
   ): Promise<void> {
+    const sequenceField = sequence === undefined ? {} : { sequence };
     switch (chunk.type) {
       case "stdout":
         if (chunk.data) {
@@ -821,6 +835,7 @@ export class DesktopSandboxBridge {
             type: "stdout",
             commandId,
             data: chunk.data,
+            ...sequenceField,
           });
         }
         break;
@@ -830,6 +845,7 @@ export class DesktopSandboxBridge {
             type: "stderr",
             commandId,
             data: chunk.data,
+            ...sequenceField,
           });
         }
         break;
@@ -848,6 +864,7 @@ export class DesktopSandboxBridge {
           type: "exit",
           commandId,
           exitCode: chunk.exitCode ?? -1,
+          ...sequenceField,
         });
         break;
       case "error":
@@ -864,9 +881,149 @@ export class DesktopSandboxBridge {
           type: "error",
           commandId,
           message: chunk.message || "Unknown error",
+          ...sequenceField,
         });
         break;
     }
+  }
+
+  private async forwardChunkWithRetry(
+    commandId: string,
+    chunk: StreamChunk,
+    sequence: number,
+    recoveryState: DesktopStreamPublishRecoveryState,
+  ): Promise<void> {
+    let firstFailureAt: number | null = null;
+    let firstFailureReason: DesktopStreamPublishFailureReason | null = null;
+
+    for (
+      let attempt = 1;
+      attempt <= DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS;
+      attempt++
+    ) {
+      if (this.isStoppingOrStopped) return;
+
+      try {
+        await this.forwardChunk(commandId, chunk, sequence);
+        if (
+          firstFailureAt !== null &&
+          firstFailureReason !== null &&
+          !recoveryState.recoveryReported
+        ) {
+          recoveryState.recoveryReported = true;
+          const recoveryLatencyMs = Date.now() - firstFailureAt;
+          console.info(
+            JSON.stringify({
+              timestamp: new Date().toISOString(),
+              level: "info",
+              event: "desktop_stream_publish_recovered",
+              service: "desktop_bridge",
+              environment: process.env.NODE_ENV ?? "unknown",
+              request_id: commandId,
+              connection_id: this.connectionId,
+              command_id: commandId,
+              chunk_type: chunk.type,
+              reason: firstFailureReason,
+              attempts: attempt,
+              recovery_latency_ms: recoveryLatencyMs,
+            }),
+          );
+          captureAuthenticatedEvent("desktop_stream_publish_recovered", {
+            connectionId: this.connectionId,
+            commandId,
+            chunkType: chunk.type,
+            reason: firstFailureReason,
+            attempts: attempt,
+            recoveryLatencyMs,
+          });
+        }
+        return;
+      } catch (error) {
+        const reason = classifyDesktopStreamPublishFailure(error);
+        if (!reason) throw error;
+
+        firstFailureAt ??= Date.now();
+        firstFailureReason ??= reason;
+
+        if (!recoveryState.failureReported) {
+          recoveryState.failureReported = true;
+          console.warn(
+            JSON.stringify({
+              timestamp: new Date().toISOString(),
+              level: "warn",
+              event: "desktop_stream_publish_failed",
+              service: "desktop_bridge",
+              environment: process.env.NODE_ENV ?? "unknown",
+              request_id: commandId,
+              connection_id: this.connectionId,
+              command_id: commandId,
+              chunk_type: chunk.type,
+              reason,
+              attempt,
+              max_attempts: DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS,
+            }),
+          );
+          captureAuthenticatedEvent("desktop_stream_publish_failed", {
+            connectionId: this.connectionId,
+            commandId,
+            chunkType: chunk.type,
+            reason,
+            attempt,
+            maxAttempts: DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS,
+          });
+        }
+
+        if (attempt === DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS) {
+          if (!recoveryState.exhaustionReported) {
+            recoveryState.exhaustionReported = true;
+            const recoveryLatencyMs = Date.now() - firstFailureAt;
+            console.error(
+              JSON.stringify({
+                timestamp: new Date().toISOString(),
+                level: "error",
+                event: "desktop_stream_publish_recovery_exhausted",
+                service: "desktop_bridge",
+                environment: process.env.NODE_ENV ?? "unknown",
+                request_id: commandId,
+                connection_id: this.connectionId,
+                command_id: commandId,
+                chunk_type: chunk.type,
+                reason: firstFailureReason,
+                attempts: attempt,
+                recovery_latency_ms: recoveryLatencyMs,
+              }),
+            );
+            captureAuthenticatedEvent(
+              "desktop_stream_publish_recovery_exhausted",
+              {
+                connectionId: this.connectionId,
+                commandId,
+                chunkType: chunk.type,
+                reason: firstFailureReason,
+                attempts: attempt,
+                recoveryLatencyMs,
+              },
+            );
+          }
+          throw error;
+        }
+
+        await this.waitForRelayReady(attempt);
+      }
+    }
+  }
+
+  private async waitForRelayReady(attempt: number): Promise<void> {
+    const backoffMs =
+      DESKTOP_STREAM_PUBLISH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    if (this.isStoppingOrStopped) return;
+
+    const readyChecks = [
+      this.client?.ready(DESKTOP_STREAM_RECONNECT_WAIT_MS),
+      this.subscription?.ready(DESKTOP_STREAM_RECONNECT_WAIT_MS),
+    ].filter((promise): promise is Promise<void> => Boolean(promise));
+    await Promise.allSettled(readyChecks);
   }
 
   private async publishResult(message: SandboxMessage): Promise<void> {
@@ -881,7 +1038,12 @@ export class DesktopSandboxBridge {
         message as unknown as Record<string, unknown>,
       );
     } catch (error) {
-      console.error("[DesktopSandboxBridge] Failed to publish result:", error);
+      if (!classifyDesktopStreamPublishFailure(error)) {
+        console.error(
+          "[DesktopSandboxBridge] Failed to publish result:",
+          error,
+        );
+      }
       throw error;
     }
   }

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -57,6 +57,7 @@ type DesktopStreamPublishFailureReason = "connection_closed" | "timeout";
 const DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS = 3;
 const DESKTOP_STREAM_PUBLISH_RETRY_BASE_DELAY_MS = 250;
 const DESKTOP_STREAM_RECONNECT_WAIT_MS = 5_000;
+const DESKTOP_STREAM_RECOVERY_DEADLINE_BUFFER_MS = 3_000;
 
 interface StreamChunk {
   type: "stdout" | "stderr" | "exit" | "error";
@@ -508,6 +509,10 @@ export class DesktopSandboxBridge {
         recoveryReported: false,
         exhaustionReported: false,
       };
+      const recoveryDeadlineAt =
+        Date.now() +
+        (command.timeout ?? 30_000) +
+        DESKTOP_STREAM_RECOVERY_DEADLINE_BUFFER_MS;
       let nextSequence = 0;
       let streamPublishTail: Promise<void> = Promise.resolve();
 
@@ -522,6 +527,7 @@ export class DesktopSandboxBridge {
               chunk,
               sequence,
               recoveryState,
+              recoveryDeadlineAt,
             );
           } catch (error) {
             // Tauri does not await Channel callbacks. Exhausted known
@@ -892,6 +898,7 @@ export class DesktopSandboxBridge {
     chunk: StreamChunk,
     sequence: number,
     recoveryState: DesktopStreamPublishRecoveryState,
+    recoveryDeadlineAt: number,
   ): Promise<void> {
     let firstFailureAt: number | null = null;
     let firstFailureReason: DesktopStreamPublishFailureReason | null = null;
@@ -973,55 +980,81 @@ export class DesktopSandboxBridge {
           });
         }
 
-        if (attempt === DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS) {
-          if (!recoveryState.exhaustionReported) {
-            recoveryState.exhaustionReported = true;
-            const recoveryLatencyMs = Date.now() - firstFailureAt;
-            console.error(
-              JSON.stringify({
-                timestamp: new Date().toISOString(),
-                level: "error",
-                event: "desktop_stream_publish_recovery_exhausted",
-                service: "desktop_bridge",
-                environment: process.env.NODE_ENV ?? "unknown",
-                request_id: commandId,
-                connection_id: this.connectionId,
-                command_id: commandId,
-                chunk_type: chunk.type,
-                reason: firstFailureReason,
-                attempts: attempt,
-                recovery_latency_ms: recoveryLatencyMs,
-              }),
-            );
-            captureAuthenticatedEvent(
-              "desktop_stream_publish_recovery_exhausted",
-              {
-                connectionId: this.connectionId,
-                commandId,
-                chunkType: chunk.type,
-                reason: firstFailureReason,
-                attempts: attempt,
-                recoveryLatencyMs,
-              },
-            );
-          }
-          throw error;
+        if (
+          attempt < DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS &&
+          Date.now() < recoveryDeadlineAt
+        ) {
+          await this.waitForRelayReady(attempt, recoveryDeadlineAt);
+          if (this.isStoppingOrStopped) return;
+          if (Date.now() < recoveryDeadlineAt) continue;
         }
 
-        await this.waitForRelayReady(attempt);
+        if (!recoveryState.exhaustionReported) {
+          recoveryState.exhaustionReported = true;
+          const recoveryLatencyMs = Date.now() - firstFailureAt;
+          const exhaustionReason =
+            Date.now() >= recoveryDeadlineAt ? "deadline" : "attempts";
+          console.error(
+            JSON.stringify({
+              timestamp: new Date().toISOString(),
+              level: "error",
+              event: "desktop_stream_publish_recovery_exhausted",
+              service: "desktop_bridge",
+              environment: process.env.NODE_ENV ?? "unknown",
+              request_id: commandId,
+              connection_id: this.connectionId,
+              command_id: commandId,
+              chunk_type: chunk.type,
+              reason: firstFailureReason,
+              attempts: attempt,
+              exhaustion_reason: exhaustionReason,
+              recovery_latency_ms: recoveryLatencyMs,
+            }),
+          );
+          captureAuthenticatedEvent(
+            "desktop_stream_publish_recovery_exhausted",
+            {
+              connectionId: this.connectionId,
+              commandId,
+              chunkType: chunk.type,
+              reason: firstFailureReason,
+              attempts: attempt,
+              exhaustionReason,
+              recoveryLatencyMs,
+            },
+          );
+        }
+        throw error;
       }
     }
   }
 
-  private async waitForRelayReady(attempt: number): Promise<void> {
-    const backoffMs =
-      DESKTOP_STREAM_PUBLISH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
-    await new Promise((resolve) => setTimeout(resolve, backoffMs));
+  private async waitForRelayReady(
+    attempt: number,
+    recoveryDeadlineAt: number,
+  ): Promise<void> {
+    const remainingBeforeBackoffMs = Math.max(
+      0,
+      recoveryDeadlineAt - Date.now(),
+    );
+    const backoffMs = Math.min(
+      DESKTOP_STREAM_PUBLISH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+      remainingBeforeBackoffMs,
+    );
+    if (backoffMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
     if (this.isStoppingOrStopped) return;
 
+    const readyTimeoutMs = Math.min(
+      DESKTOP_STREAM_RECONNECT_WAIT_MS,
+      Math.max(0, recoveryDeadlineAt - Date.now()),
+    );
+    if (readyTimeoutMs <= 0) return;
+
     const readyChecks = [
-      this.client?.ready(DESKTOP_STREAM_RECONNECT_WAIT_MS),
-      this.subscription?.ready(DESKTOP_STREAM_RECONNECT_WAIT_MS),
+      this.client?.ready(readyTimeoutMs),
+      this.subscription?.ready(readyTimeoutMs),
     ].filter((promise): promise is Promise<void> => Boolean(promise));
     await Promise.allSettled(readyChecks);
   }

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -177,6 +177,27 @@ describe("CentrifugoSandbox", () => {
         warnSpy.mockRestore();
       }
     });
+
+    it("rejects invalid command stream sequence numbers", () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        expect(
+          parseSandboxMessage({
+            type: "stdout",
+            commandId: FIXED_UUID,
+            data: "hello",
+            sequence: -1,
+          }),
+        ).toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          "Invalid sandbox message: sequence is not a non-negative integer",
+          expect.objectContaining({ sequence: -1 }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   describe("commands.run happy path", () => {
@@ -253,6 +274,101 @@ describe("CentrifugoSandbox", () => {
       });
       expect(onStdout).toHaveBeenCalledWith("hello\n");
       expect(onStderr).toHaveBeenCalledWith("warn\n");
+    });
+
+    it("deduplicates retried desktop stream chunks by sequence", async () => {
+      const sandbox = createDesktopSandbox();
+      const onStdout = jest.fn();
+      const { promise } = startCommand(sandbox, "echo hello", {
+        timeoutMs: 5000,
+        onStdout,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      const stdout = {
+        type: "stdout",
+        commandId: FIXED_UUID,
+        data: "hello\n",
+        sequence: 0,
+      };
+      sub.emit("publication", { data: stdout });
+      sub.emit("publication", { data: stdout });
+      sub.emit("publication", {
+        data: {
+          type: "exit",
+          commandId: FIXED_UUID,
+          exitCode: 0,
+          sequence: 1,
+        },
+      });
+
+      await expect(promise).resolves.toEqual({
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(onStdout).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a sequenced desktop stream with a missing chunk", async () => {
+      const sandbox = createDesktopSandbox();
+      const { promise } = startCommand(sandbox, "echo incomplete", {
+        timeoutMs: 5000,
+      });
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      try {
+        await jest.advanceTimersByTimeAsync(0);
+        const sub = mockSubscriptions[0];
+        sub.emit("subscribed");
+        await jest.advanceTimersByTimeAsync(0);
+
+        sub.emit("publication", {
+          data: {
+            type: "stdout",
+            commandId: FIXED_UUID,
+            data: "late",
+            sequence: 1,
+          },
+        });
+
+        await expect(promise).rejects.toThrow(
+          "Local sandbox output stream lost a chunk (expected sequence 0, received 1)",
+        );
+        const structuredLog = errorSpy.mock.calls
+          .map(([value]) => {
+            try {
+              return JSON.parse(String(value)) as Record<string, unknown>;
+            } catch {
+              return null;
+            }
+          })
+          .find(
+            (value) => value?.event === "local_command_stream_sequence_gap",
+          );
+        expect(structuredLog).toEqual(
+          expect.objectContaining({
+            timestamp: expect.any(String),
+            level: "error",
+            event: "local_command_stream_sequence_gap",
+            service: "web",
+            environment: "test",
+            request_id: FIXED_UUID,
+            command_id: FIXED_UUID,
+            connection_id: "conn-1",
+            expected_sequence: 0,
+            received_sequence: 1,
+          }),
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
 
     it("reassembles oversized stdout before completing the command", async () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -141,6 +141,19 @@ export function parseSandboxMessage(
     return null;
   }
 
+  if (
+    msg.sequence !== undefined &&
+    (typeof msg.sequence !== "number" ||
+      !Number.isSafeInteger(msg.sequence) ||
+      msg.sequence < 0)
+  ) {
+    console.warn(
+      "Invalid sandbox message: sequence is not a non-negative integer",
+      msg,
+    );
+    return null;
+  }
+
   switch (msg.type) {
     case "exit":
       if (typeof msg.exitCode !== "number") {
@@ -552,6 +565,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         let cancelRequested = false;
         let cancelPublishStarted = false;
         let cancelTriggeredBySignal = false;
+        let lastStreamSequence = -1;
         let cancelAttemptPromise: Promise<boolean> | null = null;
         let resolveCancelAttempt: ((confirmed: boolean) => void) | null = null;
         const reassembler = new CentrifugoMessageReassembler();
@@ -722,6 +736,36 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           if (message.commandId !== commandId) return;
           if (message.type === "command" || message.type === "command_cancel") {
             return;
+          }
+
+          const sequence = "sequence" in message ? message.sequence : undefined;
+          if (sequence !== undefined) {
+            if (sequence <= lastStreamSequence) return;
+            if (sequence !== lastStreamSequence + 1) {
+              settled = true;
+              cleanup();
+              console.error(
+                JSON.stringify({
+                  timestamp: new Date().toISOString(),
+                  level: "error",
+                  event: "local_command_stream_sequence_gap",
+                  service: "web",
+                  environment: process.env.NODE_ENV ?? "unknown",
+                  request_id: commandId,
+                  command_id: commandId,
+                  connection_id: this.connectionInfo.connectionId,
+                  expected_sequence: lastStreamSequence + 1,
+                  received_sequence: sequence,
+                }),
+              );
+              reject(
+                new Error(
+                  `Local sandbox output stream lost a chunk (expected sequence ${lastStreamSequence + 1}, received ${sequence}). Reconnect the local runner or Desktop app, then try again.`,
+                ),
+              );
+              return;
+            }
+            lastStreamSequence = sequence;
           }
           if (!tFirstMessage) tFirstMessage = Date.now();
 

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -149,7 +149,7 @@ export function parseSandboxMessage(
   ) {
     console.warn(
       "Invalid sandbox message: sequence is not a non-negative integer",
-      msg,
+      { commandId: msg.commandId, sequence: msg.sequence },
     );
     return null;
   }

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -26,12 +26,14 @@ export interface StdoutMessage {
   type: "stdout";
   commandId: string;
   data: string;
+  sequence?: number;
 }
 
 export interface StderrMessage {
   type: "stderr";
   commandId: string;
   data: string;
+  sequence?: number;
 }
 
 export interface ExitMessage {
@@ -39,12 +41,14 @@ export interface ExitMessage {
   commandId: string;
   exitCode: number;
   pid?: number;
+  sequence?: number;
 }
 
 export interface ErrorMessage {
   type: "error";
   commandId: string;
   message: string;
+  sequence?: number;
 }
 
 // -- Native desktop file relay messages (server -> desktop bridge) ----------


### PR DESCRIPTION
## Summary

- retry recognized Centrifugo `connection closed` and `timeout` failures after waiting for the client and subscription to reconnect
- sequence desktop command output so retried chunks are deduplicated server-side and missing chunks fail explicitly
- add privacy-safe recovery, exhaustion, latency, and stream-gap telemetry

## Root cause

The desktop bridge classified transient publish failures but swallowed the failed output chunk. A brief relay disconnect could therefore leave Agent command output incomplete or make the terminal appear frozen. Blind retries were unsafe because a publish timeout can occur after the server has already received the chunk.

## Impact

Short relay interruptions can now recover without losing or duplicating command output. If a chunk remains missing and later output arrives, the server rejects the sequence gap instead of silently returning incomplete output; fully exhausted retries are measured separately.

## Validation

- `pnpm exec jest app/services/__tests__/desktop-sandbox-bridge.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand` — 90 tests passed
- full commit-hook Jest run — 326 suites and 3,245 tests passed
- `pnpm typecheck`
- `pnpm lint` — passes with five unrelated existing warnings
- Prettier check on all touched files

## Manual verification

1. Run a local/Desktop Agent command that emits several output chunks.
2. Briefly interrupt the relay connection, then restore it.
3. Confirm output resumes once, remains ordered, and the command completes without duplicated text.
4. Keep the relay unavailable through all retry attempts and confirm recovery exhaustion is recorded; if a later chunk arrives, confirm the command fails explicitly rather than returning incomplete output.

Visual browser verification is not required because this is a non-visual relay protocol and recovery change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved desktop command-stream delivery with ordered output and sequence validation.
  - Added automatic retries for temporary connection and timeout failures.
  - Commands now wait for queued output to finish before completing.

- **Bug Fixes**
  - Prevented empty output chunks, duplicate messages, and incomplete streams from being processed.
  - Added clearer error handling when stream messages are missing or arrive out of order.
  - Improved recovery tracking and failure diagnostics for interrupted command streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->