### PR TITLE
Retry transient Convex write-rate limits

### DIFF
--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -804,6 +804,76 @@ describe("saveMessage", () => {
     }
   });
 
+  it("retries and classifies exhausted Convex write-rate limits as unavailable", async () => {
+    const { saveMessage, mockMutation, mockPhEvent } =
+      await loadSaveMessageWithMocks();
+    const writeRateError = new Error(
+      "[Request ID: abc] Server Error",
+    ) as Error & {
+      data?: unknown;
+    };
+    writeRateError.name = "ConvexError";
+    writeRateError.data = {
+      code: "MESSAGE_SAVE_FAILED",
+      message: "Failed to save message",
+      failureStage: "insert_message",
+      causeName: "TooManyWrites",
+      causeMessage:
+        "Too many writes per second. Your deployment is limited to 8 MiB bytes written per 1 second.",
+    };
+    mockMutation.mockRejectedValue(writeRateError as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const thrown = await saveMessage({
+        chatId: "chat-1",
+        userId: "user-1",
+        message: {
+          id: "message-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      }).catch((error) => error);
+
+      expect(thrown).toMatchObject({
+        type: "offline",
+        surface: "database",
+        statusCode: 503,
+        metadata: expect.objectContaining({
+          db_operation: "messages.saveMessage",
+          db_retry_reason: "convex_write_rate_limited",
+        }),
+      });
+      expect(mockMutation).toHaveBeenCalledTimes(3);
+
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "message_save_retry_scheduled");
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[0]).toMatchObject({
+        retry_reason: "convex_write_rate_limited",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+        message_id: "message-1",
+      });
+      expect(mockPhEvent).toHaveBeenCalledWith(
+        "database_operation_failed",
+        expect.objectContaining({
+          db_operation: "messages.saveMessage",
+          db_retry_reason: "convex_write_rate_limited",
+        }),
+      );
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
   it("maps Convex message-size rejections to a user-facing bad request", async () => {
     const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
     const convexError = new Error("[Request ID: abc] Server Error") as Error & {

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -353,7 +353,27 @@ const getRetryableDatabaseErrorReason = (
   return undefined;
 };
 
-const getRetryableSaveMessageErrorReason = getRetryableDatabaseErrorReason;
+const getRetryableSaveMessageErrorReason = (
+  error: unknown,
+): string | undefined => {
+  const retryReason = getRetryableDatabaseErrorReason(error);
+  if (retryReason) return retryReason;
+
+  const dbErrorData = getErrorData(error);
+  const errorText = [
+    stringifyError(error),
+    getObjectString(dbErrorData, "causeName"),
+    getObjectString(dbErrorData, "causeMessage"),
+    getObjectString(dbErrorData, "message"),
+  ]
+    .filter(Boolean)
+    .join(" ");
+  if (/Too many writes per second/i.test(errorText)) {
+    return "convex_write_rate_limited";
+  }
+
+  return undefined;
+};
 const getRetryableGetChatErrorReason = getRetryableDatabaseErrorReason;
 
 const getRetryableChatDeletionErrorReason = (
@@ -388,6 +408,9 @@ const getRetryableReasonForDatabaseOperation = (
   operation: string,
   error: unknown,
 ): string | undefined => {
+  if (operation === "messages.saveMessage") {
+    return getRetryableSaveMessageErrorReason(error);
+  }
   if (operation === "chats.saveChat") {
     return getRetryableSaveChatErrorReason(error);
   }


### PR DESCRIPTION
## Summary
- classify the exact Convex deployment write-rate rejection as a transient `messages.saveMessage` database failure
- reuse the existing bounded save retry schedule (250 ms, then 1 s)
- return `503/offline:database` instead of a non-retriable `400/bad_request:database` if capacity remains exhausted
- cover wrapped Convex error data for Vercel/Convex deploy-skew compatibility

## Production evidence
Frozen audit window: `2026-08-05T20:02:14.813Z` through `2026-08-06T20:02:14.813Z`.

Vercel recorded one `/api/chat` failure for one user/chat on production commit `691a8c7`:

```
Too many writes per second. Your deployment is limited to 8 MiB bytes written per 1 second.
```

The server classified this deployment-wide transient as `bad_request:database`, HTTP 400, and `retriable:false`. Separate exhausted `chats.saveChat` 503s remained visible and are not suppressed or broadened by this change.

## Root cause
The generic Convex retry classifier recognized explicit 429/rate-limit wording but not Convex's exact write-throughput message. `saveMessage` therefore skipped its existing bounded retry loop and converted the platform capacity condition into a client bad request.

## Change
- Add an exact `Too many writes per second` classifier only for `messages.saveMessage`.
- Read both flattened error messages and wrapped `causeName`/`causeMessage` data so older/newer Convex function shapes behave consistently.
- Preserve all existing error logging with the bounded reason `convex_write_rate_limited`; no prompts, message content, file data, URLs, or new identifiers are logged.
- Leave query, chat-save, provider, OOM, attachment, and unknown failures unchanged.

## Adversarial review
- Retry scope is one message operation with the existing two-attempt cap; there is no unbounded or per-page retry.
- The delays cross the platform's one-second write-rate interval.
- The mutation's existing message-ID lookup keeps ambiguous retries idempotent across chat, Agent, partial-save, and internal callers.
- Exhaustion remains visible as a 503 with structured database diagnostics.
- Wrapped and flattened errors are supported without changing Vercel/Trigger payload contracts.

## Validation
- `corepack pnpm jest lib/db/__tests__/actions-save-message.test.ts --runInBand` — 1 suite / 32 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint and Prettier — passed
- commit hooks — 330 suites / 3,288 tests passed, plus typecheck and staged lint/format
- `git diff --check` — passed

Visual QA is not applicable because this is a backend persistence resilience change.

## Manual verification
After production deployment:
1. Cause a temporary Convex write-throughput rejection while saving a disposable chat message.
2. Confirm `message_save_retry_scheduled` records `convex_write_rate_limited` with no message content.
3. Confirm recovery when capacity clears; if it persists through both retries, confirm the route returns 503 rather than 400.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message saving when write-rate limits are reached.
  * The system now retries affected saves and provides a clear database-unavailable error if retries are exhausted.
  * Failures are reported and logged consistently for improved reliability and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->