### PR TITLE
Show generated commands during automatic review

### DIFF
--- a/app/components/ComputerSidebar.tsx
+++ b/app/components/ComputerSidebar.tsx
@@ -666,6 +666,7 @@ export const ComputerSidebarBase: React.FC<ComputerSidebarProps> = ({
                           wrap={isWrapped}
                           shellAction={resolvedTerminal.shellAction}
                           rawBytes={resolvedTerminal.rawBytes}
+                          executionPhase={resolvedTerminal.executionPhase}
                         />
                       )}
                       {isProxy && resolvedProxy && (

--- a/app/components/TerminalCodeBlock.tsx
+++ b/app/components/TerminalCodeBlock.tsx
@@ -7,6 +7,7 @@ import { codeToHtml } from "shiki";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { isInteractiveShellAction } from "@/app/components/tools/shell-tool-utils";
 import { isWebAssemblyAvailable } from "@/lib/utils/shiki";
+import type { SidebarTerminal } from "@/types/chat";
 
 const XtermRenderer = dynamic(
   () => import("./XtermRenderer").then((m) => m.XtermRenderer),
@@ -23,6 +24,7 @@ interface TerminalCodeBlockProps {
   wrap?: boolean;
   shellAction?: string;
   rawBytes?: string; // Raw PTY bytes for xterm rendering
+  executionPhase?: SidebarTerminal["executionPhase"];
 }
 
 interface AnsiCodeBlockProps {
@@ -226,6 +228,7 @@ export const TerminalCodeBlock = ({
   wrap = false,
   shellAction,
   rawBytes,
+  executionPhase,
 }: TerminalCodeBlockProps) => {
   const [isWrapped, setIsWrapped] = useState(wrap);
 
@@ -304,6 +307,12 @@ export const TerminalCodeBlock = ({
   // actions or run_terminal_cmd interactive=true) where cursor-movement / TUI rendering
   // matters. Non-interactive exec falls through to AnsiCodeBlock (shiki).
   const useXterm = rawBytes !== undefined;
+  const preExecutionLabel =
+    executionPhase === "reviewing"
+      ? "Reviewing before execution…"
+      : executionPhase === "awaiting_approval"
+        ? "Awaiting approval…"
+        : undefined;
 
   return (
     <div className="shiki not-prose relative h-full w-full bg-transparent overflow-hidden">
@@ -312,7 +321,22 @@ export const TerminalCodeBlock = ({
       <div
         className={`h-full w-full bg-background ${useXterm ? "overflow-hidden" : "overflow-auto"}`}
       >
-        {isExecuting && !output && status === "streaming" ? (
+        {preExecutionLabel ? (
+          <div className="h-full w-full overflow-auto px-[1em] py-[1em] text-sm font-[450] text-card-foreground">
+            <pre
+              className={`m-0 font-mono ${
+                isWrapped
+                  ? "whitespace-pre-wrap break-words"
+                  : "whitespace-pre overflow-x-auto"
+              }`}
+            >
+              <code>{`${commandPrefix} ${command}`}</code>
+            </pre>
+            <div className="mt-3 text-muted-foreground">
+              {preExecutionLabel}
+            </div>
+          </div>
+        ) : isExecuting && !output && status === "streaming" ? (
           isInteractiveAction ? (
             <div className="px-4 py-4 text-muted-foreground h-full flex items-start">
               <Shimmer>Waiting for output</Shimmer>

--- a/app/components/__tests__/TerminalCodeBlock.review.test.tsx
+++ b/app/components/__tests__/TerminalCodeBlock.review.test.tsx
@@ -1,0 +1,27 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => () => null,
+}));
+
+import { TerminalCodeBlock } from "../TerminalCodeBlock";
+
+describe("TerminalCodeBlock automatic review preview", () => {
+  it("shows the exact command before execution starts", () => {
+    render(
+      <TerminalCodeBlock
+        command="wafw00f https://hackerone.com"
+        executionPhase="reviewing"
+        isExecuting={false}
+        status="ready"
+        variant="sidebar"
+      />,
+    );
+
+    expect(screen.getByText("$ wafw00f https://hackerone.com")).toBeVisible();
+    expect(screen.getByText("Reviewing before execution…")).toBeVisible();
+    expect(screen.queryByText("Executing command")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/__tests__/computer-sidebar-utils.test.tsx
+++ b/app/components/__tests__/computer-sidebar-utils.test.tsx
@@ -1,0 +1,19 @@
+import { getActionText } from "../computer-sidebar-utils";
+
+describe("terminal Computer sidebar labels", () => {
+  const terminal = {
+    command: "wafw00f https://hackerone.com",
+    output: "",
+    isExecuting: false,
+    toolCallId: "call-1",
+  };
+
+  it("labels review without implying the command is executing", () => {
+    expect(getActionText({ ...terminal, executionPhase: "reviewing" })).toBe(
+      "Reviewing",
+    );
+    expect(
+      getActionText({ ...terminal, executionPhase: "awaiting_approval" }),
+    ).toBe("Awaiting approval");
+  });
+});

--- a/app/components/computer-sidebar-utils.tsx
+++ b/app/components/computer-sidebar-utils.tsx
@@ -131,6 +131,11 @@ export function getActionText(content: SidebarContent): string {
   }
 
   if (isSidebarTerminal(content)) {
+    if (content.executionPhase === "reviewing") return "Reviewing";
+    if (content.executionPhase === "awaiting_approval") {
+      return "Awaiting approval";
+    }
+    if (content.executionPhase === "failed") return "Command failed";
     return getShellActionLabel({
       isShellTool: !!content.shellAction,
       action: content.shellAction,

--- a/app/components/tools/FileHandler.tsx
+++ b/app/components/tools/FileHandler.tsx
@@ -529,7 +529,7 @@ export const FileHandler = memo(function FileHandler({
             key={toolCallId}
             icon={<FilePlus />}
             action={autoReviewDisplay?.action ?? briefLabel("Writing to")}
-            target={autoReviewDisplay ? undefined : briefTarget(input?.path)}
+            target={briefTarget(input?.path)}
             isShimmer={autoReviewDisplay?.isShimmer ?? true}
             isClickable={isClickable}
             onClick={isClickable ? handleOpenInSidebar : undefined}
@@ -623,7 +623,7 @@ export const FileHandler = memo(function FileHandler({
             key={toolCallId}
             icon={<FileOutput />}
             action={autoReviewDisplay?.action ?? briefLabel("Appending to")}
-            target={autoReviewDisplay ? undefined : briefTarget(input?.path)}
+            target={briefTarget(input?.path)}
             isShimmer={autoReviewDisplay?.isShimmer ?? true}
             isClickable={isClickable}
             onClick={isClickable ? handleOpenInSidebar : undefined}
@@ -707,7 +707,7 @@ export const FileHandler = memo(function FileHandler({
                   : "Editing",
               )
             }
-            target={autoReviewDisplay ? undefined : briefTarget(input?.path)}
+            target={briefTarget(input?.path)}
             isShimmer={autoReviewDisplay?.isShimmer ?? true}
           />
         ) : null;

--- a/app/components/tools/TerminalToolHandler.tsx
+++ b/app/components/tools/TerminalToolHandler.tsx
@@ -7,6 +7,7 @@ import { isSidebarTerminal } from "@/types/chat";
 import { useToolSidebar } from "../../hooks/useToolSidebar";
 import {
   computeShellTerminalBlock,
+  getTerminalExecutionPhase,
   getTerminalFailureAction,
   getShellDisplayCommand,
   getStreamingTerminalOutput,
@@ -16,6 +17,7 @@ import {
 import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 import {
   getAgentAutoReviewDisplayState,
+  getStreamedAgentAutoReviewLifecycle,
   getStreamedAgentAutoReviewSummary,
   getToolApprovalDisplayState,
   getToolApprovalDisplayTarget,
@@ -90,13 +92,27 @@ export const TerminalToolHandler = memo(function TerminalToolHandler({
       }),
     [message.parts, part.approval?.id, toolCallId],
   );
-  const autoReviewLifecycle = useAgentAutoReviewLifecycleDisplay({
+  const streamedAutoReviewLifecycle = useMemo(
+    () =>
+      getStreamedAgentAutoReviewLifecycle({
+        parts: message.parts,
+        toolCallId,
+      }),
+    [message.parts, toolCallId],
+  );
+  const autoReviewLifecycleDisplay = useAgentAutoReviewLifecycleDisplay({
     parts: message.parts,
     toolCallId,
   });
-  const autoReviewDisplay = getAgentAutoReviewDisplayState(autoReviewLifecycle);
+  const autoReviewDisplay = getAgentAutoReviewDisplayState(
+    autoReviewLifecycleDisplay,
+  );
 
-  const isExecuting = state === "input-available" && status === "streaming";
+  const executionPhase = getTerminalExecutionPhase({
+    toolState: state,
+    autoReviewStatus: streamedAutoReviewLifecycle?.status,
+  });
+  const isExecuting = executionPhase === "executing";
   const hasResult = state === "output-available";
 
   const { blockAction, blockTarget, sidebarContent } = useMemo(
@@ -117,6 +133,7 @@ export const TerminalToolHandler = memo(function TerminalToolHandler({
           ? terminalInput?.is_background
           : undefined,
         legacyCommand: !isShellTool ? terminalInput?.command : undefined,
+        executionPhase,
       }),
     [
       isShellTool,
@@ -130,6 +147,7 @@ export const TerminalToolHandler = memo(function TerminalToolHandler({
       terminalInput?.interactive,
       terminalInput?.is_background,
       terminalInput?.command,
+      executionPhase,
     ],
   );
 
@@ -175,7 +193,7 @@ export const TerminalToolHandler = memo(function TerminalToolHandler({
           action={
             autoReviewDisplay?.action ?? blockAction(status === "streaming")
           }
-          target={autoReviewDisplay ? undefined : blockTarget}
+          target={blockTarget}
           isShimmer={autoReviewDisplay?.isShimmer ?? status === "streaming"}
           isClickable
           onClick={handleOpenInSidebar}

--- a/app/components/tools/ToolApprovalControls.tsx
+++ b/app/components/tools/ToolApprovalControls.tsx
@@ -33,10 +33,8 @@ type AgentAutoReviewLifecycleDataPart = {
 };
 
 export const AGENT_AUTO_REVIEW_DISPLAY_DELAY_MS = 450;
-export const AGENT_AUTO_REVIEW_APPROVED_DISPLAY_MS = 900;
 
-export type AgentAutoReviewLifecycleDisplay =
-  "reviewing" | "approved" | "needs_approval";
+export type AgentAutoReviewLifecycleDisplay = "reviewing" | "needs_approval";
 
 export const getStreamedAgentAutoReviewLifecycle = ({
   parts,
@@ -99,27 +97,21 @@ export const useAgentAutoReviewLifecycleDisplay = ({
       return () => clearTimeout(timeout);
     }
 
-    if (!reviewWasVisibleRef.current || lifecycleStatus === "dismissed") {
+    if (lifecycleStatus === "approved" || lifecycleStatus === "dismissed") {
       return;
     }
 
-    let hideTimeout: ReturnType<typeof setTimeout> | undefined;
+    if (!reviewWasVisibleRef.current) {
+      return;
+    }
+
     const showTimeout = setTimeout(() => {
       setDisplay({
         approvalId: lifecycleApprovalId,
         status: lifecycleStatus,
       });
-      if (lifecycleStatus === "approved") {
-        hideTimeout = setTimeout(
-          () => setDisplay(undefined),
-          AGENT_AUTO_REVIEW_APPROVED_DISPLAY_MS,
-        );
-      }
     }, 0);
-    return () => {
-      clearTimeout(showTimeout);
-      if (hideTimeout) clearTimeout(hideTimeout);
-    };
+    return () => clearTimeout(showTimeout);
   }, [lifecycleApprovalId, lifecycleStartedAt, lifecycleStatus]);
 
   return lifecycle &&
@@ -131,13 +123,11 @@ export const useAgentAutoReviewLifecycleDisplay = ({
 };
 
 export const getAgentAutoReviewDisplayState = (
-  display: AgentAutoReviewLifecycleDisplay | undefined,
+  display: AgentAutoReviewLifecycle["status"] | undefined,
 ): { action: string; isShimmer: boolean } | undefined => {
   switch (display) {
     case "reviewing":
-      return { action: "Reviewing action", isShimmer: false };
-    case "approved":
-      return { action: "Approved automatically", isShimmer: false };
+      return { action: "Reviewing", isShimmer: false };
     case "needs_approval":
       return { action: "Needs your approval", isShimmer: false };
     default:
@@ -202,15 +192,12 @@ export function getToolApprovalDisplayState({
 }
 
 export function getToolApprovalDisplayTarget({
-  sendState,
   target,
 }: {
   sendState: AgentApprovalSendState;
   target?: string;
 }): string | undefined {
-  return sendState === "approved" || sendState === "denied"
-    ? target
-    : undefined;
+  return target;
 }
 
 export function ToolApprovalControls({

--- a/app/components/tools/__tests__/ToolApprovalControls.test.tsx
+++ b/app/components/tools/__tests__/ToolApprovalControls.test.tsx
@@ -279,7 +279,7 @@ describe("ToolApprovalControls", () => {
     jest.useRealTimers();
   });
 
-  it("shows delayed review progress and a brief automatic approval", () => {
+  it("shows delayed review progress and removes it after automatic approval", () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date("2026-08-10T12:00:00.000Z"));
     const startedAt = Date.now();
@@ -315,9 +315,6 @@ describe("ToolApprovalControls", () => {
       ],
     });
     act(() => jest.advanceTimersByTime(0));
-    expect(result.current).toBe("approved");
-
-    act(() => jest.advanceTimersByTime(900));
     expect(result.current).toBeUndefined();
     jest.useRealTimers();
   });
@@ -386,27 +383,23 @@ describe("ToolApprovalControls", () => {
 
   it("keeps lifecycle labels lightweight and free of additional motion", () => {
     expect(getAgentAutoReviewDisplayState("reviewing")).toEqual({
-      action: "Reviewing action",
+      action: "Reviewing",
       isShimmer: false,
     });
-    expect(getAgentAutoReviewDisplayState("approved")).toEqual({
-      action: "Approved automatically",
-      isShimmer: false,
-    });
+    expect(getAgentAutoReviewDisplayState("approved")).toBeUndefined();
     expect(getAgentAutoReviewDisplayState("needs_approval")).toEqual({
       action: "Needs your approval",
       isShimmer: false,
     });
   });
 
-  it("shows the target in the tool row only after the approval decision", () => {
-    for (const sendState of ["idle", "sending"] as const) {
-      expect(
-        getToolApprovalDisplayTarget({ sendState, target: "rm -rf /tmp/test" }),
-      ).toBeUndefined();
-    }
-
-    for (const sendState of ["approved", "denied"] as const) {
+  it("keeps the exact target visible throughout approval", () => {
+    for (const sendState of [
+      "idle",
+      "sending",
+      "approved",
+      "denied",
+    ] as const) {
       expect(
         getToolApprovalDisplayTarget({ sendState, target: "rm -rf /tmp/test" }),
       ).toBe("rm -rf /tmp/test");

--- a/app/components/tools/__tests__/shell-tool-utils.test.ts
+++ b/app/components/tools/__tests__/shell-tool-utils.test.ts
@@ -1,5 +1,6 @@
 import {
   computeShellTerminalBlock,
+  getTerminalExecutionPhase,
   getTerminalFailureAction,
   isToolInputValidationError,
   stripAgentOnlyTerminalGuidance,
@@ -8,6 +9,33 @@ import {
 describe("terminal shell tool display helpers", () => {
   const validationError =
     "Invalid input for tool run_terminal_cmd: Type validation failed: Value: {}.";
+
+  it("keeps review separate from process execution", () => {
+    expect(
+      getTerminalExecutionPhase({
+        toolState: "input-available",
+        autoReviewStatus: "reviewing",
+      }),
+    ).toBe("reviewing");
+    expect(
+      getTerminalExecutionPhase({
+        toolState: "input-available",
+        autoReviewStatus: "approved",
+      }),
+    ).toBe("executing");
+    expect(
+      getTerminalExecutionPhase({
+        toolState: "approval-requested",
+        autoReviewStatus: "needs_approval",
+      }),
+    ).toBe("awaiting_approval");
+    expect(
+      getTerminalExecutionPhase({
+        toolState: "output-available",
+        autoReviewStatus: "reviewing",
+      }),
+    ).toBe("completed");
+  });
 
   it("classifies tool input validation errors as invalid commands", () => {
     expect(isToolInputValidationError(validationError)).toBe(true);
@@ -31,6 +59,7 @@ describe("terminal shell tool display helpers", () => {
       hasResult: false,
       toolCallId: "call-empty",
       legacyCommand: undefined,
+      executionPhase: "failed",
     });
 
     expect(result.blockAction(false)).toBe("Invalid command");
@@ -40,6 +69,7 @@ describe("terminal shell tool display helpers", () => {
       command: "Invalid command",
       output: validationError,
       toolCallId: "call-empty",
+      executionPhase: "failed",
     });
   });
 

--- a/app/components/tools/shell-tool-utils.ts
+++ b/app/components/tools/shell-tool-utils.ts
@@ -5,13 +5,39 @@
  * SharedMessagePartHandler (shared/read-only view).
  */
 
-import type { SidebarTerminal } from "@/types/chat";
+import type { AgentAutoReviewLifecycleStatus, SidebarTerminal } from "@/types";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export type ShellAction = "exec" | "view" | "wait" | "send" | "kill";
+
+export type TerminalExecutionPhase = NonNullable<
+  SidebarTerminal["executionPhase"]
+>;
+
+export function getTerminalExecutionPhase({
+  toolState,
+  autoReviewStatus,
+}: {
+  toolState?: string;
+  autoReviewStatus?: AgentAutoReviewLifecycleStatus;
+}): TerminalExecutionPhase | undefined {
+  if (toolState === "output-error") return "failed";
+  if (toolState === "output-available") return "completed";
+  if (
+    toolState === "approval-requested" ||
+    autoReviewStatus === "needs_approval"
+  ) {
+    return "awaiting_approval";
+  }
+  if (autoReviewStatus === "reviewing") return "reviewing";
+  if (toolState === "input-available" || toolState === "running") {
+    return "executing";
+  }
+  return undefined;
+}
 
 export interface ShellToolInput {
   command?: string;
@@ -360,6 +386,7 @@ export interface ComputeShellBlockArgs {
   legacyIsBackground?: boolean;
   /** Legacy run_terminal_cmd: input.command. */
   legacyCommand?: string;
+  executionPhase?: TerminalExecutionPhase;
 }
 
 export interface ShellBlockComputed {
@@ -386,6 +413,7 @@ export function computeShellTerminalBlock(
     legacyInteractive,
     legacyIsBackground,
     legacyCommand,
+    executionPhase,
   } = args;
 
   const shellAction = isShellTool ? shellInput?.action : undefined;
@@ -460,6 +488,7 @@ export function computeShellTerminalBlock(
           command: isInteractiveAction ? displayTarget : displayCommand,
           output: stripAgentOnlyTerminalGuidance(finalOutput),
           isExecuting,
+          executionPhase,
           isBackground: !isShellTool ? legacyIsBackground : undefined,
           isInteractive: !isShellTool ? legacyInteractive : undefined,
           toolCallId,

--- a/docs/agent-auto-review.md
+++ b/docs/agent-auto-review.md
@@ -71,12 +71,11 @@ condition. After merge, enable shadow for an explicit internal allowlist, then
 expand shadow and enforcement only after the HAC-61 guardrails are healthy.
 Disabling the flag immediately restores human approval for Approve for me users.
 
-PR previews can opt in independently of production identity and flag state by
-setting the server-only `AGENT_AUTO_REVIEW_PREVIEW_PHASE` environment variable
-to `shadow` or `enforce` for that preview branch. The override is ignored unless
-`VERCEL_ENV=preview`; production and local development continue to fail closed
-through the PostHog assignment path. Remove the branch-scoped variable when the
-preview is no longer needed.
+Every Vercel preview uses `enforce` independently of PostHog project, identity,
+flag state, or branch-scoped environment variables. This keeps feature previews
+directly testable without changing production rollout configuration. Production
+and local development continue to fail closed through the PostHog assignment
+path.
 
 Review on 2026-08-23 UTC. After full rollout and one stable review window,
 remove the flag evaluation and shadow comparison plumbing. If guardrails fail,

--- a/lib/experiments/__tests__/agent-auto-review.test.ts
+++ b/lib/experiments/__tests__/agent-auto-review.test.ts
@@ -8,41 +8,21 @@ import {
 
 describe("Agent Auto review flag", () => {
   describe("preview assignment", () => {
-    it.each(["shadow", "enforce"] as const)(
-      "accepts an explicit %s override only on Vercel previews",
-      (phase) => {
-        expect(
-          resolveAgentAutoReviewPreviewAssignment({
-            VERCEL_ENV: "preview",
-            AGENT_AUTO_REVIEW_PREVIEW_PHASE: phase,
-          }),
-        ).toEqual({ key: AGENT_AUTO_REVIEW_FLAG_KEY, phase });
-        expect(
-          resolveAgentAutoReviewPreviewAssignment({
-            VERCEL_ENV: "production",
-            AGENT_AUTO_REVIEW_PREVIEW_PHASE: phase,
-          }),
-        ).toBeUndefined();
-      },
-    );
+    it("enables enforcement on every Vercel preview", () => {
+      expect(
+        resolveAgentAutoReviewPreviewAssignment({ VERCEL_ENV: "preview" }),
+      ).toEqual({ key: AGENT_AUTO_REVIEW_FLAG_KEY, phase: "enforce" });
+      expect(
+        resolveAgentAutoReviewPreviewAssignment({ VERCEL_ENV: "production" }),
+      ).toBeUndefined();
+      expect(
+        resolveAgentAutoReviewPreviewAssignment({ VERCEL_ENV: "development" }),
+      ).toBeUndefined();
+    });
 
-    it.each([undefined, "", "approve", "true"])(
-      "fails closed for a malformed preview override: %p",
-      (phase) => {
-        expect(
-          resolveAgentAutoReviewPreviewAssignment({
-            VERCEL_ENV: "preview",
-            AGENT_AUTO_REVIEW_PREVIEW_PHASE: phase,
-          }),
-        ).toBeUndefined();
-      },
-    );
-
-    it("does not require PostHog for an explicit preview assignment", async () => {
+    it("does not require PostHog for a preview assignment", async () => {
       const previousVercelEnv = process.env.VERCEL_ENV;
-      const previousPreviewPhase = process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE;
       process.env.VERCEL_ENV = "preview";
-      process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE = "enforce";
 
       try {
         await expect(
@@ -60,19 +40,12 @@ describe("Agent Auto review flag", () => {
         } else {
           process.env.VERCEL_ENV = previousVercelEnv;
         }
-        if (previousPreviewPhase === undefined) {
-          delete process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE;
-        } else {
-          process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE = previousPreviewPhase;
-        }
       }
     });
 
-    it("fails closed when preview exposure capture throws", async () => {
+    it("does not call PostHog when resolving preview availability", async () => {
       const previousVercelEnv = process.env.VERCEL_ENV;
-      const previousPreviewPhase = process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE;
       process.env.VERCEL_ENV = "preview";
-      process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE = "enforce";
       const posthog = {
         evaluateFlags: jest.fn(),
         capture: jest.fn(() => {
@@ -87,18 +60,17 @@ describe("Agent Auto review flag", () => {
             userId: "development-user",
             captureExposure: true,
           }),
-        ).resolves.toBeUndefined();
+        ).resolves.toEqual({
+          key: AGENT_AUTO_REVIEW_FLAG_KEY,
+          phase: "enforce",
+        });
         expect(posthog.evaluateFlags).not.toHaveBeenCalled();
+        expect(posthog.capture).not.toHaveBeenCalled();
       } finally {
         if (previousVercelEnv === undefined) {
           delete process.env.VERCEL_ENV;
         } else {
           process.env.VERCEL_ENV = previousVercelEnv;
-        }
-        if (previousPreviewPhase === undefined) {
-          delete process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE;
-        } else {
-          process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE = previousPreviewPhase;
         }
       }
     });

--- a/lib/experiments/agent-auto-review.ts
+++ b/lib/experiments/agent-auto-review.ts
@@ -5,8 +5,6 @@ import type { AgentAutoReviewRolloutPhase } from "@/types";
 export const AGENT_AUTO_REVIEW_FLAG_KEY = "agent_auto_review_v1";
 export const AGENT_AUTO_REVIEW_EXPOSURE_EVENT = "agent_auto_review_exposed";
 export const AGENT_AUTO_REVIEW_FEATURE_PROPERTY = `$feature/${AGENT_AUTO_REVIEW_FLAG_KEY}`;
-export const AGENT_AUTO_REVIEW_PREVIEW_PHASE_ENV =
-  "AGENT_AUTO_REVIEW_PREVIEW_PHASE";
 
 export type AgentAutoReviewAssignment = {
   key: typeof AGENT_AUTO_REVIEW_FLAG_KEY;
@@ -15,22 +13,15 @@ export type AgentAutoReviewAssignment = {
 
 type AgentAutoReviewEnvironment = {
   VERCEL_ENV?: string;
-  AGENT_AUTO_REVIEW_PREVIEW_PHASE?: string;
 };
 
 export function resolveAgentAutoReviewPreviewAssignment(
   environment: AgentAutoReviewEnvironment = {
     VERCEL_ENV: process.env.VERCEL_ENV,
-    AGENT_AUTO_REVIEW_PREVIEW_PHASE:
-      process.env.AGENT_AUTO_REVIEW_PREVIEW_PHASE,
   },
 ): AgentAutoReviewAssignment | undefined {
   if (environment.VERCEL_ENV !== "preview") return undefined;
-
-  const phase = environment.AGENT_AUTO_REVIEW_PREVIEW_PHASE;
-  if (phase !== "shadow" && phase !== "enforce") return undefined;
-
-  return { key: AGENT_AUTO_REVIEW_FLAG_KEY, phase };
+  return { key: AGENT_AUTO_REVIEW_FLAG_KEY, phase: "enforce" };
 }
 
 export async function evaluateAgentAutoReviewFlag({
@@ -46,21 +37,7 @@ export async function evaluateAgentAutoReviewFlag({
 }): Promise<AgentAutoReviewAssignment | undefined> {
   try {
     const previewAssignment = resolveAgentAutoReviewPreviewAssignment();
-    if (previewAssignment) {
-      if (captureExposure && posthog) {
-        posthog.capture({
-          distinctId: userId,
-          event: AGENT_AUTO_REVIEW_EXPOSURE_EVENT,
-          properties: {
-            rollout_phase: previewAssignment.phase,
-            surface,
-            [AGENT_AUTO_REVIEW_FEATURE_PROPERTY]: previewAssignment.phase,
-            $process_person_profile: false,
-          },
-        });
-      }
-      return previewAssignment;
-    }
+    if (previewAssignment) return previewAssignment;
 
     if (!posthog) return undefined;
 

--- a/lib/utils/__tests__/sidebar-utils.test.ts
+++ b/lib/utils/__tests__/sidebar-utils.test.ts
@@ -1,6 +1,39 @@
 import { extractSidebarContentFromMessage } from "../sidebar-utils";
 
 describe("terminal sidebar output", () => {
+  it("shows the generated command while automatic review is still pending", () => {
+    const startedAt = Date.now();
+    const [terminal] = extractSidebarContentFromMessage({
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-shell",
+          toolCallId: "call-reviewing",
+          state: "input-available",
+          input: {
+            action: "exec",
+            command: "wafw00f https://hackerone.com",
+          },
+        },
+        {
+          type: "data-agent-auto-review-lifecycle",
+          data: {
+            approvalId: "approval-1",
+            toolCallId: "call-reviewing",
+            status: "reviewing",
+            startedAt,
+          },
+        },
+      ],
+    });
+
+    expect(terminal).toMatchObject({
+      command: "wafw00f https://hackerone.com",
+      executionPhase: "reviewing",
+      isExecuting: false,
+    });
+  });
+
   it("hides agent-only timeout guidance in fallback sidebar extraction", () => {
     const [terminal] = extractSidebarContentFromMessage({
       role: "assistant",

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -7,9 +7,11 @@ import {
 } from "@/types/chat";
 import {
   formatSendInput,
+  getTerminalExecutionPhase,
   isInteractiveShellAction,
   stripAgentOnlyTerminalGuidance,
 } from "@/app/components/tools/shell-tool-utils";
+import { parseAgentAutoReviewLifecycle } from "@/types";
 
 interface MessagePart {
   type: string;
@@ -44,6 +46,10 @@ export function extractSidebarContentFromMessage(
 
   // Collect terminal output from data-terminal parts (for streaming)
   const terminalDataMap = new Map<string, string>();
+  const autoReviewStatusByToolCallId = new Map<
+    string,
+    NonNullable<ReturnType<typeof parseAgentAutoReviewLifecycle>>["status"]
+  >();
   // Collect diff data from data-diff parts (for search_replace UI-only diff display)
   const diffDataMap = new Map<
     string,
@@ -56,6 +62,15 @@ export function extractSidebarContentFromMessage(
       const terminalOutput = part.data?.terminal || "";
       const existing = terminalDataMap.get(toolCallId) || "";
       terminalDataMap.set(toolCallId, existing + terminalOutput);
+    }
+    if (part.type === "data-agent-auto-review-lifecycle") {
+      const lifecycle = parseAgentAutoReviewLifecycle(part.data);
+      if (lifecycle) {
+        autoReviewStatusByToolCallId.set(
+          lifecycle.toolCallId,
+          lifecycle.status,
+        );
+      }
     }
     if (part.type === "data-diff" && part.data?.toolCallId) {
       const toolCallId = part.data.toolCallId;
@@ -88,6 +103,12 @@ export function extractSidebarContentFromMessage(
       part.input
     ) {
       const action = part.input.action || "exec";
+      const executionPhase = getTerminalExecutionPhase({
+        toolState: part.state,
+        autoReviewStatus: autoReviewStatusByToolCallId.get(
+          part.toolCallId || "",
+        ),
+      });
       const isInteractive =
         isInteractiveShellAction(action) || !!part.input.interactive;
       // For action=send, format each token through formatSendInput (same
@@ -159,8 +180,8 @@ export function extractSidebarContentFromMessage(
       contentList.push({
         command,
         output: stripAgentOnlyTerminalGuidance(finalOutput),
-        isExecuting:
-          part.state === "input-available" || part.state === "running",
+        isExecuting: executionPhase === "executing",
+        executionPhase,
         isBackground: part.input.is_background,
         toolCallId: part.toolCallId || "",
         rawBytes: effectiveRawBytes,
@@ -178,6 +199,12 @@ export function extractSidebarContentFromMessage(
     // Shell tool (new interactive PTY-based shell)
     if (part.type === "tool-shell" && part.input) {
       const command = part.input.command || part.input.brief || "";
+      const executionPhase = getTerminalExecutionPhase({
+        toolState: part.state,
+        autoReviewStatus: autoReviewStatusByToolCallId.get(
+          part.toolCallId || "",
+        ),
+      });
 
       // Skip if no command/brief available yet
       if (!command) return;
@@ -207,8 +234,8 @@ export function extractSidebarContentFromMessage(
       contentList.push({
         command,
         output: stripAgentOnlyTerminalGuidance(finalOutput),
-        isExecuting:
-          part.state === "input-available" || part.state === "running",
+        isExecuting: executionPhase === "executing",
+        executionPhase,
         isBackground: false,
         toolCallId: part.toolCallId || "",
         shellAction: part.input.action,
@@ -235,12 +262,18 @@ export function extractSidebarContentFromMessage(
       }
 
       const finalOutput = output || streamingOutput || "";
+      const executionPhase = getTerminalExecutionPhase({
+        toolState: part.state,
+        autoReviewStatus: autoReviewStatusByToolCallId.get(
+          part.toolCallId || "",
+        ),
+      });
 
       contentList.push({
         command,
         output: finalOutput,
-        isExecuting:
-          part.state === "input-available" || part.state === "running",
+        isExecuting: executionPhase === "executing",
+        executionPhase,
         isBackground: false,
         toolCallId: part.toolCallId || "",
       });

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -285,6 +285,9 @@ export interface SidebarTerminal {
   command: string;
   output: string;
   isExecuting: boolean;
+  /** Distinguishes approval review from actual process execution. */
+  executionPhase?:
+    "reviewing" | "awaiting_approval" | "executing" | "completed" | "failed";
   isBackground?: boolean;
   /** Legacy run_terminal_cmd: input.interactive — true if PTY-backed session. */
   isInteractive?: boolean;


### PR DESCRIPTION
## Summary
- show the exact terminal command or file target while Approve for me is reviewing it
- distinguish review, approval, execution, completion, and failure in Computer sidebar state
- remove the transient “Approved automatically” completion state so successful reviews disappear without adding per-tool completion UI
- enable Approve for me on every Vercel preview without PostHog flags or branch-scoped environment variables
- add focused coverage for review lifecycle, preview assignment, sidebar extraction, labels, and terminal preview

## Why
The AI SDK marks a tool input as available before approval completes. The UI treated that state as active execution and hid the generated target while auto-review was running, so a harmless request such as `get waf for hackerone.com` looked like an unexplained terminal approval/execution step.

Preview availability also depended on both a PostHog assignment and a branch-scoped `AGENT_AUTO_REVIEW_PREVIEW_PHASE` variable. That made new PR previews hide the feature unless external rollout configuration was duplicated for every branch.

## User impact
Users can inspect what the Agent generated immediately in chat and Computer. “Reviewing” is clearly separate from execution, and successful automatic reviews transition directly into the normal terminal lifecycle without a permanent checkmark or approval row.

Every Vercel preview now defaults to the `enforce` phase before PostHog evaluation. Production remains controlled by the production PostHog flag.

## Validation
- `pnpm test --runInBand` — 351 suites, 3,567 tests passed
- `pnpm typecheck`
- `pnpm lint` — no errors; five existing warnings
- focused preview/auto-review tests — 3 suites, 25 tests passed
- focused auto-review/sidebar tests — 5 suites, 35 tests passed
- Prettier check and `git diff --check`
- Google Chrome visual verification using the real `ToolBlock` and `TerminalCodeBlock` components

## Manual verification
1. Open any Vercel PR preview without configuring a PostHog flag or `AGENT_AUTO_REVIEW_PREVIEW_PHASE`.
2. In Agent mode, confirm **Approve for me** is available.
3. Ask `get waf for hackerone.com`.
4. During review, confirm chat shows **Reviewing** plus the exact command and Computer shows `$ wafw00f https://hackerone.com` before execution.
5. Confirm an approved review disappears into normal execution without a completed-review checkmark; a review requiring user approval should show the existing approval prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal actions now clearly show whether they are under review, awaiting approval, executing, completed, or failed.
  * Review and approval states display the exact command and appropriate status messaging before execution.
  * Command targets remain visible during automatic review.
  * Vercel previews now consistently use enforced automatic review.
* **Bug Fixes**
  * Automatic review indicators disappear immediately after approval.
  * Failed and completed terminal states are displayed more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->