### PR TITLE
Make free Desktop Agent-only

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -224,6 +224,8 @@ export const ChatInput = ({
     subscription,
     isCheckingProPlan,
     hasLocalSandbox,
+    freeDesktopAgentOnlyActive,
+    desktopBridgeStatus,
     defaultLocalSandboxPreference,
   } = useGlobalState();
   const input = useComposerInput();
@@ -536,7 +538,8 @@ export const ChatInput = ({
   }, [draftId, restoreDraftAttachments, uploadedFiles]);
 
   // Free agent mode constraints:
-  // 1. Requires local sandbox — fall back to ask mode if disconnected
+  // 1. Requires local sandbox — web users fall back to Ask if disconnected,
+  //    while Desktop stays Agent-only and waits for its bridge to reconnect
   // 2. Force local sandbox preference (not e2b)
   // 3. Force auto model selection
   const isFreeAgent =
@@ -551,6 +554,16 @@ export const ChatInput = ({
     // Only show toast on actual disconnect (true → false), not on
     // initial mount or logout where hasLocalSandbox starts as false.
     if (!hasLocalSandbox) {
+      if (freeDesktopAgentOnlyActive) {
+        if (wasConnected) {
+          toast.info("Desktop sandbox disconnected.", {
+            description: "Reconnect the Desktop sandbox to keep using Agent.",
+            duration: 5000,
+          });
+        }
+        return;
+      }
+
       setChatMode("ask");
       if (wasConnected) {
         toast.info("Local sandbox disconnected. Switched to Ask mode.", {
@@ -559,8 +572,7 @@ export const ChatInput = ({
         });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFreeAgent, hasLocalSandbox]);
+  }, [freeDesktopAgentOnlyActive, isFreeAgent, hasLocalSandbox, setChatMode]);
 
   useEffect(() => {
     if (!isFreeAgent) return;
@@ -576,9 +588,18 @@ export const ChatInput = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFreeAgent]);
 
+  const desktopSandboxUnavailableReason =
+    freeDesktopAgentOnlyActive && !hasLocalSandbox
+      ? desktopBridgeStatus === "connecting"
+        ? "Desktop sandbox is connecting"
+        : "Reconnect the Desktop sandbox to use Agent"
+      : undefined;
+  const effectiveSendDisabledReason =
+    sendDisabledReason ?? desktopSandboxUnavailableReason;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (isOffline || sendDisabledReason) return;
+    if (isOffline || effectiveSendDisabledReason) return;
 
     const canSubmit =
       (status === "ready" || status === "streaming") &&
@@ -741,7 +762,7 @@ export const ChatInput = ({
               uploadedFiles={uploadedFiles}
               chatMode={chatMode}
               isOnline={!isOffline}
-              sendDisabledReason={sendDisabledReason}
+              sendDisabledReason={effectiveSendDisabledReason}
             />
           </div>
         )}

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -544,16 +544,19 @@ export const ChatInput = ({
   // 3. Force auto model selection
   const isFreeAgent =
     !isCheckingProPlan && subscription === "free" && isAgentMode(chatMode);
+  const freeAgentSandboxAvailable = freeDesktopAgentOnlyActive
+    ? desktopBridgeStatus === "connected"
+    : hasLocalSandbox;
 
-  const prevHasLocalSandboxRef = useRef(hasLocalSandbox);
+  const prevFreeAgentSandboxAvailableRef = useRef(freeAgentSandboxAvailable);
   useEffect(() => {
-    const wasConnected = prevHasLocalSandboxRef.current;
-    prevHasLocalSandboxRef.current = hasLocalSandbox;
+    const wasConnected = prevFreeAgentSandboxAvailableRef.current;
+    prevFreeAgentSandboxAvailableRef.current = freeAgentSandboxAvailable;
 
     if (!isFreeAgent) return;
     // Only show toast on actual disconnect (true → false), not on
-    // initial mount or logout where hasLocalSandbox starts as false.
-    if (!hasLocalSandbox) {
+    // initial mount or logout where sandbox availability starts as false.
+    if (!freeAgentSandboxAvailable) {
       if (freeDesktopAgentOnlyActive) {
         if (wasConnected) {
           toast.info("Desktop sandbox disconnected.", {
@@ -572,7 +575,12 @@ export const ChatInput = ({
         });
       }
     }
-  }, [freeDesktopAgentOnlyActive, isFreeAgent, hasLocalSandbox, setChatMode]);
+  }, [
+    freeAgentSandboxAvailable,
+    freeDesktopAgentOnlyActive,
+    isFreeAgent,
+    setChatMode,
+  ]);
 
   useEffect(() => {
     if (!isFreeAgent) return;
@@ -589,7 +597,7 @@ export const ChatInput = ({
   }, [isFreeAgent]);
 
   const desktopSandboxUnavailableReason =
-    freeDesktopAgentOnlyActive && !hasLocalSandbox
+    freeDesktopAgentOnlyActive && desktopBridgeStatus !== "connected"
       ? desktopBridgeStatus === "connecting"
         ? "Desktop sandbox is connecting"
         : "Reconnect the Desktop sandbox to use Agent"

--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -25,6 +25,7 @@ export function ChatInputToolbar({
 }: ChatInputToolbarProps) {
   const {
     chatModeAccessResolved,
+    freeDesktopAgentOnlyActive,
     hasLocalSandbox,
     paidAgentOnlyActive,
     selectedModel,
@@ -45,7 +46,9 @@ export function ChatInputToolbar({
       <div className="shrink-0">
         <AttachmentButton onAttachClick={onAttachClick} disabled={!isOnline} />
       </div>
-      {chatModeAccessResolved && !paidAgentOnlyActive ? (
+      {chatModeAccessResolved &&
+      !paidAgentOnlyActive &&
+      !freeDesktopAgentOnlyActive ? (
         <ChatModeSelector />
       ) : null}
       {showFreeAskComputerActivation ? <FreeAskComputerActivation /> : null}

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -7,6 +7,7 @@ import type { SubscriptionTier } from "@/types";
 let mockSubscription: SubscriptionTier = "free";
 let mockChatModeAccessResolved = true;
 let mockPaidAgentOnlyActive = false;
+let mockFreeDesktopAgentOnlyActive = false;
 let mockHasLocalSandbox = false;
 
 jest.mock("@/app/components/AttachmentButton", () => ({
@@ -49,6 +50,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     chatModeAccessResolved: mockChatModeAccessResolved,
     hasLocalSandbox: mockHasLocalSandbox,
     paidAgentOnlyActive: mockPaidAgentOnlyActive,
+    freeDesktopAgentOnlyActive: mockFreeDesktopAgentOnlyActive,
   }),
 }));
 
@@ -84,6 +86,7 @@ describe("ChatInputToolbar", () => {
     mockSubscription = "free";
     mockChatModeAccessResolved = true;
     mockPaidAgentOnlyActive = false;
+    mockFreeDesktopAgentOnlyActive = false;
     mockHasLocalSandbox = false;
     mockAuthUser(null);
   });
@@ -167,6 +170,17 @@ describe("ChatInputToolbar", () => {
 
     expect(screen.queryByTestId("chat-mode-selector")).not.toBeInTheDocument();
     expect(screen.getByTestId("agent-permission-selector")).toBeInTheDocument();
+  });
+
+  it("removes only the mode selector for free Desktop Agent-only mode", () => {
+    mockAuthUser({ id: "user_123" });
+    mockFreeDesktopAgentOnlyActive = true;
+
+    render(<ChatInputToolbar {...defaultProps} chatMode="agent" />);
+
+    expect(screen.queryByTestId("chat-mode-selector")).not.toBeInTheDocument();
+    expect(screen.getByTestId("agent-permission-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("model-selector")).toBeInTheDocument();
   });
 
   it("never flashes the mode selector while paid access resolves", () => {

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -656,6 +656,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     paidAgentSubscription === "free" &&
     isTauriEnvironment();
   const agentOnlyActive = paidAgentOnlyActive || freeDesktopAgentOnlyActive;
+  const accessibleChatMode: ChatMode = agentOnlyActive ? "agent" : chatMode;
 
   const setChatMode = useCallback(
     (mode: ChatMode) => {
@@ -668,9 +669,6 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
 
   useEffect(() => {
     if (!agentOnlyActive) return;
-    if (chatMode !== "agent") {
-      setChatModeState("agent");
-    }
     if (freeDesktopAgentOnlyActive && sandboxPreference !== "desktop") {
       setSandboxPreference("desktop");
     }
@@ -679,7 +677,6 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     }
   }, [
     agentOnlyActive,
-    chatMode,
     freeDesktopAgentOnlyActive,
     sandboxPreference,
     selectedModel,
@@ -1159,7 +1156,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     updateUploadedFile,
     getTotalTokens,
     isUploadingFiles,
-    chatMode,
+    chatMode: accessibleChatMode,
     setChatMode,
     chatModeAccessResolved,
     paidAgentOnlyActive,

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -89,6 +89,7 @@ interface GlobalStateType {
   setChatMode: (mode: ChatMode) => void;
   chatModeAccessResolved: boolean;
   paidAgentOnlyActive: boolean;
+  freeDesktopAgentOnlyActive: boolean;
 
   // Computer sidebar state (right side)
   sidebarOpen: boolean;
@@ -241,10 +242,6 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     initialSavedChatModeRef.current = saved;
     return saved;
   });
-  const setChatMode = useCallback((mode: ChatMode) => {
-    hasUserSelectedModeThisSessionRef.current = true;
-    setChatModeState(mode);
-  }, []);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarContent, setSidebarContent] = useState<SidebarContent | null>(
     null,
@@ -652,11 +649,42 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     subscriptionResolved &&
     !isCheckingProPlan &&
     paidAgentSubscription !== "free";
+  const freeDesktopAgentOnlyActive =
+    Boolean(user) &&
+    subscriptionResolved &&
+    !isCheckingProPlan &&
+    paidAgentSubscription === "free" &&
+    isTauriEnvironment();
+  const agentOnlyActive = paidAgentOnlyActive || freeDesktopAgentOnlyActive;
+
+  const setChatMode = useCallback(
+    (mode: ChatMode) => {
+      if (agentOnlyActive && mode !== "agent") return;
+      hasUserSelectedModeThisSessionRef.current = true;
+      setChatModeState(mode);
+    },
+    [agentOnlyActive],
+  );
 
   useEffect(() => {
-    if (!paidAgentOnlyActive || chatMode === "agent") return;
-    setChatModeState("agent");
-  }, [chatMode, paidAgentOnlyActive]);
+    if (!agentOnlyActive) return;
+    if (chatMode !== "agent") {
+      setChatModeState("agent");
+    }
+    if (freeDesktopAgentOnlyActive && sandboxPreference !== "desktop") {
+      setSandboxPreference("desktop");
+    }
+    if (freeDesktopAgentOnlyActive && selectedModel !== "auto") {
+      setSelectedModelRaw("auto");
+    }
+  }, [
+    agentOnlyActive,
+    chatMode,
+    freeDesktopAgentOnlyActive,
+    sandboxPreference,
+    selectedModel,
+    setSandboxPreference,
+  ]);
 
   // Initialize team pricing dialog from URL hash
   const [teamPricingDialogOpen, setTeamPricingDialogOpen] = useState(() => {
@@ -1135,6 +1163,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     setChatMode,
     chatModeAccessResolved,
     paidAgentOnlyActive,
+    freeDesktopAgentOnlyActive,
     sidebarOpen,
     setSidebarOpen,
     sidebarContent,

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -50,6 +50,7 @@ function GlobalStateProbe() {
     agentPermissionMode,
     chatModeAccessResolved,
     chatMode,
+    freeDesktopAgentOnlyActive,
     isCheckingProPlan,
     paidAgentOnlyActive,
     sandboxPreference,
@@ -64,6 +65,9 @@ function GlobalStateProbe() {
         {String(chatModeAccessResolved)}
       </div>
       <div data-testid="chat-mode">{chatMode}</div>
+      <div data-testid="free-desktop-agent-only">
+        {String(freeDesktopAgentOnlyActive)}
+      </div>
       <div data-testid="checking-pro-plan">{String(isCheckingProPlan)}</div>
       <div data-testid="paid-agent-only">{String(paidAgentOnlyActive)}</div>
       <div data-testid="sandbox-preference">{sandboxPreference}</div>
@@ -135,7 +139,7 @@ describe("GlobalStateProvider agent defaults", () => {
     expect(onNavigate).toHaveBeenCalledWith("destination-chat");
   });
 
-  it("reveals free desktop mode access before token refresh finishes", async () => {
+  it("makes free Desktop users Agent-only before token refresh finishes", async () => {
     window.__TAURI_INTERNALS__ = {};
     const refreshAuth = jest.fn(() => new Promise<void>(() => {}));
     mockAuthUser(undefined, { refreshAuth });
@@ -165,8 +169,46 @@ describe("GlobalStateProvider agent defaults", () => {
         "false",
       );
     });
-    expect(screen.getByTestId("subscription")).toHaveTextContent("free");
-    expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("false");
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription")).toHaveTextContent("free");
+      expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("false");
+      expect(screen.getByTestId("free-desktop-agent-only")).toHaveTextContent(
+        "true",
+      );
+      expect(screen.getByTestId("chat-mode")).toHaveTextContent("agent");
+    });
+  });
+
+  it("forces returning free Desktop users out of saved Ask mode", async () => {
+    window.__TAURI_INTERNALS__ = {};
+    window.localStorage.setItem("chat_mode", "ask");
+    window.localStorage.setItem("agent_permission_mode", "full_access");
+    mockAuthUser([]);
+    global.fetch = jest.fn((input) => {
+      if (String(input) === "/api/entitlements") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ entitlements: [] }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("free-desktop-agent-only")).toHaveTextContent(
+        "true",
+      );
+      expect(screen.getByTestId("chat-mode")).toHaveTextContent("agent");
+    });
+    expect(screen.getByTestId("agent-permission-mode")).toHaveTextContent(
+      "full_access",
+    );
   });
 
   it("reveals free web mode access when AuthKit omits entitlements", async () => {


### PR DESCRIPTION
## What changed

- make authenticated free users in the HackerAI Desktop app automatically use Agent mode
- remove the Ask/Agent mode selector for those users while keeping the Agent permission and model controls
- pin free Desktop Agent runs to the local Desktop sandbox and Auto model
- keep Agent mode active across Desktop bridge disconnects and disable sending until the bridge reconnects
- preserve the existing free Ask experience on web and mobile

## Why

Free Desktop users already have a local execution environment. Making the Desktop experience Agent-only aligns it with the paid-user mode structure and removes an unnecessary mode choice without granting free users cloud sandbox access.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with 5 existing warnings outside this diff)
- focused state, toolbar, and ChatInput integration suites: 57 tests passed
- full pre-commit suite: 344 suites / 3,455 tests passed
- local browser smoke test: HTTP 200, composer rendered, no Next.js error overlay, no console errors

## Manual verification

1. Sign in to HackerAI Desktop with a free account.
2. Confirm the composer opens in Agent mode and has no Ask/Agent selector.
3. Confirm the Agent permission selector remains available, including Full Access.
4. Disconnect the Desktop sandbox and confirm the app stays in Agent mode while send is disabled with a reconnect message.
5. Open the web app with the same free account and confirm Ask remains available there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Free desktop access now defaults to Agent mode, including for returning users with a previously selected mode.
  * Agent mode remains active if the desktop connection is interrupted, with a dedicated reconnect notification.
  * Chat submission and related controls indicate when the desktop sandbox is connecting or unavailable.
  * Free desktop users retain access to permission and model selectors while the chat-mode selector is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->