### PR TITLE
Bound PTY parser diagnostics

### DIFF
--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -39,6 +39,7 @@ import type { Geo } from "@vercel/functions";
 import { FileAccumulator } from "./utils/file-accumulator";
 import { BackgroundProcessTracker } from "./utils/background-process-tracker";
 import { ptySessionManager } from "./utils/pty-session-manager";
+import { createPtyParserLogBudget } from "./utils/pty-output-formatter";
 import { isE2BSandbox } from "./utils/sandbox-types";
 import { getSandboxWithFallbackGuard } from "./utils/sandbox-fallback";
 import { createE2BResourcePressureObserver } from "@/lib/analytics/sandbox-resource-pressure";
@@ -133,6 +134,7 @@ export const createTools = (
     fileAccumulator,
     backgroundProcessTracker,
     ptySessionManager,
+    ptyParserLogBudget: createPtyParserLogBudget(),
     mode,
     modelName,
     getCurrentModelName: () => currentModelName,

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -4,6 +4,7 @@ import type { PtySession } from "./utils/pty-session-manager";
 import {
   cleanPtyForUI,
   getSessionSnapshots,
+  type PtyParserLogContext,
 } from "./utils/pty-output-formatter";
 import {
   waitForOutput,
@@ -38,6 +39,22 @@ export const createInteractTerminalSession = (context: ToolContext) => {
     context.measureAgentActiveTime
       ? context.measureAgentActiveTime("terminal_wait", operation)
       : operation();
+  const buildPtyParserLogContext = (
+    sessionId: string,
+  ): PtyParserLogContext => ({
+    service: context.triggerRunId ? "agent-long" : "chat-handler",
+    environment:
+      process.env.TRIGGER_ENV ??
+      process.env.VERCEL_ENV ??
+      process.env.NODE_ENV ??
+      "unknown",
+    request_id: context.triggerRunId ?? process.env.VERCEL_REQUEST_ID ?? null,
+    trigger_run_id: context.triggerRunId ?? null,
+    chat_id: context.chatId,
+    user_id: context.userID,
+    session_id: sessionId,
+    log_budget: context.ptyParserLogBudget,
+  });
 
   return tool({
     ...interactTerminalSessionTool,
@@ -235,7 +252,11 @@ export const createInteractTerminalSession = (context: ToolContext) => {
           ),
         );
         await drainEmitQueue();
-        const snapshots = await getSessionSnapshots(ptySessionManager, session);
+        const snapshots = await getSessionSnapshots(
+          ptySessionManager,
+          session,
+          buildPtyParserLogContext(session.sessionId),
+        );
         return {
           result: {
             output: capOutput(stripAnsi(new TextDecoder().decode(delta))),
@@ -266,7 +287,11 @@ export const createInteractTerminalSession = (context: ToolContext) => {
           ),
         );
         await drainEmitQueue();
-        const snapshots = await getSessionSnapshots(ptySessionManager, session);
+        const snapshots = await getSessionSnapshots(
+          ptySessionManager,
+          session,
+          buildPtyParserLogContext(session.sessionId),
+        );
         const exited = alreadyExited ?? (await peekExited(session));
         const out: Record<string, unknown> = {
           output: capOutput(stripAnsi(new TextDecoder().decode(delta))),
@@ -294,7 +319,10 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         return {
           result: {
             output: capOutput(stripAnsi(rawText)),
-            sessionSnapshot: await cleanPtyForUI(rawText),
+            sessionSnapshot: await cleanPtyForUI(
+              rawText,
+              buildPtyParserLogContext(session.sessionId),
+            ),
             rawSnapshot: rawText,
             ...(session.bufferTruncated ? { bufferTruncated: true } : {}),
             ...(internal.exitedNaturally

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -30,7 +30,10 @@ import {
   DEFAULT_PTY_ROWS,
   type PtySession,
 } from "./utils/pty-session-manager";
-import { getSessionSnapshots } from "./utils/pty-output-formatter";
+import {
+  getSessionSnapshots,
+  type PtyParserLogContext,
+} from "./utils/pty-output-formatter";
 import {
   getSandboxWithFallbackGuard,
   resolveToolErrorMessage,
@@ -127,7 +130,10 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     context.measureAgentActiveTime
       ? context.measureAgentActiveTime("sandbox_recovery", operation)
       : operation();
-  const buildTerminalLogContext = () => ({
+  const buildTerminalLogContext = (): Pick<
+    PtyParserLogContext,
+    "service" | "environment" | "request_id" | "trigger_run_id"
+  > => ({
     service: context.triggerRunId ? "agent-long" : "chat-handler",
     environment:
       process.env.TRIGGER_ENV ??
@@ -136,6 +142,15 @@ export const createRunTerminalCmd = (context: ToolContext) => {
       "unknown",
     request_id: context.triggerRunId ?? process.env.VERCEL_REQUEST_ID ?? null,
     trigger_run_id: context.triggerRunId ?? null,
+  });
+  const buildPtyParserLogContext = (
+    sessionId: string,
+  ): PtyParserLogContext => ({
+    ...buildTerminalLogContext(),
+    chat_id: context.chatId,
+    user_id: context.userID,
+    session_id: sessionId,
+    log_budget: context.ptyParserLogBudget,
   });
   const logSandboxReadinessRecovery = (args: {
     level: "info" | "warn" | "error";
@@ -363,6 +378,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
           const snapshots = await getSessionSnapshots(
             ptySessionManager,
             session,
+            buildPtyParserLogContext(session.sessionId),
           );
           // If the command finished during the quiet window (e.g. a one-shot
           // `echo … && whoami`), surface that so the agent doesn't try to

--- a/lib/ai/tools/utils/__tests__/pty-output-formatter.test.ts
+++ b/lib/ai/tools/utils/__tests__/pty-output-formatter.test.ts
@@ -1,0 +1,87 @@
+import {
+  cleanPtyForUI,
+  createPtyParserLogBudget,
+  type PtyParserLogContext,
+} from "../pty-output-formatter";
+
+const LOG_CONTEXT: PtyParserLogContext = {
+  service: "agent-long",
+  environment: "test",
+  request_id: "run_test",
+  trigger_run_id: "run_test",
+  chat_id: "chat_test",
+  user_id: "user_test",
+  session_id: "session_test",
+};
+
+describe("cleanPtyForUI", () => {
+  it("keeps normal terminal output without emitting diagnostics", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    await expect(cleanPtyForUI("hello\r\nworld", LOG_CONTEXT)).resolves.toBe(
+      "hello\nworld",
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("aggregates and caps repeated parser diagnostics without logging PTY content", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const raw = `private-prefix${"\x7f".repeat(10_005)}private-suffix`;
+
+    await expect(cleanPtyForUI(raw, LOG_CONTEXT)).resolves.toBe(
+      "private-prefixprivate-suffix",
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(warnSpy.mock.calls[0]?.[0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      level: "warn",
+      event: "pty_xterm_diagnostics_aggregated",
+      service: "agent-long",
+      environment: "test",
+      request_id: "run_test",
+      trigger_run_id: "run_test",
+      chat_id: "chat_test",
+      user_id: "user_test",
+      session_id: "session_test",
+      reason: "xterm_parser_error",
+      parser_error_count: 10_000,
+      other_error_count: 0,
+      diagnostic_count_capped: true,
+      diagnostic_log_scope: "task_run",
+      diagnostic_log_limit: null,
+      input_bytes: Buffer.byteLength(raw, "utf8"),
+      cleaned_output_chars: "private-prefixprivate-suffix".length,
+    });
+    expect(warnSpy.mock.calls[0]?.[0]).not.toContain("private-prefix");
+    expect(warnSpy.mock.calls[0]?.[0]).not.toContain("private-suffix");
+
+    warnSpy.mockRestore();
+  });
+
+  it("shares one diagnostic log budget across a durable task run", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const context = {
+      ...LOG_CONTEXT,
+      log_budget: createPtyParserLogBudget(),
+    };
+
+    await cleanPtyForUI("\x7f", context);
+    await cleanPtyForUI("\x7f\x7f", context);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(warnSpy.mock.calls[0]?.[0] as string)).toMatchObject({
+      diagnostic_log_scope: "task_run",
+      diagnostic_log_limit: 1,
+      parser_error_count: 1,
+    });
+    expect(context.log_budget.remaining_logs).toBe(0);
+
+    warnSpy.mockRestore();
+  });
+});

--- a/lib/ai/tools/utils/pty-output-formatter.ts
+++ b/lib/ai/tools/utils/pty-output-formatter.ts
@@ -15,6 +15,32 @@ import { DEFAULT_PTY_COLS } from "./pty-session-manager";
 // in-memory scrollback replay, not the live terminal.
 const PARSER_ROWS = 500;
 const PARSER_SCROLLBACK = 5000;
+const MAX_REPORTED_XTERM_DIAGNOSTICS = 10_000;
+
+export type PtyParserLogBudget = { remaining_logs: number };
+
+export const createPtyParserLogBudget = (): PtyParserLogBudget => ({
+  remaining_logs: 1,
+});
+
+type XtermLogger = {
+  trace: (message: string, ...args: unknown[]) => void;
+  debug: (message: string, ...args: unknown[]) => void;
+  info: (message: string, ...args: unknown[]) => void;
+  warn: (message: string, ...args: unknown[]) => void;
+  error: (message: string | Error, ...args: unknown[]) => void;
+};
+
+export type PtyParserLogContext = {
+  service: "agent-long" | "chat-handler";
+  environment: string;
+  request_id: string | null;
+  trigger_run_id: string | null;
+  chat_id: string;
+  user_id: string;
+  session_id: string;
+  log_budget?: PtyParserLogBudget;
+};
 
 let TerminalCtor:
   | (new (opts: {
@@ -22,6 +48,8 @@ let TerminalCtor:
       rows: number;
       scrollback: number;
       allowProposedApi?: boolean;
+      logLevel?: "error";
+      logger?: XtermLogger;
     }) => {
       write: (data: string, callback?: () => void) => void;
       buffer: {
@@ -67,13 +95,106 @@ function fallbackClean(text: string): string {
     .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, ""); // Other control chars
 }
 
-export async function cleanPtyForUI(text: string): Promise<string> {
+function createXtermDiagnosticTracker(): {
+  logger: XtermLogger;
+  snapshot: () => {
+    parserErrorCount: number;
+    otherErrorCount: number;
+    countCapped: boolean;
+  };
+} {
+  let parserErrorCount = 0;
+  let otherErrorCount = 0;
+  let countCapped = false;
+  const increment = (kind: "parser" | "other"): void => {
+    const current = kind === "parser" ? parserErrorCount : otherErrorCount;
+    if (current >= MAX_REPORTED_XTERM_DIAGNOSTICS) {
+      countCapped = true;
+      return;
+    }
+    if (kind === "parser") parserErrorCount += 1;
+    else otherErrorCount += 1;
+  };
+  const noop = (): void => {};
+
+  return {
+    logger: {
+      trace: noop,
+      debug: noop,
+      info: noop,
+      warn: noop,
+      error: (message) =>
+        increment(
+          typeof message === "string" && message.startsWith("Parsing error")
+            ? "parser"
+            : "other",
+        ),
+    },
+    snapshot: () => ({ parserErrorCount, otherErrorCount, countCapped }),
+  };
+}
+
+function logAggregatedXtermDiagnostics(
+  text: string,
+  cleaned: string,
+  context: PtyParserLogContext | undefined,
+  diagnostics: ReturnType<
+    ReturnType<typeof createXtermDiagnosticTracker>["snapshot"]
+  >,
+): void {
+  if (diagnostics.parserErrorCount === 0 && diagnostics.otherErrorCount === 0) {
+    return;
+  }
+  if (context?.log_budget && context.log_budget.remaining_logs <= 0) return;
+  if (context?.log_budget) context.log_budget.remaining_logs -= 1;
+
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: "warn",
+      event: "pty_xterm_diagnostics_aggregated",
+      service: context?.service ?? "terminal-tools",
+      environment:
+        context?.environment ??
+        process.env.TRIGGER_ENV ??
+        process.env.VERCEL_ENV ??
+        process.env.NODE_ENV ??
+        "unknown",
+      request_id: context?.request_id ?? null,
+      trigger_run_id: context?.trigger_run_id ?? null,
+      chat_id: context?.chat_id ?? null,
+      user_id: context?.user_id ?? null,
+      session_id: context?.session_id ?? null,
+      reason:
+        diagnostics.otherErrorCount > 0
+          ? diagnostics.parserErrorCount > 0
+            ? "mixed_xterm_errors"
+            : "xterm_error"
+          : "xterm_parser_error",
+      parser_error_count: diagnostics.parserErrorCount,
+      other_error_count: diagnostics.otherErrorCount,
+      diagnostic_count_capped: diagnostics.countCapped,
+      diagnostic_log_scope: context?.trigger_run_id ? "task_run" : "request",
+      diagnostic_log_limit: context?.log_budget ? 1 : null,
+      input_bytes: Buffer.byteLength(text, "utf8"),
+      cleaned_output_chars: cleaned.length,
+    }),
+  );
+}
+
+export async function cleanPtyForUI(
+  text: string,
+  logContext?: PtyParserLogContext,
+): Promise<string> {
   if (TerminalCtor) {
+    const diagnostics = createXtermDiagnosticTracker();
     const term = new TerminalCtor({
       cols: DEFAULT_PTY_COLS,
       rows: PARSER_ROWS,
       scrollback: PARSER_SCROLLBACK,
       allowProposedApi: true,
+      logLevel: "error",
+      logger: diagnostics.logger,
     });
     try {
       // `@xterm/headless` Terminal.write is asynchronous — it enqueues into a
@@ -90,7 +211,14 @@ export async function cleanPtyForUI(text: string): Promise<string> {
         lines.push(str);
         if (str.trim()) lastNonEmpty = i;
       }
-      return lines.slice(0, lastNonEmpty + 1).join("\n");
+      const cleaned = lines.slice(0, lastNonEmpty + 1).join("\n");
+      logAggregatedXtermDiagnostics(
+        text,
+        cleaned,
+        logContext,
+        diagnostics.snapshot(),
+      );
+      return cleaned;
     } catch (err) {
       console.warn(
         "[pty-output-formatter] xterm parsing failed, using fallback:",
@@ -111,9 +239,10 @@ interface SnapshotSource {
 export async function getSessionSnapshots(
   mgr: SnapshotSource,
   session: { sessionId: string; chatId: string },
+  logContext?: PtyParserLogContext,
 ): Promise<{ raw: string; cleaned: string }> {
   const bytes = mgr.snapshot(session);
   const raw = new TextDecoder().decode(bytes);
-  const cleaned = await cleanPtyForUI(raw);
+  const cleaned = await cleanPtyForUI(raw, logContext);
   return { raw, cleaned };
 }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -5,6 +5,7 @@ import type { TodoManager } from "@/lib/ai/tools/utils/todo-manager";
 import type { FileAccumulator } from "@/lib/ai/tools/utils/file-accumulator";
 import type { BackgroundProcessTracker } from "@/lib/ai/tools/utils/background-process-tracker";
 import type { PtySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
+import type { PtyParserLogBudget } from "@/lib/ai/tools/utils/pty-output-formatter";
 import type { ChatMode, SubscriptionTier } from "./chat";
 import type { CentrifugoSandbox } from "@/lib/ai/tools/utils/centrifugo-sandbox";
 import type { SandboxFallbackInfo } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
@@ -465,6 +466,8 @@ export interface ToolContext {
   backgroundProcessTracker: BackgroundProcessTracker;
   /** Manages interactive PTY sessions for `run_terminal_cmd` interactive actions. */
   ptySessionManager: PtySessionManager;
+  /** Caps aggregated xterm diagnostics across this request or durable task run. */
+  ptyParserLogBudget?: PtyParserLogBudget;
   mode: ChatMode;
   /** Configured model key for this request, used for model-aware tool capabilities. */
   modelName?: string;


### PR DESCRIPTION
## Summary

- route `@xterm/headless` errors through a bounded logger so malformed PTY bytes cannot create one Trigger trace span per parser error
- emit at most one structured `pty_xterm_diagnostics_aggregated` warning per Trigger task run or Vercel request, with capped counts, sizes, and opaque correlation IDs
- preserve cleaned terminal output, the regex fallback, and both `run_terminal_cmd` / `interact_terminal_session` entry paths

## Production evidence

Frozen audit window: `2026-08-07T20:03:03.501Z` through `2026-08-08T20:03:03.501Z`.

Trigger.dev recorded 10 `TASK_PROCESS_OOM_KILLED` runs versus 6 in the previous equivalent window. Representative run `run_06fu3cfao6bk71799i541dfnc1` reached RSS 436,301,824 bytes (98.6% of the V8 heap-limit byte value) and produced a 64,485-line trace dominated by repeated `xterm.js: Parsing error` spans immediately before the last heap-growth checkpoint.

The other sampled OOMs had stale low-memory checkpoints, so this PR intentionally fixes only the demonstrated parser-diagnostic amplification subtype. It does not suppress OOMs, change the Trigger machine preset, or claim to solve every crash.

A separate 11:09–11:18 UTC Convex/Cloudflare HTTP 520 outage affected Vercel and 11 Trigger runs. That incident remains visible and is not addressed by this patch.

## Root cause

`cleanPtyForUI` replayed raw PTY bytes through headless xterm using its default console logger. Xterm logs every parser error together with parser state; malformed terminal bytes therefore amplified one snapshot operation into tens of thousands of trace records and additional memory pressure.

## Validation

- `corepack pnpm jest lib/ai/tools/utils/__tests__/pty-output-formatter.test.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/ai/tools/__tests__/interact-terminal-session.test.ts --runInBand` — 49 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint, Prettier, and `git diff --check` — passed
- commit hooks — 336 suites / 3,348 tests passed
- one initial hook worker exited with an unrelated SIGSEGV before `agent-partial-save-route.test.ts` ran; that suite passed 12/12 in isolation and the complete hook rerun passed

## Manual verification

After deployment:

1. Run an interactive terminal command that includes repeated invalid DEL bytes in its PTY snapshot.
2. Confirm cleaned terminal output remains unchanged.
3. Confirm only one `pty_xterm_diagnostics_aggregated` warning is emitted for the task run/request, with capped counts and opaque run/chat/user/session IDs.
4. Confirm the event contains no command, PTY output, prompt, URL, or other terminal content.

Visual QA is not applicable because this is a backend runtime/observability fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output handling by normalizing PTY output and aggregating parser diagnostics.
  * Added safeguards to cap repeated diagnostic messages and prevent terminal content from being exposed in warnings.
  * Applied shared diagnostic limits across terminal interactions and durable task runs.

* **Tests**
  * Added coverage for newline normalization, diagnostic aggregation, content protection, and shared log budgeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->