### PR TITLE
Preserve Agent sessions during auth rate limits

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -341,6 +341,101 @@ describe("proxy", () => {
     );
   });
 
+  it("preserves session cookies when an API refresh is rate-limited", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const authkitHeaders = new Headers({
+      "cache-control": "no-store",
+      "set-cookie":
+        "wos-session=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; HttpOnly",
+      "x-workos-session": "internal-session-value",
+    });
+    authkitHeaders.append(
+      "set-cookie",
+      "wos-auth-verifier-state=sealed-state; Path=/; HttpOnly",
+    );
+
+    try {
+      mockAuthkit.mockImplementation((_request, options: any) => {
+        options.onSessionRefreshError({
+          error: Object.assign(new Error("Rate limit exceeded"), {
+            status: 429,
+          }),
+        });
+        return Promise.resolve({
+          session: { user: null },
+          headers: authkitHeaders,
+          authorizationUrl: "https://auth.hackerai.co/login",
+        });
+      });
+      const { default: proxy } = await import("../proxy");
+
+      await proxy(
+        createRequest({
+          pathname: "/api/agent/resume",
+          hasSession: true,
+        }),
+      );
+
+      expect(mockNextResponseJson).toHaveBeenCalledWith(
+        { code: "rate_limited", message: "Please retry shortly." },
+        expect.objectContaining({ status: 503 }),
+      );
+      const responseInit = mockNextResponseJson.mock.calls[0][1] as {
+        headers: Headers;
+      };
+      expect(responseInit.headers.get("retry-after")).toBe("5");
+      expect(responseInit.headers.get("cache-control")).toBe("no-store");
+      expect(responseInit.headers.get("set-cookie")).toBeNull();
+      expect(responseInit.headers.get("x-workos-session")).toBeNull();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preserves session cookies when a browser refresh is rate-limited", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const authkitHeaders = new Headers({
+      "set-cookie":
+        "wos-session=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; HttpOnly",
+      "x-workos-session": "internal-session-value",
+    });
+
+    try {
+      mockAuthkit.mockImplementation((_request, options: any) => {
+        options.onSessionRefreshError({
+          error: Object.assign(new Error("Too many requests"), {
+            status: 429,
+          }),
+        });
+        return Promise.resolve({
+          session: { user: null },
+          headers: authkitHeaders,
+          authorizationUrl: "https://auth.hackerai.co/login",
+        });
+      });
+      const { default: proxy } = await import("../proxy");
+
+      await proxy(
+        createRequest({
+          pathname: "/dashboard",
+          accept: "text/html",
+          hasSession: true,
+          userAgent: "Mozilla/5.0",
+        }),
+      );
+
+      expect(mockNextResponseNext).toHaveBeenCalledTimes(1);
+      const responseInit = mockNextResponseNext.mock.calls[0][0] as {
+        headers: Headers;
+      };
+      expect(responseInit.headers.get("set-cookie")).toBeNull();
+      expect(responseInit.headers.get("x-workos-session")).toBeNull();
+      expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("treats thrown ended-session refresh errors as unauthenticated home requests", async () => {
     const endedSessionError = Object.assign(
       new Error("Failed to refresh session: Error: invalid_grant"),

--- a/proxy.ts
+++ b/proxy.ts
@@ -338,7 +338,9 @@ export default async function proxy(request: NextRequest) {
   }
 
   const requestHeaders = buildRequestHeaders(request, headers);
-  const responseHeaders = buildResponseHeaders(headers);
+  const responseHeaders = buildResponseHeaders(headers, {
+    preserveSessionCookies: hadSessionCookie && refreshHitRateLimit,
+  });
 
   if (session.user || isUnauthenticatedPath(pathname)) {
     return withReferralCookie(
@@ -419,9 +421,20 @@ function buildRequestHeaders(
   return merged;
 }
 
-function buildResponseHeaders(authkitHeaders: Headers): Headers {
+function buildResponseHeaders(
+  authkitHeaders: Headers,
+  { preserveSessionCookies = false } = {},
+): Headers {
   const responseHeaders = new Headers(authkitHeaders);
   responseHeaders.delete(SESSION_HEADER);
+
+  // AuthKit clears session cookies for every refresh exception. A provider
+  // rate limit is transient, so forwarding those deletions would turn a
+  // recoverable retry into a logged-out session.
+  if (preserveSessionCookies) {
+    responseHeaders.delete("set-cookie");
+  }
+
   return responseHeaders;
 }
 


### PR DESCRIPTION
## Production evidence

- The latest product pulse recorded 1,896 `/api/agent/resume` 503 request rows with `auth.session_refresh_rate_limited`. Request retries can amplify this count, so it is not treated as a user count.
- The failures prevent Agent clients from obtaining fresh resume access while WorkOS refreshes are rate-limited.

## Root cause

AuthKit emits cookies that delete the WorkOS session and eager-auth JWT for every session-refresh exception. The proxy correctly classified provider rate limits as transient and returned `503` with `Retry-After`, but it forwarded those deletion cookies. A recoverable provider throttle could therefore log the user out and make later Agent reconnects fail.

## Change

- Strip AuthKit `Set-Cookie` headers only when a request already had a session and the refresh callback confirms a rate limit.
- Preserve the existing `503` plus `Retry-After: 5` contract for API clients.
- Preserve the existing browser pass-through behavior.
- Leave real ended-session and other authentication-failure handling unchanged.
- Cover API resume and browser navigation paths with focused regressions.

## Validation

- `pnpm jest __tests__/proxy.test.ts --runInBand`
- `pnpm exec eslint proxy.ts __tests__/proxy.test.ts`
- `pnpm exec prettier --check proxy.ts __tests__/proxy.test.ts`
- `pnpm typecheck`
- Commit hooks: 344 suites, 3,458 tests passed
- Local dependency links verified as checkout-scoped

## Manual verification

1. With an authenticated test account and a controlled WorkOS refresh 429, request `/api/agent/resume`.
2. Confirm the response is `503`, includes `Retry-After: 5`, and does not include a `Set-Cookie` header that expires the session.
3. Retry after the provider recovers and confirm Agent reconnects without requiring a new sign-in.
4. End a test session normally and confirm protected APIs still return `401` and clear the session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling when session refresh requests are temporarily rate-limited.
  * Prevented valid session cookies from being cleared during transient rate-limit responses.
  * Ensured rate-limited requests return appropriate retry and caching headers without unnecessary redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->