### PR TITLE
Harden Agent provider response reliability

### DIFF
--- a/lib/ai/__tests__/provider-response-guard.test.ts
+++ b/lib/ai/__tests__/provider-response-guard.test.ts
@@ -1,0 +1,418 @@
+import { streamText, tool, type LanguageModel } from "ai";
+import { WritableStream as NodeWritableStream } from "node:stream/web";
+import { z } from "zod";
+import {
+  guardLanguageModelProviderResponse,
+  MAX_PROVIDER_TOOL_CALLS_PER_RESPONSE,
+  type LanguageModelStreamPart,
+} from "../provider-response-guard";
+import { namespaceLanguageModelToolCalls } from "../tool-call-id-namespace";
+import {
+  getProviderErrorCategory,
+  getUserFriendlyProviderError,
+  PROVIDER_CONTENT_BLOCKED_USER_MESSAGE,
+  extractErrorDetails,
+} from "@/lib/utils/error-utils";
+
+const originalWritableStream = globalThis.WritableStream;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "WritableStream", {
+    configurable: true,
+    value: NodeWritableStream,
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(globalThis, "WritableStream", {
+    configurable: true,
+    value: originalWritableStream,
+  });
+});
+
+const usage = {
+  inputTokens: {
+    total: 10,
+    noCache: 10,
+    cacheRead: 0,
+    cacheWrite: 0,
+  },
+  outputTokens: { total: 5, text: 5, reasoning: 0 },
+};
+
+const finish = (
+  unified:
+    "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other",
+) => ({
+  type: "finish" as const,
+  finishReason: { unified, raw: unified },
+  usage,
+});
+
+const toolCall = (toolCallId: string, toolName = "run_terminal_cmd") => ({
+  type: "tool-call" as const,
+  toolCallId,
+  toolName,
+  input: "{}",
+});
+
+const createModel = ({
+  streamParts = [finish("stop")],
+  content = [],
+}: {
+  streamParts?: LanguageModelStreamPart[];
+  content?: Array<Record<string, unknown>>;
+} = {}): LanguageModel =>
+  ({
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "test-model",
+    supportedUrls: {},
+    doGenerate: jest.fn(async () => ({
+      content,
+      finishReason: { unified: "stop", raw: "stop" },
+      usage,
+      warnings: [],
+    })),
+    doStream: jest.fn(async () => ({
+      stream: new ReadableStream({
+        start(controller) {
+          streamParts.forEach((part) => controller.enqueue(part));
+          controller.close();
+        },
+      }),
+    })),
+  }) as unknown as LanguageModel;
+
+const readProviderStream = async (model: LanguageModel) => {
+  if (typeof model === "string") throw new Error("Expected model object");
+  const result = await model.doStream({} as never);
+  const parts: LanguageModelStreamPart[] = [];
+  const reader = result.stream.getReader();
+  while (true) {
+    const next = await reader.read();
+    if (next.done) break;
+    parts.push(next.value);
+  }
+  return parts;
+};
+
+const consumeFullStream = async (
+  result: ReturnType<typeof streamText>,
+): Promise<unknown[]> => {
+  const parts: unknown[] = [];
+  for await (const part of result.fullStream) parts.push(part);
+  return parts;
+};
+
+describe("provider response tool-call guard", () => {
+  it("preserves non-streamed responses below and at the configured limit", async () => {
+    for (const callCount of [2, 3]) {
+      const content = Array.from({ length: callCount }, (_, index) =>
+        toolCall(`call-${index}`),
+      );
+      const model = guardLanguageModelProviderResponse(
+        createModel({ content }),
+        { maxToolCalls: 3 },
+      );
+      if (typeof model === "string") throw new Error("Expected model object");
+
+      const result = await model.doGenerate({} as never);
+
+      expect(result.content).toEqual(content);
+    }
+  });
+
+  it("bounds runaway non-streamed calls while preserving mixed content", async () => {
+    const report = jest.fn();
+    const content = [
+      { type: "text", text: "visible" },
+      toolCall("call-1"),
+      { type: "reasoning", text: "private reasoning" },
+      toolCall("call-2"),
+      toolCall("call-3"),
+      {
+        type: "tool-result",
+        toolCallId: "call-3",
+        toolName: "run_terminal_cmd",
+        result: { ok: true },
+      },
+    ];
+    const model = guardLanguageModelProviderResponse(createModel({ content }), {
+      maxToolCalls: 2,
+      onToolCallsDropped: report,
+    });
+    if (typeof model === "string") throw new Error("Expected model object");
+
+    const result = await model.doGenerate({} as never);
+
+    expect(result.content).toEqual(content.slice(0, 4));
+    expect(report).toHaveBeenCalledWith({
+      droppedToolCallCount: 1,
+      maxToolCalls: 2,
+    });
+  });
+
+  it("counts repeated provider IDs as separate calls", async () => {
+    const repeated = [toolCall("provider-id"), toolCall("provider-id")];
+    const model = guardLanguageModelProviderResponse(
+      createModel({ content: repeated }),
+      { maxToolCalls: 1 },
+    );
+    if (typeof model === "string") throw new Error("Expected model object");
+
+    const result = await model.doGenerate({} as never);
+
+    expect(result.content).toEqual([repeated[0]]);
+  });
+
+  it("keeps streamed input start/delta/end correlated for retained calls", async () => {
+    const parts = [
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "working" },
+      { type: "reasoning-start", id: "reasoning-1" },
+      { type: "reasoning-delta", id: "reasoning-1", delta: "thinking" },
+      { type: "reasoning-end", id: "reasoning-1" },
+      ...["call-1", "call-2", "call-3"].flatMap((id) => [
+        {
+          type: "tool-input-start" as const,
+          id,
+          toolName: "run_terminal_cmd",
+        },
+        { type: "tool-input-delta" as const, id, delta: "{}" },
+        { type: "tool-input-end" as const, id },
+        toolCall(id),
+      ]),
+      { type: "text-end", id: "text-1" },
+      finish("tool-calls"),
+    ] as LanguageModelStreamPart[];
+    const model = guardLanguageModelProviderResponse(
+      createModel({ streamParts: parts }),
+      { maxToolCalls: 2 },
+    );
+
+    const guarded = await readProviderStream(model);
+    const serialized = JSON.stringify(guarded);
+
+    expect(serialized).toContain("call-1");
+    expect(serialized).toContain("call-2");
+    expect(serialized).not.toContain("call-3");
+    expect(guarded.filter((part) => part.type === "tool-call")).toHaveLength(2);
+    expect(guarded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text-delta", delta: "working" }),
+        expect.objectContaining({
+          type: "reasoning-delta",
+          delta: "thinking",
+        }),
+        expect.objectContaining({ type: "finish" }),
+      ]),
+    );
+  });
+
+  it("preserves compaction namespaces and retained tool-result matching", async () => {
+    const model = namespaceLanguageModelToolCalls(
+      guardLanguageModelProviderResponse(
+        createModel({
+          streamParts: [
+            {
+              type: "tool-input-start",
+              id: "call-1",
+              toolName: "run_terminal_cmd",
+            },
+            { type: "tool-input-delta", id: "call-1", delta: "{}" },
+            { type: "tool-input-end", id: "call-1" },
+            toolCall("call-1"),
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "run_terminal_cmd",
+              result: { ok: true },
+            },
+            toolCall("call-2"),
+            finish("tool-calls"),
+          ],
+        }),
+        { maxToolCalls: 1 },
+      ),
+      "rrun1c2s3",
+    );
+
+    const guarded = await readProviderStream(model);
+    const toolParts = guarded.filter((part) => part.type.startsWith("tool-"));
+
+    expect(toolParts).toEqual([
+      expect.objectContaining({
+        type: "tool-input-start",
+        id: "rrun1c2s3_call-1",
+      }),
+      expect.objectContaining({
+        type: "tool-input-delta",
+        id: "rrun1c2s3_call-1",
+      }),
+      expect.objectContaining({
+        type: "tool-input-end",
+        id: "rrun1c2s3_call-1",
+      }),
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "rrun1c2s3_call-1",
+      }),
+      expect.objectContaining({
+        type: "tool-result",
+        toolCallId: "rrun1c2s3_call-1",
+      }),
+    ]);
+  });
+
+  it("deduplicates wait_for_agents within one provider response", async () => {
+    const content = [
+      toolCall("wait-1", "wait_for_agents"),
+      toolCall("work-1"),
+      toolCall("wait-2", "wait_for_agents"),
+    ];
+    const model = guardLanguageModelProviderResponse(createModel({ content }), {
+      maxToolCalls: 10,
+    });
+    if (typeof model === "string") throw new Error("Expected model object");
+
+    const result = await model.doGenerate({} as never);
+
+    expect(result.content).toEqual(content.slice(0, 2));
+  });
+
+  it("filters calls before the AI SDK launches tool executions", async () => {
+    const execute = jest.fn(async () => ({ ok: true }));
+    const model = guardLanguageModelProviderResponse(
+      createModel({
+        streamParts: [
+          toolCall("call-1"),
+          toolCall("call-2"),
+          toolCall("call-3"),
+          finish("tool-calls"),
+        ],
+      }),
+      { maxToolCalls: 2 },
+    );
+
+    const result = streamText({
+      model,
+      prompt: "test",
+      tools: {
+        run_terminal_cmd: tool({
+          inputSchema: z.object({}),
+          execute,
+        }),
+      },
+    });
+    await consumeFullStream(result);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("executes only one streamed wait_for_agents call per model turn", async () => {
+    const waitForAgents = jest.fn(async () => ({ status: "complete" }));
+    const runTerminal = jest.fn(async () => ({ ok: true }));
+    const model = guardLanguageModelProviderResponse(
+      createModel({
+        streamParts: [
+          toolCall("wait-1", "wait_for_agents"),
+          toolCall("work-1"),
+          toolCall("wait-2", "wait_for_agents"),
+          finish("tool-calls"),
+        ],
+      }),
+      { maxToolCalls: 10 },
+    );
+
+    const result = streamText({
+      model,
+      prompt: "test",
+      tools: {
+        wait_for_agents: tool({
+          inputSchema: z.object({}),
+          execute: waitForAgents,
+        }),
+        run_terminal_cmd: tool({
+          inputSchema: z.object({}),
+          execute: runTerminal,
+        }),
+      },
+    });
+    await consumeFullStream(result);
+
+    expect(waitForAgents).toHaveBeenCalledTimes(1);
+    expect(runTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses 32 as the explicit production ceiling", () => {
+    expect(MAX_PROVIDER_TOOL_CALLS_PER_RESPONSE).toBe(32);
+  });
+});
+
+describe("content-filter finish handling", () => {
+  it.each([
+    { label: "no output", outputParts: [] },
+    {
+      label: "partial output",
+      outputParts: [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "partial answer" },
+        { type: "text-end", id: "text-1" },
+      ],
+    },
+  ])(
+    "surfaces $label as a terminal provider content block",
+    async ({ outputParts }) => {
+      const errors: unknown[] = [];
+      const finishes: Array<{ finishReason: string; text: string }> = [];
+      const model = guardLanguageModelProviderResponse(
+        createModel({
+          streamParts: [
+            ...(outputParts as LanguageModelStreamPart[]),
+            finish("content-filter"),
+          ],
+        }),
+      );
+      const result = streamText({
+        model,
+        prompt: "test",
+        onError: ({ error }) => {
+          errors.push(error);
+        },
+        onFinish: ({ finishReason, text }) => {
+          finishes.push({ finishReason, text });
+        },
+      });
+
+      await consumeFullStream(result);
+
+      expect(errors).toHaveLength(1);
+      expect(getProviderErrorCategory(extractErrorDetails(errors[0]))).toBe(
+        "content_blocked",
+      );
+      expect(getUserFriendlyProviderError(errors[0])).toBe(
+        PROVIDER_CONTENT_BLOCKED_USER_MESSAGE,
+      );
+      expect(finishes).toEqual([
+        {
+          finishReason: "content-filter",
+          text: outputParts.length === 0 ? "" : "partial answer",
+        },
+      ]);
+    },
+  );
+
+  it.each(["stop", "error", "other"] as const)(
+    "passes through the normal %s finish reason without synthesis",
+    async (finishReason) => {
+      const model = guardLanguageModelProviderResponse(
+        createModel({ streamParts: [finish(finishReason)] }),
+      );
+
+      const parts = await readProviderStream(model);
+
+      expect(parts).toEqual([finish(finishReason)]);
+    },
+  );
+});

