### PR TITLE
Attribute stale Agent cancellation conflicts

### DIFF
--- a/lib/api/__tests__/agent-cancel-route.test.ts
+++ b/lib/api/__tests__/agent-cancel-route.test.ts
@@ -165,6 +165,19 @@ describe("agent cancel route", () => {
       canceled: false,
       reason: "stale_run",
     });
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Rejected Agent cancellation request",
+      expect.objectContaining({
+        event: "agent_cancel_rejected",
+        request_id: "req_agent_cancel",
+        endpoint: "/api/agent",
+        route: "/api/agent/cancel",
+        reason: "stale_run",
+        status_code: 409,
+        user_id: "user-1",
+        chat_id: "chat-1",
+      }),
+    );
     expect(mockCloseAgentApprovalSession).not.toHaveBeenCalled();
     expect(mockCancelAgentTriggerRun).not.toHaveBeenCalled();
     expect(mockSetActiveTriggerRun).not.toHaveBeenCalled();

--- a/lib/api/agent-cancel-route.ts
+++ b/lib/api/agent-cancel-route.ts
@@ -10,7 +10,8 @@ import {
 } from "@/lib/api/agent-approval-session";
 import { logger } from "@/lib/logger";
 
-type AgentCancelRejectionReason = "chat_owner_mismatch" | "chat_missing";
+type AgentCancelRejectionReason =
+  "chat_owner_mismatch" | "chat_missing" | "stale_run";
 
 function logAgentCancelRejection({
   req,
@@ -34,7 +35,7 @@ function logAgentCancelRejection({
     endpoint,
     action: "cancel",
     reason,
-    status_code: 403,
+    status_code: reason === "stale_run" ? 409 : 403,
     user_id: userId,
     chat_id: chatId,
   });
@@ -92,6 +93,13 @@ export const createAgentCancelPost =
       const approvalSessionId = chat.active_agent_approval_session_id;
       const runId = chat.active_trigger_run_id;
       if (expectedTriggerRunId && runId !== expectedTriggerRunId) {
+        logAgentCancelRejection({
+          req,
+          endpoint,
+          userId,
+          chatId,
+          reason: "stale_run",
+        });
         return NextResponse.json(
           { canceled: false, reason: "stale_run" },
           { status: 409 },


### PR DESCRIPTION
## Summary

- emit the existing `agent_cancel_rejected` structured event when an expected Agent run is stale
- record the bounded `stale_run` reason and HTTP 409 with the existing request, endpoint, user, and chat correlation
- preserve the 409 response and all cancellation side-effect guards for both current and legacy Agent cancel routes

## Production evidence

The frozen production audit window was `2026-08-09T20:02:47.734Z` through `2026-08-10T20:02:47.734Z`.

PostHog recorded 20 Agent cancellation 409 exceptions across 12 sessions and 12 users, up from 10 in the previous equivalent window. The route already identifies these requests as `stale_run`, but only the generic client exception was observable; the server logger covered only 403 ownership/missing-chat rejections.

This change adds attribution without changing cancellation behavior or suppressing the signal.

## Validation

- `corepack pnpm jest lib/api/__tests__/agent-cancel-route.test.ts --runInBand`
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint lib/api/agent-cancel-route.ts lib/api/__tests__/agent-cancel-route.test.ts`
- `corepack pnpm exec prettier --check lib/api/agent-cancel-route.ts lib/api/__tests__/agent-cancel-route.test.ts`
- commit hooks: 344 suites / 3,455 tests passed

## Manual verification

1. Start Agent run A, then let a replacement run B become active for the same chat.
2. Send a cancellation that still expects run A.
3. Confirm the route returns the existing 409 `stale_run` response and does not cancel or clear run B.
4. Confirm one `agent_cancel_rejected` warning contains bounded reason `stale_run`, status 409, and opaque request/user/chat correlation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of cancellation requests for runs that are no longer current.
  - These stale requests now return the appropriate **409 Conflict** response instead of an authorization error.
  - Rejection details now include a clear stale-run reason, improving error clarity and troubleshooting.
  - Added verification to ensure stale cancellation events produce the expected structured warning information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->