### PR TITLE
Reject malformed Server Action origins

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -175,6 +175,96 @@ describe("proxy", () => {
     expect(mockNextResponseJson).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["fetch action", { "next-action": "action-id" }],
+    ["multipart action", { "content-type": "multipart/form-data; boundary=x" }],
+  ])(
+    "rejects malformed %s origins before AuthKit without logging them",
+    async (_kind, actionHeaders) => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const requestId = `iad1::${"r".repeat(200)}`;
+      try {
+        const { default: proxy } = await import("../proxy");
+
+        const response = await proxy(
+          createRequest({
+            pathname: "/c/chat_123",
+            method: "POST",
+            hasSession: true,
+            headers: {
+              ...actionHeaders,
+              origin: "https://hackerai.co, foo.example.org",
+              "x-vercel-id": requestId,
+            },
+          }),
+        );
+
+        expect(response).toMatchObject({ kind: "json" });
+        expect(mockAuthkit).not.toHaveBeenCalled();
+        expect(mockNextResponseJson).toHaveBeenCalledWith(
+          {
+            code: "bad_request:request",
+            message: "The request origin is invalid.",
+          },
+          { status: 400 },
+        );
+
+        const warning = String(warnSpy.mock.calls[0][0]);
+        expect(JSON.parse(warning)).toMatchObject({
+          level: "warn",
+          event: "server_action_request_rejected",
+          request_id: requestId.slice(0, 128),
+          pathname: "/c/chat_123",
+          reason: "malformed_origin",
+        });
+        expect(warning).not.toContain("foo.example.org");
+        expect(warning).not.toContain(requestId);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    ["missing fetch-action", { "next-action": "action-id" }, undefined],
+    ["null fetch-action", { "next-action": "action-id" }, "null"],
+    [
+      "cross-origin fetch-action",
+      { "next-action": "action-id" },
+      "https://cross-origin.example",
+    ],
+    [
+      "cross-origin multipart-action",
+      { "content-type": "multipart/form-data; boundary=x" },
+      "https://cross-origin.example",
+    ],
+  ])(
+    "leaves the %s origin to Next CSRF validation",
+    async (_kind, actionHeaders, origin) => {
+      mockAuthkit.mockResolvedValue({
+        session: { user: { id: "user_123" } },
+        headers: new Headers(),
+        authorizationUrl: undefined,
+      });
+      const { default: proxy } = await import("../proxy");
+
+      const headers: Record<string, string> = { ...actionHeaders };
+      if (origin !== undefined) headers.origin = origin;
+
+      const response = await proxy(
+        createRequest({
+          pathname: "/c/chat_123",
+          method: "POST",
+          hasSession: true,
+          headers,
+        }),
+      );
+
+      expect(response).toMatchObject({ kind: "next" });
+      expect(mockAuthkit).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("treats callback-only ended-session refresh errors as logged-out requests", async () => {
     const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
     const endedSessionError = Object.assign(

--- a/proxy.ts
+++ b/proxy.ts
@@ -86,6 +86,30 @@ function isNextActionRequest(request: NextRequest): boolean {
   return request.method === "POST" && request.headers.has(NEXT_ACTION_HEADER);
 }
 
+function isOriginParsedServerActionRequest(request: NextRequest): boolean {
+  if (request.method !== "POST") return false;
+  if (request.headers.has(NEXT_ACTION_HEADER)) return true;
+
+  return (
+    request.headers.get("content-type")?.startsWith("multipart/form-data") ??
+    false
+  );
+}
+
+function hasMalformedNextActionOrigin(request: NextRequest): boolean {
+  if (!isOriginParsedServerActionRequest(request)) return false;
+
+  const origin = request.headers.get("origin");
+  if (!origin || origin === "null") return false;
+
+  try {
+    new URL(origin);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 function isBrowserRequest(request: NextRequest): boolean {
   const accept = request.headers.get("accept") ?? "";
   return accept.includes("text/html");
@@ -195,6 +219,34 @@ export default async function proxy(request: NextRequest) {
           Allow: request.method === "POST" ? "GET, HEAD" : "GET, HEAD, POST",
         },
       },
+    );
+  }
+
+  // Next parses the Origin header before its Server Action CSRF comparison.
+  // Reject malformed values here so an invalid client header cannot turn into
+  // an unhandled URL-construction error. Well-formed cross-origin requests are
+  // still left to Next's existing CSRF validation.
+  if (hasMalformedNextActionOrigin(request)) {
+    const requestId = request.headers.get("x-vercel-id");
+    console.warn(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "warn",
+        event: "server_action_request_rejected",
+        service: "hackerai-web",
+        environment:
+          process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+        request_id: requestId?.slice(0, 128),
+        pathname,
+        reason: "malformed_origin",
+      }),
+    );
+    return NextResponse.json(
+      {
+        code: "bad_request:request",
+        message: "The request origin is invalid.",
+      },
+      { status: 400 },
     );
   }
 


### PR DESCRIPTION
## Summary

- reject malformed fetch and multipart Server Action `Origin` headers before AuthKit and Next.js handling
- return a client 400 instead of allowing URL parsing to fail as an unhandled 500
- emit a bounded `server_action_request_rejected` warning with reason, route, environment, and truncated opaque Vercel request ID
- preserve Next.js CSRF handling for valid, missing, `null`, and well-formed cross-origin values

## Production evidence

Frozen audit window: `2026-08-06T20:01:19.471Z` through `2026-08-07T20:01:19.471Z`.

Vercel recorded 11 production `POST /c/[id]` HTTP 500 requests across two deployments with:

```
TypeError: Invalid URL (ERR_INVALID_URL)
input: https://hackerai.co, foo.example.org
```

Eight requests occurred on the prior production deployment and three on the current deployment, so the failure spans releases and is unrelated to the latest product change. Vercel exposed only ignore-listed frames.

Local tracing confirmed Next.js parses the `Origin` header with `new URL(...)` before its Server Action CSRF host comparison. A comma-separated malformed value therefore throws before Next can reject the request normally.

## Change

The proxy now validates only request forms where Next performs that parse: fetch-style Server Actions carrying `next-action` and multipart progressive-enhancement actions. Only unparseable non-null origins are rejected.

The warning does not include the raw origin, cookies, action arguments, body content, or user content. Its opaque request ID is capped at 128 characters. Auth, session, action payload, and valid CSRF behavior are unchanged.

## Adversarial review

- request-scoped guard, with no retry or aggregate-limit behavior
- covers fetch and multipart Server Action entry points
- valid, missing, `null`, and well-formed cross-origin values remain delegated to Next.js CSRF validation
- malformed requests stop before AuthKit and action execution
- logs contain a fixed reason and bounded opaque correlation ID, without the rejected value
- no Vercel/Trigger deploy-skew contract or API payload changes

## Validation

- `corepack pnpm jest __tests__/proxy.test.ts --runInBand` — 1 suite / 20 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint and Prettier — passed
- `git diff --check` — passed
- commit hooks — 335 suites / 3,360 tests passed, plus typecheck and staged lint/format

Visual QA is not applicable because this is a server-side request-validation change.

## Manual verification

1. On the preview deployment, send a disposable Server Action-shaped POST with a comma-separated malformed `Origin`; confirm HTTP 400 and no action execution.
2. Confirm a normal same-origin Server Action still reaches its existing handler, while a well-formed cross-origin request remains subject to Next.js CSRF rejection.
3. Confirm `server_action_request_rejected` contains `reason=malformed_origin`, route, environment, and a bounded request ID, but no raw origin or request body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for malformed `Origin` headers in Server Action requests.
  - Malformed requests now receive an immediate 400 response instead of being processed.
  - Valid, missing, or cross-origin requests continue through standard CSRF validation.
  - Improved warning logs with sanitized, bounded request identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->