--- a/lib/ai/provider-response-guard.ts
+++ b/lib/ai/provider-response-guard.ts
@@ -1,0 +1,248 @@
+import {
+  wrapLanguageModel,
+  type LanguageModel,
+  type LanguageModelMiddleware,
+} from "ai";
+import { createProviderContentBlockedFinishReasonError } from "@/lib/utils/error-utils";
+
+type MiddlewareGenerateOptions = Parameters<
+  NonNullable<LanguageModelMiddleware["wrapGenerate"]>
+>[0];
+type LanguageModelGenerateResult = Awaited<
+  ReturnType<MiddlewareGenerateOptions["doGenerate"]>
+>;
+type LanguageModelContentPart = LanguageModelGenerateResult["content"][number];
+
+type MiddlewareStreamOptions = Parameters<
+  NonNullable<LanguageModelMiddleware["wrapStream"]>
+>[0];
+type LanguageModelStreamResult = Awaited<
+  ReturnType<MiddlewareStreamOptions["doStream"]>
+>;
+type LanguageModelStreamPart =
+  LanguageModelStreamResult["stream"] extends ReadableStream<infer T>
+    ? T
+    : never;
+
+type GuardedToolPart = {
+  type: string;
+  id?: string;
+  toolCallId?: string;
+  toolName?: string;
+};
+
+type ToolCallDecision = {
+  retained: boolean;
+  toolName: string;
+};
+
+export type ProviderToolCallDropReport = {
+  droppedToolCallCount: number;
+  maxToolCalls: number;
+};
+
+export type ProviderResponseGuardOptions = {
+  maxToolCalls?: number;
+  perToolCallLimits?: Readonly<Record<string, number>>;
+  onToolCallsDropped?: (report: ProviderToolCallDropReport) => void;
+};
+
+// One provider response maps to one AI SDK step, whose tool executions run
+// concurrently. Thirty-two preserves deliberate parallel work while bounding
+// the promises, sandbox operations, and side effects one response can enqueue.
+export const MAX_PROVIDER_TOOL_CALLS_PER_RESPONSE = 32;
+
+export const DEFAULT_PROVIDER_TOOL_CALL_LIMITS = Object.freeze({
+  // This tool durably blocks the parent run, so duplicate calls in one model
+  // turn are redundant and can otherwise create competing wait operations.
+  wait_for_agents: 1,
+});
+
+const normalizedLimit = (value: number | undefined, fallback: number) =>
+  typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : fallback;
+
+const createToolCallLimiter = (options: ProviderResponseGuardOptions) => {
+  const maxToolCalls = normalizedLimit(
+    options.maxToolCalls,
+    MAX_PROVIDER_TOOL_CALLS_PER_RESPONSE,
+  );
+  const perToolCallLimits: Readonly<Record<string, number>> =
+    options.perToolCallLimits ?? DEFAULT_PROVIDER_TOOL_CALL_LIMITS;
+  const retainedByToolName = new Map<string, number>();
+  const pendingByToolCallId = new Map<string, ToolCallDecision[]>();
+  const activeByToolCallId = new Map<string, ToolCallDecision>();
+  const completedByToolCallId = new Map<string, ToolCallDecision>();
+  let retainedCallCount = 0;
+  let droppedToolCallCount = 0;
+  let reported = false;
+
+  const decide = (toolName: string): ToolCallDecision => {
+    const toolLimit = perToolCallLimits[toolName];
+    const retainedForTool = retainedByToolName.get(toolName) ?? 0;
+    const retained =
+      retainedCallCount < maxToolCalls &&
+      (toolLimit === undefined ||
+        retainedForTool < normalizedLimit(toolLimit, maxToolCalls));
+
+    if (retained) {
+      retainedCallCount += 1;
+      retainedByToolName.set(toolName, retainedForTool + 1);
+    }
+
+    return { retained, toolName };
+  };
+
+  const queuePendingDecision = (
+    toolCallId: string,
+    decision: ToolCallDecision,
+  ) => {
+    const pending = pendingByToolCallId.get(toolCallId) ?? [];
+    pending.push(decision);
+    pendingByToolCallId.set(toolCallId, pending);
+  };
+
+  const takePendingDecision = (
+    toolCallId: string,
+    toolName: string,
+  ): ToolCallDecision => {
+    const pending = pendingByToolCallId.get(toolCallId);
+    const pendingIndex = pending?.findIndex(
+      (decision) => decision.toolName === toolName,
+    );
+    if (pending && pendingIndex !== undefined && pendingIndex >= 0) {
+      const [decision] = pending.splice(pendingIndex, 1);
+      if (pending.length === 0) pendingByToolCallId.delete(toolCallId);
+      return decision;
+    }
+    return decide(toolName);
+  };
+
+  const shouldForward = (part: GuardedToolPart): boolean => {
+    switch (part.type) {
+      case "tool-input-start": {
+        if (typeof part.id !== "string" || typeof part.toolName !== "string") {
+          return true;
+        }
+        const decision = decide(part.toolName);
+        if (decision.retained) {
+          // Only retained calls occupy correlation state, so even a malformed
+          // response with unbounded starts cannot grow these maps past the cap.
+          queuePendingDecision(part.id, decision);
+          activeByToolCallId.set(part.id, decision);
+        }
+        return decision.retained;
+      }
+      case "tool-input-delta":
+      case "tool-input-end": {
+        if (typeof part.id !== "string") return true;
+        const decision = activeByToolCallId.get(part.id);
+        if (part.type === "tool-input-end") {
+          activeByToolCallId.delete(part.id);
+        }
+        return decision?.retained ?? false;
+      }
+      case "tool-call": {
+        if (
+          typeof part.toolCallId !== "string" ||
+          typeof part.toolName !== "string"
+        ) {
+          return true;
+        }
+        const decision = takePendingDecision(part.toolCallId, part.toolName);
+        if (decision.retained) {
+          completedByToolCallId.set(part.toolCallId, decision);
+        } else {
+          droppedToolCallCount += 1;
+        }
+        return decision.retained;
+      }
+      case "tool-approval-request":
+      case "tool-result": {
+        if (typeof part.toolCallId !== "string") return true;
+        return completedByToolCallId.get(part.toolCallId)?.retained ?? false;
+      }
+      default:
+        return true;
+    }
+  };
+
+  const reportDrops = () => {
+    if (reported || droppedToolCallCount === 0) return;
+    reported = true;
+    try {
+      options.onToolCallsDropped?.({
+        droppedToolCallCount,
+        maxToolCalls,
+      });
+    } catch (error) {
+      console.error("[provider-response-guard] drop reporter failed", {
+        event: "provider_tool_call_guard_report_failed",
+        droppedToolCallCount,
+        errorName: error instanceof Error ? error.name : "UnknownError",
+      });
+    }
+  };
+
+  return { shouldForward, reportDrops };
+};
+
+const isContentFilterFinishPart = (part: LanguageModelStreamPart): boolean =>
+  part.type === "finish" && part.finishReason.unified === "content-filter";
+
+export const guardLanguageModelProviderResponse = (
+  model: LanguageModel,
+  options: ProviderResponseGuardOptions = {},
+): LanguageModel => {
+  if (typeof model === "string" || model.specificationVersion !== "v3") {
+    return model;
+  }
+
+  return wrapLanguageModel({
+    model,
+    middleware: {
+      specificationVersion: "v3",
+      wrapGenerate: async ({ doGenerate }) => {
+        const result = await doGenerate();
+        const limiter = createToolCallLimiter(options);
+        const content = result.content.filter((part) =>
+          limiter.shouldForward(part as GuardedToolPart),
+        );
+        limiter.reportDrops();
+        return { ...result, content };
+      },
+      wrapStream: async ({ doStream }) => {
+        const result = await doStream();
+        const limiter = createToolCallLimiter(options);
+        return {
+          ...result,
+          stream: result.stream.pipeThrough(
+            new TransformStream<
+              LanguageModelStreamPart,
+              LanguageModelStreamPart
+            >({
+              transform(part, controller) {
+                if (isContentFilterFinishPart(part)) {
+                  controller.enqueue({
+                    type: "error",
+                    error: createProviderContentBlockedFinishReasonError(),
+                  });
+                }
+                if (limiter.shouldForward(part as GuardedToolPart)) {
+                  controller.enqueue(part);
+                }
+                if (part.type === "finish") limiter.reportDrops();
+              },
+              flush() {
+                limiter.reportDrops();
+              },
+            }),
+          ),
+        };
+      },
+    },
+  });
+};
+
+export type { LanguageModelContentPart, LanguageModelStreamPart };

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1170,6 +1170,46 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(throwIdx).toBeGreaterThan(terminalErrorIdx);
   });
 
