### PR TITLE
Experiment with max Kimi K3 reasoning

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -16,6 +16,7 @@ jest.mock("../contexts/GlobalState", () => ({
 }));
 
 jest.mock("@/lib/analytics/client", () => ({
+  flushPendingAuthenticatedEvents: jest.fn(),
   getPostHogClient: jest.fn(() => null),
   loadPostHogClient: jest.fn(),
 }));
@@ -29,7 +30,7 @@ const { useAuth } = jest.requireMock<
 const { useGlobalState } = jest.requireMock<
   typeof import("../contexts/GlobalState")
 >("../contexts/GlobalState");
-const { loadPostHogClient } = jest.requireMock<
+const { flushPendingAuthenticatedEvents, loadPostHogClient } = jest.requireMock<
   typeof import("@/lib/analytics/client")
 >("@/lib/analytics/client");
 const { PostHogProvider } =
@@ -37,6 +38,8 @@ const { PostHogProvider } =
 
 const mockUseAuth = useAuth as jest.Mock;
 const mockUseGlobalState = useGlobalState as jest.Mock;
+const mockFlushPendingAuthenticatedEvents =
+  flushPendingAuthenticatedEvents as jest.Mock;
 const mockLoadPostHogClient = loadPostHogClient as jest.Mock;
 
 describe("PostHogProvider", () => {
@@ -106,6 +109,7 @@ describe("PostHogProvider", () => {
       name: "Test User",
       subscription: "pro",
     });
+    expect(mockFlushPendingAuthenticatedEvents).toHaveBeenCalledTimes(1);
 
     const [, config] = posthog.init.mock.calls[0] as unknown as [
       string,

--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -16,7 +16,7 @@ jest.mock("../contexts/GlobalState", () => ({
 }));
 
 jest.mock("@/lib/analytics/client", () => ({
-  flushPendingAuthenticatedEvents: jest.fn(),
+  confirmAuthenticatedAnalyticsUserId: jest.fn(),
   getPostHogClient: jest.fn(() => null),
   loadPostHogClient: jest.fn(),
   setAuthenticatedAnalyticsUserId: jest.fn(),
@@ -32,7 +32,7 @@ const { useGlobalState } = jest.requireMock<
   typeof import("../contexts/GlobalState")
 >("../contexts/GlobalState");
 const {
-  flushPendingAuthenticatedEvents,
+  confirmAuthenticatedAnalyticsUserId,
   loadPostHogClient,
   setAuthenticatedAnalyticsUserId,
 } = jest.requireMock<typeof import("@/lib/analytics/client")>(
@@ -43,8 +43,8 @@ const { PostHogProvider } =
 
 const mockUseAuth = useAuth as jest.Mock;
 const mockUseGlobalState = useGlobalState as jest.Mock;
-const mockFlushPendingAuthenticatedEvents =
-  flushPendingAuthenticatedEvents as jest.Mock;
+const mockConfirmAuthenticatedAnalyticsUserId =
+  confirmAuthenticatedAnalyticsUserId as jest.Mock;
 const mockLoadPostHogClient = loadPostHogClient as jest.Mock;
 const mockSetAuthenticatedAnalyticsUserId =
   setAuthenticatedAnalyticsUserId as jest.Mock;
@@ -119,8 +119,11 @@ describe("PostHogProvider", () => {
     expect(mockSetAuthenticatedAnalyticsUserId).toHaveBeenCalledWith(
       "user-123",
     );
-    expect(mockFlushPendingAuthenticatedEvents).toHaveBeenCalledWith(
+    expect(mockConfirmAuthenticatedAnalyticsUserId).toHaveBeenCalledWith(
       "user-123",
+    );
+    expect(posthog.identify.mock.invocationCallOrder[0]).toBeLessThan(
+      mockConfirmAuthenticatedAnalyticsUserId.mock.invocationCallOrder[0]!,
     );
 
     const [, config] = posthog.init.mock.calls[0] as unknown as [

--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -19,6 +19,7 @@ jest.mock("@/lib/analytics/client", () => ({
   flushPendingAuthenticatedEvents: jest.fn(),
   getPostHogClient: jest.fn(() => null),
   loadPostHogClient: jest.fn(),
+  setAuthenticatedAnalyticsUserId: jest.fn(),
 }));
 
 process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
@@ -30,9 +31,13 @@ const { useAuth } = jest.requireMock<
 const { useGlobalState } = jest.requireMock<
   typeof import("../contexts/GlobalState")
 >("../contexts/GlobalState");
-const { flushPendingAuthenticatedEvents, loadPostHogClient } = jest.requireMock<
-  typeof import("@/lib/analytics/client")
->("@/lib/analytics/client");
+const {
+  flushPendingAuthenticatedEvents,
+  loadPostHogClient,
+  setAuthenticatedAnalyticsUserId,
+} = jest.requireMock<typeof import("@/lib/analytics/client")>(
+  "@/lib/analytics/client",
+);
 const { PostHogProvider } =
   require("../providers") as typeof import("../providers");
 
@@ -41,6 +46,8 @@ const mockUseGlobalState = useGlobalState as jest.Mock;
 const mockFlushPendingAuthenticatedEvents =
   flushPendingAuthenticatedEvents as jest.Mock;
 const mockLoadPostHogClient = loadPostHogClient as jest.Mock;
+const mockSetAuthenticatedAnalyticsUserId =
+  setAuthenticatedAnalyticsUserId as jest.Mock;
 
 describe("PostHogProvider", () => {
   beforeEach(() => {
@@ -109,7 +116,12 @@ describe("PostHogProvider", () => {
       name: "Test User",
       subscription: "pro",
     });
-    expect(mockFlushPendingAuthenticatedEvents).toHaveBeenCalledTimes(1);
+    expect(mockSetAuthenticatedAnalyticsUserId).toHaveBeenCalledWith(
+      "user-123",
+    );
+    expect(mockFlushPendingAuthenticatedEvents).toHaveBeenCalledWith(
+      "user-123",
+    );
 
     const [, config] = posthog.init.mock.calls[0] as unknown as [
       string,
@@ -136,6 +148,19 @@ describe("PostHogProvider", () => {
       $current_url: "https://hackerai.co/auth-error",
       $referrer: "https://idp.example/callback",
     });
+  });
+
+  it("clears the queued analytics identity when the user signs out", () => {
+    mockUseAuth.mockReturnValue({ user: null });
+
+    render(
+      <PostHogProvider>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    expect(mockSetAuthenticatedAnalyticsUserId).toHaveBeenCalledWith(null);
+    expect(mockLoadPostHogClient).not.toHaveBeenCalled();
   });
 
   it("does not resend unchanged person properties across app loads", async () => {

--- a/app/hooks/useFeedback.ts
+++ b/app/hooks/useFeedback.ts
@@ -4,6 +4,7 @@ import { ConvexError } from "convex/values";
 import { api } from "@/convex/_generated/api";
 import { toast } from "sonner";
 import type { ChatMessage } from "@/types";
+import { captureMessageFeedback } from "@/lib/analytics/client";
 
 interface UseFeedbackProps {
   messages: ChatMessage[];
@@ -43,6 +44,12 @@ export const useFeedback = ({ messages, setMessages }: UseFeedbackProps) => {
             toast.error("That message is no longer available.");
             return;
           }
+
+          captureMessageFeedback({
+            messageId,
+            feedbackType: "positive",
+            previousFeedbackType: existingFeedback,
+          });
 
           // Update local message state and merge metadata
           setMessages(
@@ -88,6 +95,12 @@ export const useFeedback = ({ messages, setMessages }: UseFeedbackProps) => {
             toast.error("That message is no longer available.");
             return;
           }
+
+          captureMessageFeedback({
+            messageId,
+            feedbackType: "negative",
+            previousFeedbackType: existingFeedback,
+          });
 
           // Update local message state and merge metadata
           setMessages(

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -13,6 +13,7 @@ import {
   flushPendingAuthenticatedEvents,
   getPostHogClient,
   loadPostHogClient,
+  setAuthenticatedAnalyticsUserId,
 } from "@/lib/analytics/client";
 import {
   createPostHogIdentitySignature,
@@ -34,6 +35,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     if (!posthogKey) return;
 
     const shouldTrack = Boolean(userId);
+    setAuthenticatedAnalyticsUserId(userId ?? null);
 
     if (!shouldTrack) {
       lastIdentifiedSignature = null;
@@ -136,7 +138,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
           }
         }
 
-        flushPendingAuthenticatedEvents();
+        flushPendingAuthenticatedEvents(userId!);
 
         if (subscription !== "free") {
           if (!posthog.sessionRecordingStarted()) {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -9,7 +9,11 @@ import {
   sanitizeFrontendExceptionUrlProperties,
   shouldDropExpectedFrontendException,
 } from "@/lib/posthog/expected-frontend-exceptions";
-import { getPostHogClient, loadPostHogClient } from "@/lib/analytics/client";
+import {
+  flushPendingAuthenticatedEvents,
+  getPostHogClient,
+  loadPostHogClient,
+} from "@/lib/analytics/client";
 import {
   createPostHogIdentitySignature,
   POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
@@ -131,6 +135,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
             }
           }
         }
+
+        flushPendingAuthenticatedEvents();
 
         if (subscription !== "free") {
           if (!posthog.sessionRecordingStarted()) {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -10,7 +10,7 @@ import {
   shouldDropExpectedFrontendException,
 } from "@/lib/posthog/expected-frontend-exceptions";
 import {
-  flushPendingAuthenticatedEvents,
+  confirmAuthenticatedAnalyticsUserId,
   getPostHogClient,
   loadPostHogClient,
   setAuthenticatedAnalyticsUserId,
@@ -138,7 +138,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
           }
         }
 
-        flushPendingAuthenticatedEvents(userId!);
+        confirmAuthenticatedAnalyticsUserId(userId!);
 
         if (subscription !== "free") {
           if (!posthog.sessionRecordingStarted()) {

--- a/lib/analytics/__tests__/client.test.ts
+++ b/lib/analytics/__tests__/client.test.ts
@@ -23,6 +23,7 @@ jest.mock("posthog-js", () => ({
 const {
   captureMessageFeedback,
   captureUpgradeCtaImpression,
+  confirmAuthenticatedAnalyticsUserId,
   flushPendingAuthenticatedEvents,
   getPostHogRequestHeaders,
   loadPostHogClient,
@@ -39,6 +40,7 @@ describe("client analytics", () => {
     window.localStorage.clear();
     mockPostHog.__loaded = true;
     setAuthenticatedAnalyticsUserId("user_123");
+    confirmAuthenticatedAnalyticsUserId("user_123");
     flushPendingAuthenticatedEvents("user_123");
     mockCapture.mockClear();
     mockPostHog.get_distinct_id.mockClear();
@@ -189,10 +191,35 @@ describe("client analytics", () => {
       messageId: "message_user_b",
       feedbackType: "negative",
     });
+    expect(mockCapture).not.toHaveBeenCalled();
+
+    expect(confirmAuthenticatedAnalyticsUserId("user_b")).toBe(true);
     expect(mockCapture).toHaveBeenCalledTimes(1);
     expect(mockCapture).toHaveBeenCalledWith(
       "message_feedback_submitted",
       expect.objectContaining({ message_id: "message_user_b" }),
+      expect.any(Object),
+    );
+  });
+
+  it("queues feedback while PostHog transitions to a new identity", () => {
+    setAuthenticatedAnalyticsUserId("user_b");
+
+    expect(
+      captureMessageFeedback({
+        messageId: "message_during_identity_transition",
+        feedbackType: "positive",
+      }),
+    ).toBe(true);
+    expect(mockCapture).not.toHaveBeenCalled();
+    expect(flushPendingAuthenticatedEvents("user_b")).toBe(false);
+
+    expect(confirmAuthenticatedAnalyticsUserId("user_b")).toBe(true);
+    expect(mockCapture).toHaveBeenCalledWith(
+      "message_feedback_submitted",
+      expect.objectContaining({
+        message_id: "message_during_identity_transition",
+      }),
       expect.any(Object),
     );
   });

--- a/lib/analytics/__tests__/client.test.ts
+++ b/lib/analytics/__tests__/client.test.ts
@@ -23,6 +23,7 @@ jest.mock("posthog-js", () => ({
 const {
   captureMessageFeedback,
   captureUpgradeCtaImpression,
+  flushPendingAuthenticatedEvents,
   getPostHogRequestHeaders,
   loadPostHogClient,
 } = require("../client") as typeof import("../client");
@@ -35,6 +36,8 @@ describe("client analytics", () => {
 
   beforeEach(() => {
     window.localStorage.clear();
+    mockPostHog.__loaded = true;
+    flushPendingAuthenticatedEvents();
     mockCapture.mockClear();
     mockPostHog.get_distinct_id.mockClear();
     mockPostHog.get_distinct_id.mockReturnValue("user_123");
@@ -124,6 +127,43 @@ describe("client analytics", () => {
         is_initial_feedback: true,
         feedback_event_version: 1,
       },
+      { uuid: expect.stringMatching(/^[0-9a-f-]{36}$/i) },
+    );
+
+    const firstUuid = mockCapture.mock.calls[0]?.[2]?.uuid;
+    captureMessageFeedback({
+      messageId: "message_123",
+      feedbackType: "positive",
+    });
+    expect(mockCapture.mock.calls[1]?.[2]?.uuid).toBe(firstUuid);
+
+    captureMessageFeedback({
+      messageId: "message_123",
+      feedbackType: "negative",
+      previousFeedbackType: "positive",
+    });
+    expect(mockCapture.mock.calls[2]?.[2]?.uuid).not.toBe(firstUuid);
+  });
+
+  it("queues message feedback until the identified PostHog client is ready", () => {
+    mockPostHog.__loaded = false;
+
+    expect(
+      captureMessageFeedback({
+        messageId: "message_queued",
+        feedbackType: "negative",
+      }),
+    ).toBe(true);
+    expect(mockCapture).not.toHaveBeenCalled();
+
+    mockPostHog.__loaded = true;
+    expect(flushPendingAuthenticatedEvents()).toBe(true);
+    expect(mockCapture).toHaveBeenCalledWith(
+      "message_feedback_submitted",
+      expect.objectContaining({
+        message_id: "message_queued",
+        feedback_type: "negative",
+      }),
       { uuid: expect.stringMatching(/^[0-9a-f-]{36}$/i) },
     );
   });

--- a/lib/analytics/__tests__/client.test.ts
+++ b/lib/analytics/__tests__/client.test.ts
@@ -26,6 +26,7 @@ const {
   flushPendingAuthenticatedEvents,
   getPostHogRequestHeaders,
   loadPostHogClient,
+  setAuthenticatedAnalyticsUserId,
 } = require("../client") as typeof import("../client");
 
 describe("client analytics", () => {
@@ -37,7 +38,8 @@ describe("client analytics", () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockPostHog.__loaded = true;
-    flushPendingAuthenticatedEvents();
+    setAuthenticatedAnalyticsUserId("user_123");
+    flushPendingAuthenticatedEvents("user_123");
     mockCapture.mockClear();
     mockPostHog.get_distinct_id.mockClear();
     mockPostHog.get_distinct_id.mockReturnValue("user_123");
@@ -157,7 +159,7 @@ describe("client analytics", () => {
     expect(mockCapture).not.toHaveBeenCalled();
 
     mockPostHog.__loaded = true;
-    expect(flushPendingAuthenticatedEvents()).toBe(true);
+    expect(flushPendingAuthenticatedEvents("user_123")).toBe(true);
     expect(mockCapture).toHaveBeenCalledWith(
       "message_feedback_submitted",
       expect.objectContaining({
@@ -165,6 +167,33 @@ describe("client analytics", () => {
         feedback_type: "negative",
       }),
       { uuid: expect.stringMatching(/^[0-9a-f-]{36}$/i) },
+    );
+  });
+
+  it("discards queued feedback across logout and identity changes", () => {
+    mockPostHog.__loaded = false;
+    setAuthenticatedAnalyticsUserId("user_a");
+    captureMessageFeedback({
+      messageId: "message_user_a",
+      feedbackType: "positive",
+    });
+
+    setAuthenticatedAnalyticsUserId(null);
+    setAuthenticatedAnalyticsUserId("user_b");
+    mockPostHog.__loaded = true;
+
+    expect(flushPendingAuthenticatedEvents("user_b")).toBe(false);
+    expect(mockCapture).not.toHaveBeenCalled();
+
+    captureMessageFeedback({
+      messageId: "message_user_b",
+      feedbackType: "negative",
+    });
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(mockCapture).toHaveBeenCalledWith(
+      "message_feedback_submitted",
+      expect.objectContaining({ message_id: "message_user_b" }),
+      expect.any(Object),
     );
   });
 

--- a/lib/analytics/__tests__/client.test.ts
+++ b/lib/analytics/__tests__/client.test.ts
@@ -21,6 +21,7 @@ jest.mock("posthog-js", () => ({
 }));
 
 const {
+  captureMessageFeedback,
   captureUpgradeCtaImpression,
   getPostHogRequestHeaders,
   loadPostHogClient,
@@ -105,5 +106,43 @@ describe("client analytics", () => {
       "x-posthog-session-id": "session_123",
     });
     expect(mockPostHog.get_distinct_id).not.toHaveBeenCalled();
+  });
+
+  it("captures content-free initial message feedback with a stable UUID", () => {
+    expect(
+      captureMessageFeedback({
+        messageId: "message_123",
+        feedbackType: "positive",
+      }),
+    ).toBe(true);
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      "message_feedback_submitted",
+      {
+        message_id: "message_123",
+        feedback_type: "positive",
+        is_initial_feedback: true,
+        feedback_event_version: 1,
+      },
+      { uuid: expect.stringMatching(/^[0-9a-f-]{36}$/i) },
+    );
+  });
+
+  it("marks feedback changes without sending feedback details", () => {
+    captureMessageFeedback({
+      messageId: "message_123",
+      feedbackType: "negative",
+      previousFeedbackType: "positive",
+    });
+
+    const [, properties] = mockCapture.mock.calls[0];
+    expect(properties).toEqual({
+      message_id: "message_123",
+      feedback_type: "negative",
+      is_initial_feedback: false,
+      previous_feedback_type: "positive",
+      feedback_event_version: 1,
+    });
+    expect(properties).not.toHaveProperty("feedback_details");
   });
 });

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -77,6 +77,40 @@ export function captureAuthenticatedEvent(
   }
 }
 
+export function captureMessageFeedback({
+  messageId,
+  feedbackType,
+  previousFeedbackType,
+}: {
+  messageId: string;
+  feedbackType: "positive" | "negative";
+  previousFeedbackType?: "positive" | "negative";
+}) {
+  return captureAuthenticatedEvent(
+    "message_feedback_submitted",
+    {
+      message_id: messageId,
+      feedback_type: feedbackType,
+      is_initial_feedback: previousFeedbackType === undefined,
+      ...(previousFeedbackType && {
+        previous_feedback_type: previousFeedbackType,
+      }),
+      feedback_event_version: 1,
+    },
+    {
+      uuid: uuidv5(
+        [
+          "message_feedback_submitted",
+          messageId,
+          previousFeedbackType ?? "none",
+          feedbackType,
+        ].join(":"),
+        uuidv5.URL,
+      ),
+    },
+  );
+}
+
 export function addAuthenticatedExceptionStep(
   message: string,
   properties: ClientAnalyticsProperties = {},

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -19,6 +19,7 @@ type PostHogClient = typeof posthogJs & {
 type PostHogCaptureOptions = Parameters<PostHogClient["capture"]>[2];
 
 type PendingAuthenticatedEvent = {
+  userId: string;
   event: string;
   properties: ClientAnalyticsProperties;
   options?: PostHogCaptureOptions;
@@ -26,6 +27,7 @@ type PendingAuthenticatedEvent = {
 
 let posthogClient: PostHogClient | null = null;
 let posthogImportPromise: Promise<PostHogClient> | null = null;
+let authenticatedAnalyticsUserId: string | null = null;
 const pendingAuthenticatedEvents: PendingAuthenticatedEvent[] = [];
 const MAX_PENDING_AUTHENTICATED_EVENTS = 100;
 const UPGRADE_IMPRESSION_STORAGE_KEY =
@@ -83,7 +85,9 @@ function queueAuthenticatedEvent(event: PendingAuthenticatedEvent) {
   if (
     uuid &&
     pendingAuthenticatedEvents.some(
-      (pendingEvent) => pendingEvent.options?.uuid === uuid,
+      (pendingEvent) =>
+        pendingEvent.userId === event.userId &&
+        pendingEvent.options?.uuid === uuid,
     )
   ) {
     return;
@@ -95,12 +99,21 @@ function queueAuthenticatedEvent(event: PendingAuthenticatedEvent) {
   }
 }
 
-export function flushPendingAuthenticatedEvents() {
+export function setAuthenticatedAnalyticsUserId(userId: string | null) {
+  if (authenticatedAnalyticsUserId === userId) return;
+  authenticatedAnalyticsUserId = userId;
+  pendingAuthenticatedEvents.splice(0);
+}
+
+export function flushPendingAuthenticatedEvents(userId: string) {
+  if (authenticatedAnalyticsUserId !== userId) return false;
+
   const posthog = getReadyPostHogClient();
   if (!posthog || pendingAuthenticatedEvents.length === 0) return false;
 
   const pendingEvents = pendingAuthenticatedEvents.splice(0);
   for (const pendingEvent of pendingEvents) {
+    if (pendingEvent.userId !== userId) continue;
     if (
       !captureWithPostHogClient(
         posthog,
@@ -128,7 +141,6 @@ export function captureAuthenticatedEvent(
     return false;
   }
 
-  flushPendingAuthenticatedEvents();
   return captureWithPostHogClient(posthog, event, properties, options);
 }
 
@@ -160,12 +172,15 @@ export function captureMessageFeedback({
     ),
   };
 
+  const userId = authenticatedAnalyticsUserId;
+  if (!userId) return false;
+
   if (captureAuthenticatedEvent(event, properties, options)) return true;
   if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return false;
 
-  queueAuthenticatedEvent({ event, properties, options });
+  queueAuthenticatedEvent({ userId, event, properties, options });
   void loadPostHogClient()
-    .then(() => flushPendingAuthenticatedEvents())
+    .then(() => flushPendingAuthenticatedEvents(userId))
     .catch(() => {});
   return true;
 }

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -18,8 +18,16 @@ type PostHogClient = typeof posthogJs & {
 };
 type PostHogCaptureOptions = Parameters<PostHogClient["capture"]>[2];
 
+type PendingAuthenticatedEvent = {
+  event: string;
+  properties: ClientAnalyticsProperties;
+  options?: PostHogCaptureOptions;
+};
+
 let posthogClient: PostHogClient | null = null;
 let posthogImportPromise: Promise<PostHogClient> | null = null;
+const pendingAuthenticatedEvents: PendingAuthenticatedEvent[] = [];
+const MAX_PENDING_AUTHENTICATED_EVENTS = 100;
 const UPGRADE_IMPRESSION_STORAGE_KEY =
   "hackerai:analytics:upgrade-impressions:v1";
 
@@ -52,6 +60,61 @@ function getReadyPostHogClient() {
   return posthogClient?.__loaded ? posthogClient : null;
 }
 
+function captureWithPostHogClient(
+  posthog: PostHogClient,
+  event: string,
+  properties: ClientAnalyticsProperties,
+  options?: PostHogCaptureOptions,
+) {
+  try {
+    if (options) {
+      posthog.capture(event, properties, options);
+    } else {
+      posthog.capture(event, properties);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function queueAuthenticatedEvent(event: PendingAuthenticatedEvent) {
+  const uuid = event.options?.uuid;
+  if (
+    uuid &&
+    pendingAuthenticatedEvents.some(
+      (pendingEvent) => pendingEvent.options?.uuid === uuid,
+    )
+  ) {
+    return;
+  }
+
+  pendingAuthenticatedEvents.push(event);
+  if (pendingAuthenticatedEvents.length > MAX_PENDING_AUTHENTICATED_EVENTS) {
+    pendingAuthenticatedEvents.shift();
+  }
+}
+
+export function flushPendingAuthenticatedEvents() {
+  const posthog = getReadyPostHogClient();
+  if (!posthog || pendingAuthenticatedEvents.length === 0) return false;
+
+  const pendingEvents = pendingAuthenticatedEvents.splice(0);
+  for (const pendingEvent of pendingEvents) {
+    if (
+      !captureWithPostHogClient(
+        posthog,
+        pendingEvent.event,
+        pendingEvent.properties,
+        pendingEvent.options,
+      )
+    ) {
+      queueAuthenticatedEvent(pendingEvent);
+    }
+  }
+  return pendingAuthenticatedEvents.length === 0;
+}
+
 export function captureAuthenticatedEvent(
   event: string,
   properties: ClientAnalyticsProperties = {},
@@ -65,16 +128,8 @@ export function captureAuthenticatedEvent(
     return false;
   }
 
-  try {
-    if (options) {
-      posthog.capture(event, properties, options);
-    } else {
-      posthog.capture(event, properties);
-    }
-    return true;
-  } catch {
-    return false;
-  }
+  flushPendingAuthenticatedEvents();
+  return captureWithPostHogClient(posthog, event, properties, options);
 }
 
 export function captureMessageFeedback({
@@ -86,29 +141,33 @@ export function captureMessageFeedback({
   feedbackType: "positive" | "negative";
   previousFeedbackType?: "positive" | "negative";
 }) {
-  return captureAuthenticatedEvent(
-    "message_feedback_submitted",
-    {
-      message_id: messageId,
-      feedback_type: feedbackType,
-      is_initial_feedback: previousFeedbackType === undefined,
-      ...(previousFeedbackType && {
-        previous_feedback_type: previousFeedbackType,
-      }),
-      feedback_event_version: 1,
-    },
-    {
-      uuid: uuidv5(
-        [
-          "message_feedback_submitted",
-          messageId,
-          previousFeedbackType ?? "none",
-          feedbackType,
-        ].join(":"),
-        uuidv5.URL,
+  const event = "message_feedback_submitted";
+  const properties = {
+    message_id: messageId,
+    feedback_type: feedbackType,
+    is_initial_feedback: previousFeedbackType === undefined,
+    ...(previousFeedbackType && {
+      previous_feedback_type: previousFeedbackType,
+    }),
+    feedback_event_version: 1,
+  };
+  const options = {
+    uuid: uuidv5(
+      [event, messageId, previousFeedbackType ?? "none", feedbackType].join(
+        ":",
       ),
-    },
-  );
+      uuidv5.URL,
+    ),
+  };
+
+  if (captureAuthenticatedEvent(event, properties, options)) return true;
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return false;
+
+  queueAuthenticatedEvent({ event, properties, options });
+  void loadPostHogClient()
+    .then(() => flushPendingAuthenticatedEvents())
+    .catch(() => {});
+  return true;
 }
 
 export function addAuthenticatedExceptionStep(

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -28,6 +28,7 @@ type PendingAuthenticatedEvent = {
 let posthogClient: PostHogClient | null = null;
 let posthogImportPromise: Promise<PostHogClient> | null = null;
 let authenticatedAnalyticsUserId: string | null = null;
+let identifiedAnalyticsUserId: string | null = null;
 const pendingAuthenticatedEvents: PendingAuthenticatedEvent[] = [];
 const MAX_PENDING_AUTHENTICATED_EVENTS = 100;
 const UPGRADE_IMPRESSION_STORAGE_KEY =
@@ -102,11 +103,17 @@ function queueAuthenticatedEvent(event: PendingAuthenticatedEvent) {
 export function setAuthenticatedAnalyticsUserId(userId: string | null) {
   if (authenticatedAnalyticsUserId === userId) return;
   authenticatedAnalyticsUserId = userId;
+  identifiedAnalyticsUserId = null;
   pendingAuthenticatedEvents.splice(0);
 }
 
 export function flushPendingAuthenticatedEvents(userId: string) {
-  if (authenticatedAnalyticsUserId !== userId) return false;
+  if (
+    authenticatedAnalyticsUserId !== userId ||
+    identifiedAnalyticsUserId !== userId
+  ) {
+    return false;
+  }
 
   const posthog = getReadyPostHogClient();
   if (!posthog || pendingAuthenticatedEvents.length === 0) return false;
@@ -126,6 +133,12 @@ export function flushPendingAuthenticatedEvents(userId: string) {
     }
   }
   return pendingAuthenticatedEvents.length === 0;
+}
+
+export function confirmAuthenticatedAnalyticsUserId(userId: string) {
+  if (authenticatedAnalyticsUserId !== userId) return false;
+  identifiedAnalyticsUserId = userId;
+  return flushPendingAuthenticatedEvents(userId);
 }
 
 export function captureAuthenticatedEvent(
@@ -175,7 +188,12 @@ export function captureMessageFeedback({
   const userId = authenticatedAnalyticsUserId;
   if (!userId) return false;
 
-  if (captureAuthenticatedEvent(event, properties, options)) return true;
+  if (
+    identifiedAnalyticsUserId === userId &&
+    captureAuthenticatedEvent(event, properties, options)
+  ) {
+    return true;
+  }
   if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return false;
 
   queueAuthenticatedEvent({ userId, event, properties, options });

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -285,6 +285,35 @@ describe("captureAgentRun", () => {
 
     expect(capture).not.toHaveBeenCalled();
   });
+
+  it("attaches content-free Kimi reasoning experiment context", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      mode: "agent",
+      subscription: "pro",
+      sandboxInfo: null,
+      outcome: "success",
+      selectedModel: "model-opus-4.6",
+      configuredModelId: "moonshotai/kimi-k3",
+      kimiReasoningExperiment: {
+        key: "agent_max_kimi_k3_reasoning_effort_v1",
+        variant: "max",
+        reasoningEffort: "max",
+      },
+    });
+
+    expect(capture.mock.calls[0][0].properties).toEqual(
+      expect.objectContaining({
+        experiment_key: "agent_max_kimi_k3_reasoning_effort_v1",
+        experiment_variant: "max",
+        reasoning_effort: "max",
+      }),
+    );
+  });
 });
 
 describe("captureAgentBudgetAbort", () => {
@@ -573,6 +602,50 @@ describe("captureUsageCost", () => {
 
     expect(capture.mock.calls[0][0].properties).not.toHaveProperty(
       "response_model",
+    );
+  });
+
+  it("attributes usage cost to the exposed Kimi reasoning variant", () => {
+    const capture = jest.fn();
+
+    captureUsageCost({
+      posthog: { capture } as any,
+      userId: "user_123",
+      subscription: "pro",
+      chatId: "chat_123",
+      endpoint: "/api/agent-long",
+      mode: "agent",
+      usage: {
+        model: "model-opus-4.6",
+        type: "included",
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        costDollars: 0.01,
+        includedCostDollars: 0.01,
+        extraUsageCostDollars: 0,
+        uncoveredCostDollars: 0,
+        includedPointsDeducted: 100,
+        extraUsagePointsDeducted: 0,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
+        modelCostDollars: 0.01,
+        nonModelCostDollars: 0,
+        costSource: "provider",
+      },
+      kimiReasoningExperiment: {
+        key: "agent_max_kimi_k3_reasoning_effort_v1",
+        variant: "control",
+        reasoningEffort: "high",
+      },
+    });
+
+    expect(capture.mock.calls[0][0].properties).toEqual(
+      expect.objectContaining({
+        experiment_key: "agent_max_kimi_k3_reasoning_effort_v1",
+        experiment_variant: "control",
+        reasoning_effort: "high",
+      }),
     );
   });
 });

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -302,6 +302,47 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
+  it("allows the Kimi Max experiment to raise a Grok-backed route to max", () => {
+    const opts = buildProviderOptions(
+      true,
+      "user-1",
+      "model-opus-4.6",
+      "agent",
+      {
+        reasoningOverride: { enabled: true, effort: "max" },
+      },
+    );
+
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "max",
+    });
+    expect(opts.openrouter.models).toEqual([GROK_SLUG]);
+  });
+
+  it.each([
+    { enabled: true, effort: "low" },
+    { enabled: true },
+    { enabled: false, effort: "max" },
+    { enabled: true, effort: "max", exclude: true },
+  ])(
+    "does not let $p weaken or exclude Grok reasoning",
+    (reasoningOverride) => {
+      const opts = buildProviderOptions(
+        true,
+        "user-1",
+        "model-opus-4.6",
+        "agent",
+        { reasoningOverride },
+      );
+
+      expect(opts.openrouter.reasoning).toEqual({
+        enabled: true,
+        effort: "high",
+      });
+    },
+  );
+
   it.each(["model-deepseek-v4-pro", "ask-model", "model-grok-4.5"])(
     "enables high reasoning for Grok-backed ask mode model %s",
     (modelName) => {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -73,6 +73,7 @@ import {
   shutdownPostHog,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
+import { evaluateKimiReasoningExperiment } from "@/lib/experiments/kimi-reasoning";
 import {
   countFileAttachments,
   stripImageAttachments,
@@ -859,9 +860,18 @@ export const createChatHandler = () => {
                 : freeMonthlyBudgetSnapshot);
             const isReasoningModel = isAgentMode(mode);
 
-            const streamStartTime = Date.now();
             const configuredModelId =
               trackedProvider.languageModel(selectedModel).modelId;
+            const kimiReasoningExperiment =
+              await evaluateKimiReasoningExperiment({
+                posthog,
+                userId,
+                subscription,
+                mode,
+                selectedModel,
+                configuredModelId,
+              });
+            const streamStartTime = Date.now();
             const budgetMonitor = effectiveBudgetSnapshot
               ? new BudgetMonitor(
                   effectiveBudgetSnapshot,
@@ -1095,6 +1105,7 @@ export const createChatHandler = () => {
                   usage: usageCostRecord,
                   responseModel: state.responseModel,
                   analyticsRequestContext,
+                  kimiReasoningExperiment,
                   ...(usageSettlementState && {
                     usageSettlement: {
                       id: usageTracker.usageSettlementId,
@@ -1255,6 +1266,15 @@ export const createChatHandler = () => {
               chatLogger,
               usageRefundTracker,
               settleUsageAfterStep,
+              ...(kimiReasoningExperiment && {
+                providerReasoningOverride: {
+                  modelName: selectedModel,
+                  reasoning: {
+                    enabled: true,
+                    effort: kimiReasoningExperiment.reasoningEffort,
+                  },
+                },
+              }),
               onBudgetAbort: (details) =>
                 captureAgentBudgetAbort({
                   posthog,
@@ -1600,6 +1620,7 @@ export const createChatHandler = () => {
                                   finishReason: state.streamFinishReason,
                                   budgetAbortDetails: state.budgetAbortDetails,
                                   isAutoContinue: !!isAutoContinue,
+                                  kimiReasoningExperiment,
                                   stepLimitTelemetry:
                                     buildAgentStepLimitTelemetry({
                                       configuredMaxSteps:
@@ -1890,6 +1911,7 @@ export const createChatHandler = () => {
                       finishReason: state.streamFinishReason,
                       budgetAbortDetails: state.budgetAbortDetails,
                       isAutoContinue: !!isAutoContinue,
+                      kimiReasoningExperiment,
                       stepLimitTelemetry: buildAgentStepLimitTelemetry({
                         configuredMaxSteps: state.configuredMaxSteps,
                         stepCount: state.agentStepCount,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -36,6 +36,7 @@ import type { UsageCostRecord } from "@/lib/usage-tracker";
 import type { UsageDeductionResult } from "@/lib/rate-limit";
 import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
+import type { KimiReasoningExperimentAssignment } from "@/lib/experiments/kimi-reasoning";
 import {
   extractErrorDetails,
   extractRetryAttempts,
@@ -1182,6 +1183,7 @@ type AgentCompletionAnalyticsArgs = {
   activeSandboxRecoveryDurationMs?: number;
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
+  kimiReasoningExperiment?: KimiReasoningExperimentAssignment;
 };
 
 export function captureAgentRun({
@@ -1209,6 +1211,7 @@ export function captureAgentRun({
   activeSandboxRecoveryDurationMs,
   isAutoContinue,
   stepLimitTelemetry,
+  kimiReasoningExperiment,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1234,6 +1237,7 @@ export function captureAgentRun({
   activeSandboxRecoveryDurationMs?: number;
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
+  kimiReasoningExperiment?: KimiReasoningExperimentAssignment;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1274,6 +1278,11 @@ export function captureAgentRun({
       }),
       ...(isAutoContinue !== undefined && {
         is_auto_continue: isAutoContinue,
+      }),
+      ...(kimiReasoningExperiment && {
+        experiment_key: kimiReasoningExperiment.key,
+        experiment_variant: kimiReasoningExperiment.variant,
+        reasoning_effort: kimiReasoningExperiment.reasoningEffort,
       }),
       ...(responseModel && { response_model: responseModel }),
       ...(responseModel &&
@@ -1339,6 +1348,7 @@ export function captureAgentCompletionAnalytics(
     activeSandboxRecoveryDurationMs: args.activeSandboxRecoveryDurationMs,
     isAutoContinue: args.isAutoContinue,
     stepLimitTelemetry: args.stepLimitTelemetry,
+    kimiReasoningExperiment: args.kimiReasoningExperiment,
   });
 }
 
@@ -1364,6 +1374,7 @@ export function captureUsageCost({
   paidDailyFreeAllowance,
   usageSettlement,
   analyticsRequestContext,
+  kimiReasoningExperiment,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1387,6 +1398,7 @@ export function captureUsageCost({
     midRunCount: number;
   };
   analyticsRequestContext?: AnalyticsRequestContext;
+  kimiReasoningExperiment?: KimiReasoningExperimentAssignment;
 }) {
   if (!posthog) return;
   const extraUsageChargeDollars = extraUsagePointsToDollars(
@@ -1405,6 +1417,11 @@ export function captureUsageCost({
       mode,
       ...(agentPermissionMode && {
         agent_permission_mode: agentPermissionMode,
+      }),
+      ...(kimiReasoningExperiment && {
+        experiment_key: kimiReasoningExperiment.key,
+        experiment_variant: kimiReasoningExperiment.variant,
+        reasoning_effort: kimiReasoningExperiment.reasoningEffort,
       }),
       model: usage.model,
       ...(responseModel && { response_model: responseModel }),

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -605,6 +605,16 @@ export type ProviderReasoningOverride = {
   exclude?: boolean;
 };
 
+const HIGH_OR_GREATER_REASONING_EFFORTS = new Set(["high", "xhigh", "max"]);
+
+const isHighOrGreaterReasoningOverride = (
+  reasoningOverride: ProviderReasoningOverride | undefined,
+): reasoningOverride is ProviderReasoningOverride & { effort: string } =>
+  reasoningOverride?.enabled === true &&
+  reasoningOverride.exclude !== true &&
+  typeof reasoningOverride.effort === "string" &&
+  HIGH_OR_GREATER_REASONING_EFFORTS.has(reasoningOverride.effort);
+
 const getFallbackKeys = (
   modelName?: string,
 ): readonly ModelName[] | undefined => {
@@ -746,6 +756,7 @@ export function buildProviderOptions(
   // OpenRouter applies one reasoning configuration to both the primary model
   // and every provider fallback. Aside from the explicit free Ask policy,
   // force high whenever Grok 4.5 is reachable so it cannot inherit less effort.
+  // Explicit high-or-greater overrides are safe for scoped experiments.
   const routesThroughGrok45 = isGrok45 || fallbackSlugs.includes(GROK_4_5_SLUG);
   const reasoning = isFreeAskDeepSeekV4
     ? {
@@ -753,10 +764,12 @@ export function buildProviderOptions(
         effort: "low",
       }
     : routesThroughGrok45
-      ? {
-          enabled: true,
-          effort: "high",
-        }
+      ? isHighOrGreaterReasoningOverride(options.reasoningOverride)
+        ? options.reasoningOverride
+        : {
+            enabled: true,
+            effort: "high",
+          }
       : (options.reasoningOverride ??
         (isHighReasoningModel(modelName) || isAgentDeepSeekV4
           ? {

--- a/lib/experiments/__tests__/kimi-reasoning.test.ts
+++ b/lib/experiments/__tests__/kimi-reasoning.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  KIMI_REASONING_EXPERIMENT_KEY,
+  evaluateKimiReasoningExperiment,
+  isEligibleForKimiReasoningExperiment,
+} from "../kimi-reasoning";
+
+const eligibleRequest = {
+  userId: "user_123",
+  subscription: "pro" as const,
+  mode: "agent" as const,
+  selectedModel: "model-opus-4.6",
+  configuredModelId: "moonshotai/kimi-k3",
+};
+
+function mockPostHogFlag(value: unknown) {
+  const getFlag = jest.fn(() => value);
+  const evaluateFlags = jest.fn(async () => ({ getFlag }));
+  return {
+    posthog: { evaluateFlags } as any,
+    evaluateFlags,
+    getFlag,
+  };
+}
+
+describe("Kimi reasoning experiment", () => {
+  it("limits eligibility to paid individual Max Agent requests served by Kimi", () => {
+    expect(isEligibleForKimiReasoningExperiment(eligibleRequest)).toBe(true);
+    expect(
+      isEligibleForKimiReasoningExperiment({
+        ...eligibleRequest,
+        selectedModel: "model-kimi-k3",
+      }),
+    ).toBe(true);
+    expect(
+      isEligibleForKimiReasoningExperiment({
+        ...eligibleRequest,
+        subscription: "free",
+      }),
+    ).toBe(false);
+    expect(
+      isEligibleForKimiReasoningExperiment({
+        ...eligibleRequest,
+        subscription: "team",
+      }),
+    ).toBe(false);
+    expect(
+      isEligibleForKimiReasoningExperiment({
+        ...eligibleRequest,
+        mode: "ask",
+      }),
+    ).toBe(false);
+    expect(
+      isEligibleForKimiReasoningExperiment({
+        ...eligibleRequest,
+        selectedModel: "agent-model",
+      }),
+    ).toBe(false);
+    expect(
+      isEligibleForKimiReasoningExperiment({
+        ...eligibleRequest,
+        configuredModelId: "x-ai/grok-4.5",
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["control", "high"],
+    ["max", "max"],
+  ] as const)(
+    "maps the %s variant to %s reasoning",
+    async (variant, effort) => {
+      const { posthog, evaluateFlags, getFlag } = mockPostHogFlag(variant);
+
+      await expect(
+        evaluateKimiReasoningExperiment({
+          posthog,
+          ...eligibleRequest,
+        }),
+      ).resolves.toEqual({
+        key: KIMI_REASONING_EXPERIMENT_KEY,
+        variant,
+        reasoningEffort: effort,
+      });
+      expect(evaluateFlags).toHaveBeenCalledWith("user_123", {
+        flagKeys: [KIMI_REASONING_EXPERIMENT_KEY],
+      });
+      expect(getFlag).toHaveBeenCalledWith(KIMI_REASONING_EXPERIMENT_KEY);
+    },
+  );
+
+  it.each([false, true, undefined, "unexpected"])(
+    "keeps the existing high default without experiment context for %p",
+    async (flagValue) => {
+      const { posthog } = mockPostHogFlag(flagValue);
+      await expect(
+        evaluateKimiReasoningExperiment({
+          posthog,
+          ...eligibleRequest,
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("does not evaluate flags for ineligible requests", async () => {
+    const { posthog, evaluateFlags } = mockPostHogFlag("max");
+    await expect(
+      evaluateKimiReasoningExperiment({
+        posthog,
+        ...eligibleRequest,
+        mode: "ask",
+      }),
+    ).resolves.toBeUndefined();
+    expect(evaluateFlags).not.toHaveBeenCalled();
+  });
+
+  it("fails closed to the existing high default", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const posthog = {
+      evaluateFlags: jest.fn(async () => {
+        throw new Error("PostHog unavailable");
+      }),
+    } as any;
+
+    try {
+      await expect(
+        evaluateKimiReasoningExperiment({
+          posthog,
+          ...eligibleRequest,
+        }),
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        "Kimi reasoning experiment evaluation failed",
+        expect.objectContaining({
+          flag_key: KIMI_REASONING_EXPERIMENT_KEY,
+          error_name: "Error",
+        }),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/lib/experiments/kimi-reasoning.ts
+++ b/lib/experiments/kimi-reasoning.ts
@@ -1,0 +1,91 @@
+import type { PostHog } from "posthog-node";
+import { KIMI_K3_SLUG } from "@/lib/ai/providers";
+import type { ChatMode, SubscriptionTier } from "@/types";
+import { PAID_INDIVIDUAL_SUBSCRIPTION_TIERS } from "@/types";
+
+export const KIMI_REASONING_EXPERIMENT_KEY =
+  "agent_max_kimi_k3_reasoning_effort_v1";
+
+export type KimiReasoningExperimentVariant = "control" | "max";
+export type KimiReasoningEffort = "high" | "max";
+
+export type KimiReasoningExperimentAssignment = {
+  key: typeof KIMI_REASONING_EXPERIMENT_KEY;
+  variant: KimiReasoningExperimentVariant;
+  reasoningEffort: KimiReasoningEffort;
+};
+
+const KIMI_MAX_MODEL_KEYS = new Set(["model-opus-4.6", "model-kimi-k3"]);
+
+export function isEligibleForKimiReasoningExperiment({
+  subscription,
+  mode,
+  selectedModel,
+  configuredModelId,
+}: {
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel: string;
+  configuredModelId: string;
+}): boolean {
+  return (
+    (
+      PAID_INDIVIDUAL_SUBSCRIPTION_TIERS as readonly SubscriptionTier[]
+    ).includes(subscription) &&
+    mode === "agent" &&
+    KIMI_MAX_MODEL_KEYS.has(selectedModel) &&
+    configuredModelId === KIMI_K3_SLUG
+  );
+}
+
+export async function evaluateKimiReasoningExperiment({
+  posthog,
+  userId,
+  subscription,
+  mode,
+  selectedModel,
+  configuredModelId,
+}: {
+  posthog: Pick<PostHog, "evaluateFlags"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel: string;
+  configuredModelId: string;
+}): Promise<KimiReasoningExperimentAssignment | undefined> {
+  if (
+    !posthog ||
+    !isEligibleForKimiReasoningExperiment({
+      subscription,
+      mode,
+      selectedModel,
+      configuredModelId,
+    })
+  ) {
+    return undefined;
+  }
+
+  try {
+    const flags = await posthog.evaluateFlags(userId, {
+      flagKeys: [KIMI_REASONING_EXPERIMENT_KEY],
+    });
+    const variant = flags.getFlag(KIMI_REASONING_EXPERIMENT_KEY);
+
+    if (variant !== "control" && variant !== "max") {
+      return undefined;
+    }
+
+    return {
+      key: KIMI_REASONING_EXPERIMENT_KEY,
+      variant,
+      reasoningEffort: variant === "max" ? "max" : "high",
+    };
+  } catch (error) {
+    console.warn("Kimi reasoning experiment evaluation failed", {
+      event: "kimi_reasoning_experiment_evaluation_failed",
+      flag_key: KIMI_REASONING_EXPERIMENT_KEY,
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return undefined;
+  }
+}

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -116,6 +116,7 @@ import {
   createChatLogger,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
+import { evaluateKimiReasoningExperiment } from "@/lib/experiments/kimi-reasoning";
 import {
   LEGACY_AGENT_API_ENDPOINT,
   type AgentApiEndpoint,
@@ -2505,6 +2506,15 @@ export const agentLongTask = task({
             const streamStartTime = taskStartTime;
             const configuredModelId =
               trackedProvider.languageModel(selectedModel).modelId;
+            const kimiReasoningExperiment =
+              await evaluateKimiReasoningExperiment({
+                posthog,
+                userId,
+                subscription,
+                mode,
+                selectedModel,
+                configuredModelId,
+              });
             const budgetMonitor = effectiveBudgetSnapshot
               ? new BudgetMonitor(
                   effectiveBudgetSnapshot,
@@ -2732,6 +2742,7 @@ export const agentLongTask = task({
                   analyticsRequestContext,
                   usage: usageCostRecord,
                   responseModel: state.responseModel,
+                  kimiReasoningExperiment,
                   ...(usageSettlementState && {
                     usageSettlement: {
                       id: usageTracker.usageSettlementId,
@@ -2906,6 +2917,15 @@ export const agentLongTask = task({
                 }
               },
               settleUsageAfterStep,
+              ...(kimiReasoningExperiment && {
+                providerReasoningOverride: {
+                  modelName: selectedModel,
+                  reasoning: {
+                    enabled: true,
+                    effort: kimiReasoningExperiment.reasoningEffort,
+                  },
+                },
+              }),
               onBudgetAbort: (details) =>
                 captureAgentBudgetAbort({
                   posthog,
@@ -3244,6 +3264,7 @@ export const agentLongTask = task({
                                       state.budgetAbortDetails,
                                     agentPermissionMode,
                                     isAutoContinue: !!isAutoContinue,
+                                    kimiReasoningExperiment,
                                     stepLimitTelemetry:
                                       buildAgentStepLimitTelemetry({
                                         configuredMaxSteps:
@@ -3406,6 +3427,7 @@ export const agentLongTask = task({
                         budgetAbortDetails: state.budgetAbortDetails,
                         agentPermissionMode,
                         isAutoContinue: !!isAutoContinue,
+                        kimiReasoningExperiment,
                         stepLimitTelemetry: buildAgentStepLimitTelemetry({
                           configuredMaxSteps: state.configuredMaxSteps,
                           stepCount: state.agentStepCount,


### PR DESCRIPTION
## Summary

- add a stable server-side PostHog assignment for paid individual Max Agent runs served by Kimi K3
- compare `reasoning.effort = high` (control) with `reasoning.effort = max` (treatment)
- preserve the existing high default when the flag is disabled, missing, unknown, or unavailable
- attribute Agent outcomes and usage costs to the exposed variant
- capture content-free initial thumbs-up/down events for the satisfaction metric

## Why

Kimi K3 is now serving the Max route, but HackerAI explicitly requests high reasoning. This experiment measures whether max reasoning improves user satisfaction and natural task completion enough to justify any additional cost or latency.

OpenRouter currently lists Kimi K3 support for `max`, `high`, and `low` reasoning efforts.

## Eligibility and safety

Only authenticated paid individual users in Agent mode with an explicit Max/Kimi selection whose configured provider is `moonshotai/kimi-k3` are evaluated. Free users, Ask mode, Auto selections, team subscriptions, and fallback-only traffic are excluded.

The linked PostHog experiment remains inactive at 0% overall rollout. Its variants are an exact 50/50 `control`/`max` split. No production exposure starts with this PR.

Linear: https://linear.app/hackerai/issue/HAC-58/experiment-test-kimi-k3-max-vs-high-reasoning-for-max-agent

PostHog draft: https://us.posthog.com/project/144137/experiments/405065

## Validation

- full repository suite: 320 suites, 3,217 tests passed
- focused experiment/routing/analytics suites: 123 tests passed after rebasing onto current main
- `pnpm typecheck`
- scoped ESLint
- scoped Prettier check
- `git diff --check origin/main...HEAD`

## Manual verification after deployment

1. Keep the experiment inactive and submit one thumbs-up/down on a test response.
2. Confirm `message_feedback_submitted` contains rating metadata but no written feedback.
3. Add primary and guardrail metrics in PostHog.
4. Target internal users only and verify provider diagnostics report `high` for control and `max` for treatment before broader rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an experiment enabling enhanced Kimi K3 reasoning with high or maximum effort.
  * Added experiment details to usage and completion analytics.
  * Improved positive and negative message feedback tracking, including feedback changes.

* **Improvements**
  * Preserved explicit high-effort reasoning preferences on supported Grok routes.
  * Improved authenticated analytics reliability by queuing events until analytics is available.
  * Cleared queued analytics events when the authenticated account changes or signs out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->