### PR TITLE
Defer desktop bridge code on web

### DIFF
--- a/app/hooks/__tests__/useSandboxPreference.test.tsx
+++ b/app/hooks/__tests__/useSandboxPreference.test.tsx
@@ -6,8 +6,10 @@ jest.mock("convex/react", () => ({
   useMutation: () => jest.fn(),
 }));
 
+const mockIsTauriEnvironment = jest.fn(() => true);
+
 jest.mock("@/app/hooks/useTauri", () => ({
-  isTauriEnvironment: () => true,
+  isTauriEnvironment: mockIsTauriEnvironment,
 }));
 
 jest.mock("@/app/services/desktop-sandbox-bridge", () => ({
@@ -36,7 +38,19 @@ type BridgeConfig = {
 describe("useSandboxPreference", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsTauriEnvironment.mockReturnValue(true);
     window.localStorage.clear();
+  });
+
+  it("does not initialize the desktop bridge in a web browser", async () => {
+    mockIsTauriEnvironment.mockReturnValue(false);
+
+    const { result } = renderHook(() => useSandboxPreference(true));
+
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("idle");
+    });
+    expect(DesktopSandboxBridge).not.toHaveBeenCalled();
   });
 
   it("invalidates bridge startup and connected state when authentication is lost", async () => {
@@ -81,6 +95,7 @@ describe("useSandboxPreference", () => {
 
     await waitFor(() => {
       expect(result.current.desktopBridgeStatus).toBe("connecting");
+      expect(bridgeInstances).toHaveLength(1);
     });
 
     rerender({ isAuthenticated: false });

--- a/app/hooks/useSandboxPreference.ts
+++ b/app/hooks/useSandboxPreference.ts
@@ -5,7 +5,7 @@ import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { SandboxPreference } from "@/types/chat";
 import { toast } from "sonner";
-import { DesktopSandboxBridge } from "@/app/services/desktop-sandbox-bridge";
+import type { DesktopSandboxBridge } from "@/app/services/desktop-sandbox-bridge";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 
 export type DesktopBridgeStatus =
@@ -110,34 +110,39 @@ export function useSandboxPreference(
       try {
         if (!bridgeStartPromise) {
           const generation = bridgeGeneration;
-          let bridge: DesktopSandboxBridge;
-          bridge = new DesktopSandboxBridge({
-            connectDesktop: (args) => connectDesktopRef.current(args),
-            refreshCentrifugoTokenDesktop: (args) =>
-              refreshTokenRef.current(args),
-            disconnectDesktop: (args) => disconnectRef.current(args),
-            onTerminated: (reason) => {
-              if (generation !== bridgeGeneration) return;
-              if (activeBridge === bridge) activeBridge = null;
-              bridgeStateListener?.(false, "failed");
-            },
-          });
-
           let startPromise: Promise<DesktopSandboxBridge | null>;
-          startPromise = bridge
-            .start()
-            .then(async () => {
-              if (generation !== bridgeGeneration) {
-                await bridge.stop();
-                return null;
-              }
-              activeBridge = bridge;
-              return bridge;
-            })
-            .catch(async (error) => {
-              await bridge.stop();
-              throw error;
-            })
+          startPromise = import("@/app/services/desktop-sandbox-bridge")
+            .then(
+              async ({ DesktopSandboxBridge: DesktopSandboxBridgeClass }) => {
+                if (generation !== bridgeGeneration) return null;
+
+                const bridge = new DesktopSandboxBridgeClass({
+                  connectDesktop: (args) => connectDesktopRef.current(args),
+                  refreshCentrifugoTokenDesktop: (args) =>
+                    refreshTokenRef.current(args),
+                  disconnectDesktop: (args) => disconnectRef.current(args),
+                  onTerminated: () => {
+                    if (generation !== bridgeGeneration) return;
+                    if (activeBridge === bridge) activeBridge = null;
+                    bridgeStateListener?.(false, "failed");
+                  },
+                });
+
+                try {
+                  await bridge.start();
+                } catch (error) {
+                  await bridge.stop();
+                  throw error;
+                }
+
+                if (generation !== bridgeGeneration) {
+                  await bridge.stop();
+                  return null;
+                }
+                activeBridge = bridge;
+                return bridge;
+              },
+            )
             .finally(() => {
               if (bridgeStartPromise === startPromise) {
                 bridgeStartPromise = null;


### PR DESCRIPTION
## Summary

- defer the Tauri-only desktop sandbox bridge until an authenticated desktop session actually needs it
- keep the bridge's Strict Mode/startup generation guards intact across the dynamic import
- cover the authenticated web path so it cannot instantiate the desktop bridge

## Why

`useSandboxPreference` returned early in web browsers, but its static import still placed the desktop bridge, Centrifuge client, and PTY session manager in the synchronous chat client graph. Next.js's route analyzer showed this Tauri-only chain at depth 6-7 on `/c/[id]`.

This is a code-splitting change only: web behavior remains Cloud/remote-control capable, and desktop behavior retains the existing bridge lifecycle.

## Measured impact

Measured from identical `next experimental-analyze` route/module graph snapshots on `/c/[id]`, using synchronous client module depth plus unmapped/polyfill bytes:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Estimated synchronous client JS (compressed) | 1,102,608 B | 1,076,696 B | -25,912 B (-2.35%) |
| Estimated synchronous client JS (raw) | 3,133,746 B | 3,031,188 B | -102,558 B (-3.27%) |

The affected modules moved from the synchronous route graph to the dynamic branch:

- desktop bridge: depth 6 → 1005
- Centrifuge: depth 7 → 1006
- PTY session manager: depth 7 → 1006
- Centrifugo transport: depth 7 → 1006

## Dead-code and test audit

- `tsc --noUnusedLocals --noUnusedParameters` produced only framework/callback/signature leads after manual tracing
- Knip's six file leads remain supported Playwright, Trigger.dev, manual diagnostic, icon-generation, and operational entrypoints
- source-contract tests sampled from chat, provider, security, and Convex paths still protect unique behavior
- no dead files or low-value tests were removed; only the now-unneeded termination callback parameter was dropped in this same import chain

## Validation

- `corepack pnpm run check:local-dependencies`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (0 errors; 5 existing warnings)
- `corepack pnpm test --runInBand` (344 suites, 3,453 tests passed)
- `corepack pnpm exec jest app/hooks/__tests__/useSandboxPreference.test.tsx --runInBand` (2 tests passed)
- `corepack pnpm exec prettier --check app/hooks/useSandboxPreference.ts app/hooks/__tests__/useSandboxPreference.test.tsx`
- `git diff --check`
- `corepack pnpm next experimental-analyze --output`
- `corepack pnpm format:check` still reports 13 unchanged files already formatted differently on `origin/main`

## Google Chrome verification

Authenticated local web verification passed in the actual Google Chrome app:

- the new-task/chat composer rendered normally
- Cloud and local-computer controls remained available
- the composer enabled for input and disabled again when cleared
- no browser console warnings/errors appeared
- none of the 63 loaded scripts matched the desktop/Centrifuge/PTY bridge chain

The local desktop daemon was not running, so Chrome's local-computer presence request could not establish a desktop connection. A Tauri desktop smoke test remains appropriate before merge.

## Manual verification

1. In the desktop app, sign in and confirm the local bridge reaches connected state.
2. Select Local and run a harmless command; confirm output streams and cleanup still work.
3. Sign out or terminate the desktop service during startup; confirm the bridge disconnects without reconnecting stale authenticated state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox connection handling across web and desktop environments.
  * Web environments now avoid initializing unnecessary desktop components.
  * Improved connection cleanup and recovery when desktop startup fails.
  * Prevented duplicate desktop bridge initialization during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->