+  test("content-filter finishes are terminal, non-replayable, and share the provider error path", () => {
+    expect(agentStreamRunnerSrc).toMatch(
+      /guardLanguageModelProviderResponse\(languageModel/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(
+      /isProviderContentBlockedFinishReasonError\(error\)/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(
+      /refundProviderContentBlockedIfSettled\(\{[\s\S]*finishReason,[\s\S]*settled: true/,
+    );
+
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      expect(source).toMatch(/const providerContentBlocked\s*=/);
+      expect(source).toMatch(/providerContentBlocked,/);
+      expect(source).toMatch(
+        /!providerContentBlocked\s*&&\s*\(shouldRetryWithFallback/,
+      );
+    }
+    expect([
+      ...chatHandlerSrc.matchAll(
+        /state\.providerError \?\?[\s\S]{0,100}createProviderContentBlockedFinishReasonError\(\)/g,
+      ),
+    ]).toHaveLength(2);
+
+    const terminalHelperIdx = taskSrc.indexOf(
+      "const getTerminalProviderStreamError",
+    );
+    const contentFilterIdx = taskSrc.indexOf(
+      "isProviderContentFilterFinishReason(state.streamFinishReason)",
+      terminalHelperIdx,
+    );
+    const terminalCheckIdx = taskSrc.indexOf(
+      "getTerminalProviderStreamError(terminalAgentState)",
+      contentFilterIdx,
+    );
+    expect(terminalHelperIdx).toBeGreaterThan(-1);
+    expect(contentFilterIdx).toBeGreaterThan(terminalHelperIdx);
+    expect(terminalCheckIdx).toBeGreaterThan(contentFilterIdx);
+  });
+
   test("direct context-limit finish reasons trigger auto-continue in both agent paths", () => {
     for (const source of [taskSrc, chatHandlerSrc]) {
       expect(source).toMatch(/getAgentAutoContinueStopSource\(\{/);
@@ -1529,6 +1569,18 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
     expect(taskSrc).toMatch(
       /isProviderApiError\(error\)\s*&&\s*!isInvalidImageInputError\(error\)/,
+    );
+  });
+
+  test("provider content blocks preserve their classification and complete after the error stream", () => {
+    expect(taskSrc).toMatch(
+      /USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES[\s\S]*"content_blocked"/,
+    );
+    expect(taskSrc).toMatch(
+      /if \(category === "content_blocked"\) return category/,
+    );
+    expect(taskSrc).toMatch(
+      /recordedFailure\.userCorrectable === true[\s\S]*return \{ chatId, assistantMessageId \}/,
     );
   });
 

--- a/lib/api/__tests__/chat-handler-pty-cleanup.test.ts
+++ b/lib/api/__tests__/chat-handler-pty-cleanup.test.ts
@@ -80,4 +80,26 @@ describe("chat-handler — PTY closeAll wired to streamText onFinish", () => {
     );
     expect(closeAllCallIdx).toBeGreaterThan(onFinishIdx);
   });
+
+  test("wires blocked-content refunds to finish and abort settlement", () => {
+    expect(runnerSrc).toMatch(
+      /createProviderContentBlockedRefundLifecycle\(\{/,
+    );
+
+    const onErrorIdx = runnerSrc.indexOf("onError:");
+    const onAbortIdx = runnerSrc.indexOf("onAbort:");
+    const onFinishIdx = runnerSrc.indexOf("onFinish: async (finishResult)");
+    const refundCalls = [onErrorIdx, onAbortIdx, onFinishIdx].map((start) =>
+      runnerSrc.indexOf("refundProviderContentBlockedIfSettled({", start),
+    );
+
+    expect(refundCalls.every((index) => index > -1)).toBe(true);
+    expect(runnerSrc.substring(refundCalls[0], onAbortIdx)).toMatch(
+      /settled: false/,
+    );
+    expect(runnerSrc.substring(refundCalls[1])).toMatch(/settled: true/);
+    expect(runnerSrc.substring(refundCalls[2], onErrorIdx)).toMatch(
+      /settled: true/,
+    );
+  });
 });

--- a/lib/api/__tests__/provider-content-blocked-refund.test.ts
+++ b/lib/api/__tests__/provider-content-blocked-refund.test.ts
@@ -1,0 +1,118 @@
+import { createProviderContentBlockedFinishReasonError } from "@/lib/utils/error-utils";
+import { createProviderContentBlockedRefundLifecycle } from "../provider-content-blocked-refund";
+
+describe("provider content-blocked refund lifecycle", () => {
+  const refundUsage = jest.fn();
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    refundUsage.mockResolvedValue(undefined);
+  });
+
+  const createLifecycle = (hasUsage: () => boolean) => {
+    let refundModule: typeof import("@/lib/rate-limit/refund") | undefined;
+    let lifecycleModule:
+      typeof import("../provider-content-blocked-refund") | undefined;
+
+    jest.isolateModules(() => {
+      jest.doMock("@/lib/rate-limit/token-bucket", () => ({ refundUsage }));
+      refundModule = require("@/lib/rate-limit/refund");
+      lifecycleModule = require("../provider-content-blocked-refund");
+    });
+    if (!refundModule || !lifecycleModule) {
+      throw new Error("Failed to initialize refund lifecycle test modules");
+    }
+
+    const tracker = new refundModule.UsageRefundTracker();
+    tracker.setUser("user-123", "pro");
+    tracker.recordDeductions({
+      remaining: 900,
+      resetTime: new Date(),
+      limit: 1000,
+      pointsDeducted: 100,
+    });
+
+    return lifecycleModule.createProviderContentBlockedRefundLifecycle({
+      hasUsage,
+      refund: () => tracker.refund(),
+    });
+  };
+
+  it("refunds once after a zero-usage blocked response settles", async () => {
+    const lifecycle = createLifecycle(() => false);
+    const error = createProviderContentBlockedFinishReasonError();
+
+    await lifecycle({ error, settled: false });
+    expect(refundUsage).not.toHaveBeenCalled();
+
+    await lifecycle({ finishReason: "content-filter", settled: true });
+    await lifecycle({ error, settled: true });
+
+    expect(refundUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes concurrent settled callbacks into one external refund", async () => {
+    let completeRefund: (() => void) | undefined;
+    refundUsage.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          completeRefund = resolve;
+        }),
+    );
+    const lifecycle = createLifecycle(() => false);
+    const error = createProviderContentBlockedFinishReasonError();
+
+    await lifecycle({ error, settled: false });
+    const finishRefund = lifecycle({
+      finishReason: "content-filter",
+      settled: true,
+    });
+    const abortRefund = lifecycle({ error, settled: true });
+
+    expect(refundUsage).toHaveBeenCalledTimes(1);
+    completeRefund?.();
+    await Promise.all([finishRefund, abortRefund]);
+    expect(refundUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a later settled callback to retry a failed refund", async () => {
+    const refund = jest
+      .fn(async () => {})
+      .mockRejectedValueOnce(new Error("temporary refund failure"));
+    const lifecycle = createProviderContentBlockedRefundLifecycle({
+      hasUsage: () => false,
+      refund,
+    });
+
+    await expect(
+      lifecycle({ finishReason: "content-filter", settled: true }),
+    ).rejects.toThrow("temporary refund failure");
+    await expect(
+      lifecycle({ finishReason: "content-filter", settled: true }),
+    ).resolves.toBeUndefined();
+
+    expect(refund).toHaveBeenCalledTimes(2);
+  });
+
+  it("refunds when a blocked stream aborts before finish", async () => {
+    const lifecycle = createLifecycle(() => false);
+    const error = createProviderContentBlockedFinishReasonError();
+
+    await lifecycle({ error, settled: false });
+    await lifecycle({ error, settled: true });
+
+    expect(refundUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refund a blocked response with observed usage", async () => {
+    const lifecycle = createLifecycle(() => true);
+    const error = createProviderContentBlockedFinishReasonError();
+
+    await lifecycle({ error, settled: false });
+    await lifecycle({ finishReason: "content-filter", settled: true });
+    await lifecycle({ error, settled: true });
+
+    expect(refundUsage).not.toHaveBeenCalled();
+  });
+});

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -93,7 +93,11 @@ import {
   mergeOpenRouterMetadata,
 } from "@/lib/api/openrouter-metadata";
 import { getOpenRouterUpstreamInferenceCostFromUsageRaw } from "@/lib/provider-usage-cost";
-import { classifyProviderOverflowError } from "@/lib/utils/error-utils";
+import {
+  classifyProviderOverflowError,
+  isProviderContentBlockedFinishReasonError,
+} from "@/lib/utils/error-utils";
+import { createProviderContentBlockedRefundLifecycle } from "@/lib/api/provider-content-blocked-refund";
 import type { UsageTracker } from "@/lib/usage-tracker";
 import type {
   BudgetAbortDetails,
@@ -113,6 +117,10 @@ import type {
 } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 import { namespaceLanguageModelToolCalls } from "@/lib/ai/tool-call-id-namespace";
+import {
+  guardLanguageModelProviderResponse,
+  MAX_PROVIDER_TOOL_CALLS_PER_RESPONSE,
+} from "@/lib/ai/provider-response-guard";
 
 const AGENT_VISION_MODEL = "model-grok-4.5";
 
@@ -570,7 +578,21 @@ export async function createAgentStream(
     stepIndex: number,
   ): LanguageModel =>
     namespaceLanguageModelToolCalls(
-      languageModel,
+      guardLanguageModelProviderResponse(languageModel, {
+        onToolCallsDropped: ({ droppedToolCallCount, maxToolCalls }) => {
+          console.warn("[agent-stream] provider tool calls bounded", {
+            event: "provider_tool_call_guard_applied",
+            model:
+              typeof languageModel === "string"
+                ? languageModel
+                : languageModel.modelId,
+            step: stepIndex + 1,
+            droppedToolCallCount,
+            maxToolCalls,
+          });
+        },
+        maxToolCalls: MAX_PROVIDER_TOOL_CALLS_PER_RESPONSE,
+      }),
       `r${toolCallRunNamespace}c${ctx.summarizationTracker.summarizationCount}s${stepIndex}`,
     );
   type AbortStepLike = {
@@ -793,6 +815,12 @@ export async function createAgentStream(
     providerOptions: initialProviderOptions,
     activeTools: initialActiveTools,
   });
+
+  const refundProviderContentBlockedIfSettled =
+    createProviderContentBlockedRefundLifecycle({
+      hasUsage: () => ctx.usageTracker.hasUsage,
+      refund: () => ctx.usageRefundTracker.refund(),
+    });
 
   return streamText({
     model: getNamespacedLanguageModel(initialModelInfo.languageModel, 0),
@@ -1434,6 +1462,11 @@ export async function createAgentStream(
         openRouterMetadata,
       );
 
+      await refundProviderContentBlockedIfSettled({
+        finishReason,
+        settled: true,
+      });
+
       await ptySessionManager
         .closeAll(ctx.chatId)
         .catch((err) =>
@@ -1443,6 +1476,10 @@ export async function createAgentStream(
 
     onError: async ({ error }) => {
       state.providerError = error;
+      await refundProviderContentBlockedIfSettled({
+        error,
+        settled: false,
+      });
       if (
         streamHasImageViewResults &&
         isProviderMultimodalToolResultRejectionError(error)
@@ -1475,7 +1512,10 @@ export async function createAgentStream(
           providerRequest: latestProviderRequestDiagnostics,
         });
       }
-      if (!ctx.usageTracker.hasUsage) {
+      if (
+        !isProviderContentBlockedFinishReasonError(error) &&
+        !ctx.usageTracker.hasUsage
+      ) {
         await ctx.usageRefundTracker.refund();
       }
       await ptySessionManager
@@ -1487,6 +1527,11 @@ export async function createAgentStream(
 
     onAbort: async ({ steps }) => {
       recordAssistantContentLoopAbortState(steps);
+      await refundProviderContentBlockedIfSettled({
+        error: state.providerError,
+        finishReason: state.streamFinishReason,
+        settled: true,
+      });
       await ptySessionManager
         .closeAll(ctx.chatId)
         .catch((err) =>

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -150,10 +150,12 @@ import {
   getRateLimitErrorCapReason,
 } from "@/lib/api/paid-daily-free-allowance-rescue";
 import {
+  createProviderContentBlockedFinishReasonError,
   extractErrorDetails,
   getProviderErrorCategory,
   getProviderStatusCode,
   getUserFriendlyProviderError,
+  isProviderContentFilterFinishReason,
 } from "@/lib/utils/error-utils";
 import {
   requireChatMessagesArray,
@@ -1399,8 +1401,13 @@ export const createChatHandler = () => {
                     const stoppedDueToAssistantContentLoop =
                       state.stoppedDueToAssistantContentLoop ||
                       (!isAborted && assistantContentLoopDetection.detected);
+                    const providerContentBlocked =
+                      isProviderContentFilterFinishReason(
+                        state.streamFinishReason,
+                      );
                     const hasTerminalProviderStreamError =
-                      state.streamFinishReason === "error";
+                      state.streamFinishReason === "error" ||
+                      providerContentBlocked;
                     const shouldRetryInterruptedToolInput =
                       shouldRetryProviderStreamAfterInterruptedToolInput(
                         lastAssistantMessageParts,
@@ -1412,6 +1419,7 @@ export const createChatHandler = () => {
                         {
                           hasTerminalProviderStreamError:
                             hasTerminalProviderStreamError,
+                          providerContentBlocked,
                           stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
                           stoppedDueToAssistantContentLoop,
                           detectAssistantContentLoop: !isAborted,
@@ -1425,8 +1433,9 @@ export const createChatHandler = () => {
                       imageRecovery.omittedCount > 0 && !isAborted;
 
                     if (
-                      shouldRetryWithFallback ||
-                      shouldRetryWithoutImageToolResults
+                      !providerContentBlocked &&
+                      (shouldRetryWithFallback ||
+                        shouldRetryWithoutImageToolResults)
                     ) {
                       const loopTriggeredRetry =
                         stoppedDueToAssistantContentLoop ||
@@ -1596,9 +1605,15 @@ export const createChatHandler = () => {
                                 // reason to budget-exhausted; do it before
                                 // analytics and persistence consume state.
                                 await deductAccumulatedUsage(retryMessageId);
+                                const providerContentBlocked =
+                                  isProviderContentFilterFinishReason(
+                                    state.streamFinishReason,
+                                  );
                                 const outcome = retryAborted
                                   ? "aborted"
-                                  : "success";
+                                  : providerContentBlocked
+                                    ? "error"
+                                    : "success";
                                 captureAgentCompletionAnalytics({
                                   posthog,
                                   userId,
@@ -1632,13 +1647,20 @@ export const createChatHandler = () => {
                                         getTodoManager().getRunMetrics(),
                                     }),
                                 });
-                                chatLogger!.emitSuccess({
-                                  finishReason: state.streamFinishReason,
-                                  wasAborted: retryAborted,
-                                  wasPreemptiveTimeout: false,
-                                  hadSummarization:
-                                    summarizationTracker.hasSummarized,
-                                });
+                                if (providerContentBlocked) {
+                                  chatLogger!.emitUnexpectedError(
+                                    state.providerError ??
+                                      createProviderContentBlockedFinishReasonError(),
+                                  );
+                                } else {
+                                  chatLogger!.emitSuccess({
+                                    finishReason: state.streamFinishReason,
+                                    wasAborted: retryAborted,
+                                    wasPreemptiveTimeout: false,
+                                    hadSummarization:
+                                      summarizationTracker.hasSummarized,
+                                  });
+                                }
 
                                 const generatedTitle = await titlePromise;
 
@@ -1890,7 +1912,15 @@ export const createChatHandler = () => {
                     // budget-exhausted; do it before analytics and persistence
                     // consume state.
                     await deductAccumulatedUsage();
-                    const outcome = isAborted ? "aborted" : "success";
+                    const finalProviderContentBlocked =
+                      isProviderContentFilterFinishReason(
+                        state.streamFinishReason,
+                      );
+                    const outcome = isAborted
+                      ? "aborted"
+                      : finalProviderContentBlocked
+                        ? "error"
+                        : "success";
                     captureAgentCompletionAnalytics({
                       posthog,
                       userId,
@@ -1919,12 +1949,19 @@ export const createChatHandler = () => {
                         todoRunMetrics: getTodoManager().getRunMetrics(),
                       }),
                     });
-                    chatLogger!.emitSuccess({
-                      finishReason: state.streamFinishReason,
-                      wasAborted: isAborted,
-                      wasPreemptiveTimeout: isPreemptiveAbort,
-                      hadSummarization: summarizationTracker.hasSummarized,
-                    });
+                    if (finalProviderContentBlocked) {
+                      chatLogger!.emitUnexpectedError(
+                        state.providerError ??
+                          createProviderContentBlockedFinishReasonError(),
+                      );
+                    } else {
+                      chatLogger!.emitSuccess({
+                        finishReason: state.streamFinishReason,
+                        wasAborted: isAborted,
+                        wasPreemptiveTimeout: isPreemptiveAbort,
+                        hadSummarization: summarizationTracker.hasSummarized,
+                      });
+                    }
                     logStep("settle_usage_and_emit_success", stepStart);
 
                     // Sandbox cleanup is automatic with auto-pause

--- a/lib/api/provider-content-blocked-refund.ts
+++ b/lib/api/provider-content-blocked-refund.ts
@@ -1,0 +1,40 @@
+import {
+  isProviderContentBlockedFinishReasonError,
+  isProviderContentFilterFinishReason,
+} from "@/lib/utils/error-utils";
+
+type ProviderContentBlockedLifecycleEvent = {
+  error?: unknown;
+  finishReason?: string;
+  settled: boolean;
+};
+
+export const createProviderContentBlockedRefundLifecycle = ({
+  hasUsage,
+  refund,
+}: {
+  hasUsage: () => boolean;
+  refund: () => Promise<void>;
+}) => {
+  let providerContentBlockedObserved = false;
+  let refundInFlight: Promise<void> | undefined;
+
+  return async ({
+    error,
+    finishReason,
+    settled,
+  }: ProviderContentBlockedLifecycleEvent): Promise<void> => {
+    if (
+      isProviderContentBlockedFinishReasonError(error) ||
+      isProviderContentFilterFinishReason(finishReason)
+    ) {
+      providerContentBlockedObserved = true;
+    }
+    if (!settled || !providerContentBlockedObserved || hasUsage()) return;
+
+    refundInFlight ??= refund().finally(() => {
+      refundInFlight = undefined;
+    });
+    await refundInFlight;
+  };
+};

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -235,6 +235,51 @@ describe("shouldRetryAgentLongWithFallback", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    {
+      label: "no output",
+      parts: [{ type: "step-start" }],
+    },
+    {
+      label: "partial text",
+      parts: [{ type: "step-start" }, { type: "text", text: "partial answer" }],
+    },
+    {
+      label: "completed tool call",
+      parts: [
+        { type: "step-start" },
+        {
+          type: "tool-run_terminal_cmd",
+          toolCallId: "call-1",
+          state: "output-available",
+          output: { result: { exitCode: 0 } },
+        },
+      ],
+    },
+  ])("never replays provider content blocks with $label", ({ parts }) => {
+    expect(
+      shouldRetryAgentLongWithFallback(parts, {
+        hasTerminalProviderStreamError: true,
+        providerContentBlocked: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat a user abort as a provider retry", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          { type: "reasoning", text: "thinking", state: "streaming" },
+        ],
+        {
+          hasTerminalProviderStreamError: false,
+          detectAssistantContentLoop: false,
+        },
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("assistant content loop detection", () => {

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -12,6 +12,7 @@ type MessagePartLike = {
 
 type RetryDecisionOptions = {
   hasTerminalProviderStreamError: boolean;
+  providerContentBlocked?: boolean;
   stoppedDueToDoomLoop?: boolean;
   stoppedDueToAssistantContentLoop?: boolean;
   detectAssistantContentLoop?: boolean;
@@ -244,6 +245,10 @@ export const shouldRetryProviderStreamWithFallback = (
   parts: unknown[],
   options: RetryDecisionOptions,
 ): boolean => {
+  // A provider content-policy decision is terminal. Replaying it on another
+  // provider can bypass the decision and can duplicate already-visible output.
+  if (options.providerContentBlocked) return false;
+
   // Preserve the older guard for streams that never got past the first step.
   if (isOnlyStepStart(parts)) return true;
 

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
 import {
   classifyProviderOverflowError,
+  createProviderContentBlockedFinishReasonError,
   extractErrorDetails,
   extractRetryAttempts,
   getUserFriendlyProviderError,
@@ -8,6 +9,8 @@ import {
   getProviderStatusCode,
   isInvalidImageInputError,
   isProviderContentBlockedError,
+  isProviderContentBlockedFinishReasonError,
+  isProviderContentFilterFinishReason,
   isProviderStreamTerminatedError,
 } from "../error-utils";
 
@@ -279,6 +282,19 @@ describe("extractErrorDetails -> wrapped provider errors", () => {
 });
 
 describe("provider error classification", () => {
+  it("maps content-filter finish reasons to the existing content-blocked classification and copy", () => {
+    const err = createProviderContentBlockedFinishReasonError();
+
+    expect(isProviderContentFilterFinishReason(err.finishReason)).toBe(true);
+    expect(isProviderContentBlockedFinishReasonError(err)).toBe(true);
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "content_blocked",
+    );
+    expect(getUserFriendlyProviderError(err)).toBe(
+      "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.",
+    );
+  });
+
   it("classifies undici terminated errors as provider stream termination", () => {
     const cause = Object.assign(new Error("other side closed"), {
       code: "UND_ERR_SOCKET",

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -382,6 +382,39 @@ export const isInvalidImageInputError = (error: unknown): boolean =>
 const PROVIDER_CONTENT_BLOCK_PATTERN =
   /\bPROHIBITED_CONTENT\b|\b(?:content[_ -]?(?:filter(?:ing)?|policy)|safety policy|moderation policy|safety system|moderation system)\b.{0,80}\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b|\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b.{0,80}\b(?:content[_ -]?(?:filter(?:ing)?|policy)|safety policy|moderation policy|safety system|moderation system)\b|\bblocked by (?:the )?(?:provider )?(?:safety|moderation)(?: system| filter)?\b|\b(?:unsafe|harmful) content\b/i;
 
+export const PROVIDER_CONTENT_BLOCKED_USER_MESSAGE =
+  "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.";
+
+export const isProviderContentFilterFinishReason = (
+  finishReason: unknown,
+): finishReason is "content-filter" => finishReason === "content-filter";
+
+export const createProviderContentBlockedFinishReasonError = (): Error & {
+  statusCode: 403;
+  finishReason: "content-filter";
+} =>
+  Object.assign(
+    new Error(
+      "PROHIBITED_CONTENT: provider returned content-filter finish reason",
+    ),
+    {
+      name: "ProviderContentBlockedFinishReasonError",
+      statusCode: 403 as const,
+      finishReason: "content-filter" as const,
+    },
+  );
+
+export const isProviderContentBlockedFinishReasonError = (
+  error: unknown,
+): boolean =>
+  Boolean(
+    error &&
+    typeof error === "object" &&
+    ((error as { finishReason?: unknown }).finishReason === "content-filter" ||
+      (error as { name?: unknown }).name ===
+        "ProviderContentBlockedFinishReasonError"),
+  );
+
 export const isProviderContentBlockedDetails = (
   details: Record<string, unknown>,
 ): boolean => {
@@ -570,7 +603,7 @@ export const getUserFriendlyProviderError = (error: unknown): string => {
   }
 
   if (isProviderContentBlockedError(error)) {
-    return "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.";
+    return PROVIDER_CONTENT_BLOCKED_USER_MESSAGE;
   }
 
   if (overflowKind === "media") {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -135,9 +135,11 @@ import {
 } from "@/lib/api/paid-daily-free-allowance-rescue";
 import {
   extractErrorDetails,
+  createProviderContentBlockedFinishReasonError,
   getProviderErrorCategory,
   getUserFriendlyProviderError,
   isInvalidImageInputError,
+  isProviderContentFilterFinishReason,
 } from "@/lib/utils/error-utils";
 import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -1022,6 +1024,7 @@ const USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES = new Set([
   "empty_after_processing",
   "local_sandbox_fallback_blocked",
   "invalid_image_input",
+  "content_blocked",
 ]);
 
 const isUserCorrectableAgentLongErrorCategory = (category: string): boolean =>
@@ -1076,6 +1079,7 @@ const classifyProviderDashboardCategory = (
 ): string => {
   if (isInvalidImageInputError(error)) return "invalid_image_input";
   const category = getProviderErrorCategory(details);
+  if (category === "content_blocked") return category;
   if (category === "stream_terminated") return "provider_stream_terminated";
   if (category === "timeout") return "provider_timeout";
   if (category !== "unknown" || isProviderApiError(error)) {
@@ -1243,8 +1247,17 @@ const getTerminalProviderStreamError = (
     Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): unknown | undefined => {
   if (!state) return undefined;
-  if (state.streamFinishReason !== "error") return undefined;
+  if (
+    state.streamFinishReason !== "error" &&
+    !isProviderContentFilterFinishReason(state.streamFinishReason)
+  ) {
+    return undefined;
+  }
   if (state.providerError) return state.providerError;
+
+  if (isProviderContentFilterFinishReason(state.streamFinishReason)) {
+    return createProviderContentBlockedFinishReasonError();
+  }
 
   return Object.assign(
     new Error("Provider stream finished with error finish reason"),
@@ -1258,7 +1271,9 @@ const getTerminalProviderStreamError = (
 const isTerminalProviderStreamError = (
   state:
     Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
-): boolean => state?.streamFinishReason === "error";
+): boolean =>
+  state?.streamFinishReason === "error" ||
+  isProviderContentFilterFinishReason(state?.streamFinishReason);
 
 type RecordedAgentLongFailure = {
   userCorrectable: boolean;
@@ -3058,6 +3073,10 @@ export const agentLongTask = task({
                       const stoppedDueToAssistantContentLoop =
                         state.stoppedDueToAssistantContentLoop ||
                         (!isAborted && assistantContentLoopDetection.detected);
+                      const providerContentBlocked =
+                        isProviderContentFilterFinishReason(
+                          state.streamFinishReason,
+                        );
                       const hasTerminalProviderStreamError =
                         isTerminalProviderStreamError(state);
                       const shouldRetryInterruptedToolInput =
@@ -3071,6 +3090,7 @@ export const agentLongTask = task({
                           {
                             hasTerminalProviderStreamError:
                               hasTerminalProviderStreamError,
+                            providerContentBlocked,
                             stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
                             stoppedDueToAssistantContentLoop,
                             detectAssistantContentLoop: !isAborted,
@@ -3086,6 +3106,7 @@ export const agentLongTask = task({
                         imageRecovery.omittedCount > 0 && !isAborted;
 
                       if (
+                        !providerContentBlocked &&
                         (shouldRetryWithFallback ||
                           shouldRetryWithoutImageToolResults) &&
                         !isRetryWithFallback &&


### PR DESCRIPTION
## Summary

- treat AI SDK `content-filter` finishes as terminal provider-content-blocked outcomes using the existing friendly copy, classification, provider logging, and error presentation
- preserve partial output and reported usage, refund zero-usage blocked responses, and prevent fallback replay for blocked legs
- bound each provider response to 32 tool calls before AI SDK execution while preserving retained input/call/result IDs and compaction namespaces
- allow at most one `wait_for_agents` call per provider response through the same shared guard

## Tool-call guard

One provider response maps to one Agent step, and AI SDK starts that response's tool calls concurrently. The explicit ceiling of 32 preserves intended parallel work while bounding the promises, sandbox operations, and side effects one response can enqueue.

The guard applies to streamed and non-streamed provider responses. It keeps retained `tool-input-start` / delta / end parts correlated with their tool call and result, drops over-limit calls before execution, bounds its own correlation state, and logs only model, step, limit, and drop count.

## PR #1016 integration

PR #1016 is still open and currently conflicts with `main`. This PR does not copy or redesign its subagent runtime. The shared guard already enforces `wait_for_agents: 1` by tool name, so once #1016 is rebased after this change lands, duplicate waits in one parent model turn will be dropped before execution without adding a second wait mechanism.

Exact remaining action on #1016: rebase it onto the updated `main` after this PR merges, resolve its existing unrelated conflicts, and rerun its subagent contract/full validation.

## Safety

- content blocks are never replayed, including no-output, reasoning-only, partial-text, and completed-tool-output cases
- normal `stop`, `error`, user-abort, and other finish behavior remains unchanged
- retained tool calls keep the existing run/compaction namespace and tool-result matching
- provider routing and fallback selection are unchanged
- no prompts, tool arguments, targets, evidence, or other user content are added to logs

## Automated validation

- pre-commit hook: lint-staged, TypeScript, and full Jest suite
- full Jest: 332 suites / 3,316 tests passed
- focused provider-response, lifecycle, accounting, and contract suites passed
- targeted ESLint passed
- targeted Prettier and `git diff --check` passed

## Manual / fault-injection verification

1. Inject a provider finish with `content-filter` and no output, then with partial text. Confirm the existing provider-blocked message appears, partial text remains visible/saved, accounting uses reported usage, and no fallback leg starts.
2. Inject a response with 33 parallel tool calls. Confirm only the first 32 execute and the warning contains only model, step, limit, and drop count.
3. After #1016 is rebased, inject two `wait_for_agents` calls in one parent response. Confirm only the first executes and the run continues with its retained tool result.

Browser QA is not required because this changes backend provider-stream and tool-execution boundaries without changing UI rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of provider content-policy blocks with clearer, user-facing error messages.
  - Prevented blocked responses from being replayed or incorrectly retried.
  - Added safeguards against excessive, duplicate, or invalid tool calls.
  - Preserved valid response content while filtering unusable tool results.
  - Improved handling of streamed and non-streamed responses, including agent handoffs.

- **Reliability**
  - Improved error reporting and outcome tracking.
  - Prevented incorrect charges or refunds for content-blocked requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->