### PR TITLE
Track Agent abort sources

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -13,6 +13,7 @@ const {
   captureUsageCost,
   captureUsageSettlement,
   isUsageSettlementSuccessSampled,
+  resolveAgentAbortSource,
 } = require("../chat-logger");
 const { ChatSDKError } = require("../../errors");
 const { phLogger } = require("../../posthog/server");
@@ -266,6 +267,31 @@ describe("captureAgentRun", () => {
     expect(properties).not.toHaveProperty("fallback_served");
   });
 
+  it("adds a bounded abort source only to aborted runs", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      mode: "agent",
+      subscription: "free",
+      sandboxInfo: null,
+      outcome: "aborted",
+      abortSource: "user_stop",
+      selectedModel: "agent-model-free",
+      configuredModelId: "deepseek/deepseek-v4-flash-0731",
+    });
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0][0].properties).toEqual(
+      expect.objectContaining({
+        outcome: "aborted",
+        abort_source: "user_stop",
+      }),
+    );
+  });
+
   it("does not capture agent run events for ask mode", () => {
     const capture = jest.fn();
 
@@ -284,6 +310,37 @@ describe("captureAgentRun", () => {
     });
 
     expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAgentAbortSource", () => {
+  it.each([
+    [
+      "budget_exhausted",
+      {
+        stoppedDueToBudgetExhaustion: true,
+        stoppedDueToAgentRunSpendCap: true,
+        userStopRequested: true,
+      },
+    ],
+    ["agent_spend_cap", { stoppedDueToAgentRunSpendCap: true }],
+    ["elapsed_timeout", { stoppedDueToElapsedTimeout: true }],
+    ["user_stop", { userStopRequested: true }],
+    ["request_cancel", { requestCancelled: true }],
+    ["unknown", {}],
+  ])("resolves %s without user-content fields", (expected, flags) => {
+    expect(resolveAgentAbortSource({ outcome: "aborted", ...flags })).toBe(
+      expected,
+    );
+  });
+
+  it("omits abort attribution for completed runs", () => {
+    expect(
+      resolveAgentAbortSource({
+        outcome: "success",
+        userStopRequested: true,
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -70,6 +70,7 @@ import {
   captureUsageCost,
   captureUsageSettlement,
   createChatLogger,
+  resolveAgentAbortSource,
   shutdownPostHog,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
@@ -1674,6 +1675,17 @@ export const createChatHandler = () => {
                                   subscription,
                                   sandboxInfo,
                                   outcome,
+                                  abortSource: resolveAgentAbortSource({
+                                    outcome,
+                                    stoppedDueToBudgetExhaustion:
+                                      state.stoppedDueToBudgetExhaustion,
+                                    stoppedDueToAgentRunSpendCap:
+                                      state.stoppedDueToAgentRunSpendCap,
+                                    stoppedDueToElapsedTimeout:
+                                      state.stoppedDueToElapsedTimeout,
+                                    userStopRequested:
+                                      userStopSignal.signal.aborted,
+                                  }),
                                   chatLogger,
                                   selectedModel,
                                   configuredModelId,
@@ -1981,6 +1993,16 @@ export const createChatHandler = () => {
                       subscription,
                       sandboxInfo,
                       outcome,
+                      abortSource: resolveAgentAbortSource({
+                        outcome,
+                        stoppedDueToBudgetExhaustion:
+                          state.stoppedDueToBudgetExhaustion,
+                        stoppedDueToAgentRunSpendCap:
+                          state.stoppedDueToAgentRunSpendCap,
+                        stoppedDueToElapsedTimeout:
+                          state.stoppedDueToElapsedTimeout,
+                        userStopRequested: userStopSignal.signal.aborted,
+                      }),
                       chatLogger,
                       selectedModel,
                       configuredModelId,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1159,6 +1159,38 @@ export function captureToolCalls({
 
 export type AgentRunOutcome = "success" | "aborted" | "error";
 
+export type AgentAbortSource =
+  | "budget_exhausted"
+  | "agent_spend_cap"
+  | "elapsed_timeout"
+  | "user_stop"
+  | "request_cancel"
+  | "unknown";
+
+export function resolveAgentAbortSource({
+  outcome,
+  stoppedDueToBudgetExhaustion = false,
+  stoppedDueToAgentRunSpendCap = false,
+  stoppedDueToElapsedTimeout = false,
+  userStopRequested = false,
+  requestCancelled = false,
+}: {
+  outcome: AgentRunOutcome;
+  stoppedDueToBudgetExhaustion?: boolean;
+  stoppedDueToAgentRunSpendCap?: boolean;
+  stoppedDueToElapsedTimeout?: boolean;
+  userStopRequested?: boolean;
+  requestCancelled?: boolean;
+}): AgentAbortSource | undefined {
+  if (outcome !== "aborted") return undefined;
+  if (stoppedDueToBudgetExhaustion) return "budget_exhausted";
+  if (stoppedDueToAgentRunSpendCap) return "agent_spend_cap";
+  if (stoppedDueToElapsedTimeout) return "elapsed_timeout";
+  if (userStopRequested) return "user_stop";
+  if (requestCancelled) return "request_cancel";
+  return "unknown";
+}
+
 type AgentCompletionAnalyticsArgs = {
   posthog: PostHog | null;
   userId: string;
@@ -1168,6 +1200,7 @@ type AgentCompletionAnalyticsArgs = {
   subscription: string;
   sandboxInfo: SandboxInfo | null;
   outcome: AgentRunOutcome;
+  abortSource?: AgentAbortSource;
   chatLogger: ChatLogger | undefined;
   selectedModel: string;
   configuredModelId: string;
@@ -1197,6 +1230,7 @@ export function captureAgentRun({
   subscription,
   sandboxInfo,
   outcome,
+  abortSource,
   selectedModel,
   configuredModelId,
   responseModel,
@@ -1223,6 +1257,7 @@ export function captureAgentRun({
   subscription: string;
   sandboxInfo: SandboxInfo | null;
   outcome: AgentRunOutcome;
+  abortSource?: AgentAbortSource;
   selectedModel: string;
   configuredModelId: string;
   responseModel?: string;
@@ -1252,6 +1287,8 @@ export function captureAgentRun({
       subscription_tier: subscription,
       chat_id: chatId,
       outcome,
+      ...(outcome === "aborted" &&
+        abortSource && { abort_source: abortSource }),
       selected_model: selectedModel,
       configured_model: configuredModelId,
       ...(agentPermissionMode && {
@@ -1330,6 +1367,7 @@ export function captureAgentCompletionAnalytics(
     subscription,
     sandboxInfo,
     outcome,
+    abortSource: args.abortSource,
     selectedModel: args.selectedModel,
     configuredModelId: args.configuredModelId,
     responseModel: args.responseModel,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -115,6 +115,7 @@ import {
   captureUsageCost,
   captureUsageSettlement,
   createChatLogger,
+  resolveAgentAbortSource,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
 import {
@@ -3311,6 +3312,16 @@ export const agentLongTask = task({
                                     subscription,
                                     sandboxInfo,
                                     outcome,
+                                    abortSource: resolveAgentAbortSource({
+                                      outcome,
+                                      stoppedDueToBudgetExhaustion:
+                                        state.stoppedDueToBudgetExhaustion,
+                                      stoppedDueToAgentRunSpendCap:
+                                        state.stoppedDueToAgentRunSpendCap,
+                                      stoppedDueToElapsedTimeout:
+                                        state.stoppedDueToElapsedTimeout,
+                                      requestCancelled: triggerSignal.aborted,
+                                    }),
                                     chatLogger,
                                     selectedModel,
                                     configuredModelId,
@@ -3476,6 +3487,16 @@ export const agentLongTask = task({
                         subscription,
                         sandboxInfo,
                         outcome,
+                        abortSource: resolveAgentAbortSource({
+                          outcome,
+                          stoppedDueToBudgetExhaustion:
+                            state.stoppedDueToBudgetExhaustion,
+                          stoppedDueToAgentRunSpendCap:
+                            state.stoppedDueToAgentRunSpendCap,
+                          stoppedDueToElapsedTimeout:
+                            state.stoppedDueToElapsedTimeout,
+                          requestCancelled: triggerSignal.aborted,
+                        }),
                         chatLogger,
                         selectedModel,
                         configuredModelId,


### PR DESCRIPTION
## Summary
- add a bounded `abort_source` property to the existing `hackerai-agent_run` event
- distinguish budget exhaustion, Agent spend caps, elapsed timeouts, web user stops, Trigger cancellations, and unknown aborts
- preserve configured-model, served-model, fallback, and existing completion attribution without adding analytics capture calls

## Why
Agent aborts with a missing finish reason currently conflate several runtime outcomes. This adds privacy-safe attribution using existing runtime state so production completion softness can be investigated without collecting prompts, targets, findings, code, or other user content.

## Analytics impact
- zero additional PostHog capture calls
- one optional bounded property on aborted Agent run events only
- ambiguous aborts remain `unknown` instead of inferring an unsupported cause

## Validation
- `corepack pnpm test -- lib/api/__tests__/chat-logger.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint lib/api/chat-logger.ts lib/api/chat-handler.ts trigger/agent-long.ts lib/api/__tests__/chat-logger.test.ts`
- `corepack pnpm exec prettier --check lib/api/chat-logger.ts lib/api/chat-handler.ts trigger/agent-long.ts lib/api/__tests__/chat-logger.test.ts`
- commit hooks: 340 suites, 3,376 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved tracking of interrupted agent runs by identifying whether they ended due to budget limits, spend caps, timeouts, user stops, request cancellations, or unknown causes.
  - Completion analytics now consistently record interruption details across standard and fallback response flows.
  - Added safeguards to keep interruption classifications bounded and consistently reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->