### PR TITLE
Show new task action on the Tasks header

### DIFF
--- a/app/components/SidebarChatSections.tsx
+++ b/app/components/SidebarChatSections.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, SquarePen } from "lucide-react";
 import { toast } from "sonner";
 import {
   DndContext,
@@ -27,7 +27,14 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core";
 import type { Doc } from "@/convex/_generated/dataModel";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { usePinChat, useUnpinChat } from "@/app/hooks/useChats";
+import { useStartNewChat } from "@/app/hooks/useStartNewChat";
 import {
   getOpenSidebarProjectIdsSnapshot,
   getServerOpenSidebarProjectIdsSnapshot,
@@ -68,6 +75,7 @@ interface SidebarChatSectionsProps {
 }
 
 interface CollapsibleChatSectionProps {
+  action?: ReactNode;
   children: ReactNode;
   dropId: string;
   onDrop: SidebarChatDropData["onDrop"];
@@ -86,6 +94,7 @@ const sidebarChatCollisionDetection: CollisionDetection = (args) => {
 };
 
 function CollapsibleChatSection({
+  action,
   children,
   dropId,
   onDrop,
@@ -113,30 +122,35 @@ function CollapsibleChatSection({
       data-testid={testId}
       data-drop-active={isOver ? "true" : undefined}
     >
-      <button
-        type="button"
-        className={`group/chat-section sticky top-0 z-[3] flex h-9 w-full items-center gap-0.5 bg-sidebar py-0.5 ps-2.5 pe-0.5 text-left hover:rounded-[10px] hover:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring ${
+      <div
+        className={`group/chat-section sticky top-0 z-[3] flex h-9 w-full items-center bg-sidebar py-0.5 ps-2.5 pe-0.5 hover:rounded-[10px] hover:bg-sidebar-accent/40 ${
           isOver
             ? "rounded-[10px] bg-sidebar-accent/70 ring-1 ring-sidebar-ring"
             : ""
         }`}
-        onClick={() => onOpenChange(!open)}
-        aria-expanded={open}
-        aria-controls={contentId}
       >
-        <span className="min-w-0 truncate text-[13px] font-medium leading-[18px] tracking-[-0.091px] text-sidebar-foreground/50">
-          {title}
-        </span>
-        <ChevronRight
-          className={`size-3.5 shrink-0 text-sidebar-foreground/45 transition-[transform,opacity] ${
-            open
-              ? "rotate-90 opacity-0 group-hover/chat-section:opacity-100"
-              : "opacity-100"
-          }`}
-          data-testid={`${testId}-chevron`}
-          aria-hidden="true"
-        />
-      </button>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-0.5 self-stretch rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+          onClick={() => onOpenChange(!open)}
+          aria-expanded={open}
+          aria-controls={contentId}
+        >
+          <span className="min-w-0 truncate text-[13px] font-medium leading-[18px] tracking-[-0.091px] text-sidebar-foreground/50">
+            {title}
+          </span>
+          <ChevronRight
+            className={`size-3.5 shrink-0 text-sidebar-foreground/45 transition-[transform,opacity] ${
+              open
+                ? "rotate-90 opacity-0 group-hover/chat-section:opacity-100"
+                : "opacity-100"
+            }`}
+            data-testid={`${testId}-chevron`}
+            aria-hidden="true"
+          />
+        </button>
+        {action}
+      </div>
 
       {open ? <div id={contentId}>{children}</div> : null}
     </section>
@@ -164,6 +178,7 @@ export function SidebarChatSections({
     [openProjectIdsSnapshot],
   );
   const [activeTask, setActiveTask] = useState<SidebarChatDragData>();
+  const startNewChat = useStartNewChat();
   const pinChat = usePinChat();
   const unpinChat = useUnpinChat();
   const pinnedChats = chats.filter((chat) => chat.pinned_at != null);
@@ -296,6 +311,31 @@ export function SidebarChatSections({
           open={isTasksOpen}
           onOpenChange={setIsTasksOpen}
           testId="sidebar-tasks-section"
+          action={
+            !isTasksOpen ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 rounded-lg text-sidebar-foreground/45 opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-foreground group-hover/chat-section:opacity-100 group-focus-within/chat-section:opacity-100 focus-visible:opacity-100 touch-device:!opacity-100"
+                    onClick={() => startNewChat()}
+                    aria-label="Start new task"
+                  >
+                    <SquarePen className="size-[18px]" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="top"
+                  sideOffset={8}
+                  className="border-0 bg-black px-3 py-1.5 text-sm text-white shadow-md [&_svg]:bg-black [&_svg]:fill-black"
+                >
+                  New task
+                </TooltipContent>
+              </Tooltip>
+            ) : null
+          }
         >
           <SidebarHistory
             chats={taskChats}

--- a/app/components/SidebarChatSections.tsx
+++ b/app/components/SidebarChatSections.tsx
@@ -312,29 +312,27 @@ export function SidebarChatSections({
           onOpenChange={setIsTasksOpen}
           testId="sidebar-tasks-section"
           action={
-            !isTasksOpen ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-8 rounded-lg text-sidebar-foreground/45 opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-foreground group-hover/chat-section:opacity-100 group-focus-within/chat-section:opacity-100 focus-visible:opacity-100 touch-device:!opacity-100"
-                    onClick={() => startNewChat()}
-                    aria-label="Start new task"
-                  >
-                    <SquarePen className="size-[18px]" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent
-                  side="top"
-                  sideOffset={8}
-                  className="border-0 bg-black px-3 py-1.5 text-sm text-white shadow-md [&_svg]:bg-black [&_svg]:fill-black"
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 rounded-lg text-sidebar-foreground/45 opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-foreground group-hover/chat-section:opacity-100 group-focus-within/chat-section:opacity-100 focus-visible:opacity-100 touch-device:!opacity-100"
+                  onClick={() => startNewChat()}
+                  aria-label="Start new task"
                 >
-                  New task
-                </TooltipContent>
-              </Tooltip>
-            ) : null
+                  <SquarePen className="size-[18px]" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                sideOffset={8}
+                className="border-0 bg-black px-3 py-1.5 text-sm text-white shadow-md [&_svg]:bg-black [&_svg]:fill-black"
+              >
+                New task
+              </TooltipContent>
+            </Tooltip>
           }
         >
           <SidebarHistory

--- a/app/components/__tests__/SidebarChatSections.test.tsx
+++ b/app/components/__tests__/SidebarChatSections.test.tsx
@@ -318,7 +318,7 @@ describe("SidebarChatSections", () => {
     );
   });
 
-  it("shows a hover-revealed new-task action when Tasks is collapsed", () => {
+  it("shows a project-sized new-task action in both Tasks states", () => {
     render(
       <SidebarChatSections
         chats={chats}
@@ -327,22 +327,28 @@ describe("SidebarChatSections", () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("button", { name: "Start new task" }),
-    ).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
-
     const newTaskButton = screen.getByRole("button", {
       name: "Start new task",
     });
     expect(newTaskButton).toHaveClass(
+      "size-8",
       "opacity-0",
       "group-hover/chat-section:opacity-100",
       "group-focus-within/chat-section:opacity-100",
       "focus-visible:opacity-100",
       "touch-device:!opacity-100",
     );
+    expect(newTaskButton.querySelector("svg")).toHaveClass("size-[18px]");
+    expect(screen.getByRole("button", { name: "Tasks" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
+
+    expect(
+      screen.getByRole("button", { name: "Start new task" }),
+    ).toBeInTheDocument();
 
     fireEvent.click(newTaskButton);
 

--- a/app/components/__tests__/SidebarChatSections.test.tsx
+++ b/app/components/__tests__/SidebarChatSections.test.tsx
@@ -17,6 +17,7 @@ import { SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY } from "@/lib/utils/client-storage
 
 const mockPinChat = jest.fn();
 const mockUnpinChat = jest.fn();
+const mockStartNewChat = jest.fn();
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
 let mockDndContextProps: {
@@ -66,6 +67,9 @@ jest.mock("@dnd-kit/core", () => ({
 jest.mock("@/app/hooks/useChats", () => ({
   usePinChat: () => mockPinChat,
   useUnpinChat: () => mockUnpinChat,
+}));
+jest.mock("@/app/hooks/useStartNewChat", () => ({
+  useStartNewChat: () => mockStartNewChat,
 }));
 jest.mock("sonner", () => ({
   toast: {
@@ -311,6 +315,42 @@ describe("SidebarChatSections", () => {
     expect(screen.getByTestId("sidebar-projects-section")).toBeInTheDocument();
     expect(screen.getByTestId("sidebar-tasks-section-chevron")).toHaveClass(
       "opacity-100",
+    );
+  });
+
+  it("shows a hover-revealed new-task action when Tasks is collapsed", () => {
+    render(
+      <SidebarChatSections
+        chats={chats}
+        projects={projects}
+        paginationStatus="Exhausted"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Start new task" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
+
+    const newTaskButton = screen.getByRole("button", {
+      name: "Start new task",
+    });
+    expect(newTaskButton).toHaveClass(
+      "opacity-0",
+      "group-hover/chat-section:opacity-100",
+      "group-focus-within/chat-section:opacity-100",
+      "focus-visible:opacity-100",
+      "touch-device:!opacity-100",
+    );
+
+    fireEvent.click(newTaskButton);
+
+    expect(mockStartNewChat).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("sidebar-chat-list")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tasks" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
     );
   });
 


### PR DESCRIPTION
## Summary
- show a right-aligned new-task icon when the Tasks section is expanded or collapsed
- reveal the action on hover or keyboard focus while keeping it visible on touch devices
- match the Projects add action with a 32×32 button and an 18×18 icon
- keep the new-task action separate from the section toggle so creating a task does not change its expanded state
- add focused regression coverage for both section states, sizing, visibility, and click behavior

## Why
Starting a new task should remain contextual to the Tasks section regardless of whether its history is expanded or collapsed, without adding persistent visual noise.

## Validation
- `corepack pnpm jest app/components/__tests__/SidebarChatSections.test.tsx --runInBand`
- `corepack pnpm exec eslint app/components/SidebarChatSections.tsx app/components/__tests__/SidebarChatSections.test.tsx`
- `corepack pnpm exec prettier --check app/components/SidebarChatSections.tsx app/components/__tests__/SidebarChatSections.test.tsx`
- `corepack pnpm typecheck`
- pre-commit full suite: 330 suites and 3,288 tests passed
- Google Chrome local verification: both expanded and collapsed Tasks rows reveal the icon on hover; both use a 32×32 button and 18×18 icon matching Projects; no console errors

## Manual verification
1. Open the desktop sidebar with **Tasks** expanded.
2. Hover the Tasks header and confirm the new-task icon appears on the right at the same size as the Projects add icon.
3. Collapse Tasks, hover again, and confirm the same icon appears.
4. Click the icon in either state and confirm a new task starts without toggling the section.
5. Tab to the action and confirm it is visible with keyboard focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick action to start a new task directly from the collapsed Tasks section in the sidebar.
  * Added a tooltip to clarify the new task action.

* **Bug Fixes**
  * Improved sidebar section behavior so collapse controls and section actions work independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->