### PR TITLE
Reduce global state action rerenders

### DIFF
--- a/app/components/BranchIndicator.tsx
+++ b/app/components/BranchIndicator.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { useGlobalState } from "../contexts/GlobalState";
+import { useGlobalStateActions } from "../contexts/GlobalState";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { formatTaskTitle } from "@/app/utils/task-ui-copy";
 
@@ -18,7 +18,8 @@ export const BranchIndicator = memo(function BranchIndicator({
   onNavigate,
 }: BranchIndicatorProps) {
   const router = useRouter();
-  const { initializeChat, closeSidebar, setChatSidebarOpen } = useGlobalState();
+  const { initializeChat, closeSidebar, setChatSidebarOpen } =
+    useGlobalStateActions();
   const isMobile = useIsMobile();
   const taskTitle = formatTaskTitle(branchedFromChatTitle);
 

--- a/app/components/MessageSearchDialog.tsx
+++ b/app/components/MessageSearchDialog.tsx
@@ -22,7 +22,7 @@ import {
   isThisMonth,
 } from "date-fns";
 import type { Doc } from "@/convex/_generated/dataModel";
-import { useGlobalState } from "../contexts/GlobalState";
+import { useGlobalStateActions } from "../contexts/GlobalState";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useChats } from "../hooks/useChats";
 import {
@@ -62,7 +62,7 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
   const { user } = useAuth();
   const router = useRouter();
   const convex = useConvex();
-  const { setChatSidebarOpen, closeSidebar } = useGlobalState();
+  const { setChatSidebarOpen, closeSidebar } = useGlobalStateActions();
   const isMobile = useIsMobile();
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useRef } from "react";
-import { useGlobalState } from "../contexts/GlobalState";
+import { useGlobalStateActions } from "../contexts/GlobalState";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useChats } from "../hooks/useChats";
 import {
@@ -111,7 +111,7 @@ const MainSidebar: FC<{
   chatListData?: ChatListData;
 }> = ({ isMobileOverlay = false, chatListData: chatListDataProp }) => {
   const isMobile = useIsMobile();
-  const { setChatSidebarOpen } = useGlobalState();
+  const { setChatSidebarOpen } = useGlobalStateActions();
   // Use lifted data when provided; otherwise subscribe here (e.g. SharedChatView)
   const chatListDataFromHook = useChats(chatListDataProp === undefined);
   const chatListData = chatListDataProp ?? chatListDataFromHook;

--- a/app/components/__tests__/MessageSearchDialog.test.tsx
+++ b/app/components/__tests__/MessageSearchDialog.test.tsx
@@ -28,6 +28,10 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     setChatSidebarOpen: jest.fn(),
     closeSidebar: jest.fn(),
   }),
