### PR TITLE
Stop duplicate checkout requests and improve cleanup telemetry

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import { stripe } from "../../stripe";
 import { workos } from "../../workos";
 import { fenceAndGetActiveAgentResourcesForUser } from "@/lib/db/actions";
 import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
+import { logger } from "@/lib/logger";
 
 const mockConvexMutation = jest.fn();
 
@@ -37,6 +38,14 @@ jest.mock("@/lib/db/actions", () => ({
 
 jest.mock("@/lib/api/agent-deletion-cleanup", () => ({
   closeAndCancelAgentResources: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
 }));
 
 jest.mock("@/convex/_generated/api", () => ({
@@ -119,8 +128,17 @@ const mockCloseAndCancelAgentResources =
   closeAndCancelAgentResources as jest.MockedFunction<
     typeof closeAndCancelAgentResources
   >;
+const mockLoggerError = logger.error as jest.MockedFunction<
+  typeof logger.error
+>;
 
-const request = () => ({ url: "https://hackerai.test/api/delete-account" });
+const request = () => ({
+  url: "https://hackerai.test/api/delete-account",
+  headers: {
+    get: (name: string) =>
+      name === "x-vercel-id" ? "iad1::opaque-request" : null,
+  },
+});
 
 describe("POST /api/delete-account", () => {
   beforeEach(() => {
@@ -462,6 +480,55 @@ describe("POST /api/delete-account", () => {
       mockDeleteUser.mock.invocationCallOrder[0],
     );
     expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("logs bounded aggregate progress when the request cleanup limit is exhausted", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    mockConvexMutation
+      .mockResolvedValueOnce(null)
+      // Older Convex deployments returned only the completion marker. Keep
+      // that deploy-skew shape compatible while collecting newer progress.
+      .mockResolvedValueOnce({ hasMore: true })
+      .mockResolvedValue({
+        hasMore: true,
+        deleted: { feedback: 40, messages: 40 },
+        anonymized: { usage_logs: 10 },
+        s3ObjectsQueued: 2,
+      });
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("taking longer than expected");
+    expect(mockConvexMutation).toHaveBeenCalledTimes(51);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      "account_cleanup_batch_limit_exhausted",
+      undefined,
+      {
+        event: "account_cleanup_batch_limit_exhausted",
+        service: "hackerai-web",
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        request_id: "iad1::opaque-request",
+        user_id: "user_123",
+        reason: "cleanup_batch_limit_exhausted",
+        batch_limit: 50,
+        progress_stats_batches: 49,
+        batches_with_progress: 49,
+        deleted_documents: 3920,
+        anonymized_documents: 490,
+        s3_objects_queued: 98,
+        last_batch_deleted_documents: 80,
+        last_batch_anonymized_documents: 10,
+        last_batch_s3_objects_queued: 2,
+      },
+    );
+    expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockDeleteUserRateLimitKeys).not.toHaveBeenCalled();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 
   it("does not delete external identity resources when Convex cleanup returns an unexpected shape", async () => {

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -22,6 +22,17 @@ type MembershipDeletionPlan = {
 
 const MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES = 50;
 
+type ConvexCleanupProgress = {
+  deletedDocuments: number;
+  anonymizedDocuments: number;
+  s3ObjectsQueued: number;
+};
+
+type ParsedConvexCleanupResult = {
+  hasMore: boolean;
+  progress?: ConvexCleanupProgress;
+};
+
 function isMissingWorkosUserError(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -30,13 +41,43 @@ function isMissingWorkosUserError(error: unknown): boolean {
   );
 }
 
-function parseConvexCleanupResult(result: unknown): { hasMore: boolean } {
+function sumCleanupCounts(value: unknown): number | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  let total = 0;
+  for (const count of Object.values(value)) {
+    if (typeof count !== "number" || !Number.isFinite(count) || count < 0) {
+      return undefined;
+    }
+    total += count;
+  }
+  return total;
+}
+
+function parseConvexCleanupResult(result: unknown): ParsedConvexCleanupResult {
   if (
     result &&
     typeof result === "object" &&
     typeof (result as { hasMore?: unknown }).hasMore === "boolean"
   ) {
-    return { hasMore: (result as { hasMore: boolean }).hasMore };
+    const cleanupResult = result as Record<string, unknown> & {
+      hasMore: boolean;
+    };
+    const deletedDocuments = sumCleanupCounts(cleanupResult.deleted);
+    const anonymizedDocuments = sumCleanupCounts(cleanupResult.anonymized);
+    const s3ObjectsQueued = cleanupResult.s3ObjectsQueued;
+    const progress =
+      deletedDocuments !== undefined &&
+      anonymizedDocuments !== undefined &&
+      typeof s3ObjectsQueued === "number" &&
+      Number.isFinite(s3ObjectsQueued) &&
+      s3ObjectsQueued >= 0
+        ? { deletedDocuments, anonymizedDocuments, s3ObjectsQueued }
+        : undefined;
+
+    return { hasMore: cleanupResult.hasMore, progress };
   }
 
   throw new Error(
@@ -124,8 +165,18 @@ async function markAccountIdentityDeleted(
   });
 }
 
-async function deleteConvexUserData(userId: string, serviceKey: string) {
+async function deleteConvexUserData(
+  userId: string,
+  serviceKey: string,
+  requestId: string,
+) {
   const convex = getConvexClient();
+  let progressStatsBatches = 0;
+  let batchesWithProgress = 0;
+  let deletedDocuments = 0;
+  let anonymizedDocuments = 0;
+  let s3ObjectsQueued = 0;
+  let lastProgress: ConvexCleanupProgress | undefined;
 
   for (let batch = 0; batch < MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES; batch++) {
     const result = await convex.mutation(
@@ -136,10 +187,43 @@ async function deleteConvexUserData(userId: string, serviceKey: string) {
       },
     );
 
-    if (!parseConvexCleanupResult(result).hasMore) {
+    const parsedResult = parseConvexCleanupResult(result);
+    if (parsedResult.progress) {
+      progressStatsBatches += 1;
+      deletedDocuments += parsedResult.progress.deletedDocuments;
+      anonymizedDocuments += parsedResult.progress.anonymizedDocuments;
+      s3ObjectsQueued += parsedResult.progress.s3ObjectsQueued;
+      if (
+        parsedResult.progress.deletedDocuments > 0 ||
+        parsedResult.progress.anonymizedDocuments > 0
+      ) {
+        batchesWithProgress += 1;
+      }
+      lastProgress = parsedResult.progress;
+    }
+
+    if (!parsedResult.hasMore) {
       return;
     }
   }
+
+  logger.error("account_cleanup_batch_limit_exhausted", undefined, {
+    event: "account_cleanup_batch_limit_exhausted",
+    service: "hackerai-web",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+    request_id: requestId,
+    user_id: userId,
+    reason: "cleanup_batch_limit_exhausted",
+    batch_limit: MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES,
+    progress_stats_batches: progressStatsBatches,
+    batches_with_progress: batchesWithProgress,
+    deleted_documents: deletedDocuments,
+    anonymized_documents: anonymizedDocuments,
+    s3_objects_queued: s3ObjectsQueued,
+    last_batch_deleted_documents: lastProgress?.deletedDocuments,
+    last_batch_anonymized_documents: lastProgress?.anonymizedDocuments,
+    last_batch_s3_objects_queued: lastProgress?.s3ObjectsQueued,
+  });
 
   throw new Error(
     "Account cleanup is taking longer than expected. Please contact support so we can finish deleting this account.",
@@ -151,6 +235,7 @@ export const POST = async (req: NextRequest) => {
   let userIdForLog: string | undefined;
   let membershipCount: number | undefined;
   let freeQuotaSubjectPresent: boolean | undefined;
+  const requestId = req.headers.get("x-vercel-id") ?? "unknown";
 
   try {
     // Enforce recent login (10-minute window) before any destructive action
@@ -207,7 +292,7 @@ export const POST = async (req: NextRequest) => {
     // Own app-data cleanup on the server so account deletion does not depend
     // on the browser successfully running a Convex mutation before this route.
     stage = "delete_convex_user_data";
-    await deleteConvexUserData(userId, serviceKey);
+    await deleteConvexUserData(userId, serviceKey, requestId);
 
     // Process each organization from memberships. Only delete org-level billing
     // and identity resources after proving this user is the sole active admin.
@@ -318,6 +403,7 @@ export const POST = async (req: NextRequest) => {
         event: "account_deletion_failed",
         service: "hackerai-web",
         environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        request_id: requestId,
         stage,
         user_id: userIdForLog,
         membership_count: membershipCount,

--- a/app/hooks/__tests__/useUpgrade.test.ts
+++ b/app/hooks/__tests__/useUpgrade.test.ts
@@ -134,6 +134,82 @@ describe("useUpgrade checkout attempts", () => {
     });
   });
 
+  it("blocks duplicate sidebar checkout across pricing dialog remounts", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    global.fetch = jest
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(
+        response({ ok: true, status: 200, body: { error: "cancelled" } }),
+      );
+    mockNewCheckoutAttemptId
+      .mockReturnValueOnce("ca_sidebar_123")
+      .mockReturnValueOnce("ca_sidebar_retry_456");
+    const firstDialog = renderHook(() => useUpgrade());
+
+    let firstRequest!: Promise<void>;
+    act(() => {
+      firstRequest = firstDialog.result.current.handleUpgrade(
+        "pro-monthly-plan",
+        undefined,
+        undefined,
+        "free",
+        { source: "sidebar", surface: "pricing_dialog" },
+      );
+    });
+    firstDialog.unmount();
+
+    const remountedDialog = renderHook(() => useUpgrade());
+    await act(async () => {
+      await remountedDialog.result.current.handleUpgrade(
+        "pro-monthly-plan",
+        undefined,
+        undefined,
+        "free",
+        { source: "sidebar", surface: "pricing_dialog" },
+      );
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockNewCheckoutAttemptId).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch?.(
+        response({
+          ok: false,
+          status: 503,
+          body: { error: "Checkout temporarily unavailable" },
+        }),
+      );
+      await firstRequest;
+    });
+
+    await act(async () => {
+      await remountedDialog.result.current.handleUpgrade(
+        "pro-monthly-plan",
+        undefined,
+        undefined,
+        "free",
+        { source: "sidebar", surface: "pricing_dialog" },
+      );
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(mockNewCheckoutAttemptId).toHaveBeenCalledTimes(2);
+    const requestBodies = (global.fetch as jest.Mock).mock.calls.map(
+      ([, init]) => JSON.parse(String(init?.body)),
+    );
+    expect(requestBodies.map((body) => body.checkoutAttemptId)).toEqual([
+      "ca_sidebar_123",
+      "ca_sidebar_retry_456",
+    ]);
+  });
+
   it("creates a distinct attempt ID for a valid retry after failure", async () => {
     global.fetch = jest
       .fn()

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
 import {
@@ -12,10 +12,13 @@ import {
   type PaidFunnelPlan,
 } from "@/lib/analytics/paid-funnel";
 
+// Keep a tab's upgrade ownership across pricing dialog remounts. Server routes
+// remain authoritative across page loads and tabs, including open-session reuse.
+let upgradeInFlight = false;
+
 export const useUpgrade = () => {
   const { user } = useAuth();
   const [upgradeLoading, setUpgradeLoading] = useState(false);
-  const upgradeInFlightRef = useRef(false);
 
   const handleUpgrade = async (
     planKey?: PaidFunnelPlan,
@@ -32,7 +35,7 @@ export const useUpgrade = () => {
     e?.preventDefault();
 
     // Prevent duplicate submits
-    if (upgradeInFlightRef.current) {
+    if (upgradeInFlight) {
       return;
     }
 
@@ -41,7 +44,7 @@ export const useUpgrade = () => {
       return;
     }
 
-    upgradeInFlightRef.current = true;
+    upgradeInFlight = true;
     setUpgradeLoading(true);
 
     let navigationStarted = false;
@@ -206,7 +209,7 @@ export const useUpgrade = () => {
       }
     } finally {
       if (!navigationStarted) {
-        upgradeInFlightRef.current = false;
+        upgradeInFlight = false;
         setUpgradeLoading(false);
       }
     }


### PR DESCRIPTION
## Summary

- stop duplicate checkout requests when the sidebar-opened pricing dialog remounts during an in-flight upgrade
- keep legitimate retries after failure and preserve `/api/subscribe` as the cross-page/tab authority for reusing open Stripe Checkout Sessions
- emit one request-scoped `account_cleanup_batch_limit_exhausted` event when account deletion exhausts all 50 Convex cleanup mutations
- preserve the existing account-cleanup limit, response behavior, dependency ordering, and legacy `{ hasMore }` deploy-skew compatibility

## Production evidence

The frozen production audit window was `2026-08-08T20:00:47Z` through `2026-08-09T20:00:47Z`.

One `POST /api/delete-account` invocation returned HTTP 500 at stage `delete_convex_user_data` after all 50 request-level cleanup batches still returned `hasMore: true`. The deployed code already contained the transaction-wide 100-document budget from #911. The exact failure was not the old 16 MiB Convex read exception and not the WorkOS missing-user case fixed by #896.

The current log records only the final route stage and message, so it cannot distinguish a legitimately high-volume account from a non-converging cleanup path.

## Checkout root cause and change

The checkout lock in `useUpgrade` was stored in a hook-local ref. It survived React re-renders, but a pricing-dialog unmount/remount created a fresh ref while the original `POST /api/subscribe` was still pending. A sidebar-attributed flow could therefore submit again with a new checkout attempt ID.

The lock now lives at client-module scope, which enforces one in-flight upgrade operation across hook instances in the current tab. It releases after a failed or non-navigating response so a deliberate retry receives a fresh attempt ID, and remains held once checkout navigation starts.

The server route is unchanged. Full page loads, other tabs, and later genuine attempts still reach `/api/subscribe`, whose existing open-session lookup and metadata update continue to reuse the matching Stripe Checkout Session.

## Account cleanup observability change

The route now aggregates deleted-document, anonymized-document, and queued-S3 counts returned by each Convex cleanup mutation. It emits one structured error only when the request-level batch limit is exhausted, including the number of progress-bearing batches and the last observed batch counts.

No prompt, chat content, file path, URL, document identifier, or other user content is logged. The existing opaque user ID was already present on the failure event; this change adds the opaque Vercel request ID.

## Validation

- `pnpm jest app/hooks/__tests__/useUpgrade.test.ts app/api/subscribe/__tests__/route.test.ts app/api/delete-account/__tests__/route.test.ts --runInBand` — 31 tests passed
- `pnpm typecheck`
- changed-file ESLint and Prettier checks
- commit hooks — 340 suites / 3,370 tests passed
- adversarial review covered cross-remount ownership, retry release, redirect lock retention, team and existing-subscriber callers, full-page/tab fallback, server-side Stripe reuse, request-wide cleanup aggregation, continuation/final completion, partial progress, legacy response shapes, dependency ordering, and log privacy

## Manual verification

1. In Chrome with a free test account, open pricing from the sidebar and select a paid plan.
2. While `POST /api/subscribe` is pending, remount the pricing surface (for example, navigate between the root chat and an existing chat, then reopen pricing) and click the plan again. Confirm only one request and checkout attempt are created before Stripe navigation.
3. Make the first request fail in a non-production environment, retry once, and confirm exactly one new request with a new attempt ID.
4. With a matching open Stripe Checkout Session already present, start checkout after a page reload and confirm the server returns/reuses that session rather than creating another.
5. For account cleanup telemetry, exercise a disposable account that reaches the 50-batch boundary and confirm exactly one bounded event with numeric progress only; a normal deletion should emit no exhaustion event.

No visual appearance changed; automated component rendering plus the Chrome payment-flow steps above cover the user-visible surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account deletion reliability when cleanup spans multiple batches.
  * Added safeguards to prevent incomplete cleanup from triggering external identity deletion.
  * Enhanced failure diagnostics with request tracking and aggregated cleanup progress.
  * Prevented duplicate upgrade checkout attempts when the pricing dialog is reopened.
  * Allowed upgrade retries after a failed checkout request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->