### PR TITLE
Add HAC-56 free DeepSeek route experiment

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -3,6 +3,7 @@ import {
   getModelDisplayName,
   isAnthropicModel,
   isKimiModel,
+  createTrackedProvider,
   myProvider,
   sanitizeOpenRouterRequestForXai,
   supportsMultimodalToolResults,
@@ -73,6 +74,24 @@ describe("provider registry", () => {
     expect(isKimiModel("model-opus-4.6")).toBe(true);
     expect(isAnthropicModel("model-opus-4.6")).toBe(false);
     expect(isAnthropicModel("anthropic/claude-opus-4.6")).toBe(true);
+  });
+
+  it("can restore the previous free DeepSeek route for a scoped request", () => {
+    const provider = createTrackedProvider({
+      freeDeepSeekSlug: "deepseek/deepseek-v4-flash",
+    });
+
+    expect(
+      (provider.languageModel("ask-model-free") as { modelId: string }).modelId,
+    ).toBe("deepseek/deepseek-v4-flash");
+    expect(
+      (provider.languageModel("agent-model-free") as { modelId: string })
+        .modelId,
+    ).toBe("deepseek/deepseek-v4-flash");
+    expect(
+      (myProvider.languageModel("ask-model-free") as { modelId: string })
+        .modelId,
+    ).toBe("deepseek/deepseek-v4-flash-0731");
   });
 
   it.each([

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -183,14 +183,18 @@ export const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
 export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
+export const DEEPSEEK_V4_FLASH_PREVIOUS_SLUG = "deepseek/deepseek-v4-flash";
 const TITLE_GENERATOR_DEEPSEEK_SLUG = "deepseek/deepseek-v4-flash";
 
-const buildProviderMap = (or: OpenRouterInstance) =>
+const buildProviderMap = (
+  or: OpenRouterInstance,
+  freeDeepSeekSlug = DEEPSEEK_V4_FLASH_SLUG,
+) =>
   ({
     "ask-model": or(GROK_4_5_SLUG),
-    "ask-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
+    "ask-model-free": or(freeDeepSeekSlug),
     "agent-model": or(GROK_4_5_SLUG),
-    "agent-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
+    "agent-model-free": or(freeDeepSeekSlug),
     "model-grok-4.5": or(GROK_4_5_SLUG),
     // Dedicated HackerAI Pro alias so its GLM fallback can evolve without
     // changing Standard media fallback behavior.
@@ -332,4 +336,14 @@ export const myProvider = customProvider({
   languageModels: baseProviders,
 });
 
-export const createTrackedProvider = () => myProvider;
+export const createTrackedProvider = ({
+  freeDeepSeekSlug = DEEPSEEK_V4_FLASH_SLUG,
+}: {
+  freeDeepSeekSlug?:
+    typeof DEEPSEEK_V4_FLASH_SLUG | typeof DEEPSEEK_V4_FLASH_PREVIOUS_SLUG;
+} = {}) =>
+  freeDeepSeekSlug === DEEPSEEK_V4_FLASH_SLUG
+    ? myProvider
+    : customProvider({
+        languageModels: buildProviderMap(openrouter, freeDeepSeekSlug),
+      });

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -28,6 +28,9 @@ const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 const GLM_SLUG = "z-ai/glm-5.2";
 const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
 const DEEPSEEK_FLASH_CANONICAL_SLUG = "deepseek/deepseek-v4-flash-20260731";
+const DEEPSEEK_FLASH_PREVIOUS_SLUG = "deepseek/deepseek-v4-flash";
+const DEEPSEEK_FLASH_PREVIOUS_CANONICAL_SLUG =
+  "deepseek/deepseek-v4-flash-20260423";
 const GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "ask-model",
   "agent-model",
@@ -264,6 +267,23 @@ describe("buildProviderOptions fallback chain", () => {
       effort: "low",
     });
     expect(opts.openrouter.models).toEqual([GROK_SLUG, KIMI_K3_SLUG]);
+  });
+
+  it("restores free Ask high reasoning for the previous-route experiment", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "ask-model-free",
+      "ask",
+      {
+        reasoningOverride: { enabled: true, effort: "high" },
+      },
+    );
+
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
   });
 
   it("keeps Grok fallback reasoning high over a lower scoped override", () => {
@@ -530,6 +550,26 @@ describe("getRetryFallbackModel", () => {
 });
 
 describe("resolveServedModelForCostAccounting", () => {
+  it("preserves the previous DeepSeek Flash slug for legacy route pricing", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        responseModel: DEEPSEEK_FLASH_PREVIOUS_SLUG,
+        mode: "agent",
+      }),
+    ).toBe(DEEPSEEK_FLASH_PREVIOUS_SLUG);
+  });
+
+  it("maps the previous canonical DeepSeek Flash ID to legacy route pricing", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        responseModel: DEEPSEEK_FLASH_PREVIOUS_CANONICAL_SLUG,
+        mode: "agent",
+      }),
+    ).toBe(DEEPSEEK_FLASH_PREVIOUS_SLUG);
+  });
+
   it("maps the primary free Agent DeepSeek slug back to its local cost key", () => {
     expect(
       resolveServedModelForCostAccounting({

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -74,6 +74,7 @@ import {
   type ChatLogger,
 } from "@/lib/api/chat-logger";
 import { evaluateKimiReasoningExperiment } from "@/lib/experiments/kimi-reasoning";
+import { evaluateFreeDeepSeekRouteExperiment } from "@/lib/experiments/free-deepseek-route";
 import {
   countFileAttachments,
   stripImageAttachments,
@@ -773,7 +774,17 @@ export const createChatHandler = () => {
                 )
               : Promise.resolve(undefined);
 
-            const trackedProvider = createTrackedProvider();
+            const freeDeepSeekRouteExperiment =
+              await evaluateFreeDeepSeekRouteExperiment({
+                posthog,
+                userId,
+                subscription,
+                mode,
+                selectedModel,
+              });
+            const trackedProvider = createTrackedProvider({
+              freeDeepSeekSlug: freeDeepSeekRouteExperiment?.modelSlug,
+            });
 
             let currentSystemPrompt = await systemPrompt(
               userId,
@@ -1106,6 +1117,11 @@ export const createChatHandler = () => {
                   responseModel: state.responseModel,
                   analyticsRequestContext,
                   kimiReasoningExperiment,
+                  freeDeepSeekRouteExperiment,
+                  fallbackServed:
+                    state.responseModel && retryUsedFallbackModel
+                      ? true
+                      : state.fallbackServed,
                   ...(usageSettlementState && {
                     usageSettlement: {
                       id: usageTracker.usageSettlementId,
@@ -1266,12 +1282,14 @@ export const createChatHandler = () => {
               chatLogger,
               usageRefundTracker,
               settleUsageAfterStep,
-              ...(kimiReasoningExperiment && {
+              ...((kimiReasoningExperiment || freeDeepSeekRouteExperiment) && {
                 providerReasoningOverride: {
                   modelName: selectedModel,
                   reasoning: {
                     enabled: true,
-                    effort: kimiReasoningExperiment.reasoningEffort,
+                    effort:
+                      kimiReasoningExperiment?.reasoningEffort ??
+                      freeDeepSeekRouteExperiment?.reasoningEffort,
                   },
                 },
               }),
@@ -1621,6 +1639,7 @@ export const createChatHandler = () => {
                                   budgetAbortDetails: state.budgetAbortDetails,
                                   isAutoContinue: !!isAutoContinue,
                                   kimiReasoningExperiment,
+                                  freeDeepSeekRouteExperiment,
                                   stepLimitTelemetry:
                                     buildAgentStepLimitTelemetry({
                                       configuredMaxSteps:
@@ -1912,6 +1931,7 @@ export const createChatHandler = () => {
                       budgetAbortDetails: state.budgetAbortDetails,
                       isAutoContinue: !!isAutoContinue,
                       kimiReasoningExperiment,
+                      freeDeepSeekRouteExperiment,
                       stepLimitTelemetry: buildAgentStepLimitTelemetry({
                         configuredMaxSteps: state.configuredMaxSteps,
                         stepCount: state.agentStepCount,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -38,6 +38,12 @@ import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
 import type { KimiReasoningExperimentAssignment } from "@/lib/experiments/kimi-reasoning";
 import {
+  FREE_DEEPSEEK_ROUTE_FEATURE_PROPERTY,
+  captureFreeDeepSeekRouteExperimentExposure,
+  getFreeDeepSeekRoutePackage,
+  type FreeDeepSeekRouteExperimentAssignment,
+} from "@/lib/experiments/free-deepseek-route";
+import {
   extractErrorDetails,
   extractRetryAttempts,
   getProviderErrorCategory,
@@ -1184,6 +1190,7 @@ type AgentCompletionAnalyticsArgs = {
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
   kimiReasoningExperiment?: KimiReasoningExperimentAssignment;
+  freeDeepSeekRouteExperiment?: FreeDeepSeekRouteExperimentAssignment;
 };
 
 export function captureAgentRun({
@@ -1212,6 +1219,7 @@ export function captureAgentRun({
   isAutoContinue,
   stepLimitTelemetry,
   kimiReasoningExperiment,
+  freeDeepSeekRouteExperiment,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1238,6 +1246,7 @@ export function captureAgentRun({
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
   kimiReasoningExperiment?: KimiReasoningExperimentAssignment;
+  freeDeepSeekRouteExperiment?: FreeDeepSeekRouteExperimentAssignment;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1283,6 +1292,16 @@ export function captureAgentRun({
         experiment_key: kimiReasoningExperiment.key,
         experiment_variant: kimiReasoningExperiment.variant,
         reasoning_effort: kimiReasoningExperiment.reasoningEffort,
+      }),
+      ...(freeDeepSeekRouteExperiment && {
+        experiment_key: freeDeepSeekRouteExperiment.key,
+        experiment_variant: freeDeepSeekRouteExperiment.variant,
+        reasoning_effort: freeDeepSeekRouteExperiment.reasoningEffort,
+        [FREE_DEEPSEEK_ROUTE_FEATURE_PROPERTY]:
+          freeDeepSeekRouteExperiment.variant,
+        assigned_variant: getFreeDeepSeekRoutePackage(
+          freeDeepSeekRouteExperiment,
+        ),
       }),
       ...(responseModel && { response_model: responseModel }),
       ...(responseModel &&
@@ -1349,6 +1368,7 @@ export function captureAgentCompletionAnalytics(
     isAutoContinue: args.isAutoContinue,
     stepLimitTelemetry: args.stepLimitTelemetry,
     kimiReasoningExperiment: args.kimiReasoningExperiment,
+    freeDeepSeekRouteExperiment: args.freeDeepSeekRouteExperiment,
   });
 }
 
@@ -1375,6 +1395,8 @@ export function captureUsageCost({
   usageSettlement,
   analyticsRequestContext,
   kimiReasoningExperiment,
+  freeDeepSeekRouteExperiment,
+  fallbackServed,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1399,6 +1421,8 @@ export function captureUsageCost({
   };
   analyticsRequestContext?: AnalyticsRequestContext;
   kimiReasoningExperiment?: KimiReasoningExperimentAssignment;
+  freeDeepSeekRouteExperiment?: FreeDeepSeekRouteExperimentAssignment;
+  fallbackServed?: boolean;
 }) {
   if (!posthog) return;
   const extraUsageChargeDollars = extraUsagePointsToDollars(
@@ -1422,6 +1446,16 @@ export function captureUsageCost({
         experiment_key: kimiReasoningExperiment.key,
         experiment_variant: kimiReasoningExperiment.variant,
         reasoning_effort: kimiReasoningExperiment.reasoningEffort,
+      }),
+      ...(freeDeepSeekRouteExperiment && {
+        experiment_key: freeDeepSeekRouteExperiment.key,
+        experiment_variant: freeDeepSeekRouteExperiment.variant,
+        reasoning_effort: freeDeepSeekRouteExperiment.reasoningEffort,
+        [FREE_DEEPSEEK_ROUTE_FEATURE_PROPERTY]:
+          freeDeepSeekRouteExperiment.variant,
+        assigned_variant: getFreeDeepSeekRoutePackage(
+          freeDeepSeekRouteExperiment,
+        ),
       }),
       model: usage.model,
       ...(responseModel && { response_model: responseModel }),
@@ -1473,6 +1507,14 @@ export function captureUsageCost({
           paidDailyFreeAllowance.resetTimestamp,
       }),
     },
+  });
+  captureFreeDeepSeekRouteExperimentExposure({
+    posthog,
+    userId,
+    mode,
+    assignment: freeDeepSeekRouteExperiment,
+    responseModel,
+    fallbackServed,
   });
 }
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -682,8 +682,10 @@ export function getFallbackSlugs(
   );
 }
 
-const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
+const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, string> = {
   "anthropic/claude-opus-4.6": "model-opus-4.6",
+  "deepseek/deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+  "deepseek/deepseek-v4-flash-20260423": "deepseek/deepseek-v4-flash",
   "deepseek/deepseek-v4-flash-0731": "agent-model-free",
   "deepseek/deepseek-v4-flash-20260731": "agent-model-free",
   "x-ai/grok-4.5": "model-grok-4.5",
@@ -695,7 +697,7 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
 
 function resolveOpenRouterResponseModelCostKey(
   responseModel: string,
-): ModelName | undefined {
+): string | undefined {
   const exactKey = OPENROUTER_RESPONSE_MODEL_COST_KEYS[responseModel];
   if (exactKey) return exactKey;
   // Scope Opus response aliases to the priced generation rather than matching
@@ -759,10 +761,12 @@ export function buildProviderOptions(
   // Explicit high-or-greater overrides are safe for scoped experiments.
   const routesThroughGrok45 = isGrok45 || fallbackSlugs.includes(GROK_4_5_SLUG);
   const reasoning = isFreeAskDeepSeekV4
-    ? {
-        enabled: true,
-        effort: "low",
-      }
+    ? isHighOrGreaterReasoningOverride(options.reasoningOverride)
+      ? options.reasoningOverride
+      : {
+          enabled: true,
+          effort: "low",
+        }
     : routesThroughGrok45
       ? isHighOrGreaterReasoningOverride(options.reasoningOverride)
         ? options.reasoningOverride

--- a/lib/experiments/__tests__/free-deepseek-route.test.ts
+++ b/lib/experiments/__tests__/free-deepseek-route.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY,
+  FREE_DEEPSEEK_ROUTE_EXPOSURE_EVENT,
+  FREE_DEEPSEEK_ROUTE_FEATURE_PROPERTY,
+  captureFreeDeepSeekRouteExperimentExposure,
+  evaluateFreeDeepSeekRouteExperiment,
+  isEligibleForFreeDeepSeekRouteExperiment,
+} from "../free-deepseek-route";
+
+const eligibleRequest = {
+  userId: "user_123",
+  subscription: "free" as const,
+  mode: "ask" as const,
+  selectedModel: "ask-model-free",
+};
+
+function mockPostHogFlag(value: unknown) {
+  const getFlag = jest.fn(() => value);
+  const evaluateFlags = jest.fn(async () => ({ getFlag }));
+  return {
+    posthog: { evaluateFlags } as any,
+    evaluateFlags,
+    getFlag,
+  };
+}
+
+describe("free DeepSeek route experiment", () => {
+  it("limits eligibility to free Ask and Agent auto routes", () => {
+    expect(isEligibleForFreeDeepSeekRouteExperiment(eligibleRequest)).toBe(
+      true,
+    );
+    expect(
+      isEligibleForFreeDeepSeekRouteExperiment({
+        ...eligibleRequest,
+        mode: "agent",
+        selectedModel: "agent-model-free",
+      }),
+    ).toBe(true);
+    expect(
+      isEligibleForFreeDeepSeekRouteExperiment({
+        ...eligibleRequest,
+        subscription: "pro",
+      }),
+    ).toBe(false);
+    expect(
+      isEligibleForFreeDeepSeekRouteExperiment({
+        ...eligibleRequest,
+        selectedModel: "model-deepseek-v4-pro",
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["current_0731_low", "ask", "deepseek/deepseek-v4-flash-0731", "low"],
+    ["current_0731_low", "agent", "deepseek/deepseek-v4-flash-0731", "high"],
+    ["control", "ask", "deepseek/deepseek-v4-flash", "high"],
+    ["control", "agent", "deepseek/deepseek-v4-flash", "high"],
+  ] as const)(
+    "maps %s in %s to the intended route package",
+    async (variant, mode, modelSlug, reasoningEffort) => {
+      const { posthog } = mockPostHogFlag(variant);
+
+      await expect(
+        evaluateFreeDeepSeekRouteExperiment({
+          posthog,
+          ...eligibleRequest,
+          mode,
+          selectedModel: mode === "ask" ? "ask-model-free" : "agent-model-free",
+        }),
+      ).resolves.toEqual({
+        key: FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY,
+        variant,
+        modelSlug,
+        reasoningEffort,
+      });
+    },
+  );
+
+  it.each([false, true, undefined, "unexpected"])(
+    "keeps the current route when the flag value is %p",
+    async (flagValue) => {
+      const { posthog } = mockPostHogFlag(flagValue);
+      await expect(
+        evaluateFreeDeepSeekRouteExperiment({
+          posthog,
+          ...eligibleRequest,
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("does not evaluate flags for ineligible requests", async () => {
+    const { posthog, evaluateFlags } = mockPostHogFlag("control");
+    await expect(
+      evaluateFreeDeepSeekRouteExperiment({
+        posthog,
+        ...eligibleRequest,
+        subscription: "pro",
+      }),
+    ).resolves.toBeUndefined();
+    expect(evaluateFlags).not.toHaveBeenCalled();
+  });
+
+  it("fails closed to the current route", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const posthog = {
+      evaluateFlags: jest.fn(async () => {
+        throw new Error("PostHog unavailable");
+      }),
+    } as any;
+
+    try {
+      await expect(
+        evaluateFreeDeepSeekRouteExperiment({
+          posthog,
+          ...eligibleRequest,
+        }),
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        "Free DeepSeek route experiment evaluation failed",
+        expect.objectContaining({
+          flag_key: FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY,
+          error_name: "Error",
+        }),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("emits exposure only after a provider response model is known", () => {
+    const capture = jest.fn();
+    const assignment = {
+      key: FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY,
+      variant: "control" as const,
+      modelSlug: "deepseek/deepseek-v4-flash" as const,
+      reasoningEffort: "high" as const,
+    };
+
+    captureFreeDeepSeekRouteExperimentExposure({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "ask",
+      assignment,
+    });
+    expect(capture).not.toHaveBeenCalled();
+
+    captureFreeDeepSeekRouteExperimentExposure({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "ask",
+      assignment,
+      responseModel: "deepseek/deepseek-v4-flash",
+      fallbackServed: false,
+    });
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: FREE_DEEPSEEK_ROUTE_EXPOSURE_EVENT,
+      properties: expect.objectContaining({
+        experiment_variant: "control",
+        [FREE_DEEPSEEK_ROUTE_FEATURE_PROPERTY]: "control",
+        assigned_variant: "previous_flash_high",
+        route_package: "previous_flash_high",
+        configured_model: "deepseek/deepseek-v4-flash",
+        response_model: "deepseek/deepseek-v4-flash",
+        reasoning_effort: "high",
+        fallback_served: false,
+      }),
+    });
+  });
+});

--- a/lib/experiments/free-deepseek-route.ts
+++ b/lib/experiments/free-deepseek-route.ts
@@ -1,0 +1,145 @@
+import type { PostHog } from "posthog-node";
+import {
+  DEEPSEEK_V4_FLASH_PREVIOUS_SLUG,
+  DEEPSEEK_V4_FLASH_SLUG,
+} from "@/lib/ai/providers";
+import type { ChatMode, SubscriptionTier } from "@/types";
+
+export const FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY = "hac56-free-deepseek-route";
+export const FREE_DEEPSEEK_ROUTE_EXPOSURE_EVENT =
+  "hac56_free_deepseek_route_experiment_exposed";
+export const FREE_DEEPSEEK_ROUTE_FEATURE_PROPERTY = `$feature/${FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY}`;
+
+export type FreeDeepSeekRouteExperimentVariant = "control" | "current_0731_low";
+export type FreeDeepSeekRouteReasoningEffort = "low" | "high";
+
+export type FreeDeepSeekRouteExperimentAssignment = {
+  key: typeof FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY;
+  variant: FreeDeepSeekRouteExperimentVariant;
+  modelSlug:
+    typeof DEEPSEEK_V4_FLASH_SLUG | typeof DEEPSEEK_V4_FLASH_PREVIOUS_SLUG;
+  reasoningEffort: FreeDeepSeekRouteReasoningEffort;
+};
+
+export const getFreeDeepSeekRoutePackage = (
+  assignment: FreeDeepSeekRouteExperimentAssignment,
+): "previous_flash_high" | "current_0731_low" =>
+  assignment.variant === "control" ? "previous_flash_high" : "current_0731_low";
+
+const FREE_DEEPSEEK_MODEL_KEYS = new Set([
+  "ask-model-free",
+  "agent-model-free",
+]);
+
+export function isEligibleForFreeDeepSeekRouteExperiment({
+  subscription,
+  mode,
+  selectedModel,
+}: {
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel: string;
+}): boolean {
+  return (
+    subscription === "free" &&
+    (mode === "ask" || mode === "agent") &&
+    FREE_DEEPSEEK_MODEL_KEYS.has(selectedModel)
+  );
+}
+
+export async function evaluateFreeDeepSeekRouteExperiment({
+  posthog,
+  userId,
+  subscription,
+  mode,
+  selectedModel,
+}: {
+  posthog: Pick<PostHog, "evaluateFlags"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel: string;
+}): Promise<FreeDeepSeekRouteExperimentAssignment | undefined> {
+  if (
+    !posthog ||
+    !isEligibleForFreeDeepSeekRouteExperiment({
+      subscription,
+      mode,
+      selectedModel,
+    })
+  ) {
+    return undefined;
+  }
+
+  try {
+    const flags = await posthog.evaluateFlags(userId, {
+      flagKeys: [FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY],
+    });
+    const variant = flags.getFlag(FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY);
+
+    if (variant === "current_0731_low") {
+      return {
+        key: FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY,
+        variant,
+        modelSlug: DEEPSEEK_V4_FLASH_SLUG,
+        reasoningEffort: mode === "ask" ? "low" : "high",
+      };
+    }
+
+    if (variant === "control") {
+      return {
+        key: FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY,
+        variant,
+        modelSlug: DEEPSEEK_V4_FLASH_PREVIOUS_SLUG,
+        reasoningEffort: "high",
+      };
+    }
+
+    return undefined;
+  } catch (error) {
+    console.warn("Free DeepSeek route experiment evaluation failed", {
+      event: "free_deepseek_route_experiment_evaluation_failed",
+      flag_key: FREE_DEEPSEEK_ROUTE_EXPERIMENT_KEY,
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return undefined;
+  }
+}
+
+export function captureFreeDeepSeekRouteExperimentExposure({
+  posthog,
+  userId,
+  mode,
+  assignment,
+  responseModel,
+  fallbackServed,
+}: {
+  posthog: Pick<PostHog, "capture"> | null;
+  userId: string;
+  mode: ChatMode;
+  assignment: FreeDeepSeekRouteExperimentAssignment | undefined;
+  responseModel?: string;
+  fallbackServed?: boolean;
+}): void {
+  if (!posthog || !assignment || !responseModel) return;
+
+  posthog.capture({
+    distinctId: userId,
+    event: FREE_DEEPSEEK_ROUTE_EXPOSURE_EVENT,
+    properties: {
+      experiment_key: assignment.key,
+      experiment_variant: assignment.variant,
+      [FREE_DEEPSEEK_ROUTE_FEATURE_PROPERTY]: assignment.variant,
+      assigned_variant: getFreeDeepSeekRoutePackage(assignment),
+      route_package: getFreeDeepSeekRoutePackage(assignment),
+      mode,
+      configured_model: assignment.modelSlug,
+      response_model: responseModel,
+      reasoning_effort: assignment.reasoningEffort,
+      ...(fallbackServed !== undefined && {
+        fallback_served: fallbackServed,
+      }),
+      $process_person_profile: false,
+    },
+  });
+}

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -128,6 +128,18 @@ describe("token-bucket", () => {
       ).toBeCloseTo(0.05824, 5);
     });
 
+    it("prices the previous canonical DeepSeek V4 Flash response ID", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          cacheReadTokens: 800_000,
+          cacheWriteTokens: 100_000,
+          modelName: "deepseek/deepseek-v4-flash-20260423",
+        }),
+      ).toBeCloseTo(0.0504, 5);
+    });
+
     it("recognizes dated Anthropic response model IDs", () => {
       expect(
         calculateRawModelUsageCostDollars({
@@ -486,6 +498,17 @@ describe("token-bucket", () => {
       (modelName) => {
         expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(45000);
         expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(225000);
+      },
+    );
+
+    it.each([
+      "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-flash-20260423",
+    ])(
+      "should use previous DeepSeek V4 Flash pricing for %s ($0.09/$0.18)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(1350);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(2700);
       },
     );
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -106,6 +106,7 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   // Provider response ids can reach accounting before local-key normalization.
   "x-ai/grok-4.5": GROK_4_5_PRICING,
   "deepseek/deepseek-v4-flash": DEEPSEEK_V4_FLASH_PRICING,
+  "deepseek/deepseek-v4-flash-20260423": DEEPSEEK_V4_FLASH_PRICING,
   "deepseek/deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "deepseek/deepseek-v4-flash-20260731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "deepseek/deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,


### PR DESCRIPTION
## Summary

- evaluate one deterministic PostHog assignment per free user across Ask and Agent
- compare the previous `deepseek/deepseek-v4-flash` + high-reasoning package against the current `deepseek/deepseek-v4-flash-0731` package (Ask low, Agent high)
- emit the dedicated actual-response exposure event only after usage and `response_model` are known
- attach PostHog `$feature/...` attribution and privacy-safe variant properties to exposure, usage-cost, and Agent outcome events
- preserve legacy served-model accounting for both the undated and canonical `20260423` response IDs
- fail closed to the current production route when PostHog is unavailable or the flag is inactive

## PostHog

- experiment: https://us.posthog.com/project/144137/experiments/405178
- feature flag: https://us.posthog.com/project/144137/feature_flags/804698
- state: draft, inactive, 0% overall rollout
- variant split: 50% `control` (previous Flash/high), 50% `current_0731_low`
- launch gate: deploy, run an internal/allowlist smoke check for both routes and exposure telemetry, then move overall rollout to 100% and launch

## Validation

- `pnpm typecheck`
- targeted ESLint on all changed files
- Prettier and `git diff --check`
- focused tests: 5 suites, 215 tests passed
- full commit-hook test run: 331 suites, 3,306 tests passed

## Manual verification after deployment

1. Keep the experiment draft and flag at 0% overall rollout.
2. Allowlist internal users and make one free Ask and one free Agent request in each variant.
3. Confirm the configured and response model IDs, reasoning effort, fallback status, usage cost, and `hac56_free_deepseek_route_experiment_exposed` properties.
4. Remove the allowlist, set overall rollout to 100%, and launch the 50/50 experiment only after both packages pass.

Linear: HAC-56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experiment to route eligible free DeepSeek requests through configured model variants.
  * Preserved support for previous and current DeepSeek Flash routes.
  * Added configurable reasoning levels for eligible requests.

* **Bug Fixes**
  * Improved model and token cost recognition across DeepSeek Flash aliases.
  * Ensured routing failures safely fall back without disrupting requests.

* **Analytics**
  * Expanded route, response model, reasoning, cost, and fallback tracking for experiment monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->