+  useGlobalStateActions: () => ({
+    setChatSidebarOpen: jest.fn(),
+    closeSidebar: jest.fn(),
+  }),
 }));
 
 jest.mock("@/hooks/use-mobile", () => ({

--- a/app/components/__tests__/Sidebar.test.tsx
+++ b/app/components/__tests__/Sidebar.test.tsx
@@ -25,6 +25,7 @@ jest.mock("@/hooks/use-mobile", () => ({
 }));
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({ setChatSidebarOpen: jest.fn() }),
+  useGlobalStateActions: () => ({ setChatSidebarOpen: jest.fn() }),
 }));
 jest.mock("@/app/hooks/useChats", () => ({
   useChats: () => ({

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -191,9 +191,22 @@ interface GlobalStateType {
   setChatNavigationHandler: (fn: ((nextChatId: string) => void) | null) => void;
 }
 
+type GlobalStateActionsType = Pick<
+  GlobalStateType,
+  | "closeSidebar"
+  | "initializeChat"
+  | "initializeNewChat"
+  | "setActiveProjectId"
+  | "setChatSidebarOpen"
+  | "setSandboxPreference"
+>;
+
 const GlobalStateContext = createContext<GlobalStateType | undefined>(
   undefined,
 );
+const GlobalStateActionsContext = createContext<
+  GlobalStateActionsType | undefined
+>(undefined);
 
 interface GlobalStateProviderProps {
   children: ReactNode;
@@ -1148,6 +1161,25 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     [],
   );
 
+  const actionsValue = useMemo<GlobalStateActionsType>(
+    () => ({
+      closeSidebar,
+      initializeChat,
+      initializeNewChat,
+      setActiveProjectId,
+      setChatSidebarOpen,
+      setSandboxPreference,
+    }),
+    [
+      closeSidebar,
+      initializeChat,
+      initializeNewChat,
+      setActiveProjectId,
+      setChatSidebarOpen,
+      setSandboxPreference,
+    ],
+  );
+
   const value: GlobalStateType = {
     uploadedFiles,
     setUploadedFiles,
@@ -1235,9 +1267,11 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
   };
 
   return (
-    <GlobalStateContext.Provider value={value}>
-      {children}
-    </GlobalStateContext.Provider>
+    <GlobalStateActionsContext.Provider value={actionsValue}>
+      <GlobalStateContext.Provider value={value}>
+        {children}
+      </GlobalStateContext.Provider>
+    </GlobalStateActionsContext.Provider>
   );
 };
 
@@ -1253,6 +1287,16 @@ export const useGlobalState = (): GlobalStateType => {
   const context = useContext(GlobalStateContext);
   if (context === undefined) {
     throw new Error("useGlobalState must be used within a GlobalStateProvider");
+  }
+  return context;
+};
+
+export const useGlobalStateActions = (): GlobalStateActionsType => {
+  const context = useContext(GlobalStateActionsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useGlobalStateActions must be used within a GlobalStateProvider",
+    );
   }
   return context;
 };

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+import { useEffect } from "react";
 import {
   act,
   fireEvent,
@@ -107,7 +108,10 @@ function ChatNavigationProbe({
 
 function NavigationActionRenderProbe({ onRender }: { onRender: () => void }) {
   const { setChatSidebarOpen } = useGlobalStateActions();
-  onRender();
+
+  useEffect(() => {
+    onRender();
+  });
 
   return (
     <button type="button" onClick={() => setChatSidebarOpen(false)}>
@@ -153,10 +157,11 @@ describe("GlobalStateProvider agent defaults", () => {
       </GlobalStateProvider>,
     );
 
-    expect(onRender).toHaveBeenCalledTimes(1);
+    const initialCommittedRenderCount = onRender.mock.calls.length;
+    expect(initialCommittedRenderCount).toBe(1);
     fireEvent.click(screen.getByRole("button", { name: "Expand todo panel" }));
 
-    expect(onRender).toHaveBeenCalledTimes(1);
+    expect(onRender).toHaveBeenCalledTimes(initialCommittedRenderCount);
   });
 
   it("runs registered stream cleanup before initializing another chat", () => {

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -25,7 +25,7 @@ jest.mock("@/app/hooks/useSandboxPreference", () => {
   };
 });
 
-const { GlobalStateProvider, useGlobalState } =
+const { GlobalStateProvider, useGlobalState, useGlobalStateActions } =
   jest.requireActual<typeof import("../GlobalState")>("../GlobalState");
 
 const mockAuthUser = (
@@ -105,6 +105,27 @@ function ChatNavigationProbe({
   );
 }
 
+function NavigationActionRenderProbe({ onRender }: { onRender: () => void }) {
+  const { setChatSidebarOpen } = useGlobalStateActions();
+  onRender();
+
+  return (
+    <button type="button" onClick={() => setChatSidebarOpen(false)}>
+      Close task sidebar
+    </button>
+  );
+}
+
+function UnrelatedGlobalStateUpdater() {
+  const { setIsTodoPanelExpanded } = useGlobalState();
+
+  return (
+    <button type="button" onClick={() => setIsTodoPanelExpanded(true)}>
+      Expand todo panel
+    </button>
+  );
+}
+
 describe("GlobalStateProvider agent defaults", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -121,6 +142,21 @@ describe("GlobalStateProvider agent defaults", () => {
       Promise.resolve({ ok: false }),
     ) as unknown as typeof fetch;
     mockAuthUser([]);
+  });
+
+  it("does not rerender an action-only consumer for unrelated state", () => {
+    const onRender = jest.fn();
+    render(
+      <GlobalStateProvider>
+        <NavigationActionRenderProbe onRender={onRender} />
+        <UnrelatedGlobalStateUpdater />
+      </GlobalStateProvider>,
+    );
+
+    expect(onRender).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Expand todo panel" }));
+
+    expect(onRender).toHaveBeenCalledTimes(1);
   });
 
   it("runs registered stream cleanup before initializing another chat", () => {

--- a/app/hooks/useStartNewChat.ts
+++ b/app/hooks/useStartNewChat.ts
@@ -3,7 +3,7 @@
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useGlobalState } from "@/app/contexts/GlobalState";
+import { useGlobalStateActions } from "@/app/contexts/GlobalState";
 
 type StartNewChatOptions = {
   projectId?: string;
@@ -19,7 +19,7 @@ export function useStartNewChat() {
     setActiveProjectId,
     setChatSidebarOpen,
     setSandboxPreference,
-  } = useGlobalState();
+  } = useGlobalStateActions();
 
   return useCallback(
     ({ projectId, useDesktop = false }: StartNewChatOptions = {}) => {


### PR DESCRIPTION
## Summary
- add a stable action-only context alongside the existing global state context
- migrate sidebar, task navigation, branch navigation, and message-search consumers that only need navigation actions
- add regression coverage proving unrelated global-state updates no longer rerender action-only consumers

## Why
`GlobalStateContext` publishes a new combined value whenever any global state changes. React rerenders every context consumer when that value changes, including memoized consumers. Several always-mounted navigation surfaces subscribed to the full context even though they only call stable actions.

Keeping the existing state context preserves its public behavior. The new action context narrows subscriptions without a broad provider migration.

## Performance evidence
A render-count harness mounts an action-only navigation consumer next to an unrelated todo-panel state update.

- Before (`useGlobalState`): render count **1 → 2**
- After (`useGlobalStateActions`): render count **1 → 1**
- Result: **1 forced render → 0** for that unrelated update

The production Turbopack analyzer completed successfully. This change targets rerender fan-out, so no bundle-size reduction is claimed.

## Validation
- `corepack pnpm test --runInBand` — 344 suites, 3,456 tests passed
- `corepack pnpm typecheck` — passed
- `corepack pnpm lint` — passed with 5 existing warnings, 0 errors
- `corepack pnpm next experimental-analyze --output` — passed in 95s
- targeted Prettier check for all changed files — passed
- `git diff --check` — passed
- authenticated Google Chrome — desktop sidebar open/close, message search open/close, new-task action, and 390×844 mobile task drawer open/close passed; no console errors in the completed flow

Repository-wide Prettier still reports 13 unchanged baseline files; no changed file is affected.

## Manual verification
1. Open the authenticated home route.
2. Open and close the task sidebar, then open and dismiss message search.
3. Start a new task and confirm navigation remains on the clean task route.
4. At a mobile viewport, open and close the task drawer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved application efficiency by preventing certain interface components from rerendering when unrelated global state changes.
* **Bug Fixes**
  * Preserved existing chat, navigation, project, sandbox, and sidebar behavior while improving state-action handling.
* **Tests**
  * Added coverage to verify sidebar actions and ensure action-only components avoid unnecessary rerenders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->