### PR TITLE
Fill thumbs-up after positive feedback

### DIFF
--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -142,6 +142,11 @@ function areMessageItemPropsEqual(
       next.message.metadata?.generationTimeMs
     )
       return false;
+    if (
+      prev.message.metadata?.feedbackType !==
+      next.message.metadata?.feedbackType
+    )
+      return false;
     if (prev.message.createdAt !== next.message.createdAt) return false;
     if (prev.message.metadata?.createdAt !== next.message.metadata?.createdAt)
       return false;

--- a/app/components/__tests__/MessageActions.edit.test.tsx
+++ b/app/components/__tests__/MessageActions.edit.test.tsx
@@ -87,6 +87,33 @@ describe("MessageActions regeneration", () => {
   });
 });
 
+describe("MessageActions feedback", () => {
+  it("renders saved positive feedback as a filled thumbs-up icon", () => {
+    render(
+      <MessageActions
+        messageText="Answer"
+        isUser={false}
+        isLastAssistantMessage
+        canRegenerate={false}
+        onRegenerate={jest.fn()}
+        onEdit={jest.fn()}
+        canEdit={false}
+        isHovered
+        isEditing={false}
+        status="ready"
+        onFeedback={jest.fn()}
+        existingFeedback="positive"
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Good response" })
+        .querySelector("svg"),
+    ).toHaveAttribute("fill", "currentColor");
+  });
+});
+
 describe("MessageActions branching", () => {
   it("shows the branch icon horizontally", () => {
     render(

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -27,10 +27,17 @@ jest.mock("../MessagePartHandler", () => ({
 }));
 
 jest.mock("../MessageActions", () => ({
-  MessageActions: ({ canRegenerate }: { canRegenerate: boolean }) => (
+  MessageActions: ({
+    canRegenerate,
+    existingFeedback,
+  }: {
+    canRegenerate: boolean;
+    existingFeedback?: "positive" | "negative" | null;
+  }) => (
     <div
       data-testid="message-actions"
       data-can-regenerate={String(canRegenerate)}
+      data-existing-feedback={existingFeedback ?? "none"}
     />
   ),
 }));
@@ -127,6 +134,60 @@ const renderMessageItem = ({
   );
 
 describe("MessageItem WorkedFor rendering", () => {
+  it("re-renders message actions when positive feedback is saved", () => {
+    const props = {
+      index: 0,
+      messagesLength: 1,
+      lastAssistantMessageIndex: 0,
+      status: "ready" as const,
+      canEdit: false,
+      isHovered: false,
+      isEditing: false,
+      feedbackInputMessageId: null,
+      mode: "agent" as const,
+      branchBoundaryIndex: undefined,
+      onMouseEnter: jest.fn(),
+      onMouseLeave: jest.fn(),
+      onStartEdit: jest.fn(),
+      onSaveEdit: jest.fn(async () => {}),
+      onCancelEdit: jest.fn(),
+      onRegenerate: jest.fn(),
+      onFeedback: jest.fn(),
+      onFeedbackSubmit: jest.fn(async () => {}),
+      onFeedbackCancel: jest.fn(),
+      onShowAllFiles: jest.fn(),
+      getCachedUrl: jest.fn(),
+    };
+    const { rerender } = render(
+      <MessageItem {...props} message={assistantMessage} />,
+    );
+
+    expect(screen.getByTestId("message-actions")).toHaveAttribute(
+      "data-existing-feedback",
+      "none",
+    );
+
+    rerender(
+      <MessageItem
+        {...props}
+        message={
+          {
+            ...assistantMessage,
+            metadata: {
+              ...assistantMessage.metadata,
+              feedbackType: "positive",
+            },
+          } as ChatMessage
+        }
+      />,
+    );
+
+    expect(screen.getByTestId("message-actions")).toHaveAttribute(
+      "data-existing-feedback",
+      "positive",
+    );
+  });
+
   it("disables regeneration for an Agent response after switching to Ask", () => {
     renderMessageItem({ mode: "ask" });
 


### PR DESCRIPTION
## Summary

- re-render memoized assistant messages when `metadata.feedbackType` changes
- keep the positive thumbs-up icon visually filled immediately after feedback saves
- add regression coverage for both the memo invalidation and rendered SVG fill state

## Root cause

`MessageItem` uses a custom memo comparator. It compared several metadata fields but omitted `feedbackType`, so the positive-feedback state update was treated as render-equivalent. Negative feedback appeared correctly because opening its details input changed a separate prop and forced a render.

## Scope

This changes only feedback visual-state rendering. Feedback persistence and analytics behavior are unchanged.

## Validation

- focused feedback/message rendering suites: 25 tests passed
- full repository suite: 330 suites, 3,287 tests passed
- `pnpm exec tsc --noEmit`
- scoped ESLint
- scoped Prettier
- `git diff --check`

## Manual verification

1. Open an authenticated HackerAI chat with an assistant response that has no selected feedback.
2. Click **Good response**.
3. Confirm the success toast appears and the thumbs-up icon becomes filled immediately.
4. Confirm thumbs-down continues to fill when selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback controls now update immediately when a message’s feedback status changes.
  * Positive feedback correctly displays the “Good response” state with a filled thumbs-up icon.

* **Tests**
  * Added coverage for saved feedback and feedback state updates after message rerendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->