### PR TITLE
Attribute stalled Agent runtime settlement

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -692,6 +692,41 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/maxDurationMs:\s*agentLongMaxDurationMs/);
   });
 
+  test("attributes runtime-budget settlement stalls inside the cleanup grace", () => {
+    expect(taskSrc).toMatch(
+      /AGENT_LONG_RUNTIME_SETTLEMENT_WATCHDOG_MS\s*=\s*30\s*\*\s*1000/,
+    );
+
+    const budgetIdx = taskSrc.indexOf("createActiveRuntimeBudget({");
+    const armIdx = taskSrc.indexOf(
+      "runtimeSettlementWatchdog?.arm()",
+      budgetIdx,
+    );
+    const abortIdx = taskSrc.indexOf("userStopSignal.abort()", armIdx);
+    const stalledEventIdx = taskSrc.indexOf(
+      'event: "agent_long_runtime_settlement_stalled"',
+      abortIdx,
+    );
+    const finallyIdx = taskSrc.indexOf("} finally {", stalledEventIdx);
+    const disposeIdx = taskSrc.indexOf(
+      "runtimeSettlementWatchdog?.dispose()",
+      finallyIdx,
+    );
+
+    expect(budgetIdx).toBeGreaterThan(-1);
+    expect(armIdx).toBeGreaterThan(budgetIdx);
+    expect(abortIdx).toBeGreaterThan(armIdx);
+    expect(stalledEventIdx).toBeGreaterThan(abortIdx);
+    expect(finallyIdx).toBeGreaterThan(stalledEventIdx);
+    expect(disposeIdx).toBeGreaterThan(finallyIdx);
+
+    const eventBlock = taskSrc.slice(stalledEventIdx, finallyIdx);
+    expect(eventBlock).toMatch(/request_id:\s*ctx\.run\.id/);
+    expect(eventBlock).toMatch(/provider_error_category/);
+    expect(eventBlock).toMatch(/active_terminal_wait_duration_ms/);
+    expect(eventBlock).not.toMatch(/prompt|target|tool_output|command_output/);
+  });
+
   test("runs are triggered with filterable queued metadata and tags", () => {
     expect(routeSrc).toMatch(/tags:\s*triggerTags/);
     expect(routeSrc).toMatch(

--- a/lib/chat/__tests__/active-runtime-budget.test.ts
+++ b/lib/chat/__tests__/active-runtime-budget.test.ts
@@ -1,4 +1,7 @@
-import { createActiveRuntimeBudget } from "@/lib/chat/active-runtime-budget";
+import {
+  createActiveRuntimeBudget,
+  createRuntimeSettlementWatchdog,
+} from "@/lib/chat/active-runtime-budget";
 
 describe("createActiveRuntimeBudget", () => {
   beforeEach(() => {
@@ -48,5 +51,66 @@ describe("createActiveRuntimeBudget", () => {
     jest.advanceTimersByTime(1);
     expect(onExceeded).toHaveBeenCalledTimes(1);
     budget.dispose();
+  });
+});
+
+describe("createRuntimeSettlementWatchdog", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-11T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("reports a run that remains unsettled after the diagnostic delay", () => {
+    const onStalled = jest.fn();
+    const watchdog = createRuntimeSettlementWatchdog({
+      delayMs: 30_000,
+      onStalled,
+    });
+
+    const exceededAt = Date.now();
+    watchdog.arm(exceededAt);
+    watchdog.arm(exceededAt + 1_000);
+
+    jest.advanceTimersByTime(29_999);
+    expect(onStalled).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onStalled).toHaveBeenCalledTimes(1);
+    expect(onStalled).toHaveBeenCalledWith({
+      runtimeBudgetExceededAt: exceededAt,
+      stalledForMs: 30_000,
+    });
+  });
+
+  it("does not report after run cleanup begins", () => {
+    const onStalled = jest.fn();
+    const watchdog = createRuntimeSettlementWatchdog({
+      delayMs: 30_000,
+      onStalled,
+    });
+
+    watchdog.arm();
+    jest.advanceTimersByTime(10_000);
+    watchdog.dispose();
+    jest.advanceTimersByTime(30_000);
+
+    expect(onStalled).not.toHaveBeenCalled();
+  });
+
+  it("does not fail the task when diagnostic emission throws", () => {
+    const watchdog = createRuntimeSettlementWatchdog({
+      delayMs: 30_000,
+      onStalled: () => {
+        throw new Error("logger unavailable");
+      },
+    });
+
+    watchdog.arm();
+
+    expect(() => jest.advanceTimersByTime(30_000)).not.toThrow();
   });
 });

--- a/lib/chat/__tests__/active-runtime-budget.test.ts
+++ b/lib/chat/__tests__/active-runtime-budget.test.ts
@@ -113,4 +113,20 @@ describe("createRuntimeSettlementWatchdog", () => {
 
     expect(() => jest.advanceTimersByTime(30_000)).not.toThrow();
   });
+
+  it("does not fail the task when async diagnostic emission rejects", async () => {
+    const onStalled = jest
+      .fn<Promise<void>, []>()
+      .mockRejectedValue(new Error("async logger unavailable"));
+    const watchdog = createRuntimeSettlementWatchdog({
+      delayMs: 30_000,
+      onStalled,
+    });
+
+    watchdog.arm();
+    jest.advanceTimersByTime(30_000);
+    await Promise.resolve();
+
+    expect(onStalled).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/chat/active-runtime-budget.ts
+++ b/lib/chat/active-runtime-budget.ts
@@ -18,7 +18,7 @@ export function createRuntimeSettlementWatchdog({
   onStalled: (details: {
     runtimeBudgetExceededAt: number;
     stalledForMs: number;
-  }) => void;
+  }) => void | Promise<void>;
 }): RuntimeSettlementWatchdog {
   let armed = false;
   let disposed = false;
@@ -31,9 +31,13 @@ export function createRuntimeSettlementWatchdog({
       timeoutId = undefined;
       if (disposed) return;
       try {
-        onStalled({
-          runtimeBudgetExceededAt,
-          stalledForMs: Math.max(0, Date.now() - runtimeBudgetExceededAt),
+        void Promise.resolve(
+          onStalled({
+            runtimeBudgetExceededAt,
+            stalledForMs: Math.max(0, Date.now() - runtimeBudgetExceededAt),
+          }),
+        ).catch(() => {
+          // Diagnostic emission must never change task settlement behavior.
         });
       } catch {
         // Diagnostic emission must never change task settlement behavior.

--- a/lib/chat/active-runtime-budget.ts
+++ b/lib/chat/active-runtime-budget.ts
@@ -5,6 +5,55 @@ export type ActiveRuntimeBudget = {
   dispose: () => void;
 };
 
+export type RuntimeSettlementWatchdog = {
+  arm: (runtimeBudgetExceededAt?: number) => void;
+  dispose: () => void;
+};
+
+export function createRuntimeSettlementWatchdog({
+  delayMs,
+  onStalled,
+}: {
+  delayMs: number;
+  onStalled: (details: {
+    runtimeBudgetExceededAt: number;
+    stalledForMs: number;
+  }) => void;
+}): RuntimeSettlementWatchdog {
+  let armed = false;
+  let disposed = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const arm = (runtimeBudgetExceededAt = Date.now()) => {
+    if (armed || disposed) return;
+    armed = true;
+    timeoutId = setTimeout(() => {
+      timeoutId = undefined;
+      if (disposed) return;
+      try {
+        onStalled({
+          runtimeBudgetExceededAt,
+          stalledForMs: Math.max(0, Date.now() - runtimeBudgetExceededAt),
+        });
+      } catch {
+        // Diagnostic emission must never change task settlement behavior.
+      }
+    }, delayMs);
+    timeoutId.unref?.();
+  };
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+  };
+
+  return { arm, dispose };
+}
+
 export function createActiveRuntimeBudget({
   maxDurationMs,
   initialElapsedMs = 0,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -213,7 +213,9 @@ import {
 } from "@/lib/chat/agent-long-realtime-sanitizer";
 import {
   createActiveRuntimeBudget,
+  createRuntimeSettlementWatchdog,
   type ActiveRuntimeBudget,
+  type RuntimeSettlementWatchdog,
 } from "@/lib/chat/active-runtime-budget";
 import {
   AgentApprovalAuthorizationError,
@@ -248,6 +250,7 @@ import {
 const AGENT_LONG_FREE_MAX_DURATION_SECONDS = 60 * 60;
 const AGENT_LONG_PAID_MAX_DURATION_SECONDS = 2 * 60 * 60;
 const AGENT_LONG_CLEANUP_GRACE_MS = 2 * 60 * 1000;
+const AGENT_LONG_RUNTIME_SETTLEMENT_WATCHDOG_MS = 30 * 1000;
 const AGENT_LONG_TRIGGER_MAX_DURATION_SECONDS =
   AGENT_LONG_PAID_MAX_DURATION_SECONDS;
 
@@ -2191,6 +2194,7 @@ export const agentLongTask = task({
     });
 
     let activeRuntimeBudget: ActiveRuntimeBudget | undefined;
+    let runtimeSettlementWatchdog: RuntimeSettlementWatchdog | undefined;
 
     try {
       // Re-fetch from DB so we have fileTokens for summarization.
@@ -2324,10 +2328,65 @@ export const agentLongTask = task({
         initialElapsedMs: Date.now() - taskStartTime,
         onExceeded: () => {
           markAgentLongDurationExceeded();
+          runtimeSettlementWatchdog?.arm();
           userStopSignal.abort();
         },
       });
       activeRuntimeBudget = runtimeBudget;
+      runtimeSettlementWatchdog = createRuntimeSettlementWatchdog({
+        delayMs: AGENT_LONG_RUNTIME_SETTLEMENT_WATCHDOG_MS,
+        onStalled: ({ runtimeBudgetExceededAt, stalledForMs }) => {
+          const providerError =
+            getTerminalProviderStreamError(terminalAgentState);
+          const providerErrorSummary = providerError
+            ? classifyAgentLongError(providerError)
+            : undefined;
+          const triggerRunTelemetry = getTriggerRunTelemetry();
+          triggerLogger.error("[agent-long] runtime settlement stalled", {
+            timestamp: new Date().toISOString(),
+            level: "error",
+            event: "agent_long_runtime_settlement_stalled",
+            service: "agent-long",
+            environment:
+              process.env.TRIGGER_ENV ??
+              process.env.VERCEL_ENV ??
+              process.env.NODE_ENV ??
+              "unknown",
+            request_id: ctx.run.id,
+            run_id: ctx.run.id,
+            chat_id: chatId,
+            user_id: userId,
+            endpoint,
+            subscription,
+            runtime_budget_ms: agentLongMaxDurationMs,
+            cleanup_grace_ms: AGENT_LONG_CLEANUP_GRACE_MS,
+            runtime_budget_exceeded_at: new Date(
+              runtimeBudgetExceededAt,
+            ).toISOString(),
+            stalled_for_ms: stalledForMs,
+            stream_piped: streamPiped,
+            trigger_signal_aborted: triggerSignal.aborted,
+            stream_finish_reason:
+              terminalAgentState?.streamFinishReason ?? null,
+            provider_error_category: providerErrorSummary?.category ?? null,
+            provider_error_name: providerErrorSummary?.name ?? null,
+            provider_error_code: providerErrorSummary?.code ?? null,
+            agent_step_count: terminalAgentState?.agentStepCount ?? 0,
+            trigger_usage_duration_ms:
+              triggerRunTelemetry.triggerUsageDurationMs,
+            trigger_total_cost_usd: triggerRunTelemetry.triggerTotalCostUsd,
+            approval_wait_count: triggerRunTelemetry.approvalWaitCount,
+            approval_wait_duration_ms:
+              triggerRunTelemetry.approvalWaitDurationMs,
+            active_model_stream_duration_ms:
+              triggerRunTelemetry.activeModelStreamDurationMs,
+            active_terminal_wait_duration_ms:
+              triggerRunTelemetry.activeTerminalWaitDurationMs,
+            active_sandbox_recovery_duration_ms:
+              triggerRunTelemetry.activeSandboxRecoveryDurationMs,
+          });
+        },
+      });
 
       // Rate limit check happens inside execute so a thrown ChatSDKError
       // (e.g. "exceeded daily messages") flows through createUIMessageStream's
@@ -4363,6 +4422,7 @@ export const agentLongTask = task({
 
       throw error;
     } finally {
+      runtimeSettlementWatchdog?.dispose();
       memoryTelemetry.dispose();
       activeRuntimeBudget?.dispose();
       runCleanupMap.delete(ctx.run.id);


### PR DESCRIPTION
## Summary
- arm one task-run-scoped diagnostic watchdog when Agent active runtime reaches its soft cap
- emit one bounded `agent_long_runtime_settlement_stalled` error only when cleanup still has not begun after 30 seconds
- dispose the watchdog on every existing `finally` path and make diagnostic failure behavior-neutral

## Production evidence
Frozen audit window: `2026-08-10T20:02:27.177Z` through `2026-08-11T20:02:27.177Z`.

Trigger.dev run `run_06fv1ptem94dbb82qilhci5hc1` logged `Provider stream terminated`, followed by two local command stream sequence-gap errors. No fallback, approval/session wait, active-runtime marker, finish, `onFinish`, `stream_finished`, `run_failed`, or settlement event followed. Two-minute memory checkpoints continued until the 7,200-second task cap, while both the task and realtime `streams.pipe()` spans remained in progress.

This establishes an observability gap around the existing two-minute cleanup grace. It does not yet establish a safe stream-cancellation fix, so this PR adds attribution without changing Agent execution.

## Change
The watchdog is scoped to the whole Trigger task run, not an individual provider request or helper call. It records:
- opaque run/request, chat, and user correlation
- endpoint, subscription, runtime budget, grace, and stall duration
- bounded provider error category/name/code and finish reason
- model, terminal, sandbox-recovery, and approval-wait timing aggregates
- Trigger usage duration and cost already available in-process

It never logs prompts, targets, commands, tool output, URLs, payloads, or file content. It makes no network/provider call and does not change retries, model routing, billing, persistence, task duration, machine size, cancellation, approval waits, or settlement behavior.

## Validation
- `pnpm jest lib/chat/__tests__/active-runtime-budget.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 2 suites / 91 tests
- `pnpm typecheck`
- changed-file ESLint
- changed-file Prettier
- `pnpm check:local-dependencies`
- unbypassed commit hook — 349 suites / 3,566 tests

## Manual verification
After deployment, watch the next naturally occurring Agent run that exceeds active runtime:
1. In Trigger.dev production logs, filter for `agent_long_runtime_settlement_stalled`.
2. A run that enters cleanup within 30 seconds should emit no event.
3. A still-stalled run should emit exactly one event with bounded phase/correlation fields and no user content.

A forced two-hour provider smoke was not run because it would be billable and is unnecessary for this logging-only change. Browser visual QA is not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of runs that stall after runtime limits are exceeded.
  * Added a 30-second safeguard to detect stalled execution and report diagnostic details.
  * Ensured stalled-run diagnostics do not interrupt cleanup or normal operation.
  * Prevented duplicate alerts and cleared monitoring when tasks finish.
  * Preserved the original runtime-limit timestamp for more accurate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->