### PR TITLE
Keep composer visible during chat transitions

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import {
   useComposerActions,
@@ -69,6 +69,7 @@ interface ChatInputProps {
   restoreDraftAttachments?: boolean;
   storedApprovalRequest?: ActiveAgentToolApprovalRequest | null;
   offlineProtection?: boolean;
+  sendDisabledReason?: string;
 }
 
 const isBrowserFile = (file: UploadedFileState["file"]): file is File =>
@@ -202,6 +203,7 @@ export const ChatInput = ({
   restoreDraftAttachments = true,
   storedApprovalRequest,
   offlineProtection = true,
+  sendDisabledReason,
 }: ChatInputProps) => {
   const {
     chatMode,
@@ -470,7 +472,7 @@ export const ChatInput = ({
     };
   }, [localDraftTextFiles, setUploadedFiles]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const prevDraftId = prevDraftIdRef.current;
     prevDraftIdRef.current = draftId;
 
@@ -576,7 +578,7 @@ export const ChatInput = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (isOffline) return;
+    if (isOffline || sendDisabledReason) return;
 
     const canSubmit =
       (status === "ready" || status === "streaming") &&
@@ -739,6 +741,7 @@ export const ChatInput = ({
               uploadedFiles={uploadedFiles}
               chatMode={chatMode}
               isOnline={!isOffline}
+              sendDisabledReason={sendDisabledReason}
             />
           </div>
         )}

--- a/app/components/ChatInput/ChatInputTextarea.tsx
+++ b/app/components/ChatInput/ChatInputTextarea.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import {
@@ -55,7 +55,7 @@ export function ChatInputTextarea({
   });
 
   // Load draft when draftId changes (chat switch or mount)
-  useEffect(() => {
+  useLayoutEffect(() => {
     const prevDraftId = prevDraftIdRef.current;
     prevDraftIdRef.current = draftId;
 

--- a/app/components/ChatInput/SubmitStopButton.tsx
+++ b/app/components/ChatInput/SubmitStopButton.tsx
@@ -46,7 +46,9 @@ function getSendButtonTooltip(
   isOnline: boolean,
   hasFileErrors: boolean,
   isUploading: boolean,
+  sendDisabledReason?: string,
 ): string {
+  if (sendDisabledReason) return sendDisabledReason;
   if (!isOnline) return "Reconnect to send";
   if (hasFileErrors) return "Remove failed files to send";
   if (isUploading) return "File upload pending";
@@ -65,6 +67,7 @@ export interface SubmitStopButtonProps {
   chatMode: ChatMode;
   isPaid?: boolean;
   isOnline?: boolean;
+  sendDisabledReason?: string;
 }
 
 export function SubmitStopButton({
@@ -79,6 +82,7 @@ export function SubmitStopButton({
   chatMode,
   isPaid = false,
   isOnline = true,
+  sendDisabledReason,
 }: SubmitStopButtonProps) {
   useHotkeys(
     "ctrl+c",
@@ -130,6 +134,7 @@ export function SubmitStopButton({
               <Button
                 type="submit"
                 disabled={
+                  !!sendDisabledReason ||
                   !isOnline ||
                   status !== "ready" ||
                   isUploadingFiles ||
@@ -150,6 +155,7 @@ export function SubmitStopButton({
                 isOnline,
                 uploadedFiles.some((f) => f.error),
                 isUploadingFiles,
+                sendDisabledReason,
               )}
             </p>
           </TooltipContent>

--- a/app/components/ChatInput/__tests__/SubmitStopButton.test.tsx
+++ b/app/components/ChatInput/__tests__/SubmitStopButton.test.tsx
@@ -46,6 +46,20 @@ describe("SubmitStopButton paid mode colors", () => {
     expect(screen.getByLabelText("Send message")).toBeDisabled();
   });
 
+  it("disables sending while the destination messages load", () => {
+    render(
+      <TooltipProvider>
+        <SubmitStopButton
+          {...defaultProps}
+          chatMode="ask"
+          sendDisabledReason="Messages loading"
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByLabelText("Send message")).toBeDisabled();
+  });
+
   it("uses the default submit treatment for paid Agent mode", () => {
     const button = renderButton("agent", true);
 

--- a/app/components/ChatInput/__tests__/SubmitStopButton.test.tsx
+++ b/app/components/ChatInput/__tests__/SubmitStopButton.test.tsx
@@ -1,8 +1,26 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { jest } from "@jest/globals";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { SubmitStopButton } from "../SubmitStopButton";
+
+Object.defineProperty(globalThis, "ResizeObserver", {
+  configurable: true,
+  value: class ResizeObserverMock {
+    observe() {
+      return undefined;
+    }
+
+    unobserve() {
+      return undefined;
+    }
+
+    disconnect() {
+      return undefined;
+    }
+  },
+});
 
 const defaultProps = {
   isGenerating: false,
@@ -46,18 +64,25 @@ describe("SubmitStopButton paid mode colors", () => {
     expect(screen.getByLabelText("Send message")).toBeDisabled();
   });
 
-  it("disables sending while the destination messages load", () => {
+  it("prioritizes the loading reason while destination messages load", async () => {
+    const user = userEvent.setup();
     render(
-      <TooltipProvider>
+      <TooltipProvider delayDuration={0}>
         <SubmitStopButton
           {...defaultProps}
           chatMode="ask"
+          isOnline={false}
           sendDisabledReason="Messages loading"
         />
       </TooltipProvider>,
     );
 
-    expect(screen.getByLabelText("Send message")).toBeDisabled();
+    const sendButton = screen.getByLabelText("Send message");
+    expect(sendButton).toBeDisabled();
+
+    await user.hover(sendButton.parentElement!);
+
+    expect(await screen.findByText("Messages loading")).toBeInTheDocument();
   });
 
   it("uses the default submit treatment for paid Agent mode", () => {

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -64,7 +64,6 @@ import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { removeDraft } from "@/lib/utils/client-storage";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
-import { cancelAgentLongRealtimeStreams } from "@/lib/chat/agent-long-transport";
 import { ShareDialog } from "./ShareDialog";
 import { MoveChatToProjectDialog } from "./MoveChatToProjectDialog";
 import { ProjectCreateDialog } from "./ProjectCreateDialog";
@@ -231,9 +230,6 @@ const ChatItem: React.FC<ChatItemProps> = ({
     // Clear input and transient state only when switching to a different chat
     if (!isCurrentlyActive) {
       setOptimisticChatId(id);
-      if (routeChatId && routeChatId !== id) {
-        cancelAgentLongRealtimeStreams(routeChatId);
-      }
       initializeChat(id);
     }
 

--- a/app/components/ChatLoadingStatusPill.tsx
+++ b/app/components/ChatLoadingStatusPill.tsx
@@ -1,0 +1,19 @@
+import { LoaderCircle } from "lucide-react";
+
+const LOADING_MESSAGES_LABEL = "Loading messages...";
+
+export function ChatLoadingStatusPill() {
+  return (
+    <div
+      aria-label={LOADING_MESSAGES_LABEL}
+      className="pointer-events-none mx-auto mb-2 flex w-fit max-w-full items-center gap-2 rounded-full border border-border/60 bg-card/95 px-3 py-1.5 text-xs font-medium text-foreground shadow-sm"
+      role="status"
+    >
+      <LoaderCircle
+        aria-hidden="true"
+        className="size-3.5 shrink-0 text-muted-foreground"
+      />
+      <span className="truncate">{LOADING_MESSAGES_LABEL}</span>
+    </div>
+  );
+}

--- a/app/components/ChatLoadingStatusPill.tsx
+++ b/app/components/ChatLoadingStatusPill.tsx
@@ -1,8 +1,22 @@
 import { LoaderCircle } from "lucide-react";
+import { useEffect, useState } from "react";
 
 const LOADING_MESSAGES_LABEL = "Loading messages...";
+const LOADING_STATUS_DELAY_MS = 300;
 
 export function ChatLoadingStatusPill() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setIsVisible(true);
+    }, LOADING_STATUS_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  if (!isVisible) return null;
+
   return (
     <div
       aria-label={LOADING_MESSAGES_LABEL}

--- a/app/components/__tests__/ChatLoadingStatusPill.test.tsx
+++ b/app/components/__tests__/ChatLoadingStatusPill.test.tsx
@@ -1,11 +1,26 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { ChatLoadingStatusPill } from "../ChatLoadingStatusPill";
 
 describe("ChatLoadingStatusPill", () => {
-  it("shows an accessible, non-animated loading status", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("waits 300ms before showing an accessible, non-animated status", () => {
+    jest.useFakeTimers();
     const { container } = render(<ChatLoadingStatusPill />);
 
+    expect(
+      screen.queryByRole("status", { name: "Loading messages..." }),
+    ).not.toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(299));
+    expect(
+      screen.queryByRole("status", { name: "Loading messages..." }),
+    ).not.toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(1));
     expect(
       screen.getByRole("status", { name: "Loading messages..." }),
     ).toHaveTextContent("Loading messages...");

--- a/app/components/__tests__/ChatLoadingStatusPill.test.tsx
+++ b/app/components/__tests__/ChatLoadingStatusPill.test.tsx
@@ -1,0 +1,15 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { ChatLoadingStatusPill } from "../ChatLoadingStatusPill";
+
+describe("ChatLoadingStatusPill", () => {
+  it("shows an accessible, non-animated loading status", () => {
+    const { container } = render(<ChatLoadingStatusPill />);
+
+    expect(
+      screen.getByRole("status", { name: "Loading messages..." }),
+    ).toHaveTextContent("Loading messages...");
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import {
   useRef,
   useEffect,
+  useLayoutEffect,
   useState,
   useReducer,
   useCallback,
@@ -506,6 +507,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     initializeChat,
     setTodos,
     setChatReset,
+    setChatNavigationHandler,
     hasUserDismissedRateLimitWarning,
     setHasUserDismissedRateLimitWarning,
     messageQueue,
@@ -667,12 +669,17 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const isChatMountedRef = useRef(false);
   const browserStreamFinishedRef = useRef(false);
   const activeChatIdRef = useRef(chatId);
+  const streamChatIdRef = useRef(chatId);
   const agentLongPartialSaveKeysRef = useRef<Set<string>>(new Set());
   const agentLongRunCorrelationRef = useRef<{
     runId: string;
     token: string;
   } | null>(null);
-  activeChatIdRef.current = chatId;
+
+  useLayoutEffect(() => {
+    activeChatIdRef.current = chatId;
+    streamChatIdRef.current = chatId;
+  }, [chatId]);
 
   useEffect(() => {
     isChatMountedRef.current = true;
@@ -1060,13 +1067,13 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     shouldUseAgentLongForCurrentChat;
   const stopActiveBrowserStream = useCallback(
     (nextChatId?: string) => {
-      const activeChatId = activeChatIdRef.current;
+      const streamChatId = streamChatIdRef.current;
       if (nextChatId) {
         // Invalidate terminal callbacks before either cancellation path can
         // finish synchronously.
         activeChatIdRef.current = nextChatId;
       }
-      cancelAgentLongRealtimeStreams(activeChatId);
+      cancelAgentLongRealtimeStreams(streamChatId);
       const streamAlreadyFinished =
         shouldUseAgentLongForCurrentChatRef.current &&
         browserStreamFinishedRef.current;
@@ -1081,6 +1088,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     },
     [setDataStream, setIsAutoResuming],
   );
+
+  useEffect(() => {
+    setChatNavigationHandler(stopActiveBrowserStream);
+    return () => setChatNavigationHandler(null);
+  }, [setChatNavigationHandler, stopActiveBrowserStream]);
 
   const saveAgentLongPartialSnapshot = useCallback(
     (clientReason: string) => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -22,6 +22,7 @@ import { api } from "@/convex/_generated/api";
 import type { FileDetails } from "@/types/file";
 import { Messages } from "./Messages";
 import { ChatInput } from "./ChatInput";
+import { ChatLoadingStatusPill } from "./ChatLoadingStatusPill";
 import type { RateLimitWarningData } from "./RateLimitWarning";
 import ChatHeader from "./ChatHeader";
 import Footer from "./Footer";
@@ -1796,6 +1797,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       hasPaginatedMessageResults: !!paginatedMessageResults,
       awaitingServerChat,
     });
+  const showBottomChatInput =
+    (hasMessages || isExistingChat || isMobile) && !isChatNotFound;
   const agentRunSpendCapWarning =
     rateLimitWarning?.warningType === "agent-run-spend-cap"
       ? rateLimitWarning
@@ -1957,8 +1960,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
               )}
 
               {/* Chat Input - Bottom placement (also for mobile new chats) */}
-              {(hasMessages || isExistingChat || isMobile) &&
-                !isChatNotFound && (
+              {showBottomChatInput ? (
+                <div className="flex-shrink-0">
+                  {isInitialExistingChatLoad ? <ChatLoadingStatusPill /> : null}
                   <ChatInput
                     onSubmit={handleSubmit}
                     onStop={handleStop}
@@ -1979,7 +1983,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                     onDismissRateLimitWarning={handleDismissRateLimitWarning}
                     storedApprovalRequest={storedAgentApprovalRequest}
                   />
-                )}
+                </div>
+              ) : null}
             </div>
           </div>
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -98,7 +98,6 @@ import { useLatestRef } from "../hooks/useLatestRef";
 import { useDataStreamDispatch } from "./DataStreamProvider";
 import { removeDraft } from "@/lib/utils/client-storage";
 import { parseRateLimitWarning } from "@/lib/utils/parse-rate-limit-warning";
-import Loading from "@/components/ui/loading";
 import { formatTaskUiCopy } from "@/app/utils/task-ui-copy";
 import { finalizeNewChatRoute } from "./chat-route";
 
@@ -1860,11 +1859,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
             {/* Chat interface */}
             <div className="bg-background flex flex-col flex-1 relative min-h-0">
               {/* Messages area */}
-              {isInitialExistingChatLoad ? (
-                <div className="flex-1 flex items-center justify-center min-h-0">
-                  <Loading />
-                </div>
-              ) : isChatNotFound ? (
+              {isChatNotFound ? (
                 <div className="flex-1 flex flex-col items-center justify-center px-4 py-8 min-h-0">
                   <div className="w-full max-w-full sm:max-w-[768px] sm:min-w-[390px] flex flex-col items-center space-y-8">
                     <div className="text-center">
@@ -1879,37 +1874,45 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                   </div>
                 </div>
               ) : showChatLayout ? (
-                <Messages
-                  chatId={chatId}
-                  scrollRef={scrollRef}
-                  contentRef={contentRef}
-                  messages={messages}
-                  setMessages={setMessages}
-                  onRegenerate={handleRegenerate}
-                  onRetry={handleRetry}
-                  onContinue={handleContinue}
-                  onReconnect={resumeStream}
-                  onEditMessage={handleEditMessage}
-                  onBranchMessage={handleBranchMessage}
-                  status={status}
-                  error={error || null}
-                  paginationStatus={paginatedMessages.status}
-                  loadMore={paginatedMessages.loadMore}
-                  isMobile={isMobile}
-                  tempChatFileDetails={tempChatFileDetails}
-                  finishReason={chatDataForCurrentChat?.finish_reason}
-                  agentRunSpendCapWarning={agentRunSpendCapWarning}
-                  uploadStatus={uploadStatus}
-                  summarizationStatus={summarizationStatus}
-                  mode={
-                    chatMode ??
-                    (chatDataForCurrentChat as any)?.default_model_slug
-                  }
-                  chatTitle={chatTitle}
-                  branchedFromChatId={branchedFromChatId}
-                  branchedFromChatTitle={branchedFromChatTitle}
-                  anchorMessageId={timelineAnchorMessageId}
-                />
+                <div
+                  className={`flex min-h-0 flex-1 transition-opacity duration-150 motion-reduce:transition-none ${
+                    isInitialExistingChatLoad ? "opacity-0" : "opacity-100"
+                  }`}
+                  aria-busy={isInitialExistingChatLoad}
+                  data-testid="chat-timeline-shell"
+                >
+                  <Messages
+                    chatId={chatId}
+                    scrollRef={scrollRef}
+                    contentRef={contentRef}
+                    messages={messages}
+                    setMessages={setMessages}
+                    onRegenerate={handleRegenerate}
+                    onRetry={handleRetry}
+                    onContinue={handleContinue}
+                    onReconnect={resumeStream}
+                    onEditMessage={handleEditMessage}
+                    onBranchMessage={handleBranchMessage}
+                    status={status}
+                    error={error || null}
+                    paginationStatus={paginatedMessages.status}
+                    loadMore={paginatedMessages.loadMore}
+                    isMobile={isMobile}
+                    tempChatFileDetails={tempChatFileDetails}
+                    finishReason={chatDataForCurrentChat?.finish_reason}
+                    agentRunSpendCapWarning={agentRunSpendCapWarning}
+                    uploadStatus={uploadStatus}
+                    summarizationStatus={summarizationStatus}
+                    mode={
+                      chatMode ??
+                      (chatDataForCurrentChat as any)?.default_model_slug
+                    }
+                    chatTitle={chatTitle}
+                    branchedFromChatId={branchedFromChatId}
+                    branchedFromChatTitle={branchedFromChatTitle}
+                    anchorMessageId={timelineAnchorMessageId}
+                  />
+                </div>
               ) : (
                 <div className="flex-1 flex flex-col min-h-0">
                   <div className="flex-1 flex flex-col items-center justify-center px-4 min-h-0">
@@ -1955,7 +1958,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
               {/* Chat Input - Bottom placement (also for mobile new chats) */}
               {(hasMessages || isExistingChat || isMobile) &&
-                !isInitialExistingChatLoad &&
                 !isChatNotFound && (
                   <ChatInput
                     onSubmit={handleSubmit}
@@ -1968,6 +1970,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                     onScrollToBottom={handleScrollToBottom}
                     isNewChat={!isExistingChat}
                     chatId={chatId}
+                    sendDisabledReason={
+                      isInitialExistingChatLoad ? "Messages loading" : undefined
+                    }
                     rateLimitWarning={
                       rateLimitWarning ? rateLimitWarning : undefined
                     }

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -186,6 +186,8 @@ interface GlobalStateType {
 
   // Register a chat reset function that will be invoked on initializeNewChat
   setChatReset: (fn: (() => void) | null) => void;
+  // Register stream cleanup that runs before navigating to another chat
+  setChatNavigationHandler: (fn: ((nextChatId: string) => void) | null) => void;
 }
 
 const GlobalStateContext = createContext<GlobalStateType | undefined>(
@@ -422,6 +424,9 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     [],
   );
   const chatResetRef = useRef<(() => void) | null>(null);
+  const chatNavigationHandlerRef = useRef<
+    ((nextChatId: string) => void) | null
+  >(null);
   const entitlementRefreshUserRef = useRef<string | null>(null);
   const entitlementRefreshFailureRef = useRef<{
     userId: string;
@@ -1031,6 +1036,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
   }, []);
 
   const initializeChat = useCallback((chatId: string, _fromRoute?: boolean) => {
+    chatNavigationHandlerRef.current?.(chatId);
     // Don't clear input here - let ChatInput restore draft automatically
     // setInput("");  // Removed - ChatInput will handle draft restoration
     setTodos([]);
@@ -1051,6 +1057,13 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
   const setChatReset = useCallback((fn: (() => void) | null) => {
     chatResetRef.current = fn;
   }, []);
+
+  const setChatNavigationHandler = useCallback(
+    (fn: ((nextChatId: string) => void) | null) => {
+      chatNavigationHandlerRef.current = fn;
+    },
+    [],
+  );
 
   const openSidebar = useCallback((content: SidebarContent) => {
     setSidebarContent(content);
@@ -1164,6 +1177,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
       setMigrateFromPentestgptDialogOpenWithUrl,
 
     setChatReset,
+    setChatNavigationHandler,
 
     hasUserDismissedRateLimitWarning,
     setHasUserDismissedRateLimitWarning,

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { useAccessToken, useAuth } from "@workos-inc/authkit-nextjs/components";
 import { SHARED_TOKEN_KEY } from "@/lib/auth/shared-token";
@@ -73,6 +79,28 @@ function ActiveProjectProbe() {
   return <div data-testid="active-project-id">{activeProjectId ?? "none"}</div>;
 }
 
+function ChatNavigationProbe({
+  onNavigate,
+}: {
+  onNavigate: (nextChatId: string) => void;
+}) {
+  const { initializeChat, setChatNavigationHandler } = useGlobalState();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setChatNavigationHandler(onNavigate)}
+      >
+        Register navigation
+      </button>
+      <button type="button" onClick={() => initializeChat("destination-chat")}>
+        Open destination
+      </button>
+    </>
+  );
+}
+
 describe("GlobalStateProvider agent defaults", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -89,6 +117,22 @@ describe("GlobalStateProvider agent defaults", () => {
       Promise.resolve({ ok: false }),
     ) as unknown as typeof fetch;
     mockAuthUser([]);
+  });
+
+  it("runs registered stream cleanup before initializing another chat", () => {
+    const onNavigate = jest.fn();
+    render(
+      <GlobalStateProvider>
+        <ChatNavigationProbe onNavigate={onNavigate} />
+      </GlobalStateProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Register navigation" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open destination" }));
+
+    expect(onNavigate).toHaveBeenCalledWith("destination-chat");
   });
 
   it("reveals free desktop mode access before token refresh finishes", async () => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -542,6 +542,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(
       /setChatNavigationHandler\(stopActiveBrowserStream\)/,
     );
+    expect(chatComponentSrc).toMatch(
+      /if \(nextChatId\) \{[\s\S]*activeChatIdRef\.current = nextChatId;[\s\S]*\}[\s\S]*cancelAgentLongRealtimeStreams\(streamChatId\)/,
+    );
     expect(globalStateSrc).toMatch(/optimisticChatId:\s*string\s*\|\s*null/);
     expect(globalStateSrc).toMatch(/setOptimisticChatId/);
   });

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -478,7 +478,7 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(/const stopRef = useRef\(stop\)/);
     expect(chatComponentSrc).toMatch(/stopActiveBrowserStream/);
     expect(chatComponentSrc).toMatch(
-      /const activeChatId = activeChatIdRef\.current;[\s\S]*cancelAgentLongRealtimeStreams\(activeChatId\)/,
+      /const streamChatId = streamChatIdRef\.current;[\s\S]*cancelAgentLongRealtimeStreams\(streamChatId\)/,
     );
     expect(chatComponentSrc).toMatch(
       /statusRef\.current\s*===\s*"streaming"[\s\S]*statusRef\.current\s*===\s*"submitted"[\s\S]*stopRef\.current\(\)/,
@@ -493,7 +493,7 @@ describe("agent-long chat UI — completion reconciliation", () => {
       "const stopActiveBrowserStream = useCallback(",
     );
     const cancelIdx = chatComponentSrc.indexOf(
-      "cancelAgentLongRealtimeStreams(activeChatId)",
+      "cancelAgentLongRealtimeStreams(streamChatId)",
       stopHelperIdx,
     );
     const invalidateIdx = chatComponentSrc.indexOf(
@@ -524,12 +524,23 @@ describe("agent-long chat UI — completion reconciliation", () => {
     ).toHaveLength(3);
   });
 
-  test("sidebar navigation cancels stale agent-long realtime before route commit", () => {
-    expect(chatItemSrc).toMatch(/cancelAgentLongRealtimeStreams/);
+  test("sidebar navigation invalidates stale callbacks before canceling realtime", () => {
+    expect(chatItemSrc).not.toMatch(/cancelAgentLongRealtimeStreams/);
     expect(chatItemSrc).toMatch(/setOptimisticChatId\(id\)/);
     expect(chatItemSrc).toMatch(/optimisticChatId\s*\?\?\s*routeChatId/);
-    expect(chatItemSrc).toMatch(
-      /routeChatId\s*&&\s*routeChatId\s*!==\s*id[\s\S]*cancelAgentLongRealtimeStreams\(routeChatId\)/,
+    expect(chatItemSrc).toMatch(/initializeChat\(id\)/);
+    expect(
+      chatComponentSrc.match(/activeChatIdRef\.current = chatId;/g),
+    ).toHaveLength(1);
+    expect(chatComponentSrc).toMatch(
+      /useLayoutEffect\(\(\) => \{[\s\S]*activeChatIdRef\.current = chatId;[\s\S]*streamChatIdRef\.current = chatId;[\s\S]*\}, \[chatId\]\)/,
+    );
+    expect(globalStateSrc).toMatch(/chatNavigationHandlerRef/);
+    expect(globalStateSrc).toMatch(
+      /chatNavigationHandlerRef\.current\?\.\(chatId\)/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /setChatNavigationHandler\(stopActiveBrowserStream\)/,
     );
     expect(globalStateSrc).toMatch(/optimisticChatId:\s*string\s*\|\s*null/);
     expect(globalStateSrc).toMatch(/setOptimisticChatId/);


### PR DESCRIPTION
## Summary
- keep the destination chat shell and composer mounted while messages load
- replace the centered loading screen with a short timeline opacity transition and show the compact message-loading status only after 300ms
- restore per-chat text and attachment drafts before paint
- disable sending only while destination messages are still loading
- invalidate an outgoing stream before cancellation so its terminal callback cannot override navigation to a saved chat

## Why
Switching to an existing chat temporarily replaced the conversation with a centered spinner and removed the composer. That made navigation feel slower and caused a visible layout jump even though the surrounding chat shell was already available. Showing status immediately also made fast transitions feel slower by flashing loading UI that was not needed.

When the outgoing chat was newly created and still streaming, its cancellation callback could also finalize the outgoing URL after navigation had begun. The sidebar selected the destination, but the outgoing task stayed mounted instead of loading the saved chat.

## User impact
The chat frame now stays stable during navigation. The composer remains visible, fast transitions stay visually quiet, and a compact `Loading messages...` status appears above the composer only when loading exceeds 300ms. The destination timeline fades in when ready, drafts do not briefly show content from the previous chat, and sending remains guarded until the destination state is safe.

Switching away from a newly created streaming task now loads the selected saved task while cleaning up only the outgoing browser stream. A destination task that has its own active run keeps its own streaming state.

## Validation
- `pnpm test --runInBand` — 343 suites, 3,416 tests passed
- `pnpm typecheck`
- repository-wide lint — 0 errors (5 existing warnings)
- focused Prettier — passed
- timer regression: no status through 299ms; accessible, non-animated status appears at 300ms
- Google Chrome normal-speed switching: loading began with the composer mounted and no status, then completed before the threshold without a flash
- Google Chrome held-sync switching: status was absent initially, appeared after 350ms, kept sending disabled, and cleared immediately when sync resumed
- Google Chrome live-stream switching: a new task showed its Stop control, then switching loaded the selected saved task URL, title, history, and composer without an outgoing callback restoring the old URL
- Google Chrome destination-stream isolation: a saved task with its own active run retained its own Stop state after the switch
- Google Chrome console: no errors

## Manual verification
1. Open two saved chats and switch between them from the task sidebar.
2. Confirm the composer remains visible and the centered loading screen does not replace the chat.
3. Confirm fast transitions complete without flashing `Loading messages...`.
4. On a transition longer than 300ms, confirm `Loading messages...` appears just above the composer and clears when the destination is ready.
5. With a draft in each chat, switch between them and confirm the destination draft appears without flashing the previous draft.
6. Confirm sending becomes available once the destination messages finish loading.
7. Start a new Agent task, switch to a saved task while Stop is visible, and confirm the saved task URL and message history load. If the saved task is also running, confirm its own Stop state remains available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat sending is disabled while messages load, with a clear “Messages loading” explanation.
  * Custom send-disabled messages take priority over other button status messages.
  * A loading status indicator remains visible in the chat input while messages load.

* **Bug Fixes**
  * Existing chat layouts remain stable during message loading.
  * Draft attachments and message text restore more reliably during chat initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
