### PR TITLE
Experiment with Grok 4.6 for Pro Agent

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -34,6 +34,10 @@ describe("provider registry", () => {
         .modelId,
     ).toBe("x-ai/grok-4.5");
     expect(
+      (myProvider.languageModel("model-grok-4.6-pro") as { modelId: string })
+        .modelId,
+    ).toBe("x-ai/grok-4.6");
+    expect(
       (myProvider.languageModel("model-glm-5.2") as { modelId: string })
         .modelId,
     ).toBe("z-ai/glm-5.2");
@@ -61,6 +65,8 @@ describe("provider registry", () => {
     expect(getModelCutoffDate("agent-model-free")).toBeUndefined();
     expect(getModelDisplayName("model-grok-4.5")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
+    expect(getModelDisplayName("model-grok-4.6-pro")).toBe("xAI Grok 4.6");
+    expect(getModelCutoffDate("model-grok-4.6-pro")).toBe("August 2026");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
     expect(getModelDisplayName("model-kimi-k3")).toBe("Moonshot Kimi K3");
     expect(getModelCutoffDate("model-opus-4.6")).toBe("July 2026");
@@ -254,7 +260,9 @@ describe("supportsMultimodalToolResults", () => {
   it("allows active multimodal keys and slugs used after image tool results", () => {
     expect(supportsMultimodalToolResults("model-grok-4.5")).toBe(true);
     expect(supportsMultimodalToolResults("model-grok-4.5-pro")).toBe(true);
+    expect(supportsMultimodalToolResults("model-grok-4.6-pro")).toBe(true);
     expect(supportsMultimodalToolResults("x-ai/grok-4.5")).toBe(true);
+    expect(supportsMultimodalToolResults("x-ai/grok-4.6")).toBe(true);
   });
 
   it("rejects text-only DeepSeek model keys", () => {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -182,6 +182,7 @@ type OpenRouterInstance = typeof openrouter;
 export const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
+export const GROK_4_6_SLUG = "x-ai/grok-4.6";
 export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
 export const DEEPSEEK_V4_FLASH_PREVIOUS_SLUG = "deepseek/deepseek-v4-flash";
 const TITLE_GENERATOR_DEEPSEEK_SLUG = "deepseek/deepseek-v4-flash";
@@ -207,6 +208,9 @@ const buildProviderMap = (
     // Dedicated HackerAI Pro alias so its GLM fallback can evolve without
     // changing Standard media fallback behavior.
     "model-grok-4.5-pro": or(GROK_4_5_SLUG),
+    // HAC-64 treatment alias. The persisted tier remains hackerai-pro while
+    // the server-side experiment chooses the provider route per user.
+    "model-grok-4.6-pro": or(GROK_4_6_SLUG),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     // Keep the persisted Max compatibility key while routing new requests to
     // Kimi K3. Renaming the key would invalidate existing stored selections.
@@ -231,6 +235,7 @@ export const modelCutoffDates: Partial<Record<ModelName, string>> &
   "agent-model": "July 2026",
   "model-grok-4.5": "July 2026",
   "model-grok-4.5-pro": "July 2026",
+  "model-grok-4.6-pro": "August 2026",
   "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "July 2026",
   "model-glm-5.2": "June 2026",
@@ -248,6 +253,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "agent-model-free": "Auto, an intelligent model router built by HackerAI",
   "model-grok-4.5": "xAI Grok 4.5",
   "model-grok-4.5-pro": "xAI Grok 4.5",
+  "model-grok-4.6-pro": "xAI Grok 4.6",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Moonshot Kimi K3",
   "model-glm-5.2": "Z.ai GLM 5.2",
@@ -299,8 +305,10 @@ function isGrokModel(modelName: string): boolean {
     normalized === "fallback-ask-model" ||
     normalized === "model-grok-4.5" ||
     normalized === "model-grok-4.5-pro" ||
+    normalized === "model-grok-4.6-pro" ||
     normalized.includes("x-ai/") ||
-    normalized === "grok-4.5"
+    normalized === "grok-4.5" ||
+    normalized === "grok-4.6"
   );
 }
 

--- a/lib/analytics/__tests__/experiment-context.test.ts
+++ b/lib/analytics/__tests__/experiment-context.test.ts
@@ -1,0 +1,20 @@
+import { getExperimentAnalyticsProperties } from "../experiment-context";
+
+describe("experiment analytics context", () => {
+  it("adds the generic and PostHog feature properties", () => {
+    expect(
+      getExperimentAnalyticsProperties({
+        key: "example_experiment",
+        variant: "treatment",
+      }),
+    ).toEqual({
+      experiment_key: "example_experiment",
+      experiment_variant: "treatment",
+      "$feature/example_experiment": "treatment",
+    });
+  });
+
+  it("adds nothing without an experiment", () => {
+    expect(getExperimentAnalyticsProperties(undefined)).toEqual({});
+  });
+});

--- a/lib/analytics/experiment-context.ts
+++ b/lib/analytics/experiment-context.ts
@@ -1,0 +1,16 @@
+export type ExperimentAnalyticsContext = {
+  key: string;
+  variant: string;
+};
+
+export function getExperimentAnalyticsProperties(
+  experiment: ExperimentAnalyticsContext | undefined,
+): Record<string, string> {
+  if (!experiment) return {};
+
+  return {
+    experiment_key: experiment.key,
+    experiment_variant: experiment.variant,
+    [`$feature/${experiment.key}`]: experiment.variant,
+  };
+}

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -38,6 +38,7 @@ const GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "agent-model-free",
   "model-grok-4.5",
   "model-grok-4.5-pro",
+  "model-grok-4.6-pro",
   "model-deepseek-v4-pro",
   "model-opus-4.6",
   "model-glm-5.2",
@@ -202,6 +203,20 @@ describe("buildProviderOptions fallback chain", () => {
       });
     },
   );
+
+  it("falls back from the HAC-64 Grok 4.6 treatment through the complete current Pro route", () => {
+    const opts = buildProviderOptions(
+      true,
+      "user-1",
+      "model-grok-4.6-pro",
+      "agent",
+    );
+    expect(opts.openrouter).toMatchObject({
+      reasoning: { enabled: true, effort: "high" },
+      models: [GROK_SLUG, GLM_SLUG, KIMI_K3_SLUG],
+      user: "user-1",
+    });
+  });
 
   it("keeps the Standard Agent media route on its direct Kimi K3 fallback", () => {
     const opts = buildProviderOptions(
@@ -413,27 +428,31 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it.each(["model-grok-4.5-pro", "model-glm-5.2", "model-opus-4.6"])(
-    "enables high reasoning for ask mode model %s",
-    (modelName) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-        effort: "high",
-      });
-    },
-  );
+  it.each([
+    "model-grok-4.5-pro",
+    "model-grok-4.6-pro",
+    "model-glm-5.2",
+    "model-opus-4.6",
+  ])("enables high reasoning for ask mode model %s", (modelName) => {
+    const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
+  });
 
-  it.each(["model-grok-4.5-pro", "model-glm-5.2", "model-opus-4.6"])(
-    "enables high reasoning for agent mode model %s",
-    (modelName) => {
-      const opts = buildProviderOptions(true, "user-1", modelName, "agent");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-        effort: "high",
-      });
-    },
-  );
+  it.each([
+    "model-grok-4.5-pro",
+    "model-grok-4.6-pro",
+    "model-glm-5.2",
+    "model-opus-4.6",
+  ])("enables high reasoning for agent mode model %s", (modelName) => {
+    const opts = buildProviderOptions(true, "user-1", modelName, "agent");
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
+  });
 
   it("uses high reasoning for DeepSeek V4 Pro in agent mode", () => {
     const opts = buildProviderOptions(
@@ -560,6 +579,12 @@ describe("getRetryFallbackModel", () => {
     );
     expect(getRetryFallbackModel("model-grok-4.5-pro", "ask")).toBe(
       "model-glm-5.2",
+    );
+  });
+
+  it("retries the Grok 4.6 treatment with the current Grok 4.5 Pro route", () => {
+    expect(getRetryFallbackModel("model-grok-4.6-pro", "agent")).toBe(
+      "model-grok-4.5-pro",
     );
   });
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -537,6 +537,15 @@ describe("isAutoModelSelectionForRetry", () => {
     ).toBe(false);
   });
 
+  it("keeps the internal Grok 4.6 experiment route retryable", () => {
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "model-grok-4.6-pro",
+        selectedModelOverride: "hackerai-pro",
+      }),
+    ).toBe(true);
+  });
+
   it("preserves retry behavior for legacy auto-router model keys", () => {
     expect(
       isAutoModelSelectionForRetry({

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -66,6 +66,7 @@ import {
   closeAgentApprovalSession,
 } from "@/lib/api/agent-approval-session";
 import { createAgentRunCorrelationToken } from "@/lib/api/agent-run-correlation";
+import { evaluateProGrok46Experiment } from "@/lib/experiments/pro-grok-46";
 import {
   evaluateAgentAutoReviewFlag,
   type AgentAutoReviewAssignment,
@@ -433,6 +434,16 @@ export const createAgentTriggerPost =
         userCustomization,
         organizationId,
       });
+      const proGrok46Posthog =
+        selectedModelOverride === "hackerai-pro" ? PostHogClient() : null;
+      let proGrok46Experiment = await evaluateProGrok46Experiment({
+        posthog: proGrok46Posthog,
+        userId,
+        subscription,
+        mode: "agent",
+        selectedModel: selectedModelOverride,
+      });
+      await proGrok46Posthog?.shutdown().catch(() => undefined);
       const autoReviewPosthog =
         agentPermissionMode === "auto_review" ? PostHogClient() : null;
       const autoReviewAssignment: AgentAutoReviewAssignment | undefined =
@@ -452,6 +463,9 @@ export const createAgentTriggerPost =
         selectedModelOverride,
         extraUsageConfig,
       });
+      if (selectedModelOverride !== "hackerai-pro") {
+        proGrok46Experiment = undefined;
+      }
 
       let messagesForPersistence =
         stripLocalDesktopSourcePaths(requestMessages);
@@ -597,6 +611,7 @@ export const createAgentTriggerPost =
         approvalSessionId,
         approvalProtocolVersion: AGENT_APPROVAL_PROTOCOL_VERSION,
         selectedModel: selectedModelOverride,
+        proGrok46Experiment,
         autoReviewAssignment,
         userLocation,
         isAutoContinue,
@@ -626,6 +641,9 @@ export const createAgentTriggerPost =
         approvalProtocolVersion: AGENT_APPROVAL_PROTOCOL_VERSION,
         ...(approvalWorkerVersion ? { approvalWorkerVersion } : {}),
         ...(approvalSessionId ? { approvalSessionId } : {}),
+        ...(proGrok46Experiment && {
+          proGrok46ExperimentVariant: proGrok46Experiment.variant,
+        }),
         ...(autoReviewAssignment && {
           autoReviewRolloutPhase: autoReviewAssignment.phase,
         }),

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -455,7 +455,7 @@ export const createChatHandler = () => {
       });
 
       // PostHog client for analytics.
-      posthog = PostHogClient();
+      posthog ??= PostHogClient();
 
       const fileCounts = countFileAttachments(truncatedMessages);
       const chatLogContext = {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -147,6 +147,11 @@ import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import { readAnalyticsRequestContext } from "@/lib/analytics/request-context";
 import { buildAgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
 import {
+  captureProGrok46ExperimentExposure,
+  evaluateProGrok46Experiment,
+  getProGrok46ExperimentContext,
+} from "@/lib/experiments/pro-grok-46";
+import {
   capturePaidDailyFreeAllowanceServerEvent,
   createPaidDailyFreeAllowanceBudgetSnapshot,
   createPaidDailyFreeAllowanceRateLimitInfo,
@@ -355,6 +360,18 @@ export const createChatHandler = () => {
         organizationId,
       });
       const extraUsageAvailable = canUseExtraUsage(baseExtraUsageConfig);
+      const proGrok46Experiment =
+        isAgentMode(mode) && selectedModelOverride === "hackerai-pro"
+          ? await evaluateProGrok46Experiment({
+              posthog: (posthog ??= PostHogClient()),
+              userId,
+              subscription,
+              mode,
+              selectedModel: selectedModelOverride,
+            })
+          : undefined;
+      const routingExperimentContext =
+        getProGrok46ExperimentContext(proGrok46Experiment);
       selectedModelOverride =
         normalizeMaxModelForSubscription(selectedModelOverride, subscription, {
           extraUsageAvailable,
@@ -407,6 +424,7 @@ export const createChatHandler = () => {
         uploadBasePath,
         modelOverride: selectedModelOverride,
         extraUsageAvailable,
+        proModelKey: proGrok46Experiment?.modelKey,
         allowLocalDesktopFiles:
           isAgentMode(mode) && sandboxPreference === "desktop",
       });
@@ -1109,6 +1127,7 @@ export const createChatHandler = () => {
                   usage: usageCostRecord,
                   responseModel: state.responseModel,
                   analyticsRequestContext,
+                  experiment: routingExperimentContext,
                   fallbackServed:
                     state.responseModel && retryUsedFallbackModel
                       ? true
@@ -1314,6 +1333,15 @@ export const createChatHandler = () => {
 
             let result;
             try {
+              captureProGrok46ExperimentExposure({
+                posthog,
+                userId,
+                subscription,
+                mode,
+                selectedModel,
+                configuredModel: configuredModelId,
+                assignment: proGrok46Experiment,
+              });
               result = await createStream(selectedModel);
             } catch (error) {
               // If provider returns an API error before streaming, retry with fallback.
@@ -1677,6 +1705,7 @@ export const createChatHandler = () => {
                                   finishReason: state.streamFinishReason,
                                   budgetAbortDetails: state.budgetAbortDetails,
                                   isAutoContinue: !!isAutoContinue,
+                                  experiment: routingExperimentContext,
                                   stepLimitTelemetry:
                                     buildAgentStepLimitTelemetry({
                                       configuredMaxSteps:
@@ -1992,6 +2021,7 @@ export const createChatHandler = () => {
                       finishReason: state.streamFinishReason,
                       budgetAbortDetails: state.budgetAbortDetails,
                       isAutoContinue: !!isAutoContinue,
+                      experiment: routingExperimentContext,
                       stepLimitTelemetry: buildAgentStepLimitTelemetry({
                         configuredMaxSteps: state.configuredMaxSteps,
                         stepCount: state.agentStepCount,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -149,6 +149,7 @@ import { buildAgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-t
 import {
   captureProGrok46ExperimentExposure,
   evaluateProGrok46Experiment,
+  getActiveProGrok46ExperimentAssignment,
   getProGrok46ExperimentContext,
 } from "@/lib/experiments/pro-grok-46";
 import {
@@ -370,8 +371,6 @@ export const createChatHandler = () => {
               selectedModel: selectedModelOverride,
             })
           : undefined;
-      const routingExperimentContext =
-        getProGrok46ExperimentContext(proGrok46Experiment);
       selectedModelOverride =
         normalizeMaxModelForSubscription(selectedModelOverride, subscription, {
           extraUsageAvailable,
@@ -576,6 +575,14 @@ export const createChatHandler = () => {
           },
         });
       }
+
+      const activeProGrok46Experiment = getActiveProGrok46ExperimentAssignment(
+        proGrok46Experiment,
+        selectedModel,
+      );
+      const routingExperimentContext = getProGrok46ExperimentContext(
+        activeProGrok46Experiment,
+      );
 
       const freeMonthlyBudgetSnapshot =
         subscription === "free"
@@ -1340,7 +1347,7 @@ export const createChatHandler = () => {
                 mode,
                 selectedModel,
                 configuredModel: configuredModelId,
-                assignment: proGrok46Experiment,
+                assignment: activeProGrok46Experiment,
               });
               result = await createStream(selectedModel);
             } catch (error) {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -30,6 +30,10 @@ import {
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
 import type { AnalyticsRequestContext } from "@/lib/analytics/request-context";
+import {
+  getExperimentAnalyticsProperties,
+  type ExperimentAnalyticsContext,
+} from "@/lib/analytics/experiment-context";
 import type { AgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
 import { extraUsagePointsToDollars } from "@/convex/lib/extraUsagePricing";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
@@ -1215,6 +1219,7 @@ type AgentCompletionAnalyticsArgs = {
   activeSandboxRecoveryDurationMs?: number;
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
+  experiment?: ExperimentAnalyticsContext;
 };
 
 export function captureAgentRun({
@@ -1243,6 +1248,7 @@ export function captureAgentRun({
   activeSandboxRecoveryDurationMs,
   isAutoContinue,
   stepLimitTelemetry,
+  experiment,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1269,6 +1275,7 @@ export function captureAgentRun({
   activeSandboxRecoveryDurationMs?: number;
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
+  experiment?: ExperimentAnalyticsContext;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1343,6 +1350,7 @@ export function captureAgentRun({
         budget_abort_billing_stop_reason: budgetAbortDetails.billingStopReason,
         budget_abort_mid_stream: budgetAbortDetails.midStream,
       }),
+      ...getExperimentAnalyticsProperties(experiment),
     },
   });
 }
@@ -1377,6 +1385,7 @@ export function captureAgentCompletionAnalytics(
     activeSandboxRecoveryDurationMs: args.activeSandboxRecoveryDurationMs,
     isAutoContinue: args.isAutoContinue,
     stepLimitTelemetry: args.stepLimitTelemetry,
+    experiment: args.experiment,
   });
 }
 
@@ -1403,6 +1412,7 @@ export function captureUsageCost({
   usageSettlement,
   analyticsRequestContext,
   fallbackServed,
+  experiment,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1427,6 +1437,7 @@ export function captureUsageCost({
   };
   analyticsRequestContext?: AnalyticsRequestContext;
   fallbackServed?: boolean;
+  experiment?: ExperimentAnalyticsContext;
 }) {
   if (!posthog) return;
   const extraUsageChargeDollars = extraUsagePointsToDollars(
@@ -1495,6 +1506,7 @@ export function captureUsageCost({
         paid_daily_free_allowance_reset_timestamp:
           paidDailyFreeAllowance.resetTimestamp,
       }),
+      ...getExperimentAnalyticsProperties(experiment),
     },
   });
 }

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -579,6 +579,7 @@ const AUTO_MODEL_KEYS = new Set<string>([
   "agent-model",
   "agent-model-free",
 ]);
+const EXPLICIT_RETRY_MODEL_KEYS = new Set<string>(["model-grok-4.6-pro"]);
 
 export function isAutoModelSelectionForRetry({
   selectedModel,
@@ -590,7 +591,8 @@ export function isAutoModelSelectionForRetry({
   return (
     !selectedModelOverride ||
     selectedModelOverride === "auto" ||
-    AUTO_MODEL_KEYS.has(selectedModel)
+    AUTO_MODEL_KEYS.has(selectedModel) ||
+    EXPLICIT_RETRY_MODEL_KEYS.has(selectedModel)
   );
 }
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -24,6 +24,7 @@ import type {
 } from "@/types";
 import {
   GROK_4_5_SLUG,
+  GROK_4_6_SLUG,
   getOpenRouterProviderRoutingForModel,
   isAnthropicModel,
   myProvider,
@@ -549,6 +550,13 @@ const HACKERAI_PRO_FALLBACK_CHAIN = [
   "model-kimi-k3",
 ] as const satisfies readonly ModelName[];
 
+// HAC-64 treatment falls back through today's complete Pro route before the
+// existing GLM/Kimi recovery chain.
+const HACKERAI_GROK_4_6_PRO_FALLBACK_CHAIN = [
+  "model-grok-4.5-pro",
+  ...HACKERAI_PRO_FALLBACK_CHAIN,
+] as const satisfies readonly ModelName[];
+
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "agent-model-free": AGENT_TEXT_FALLBACK_CHAIN,
@@ -557,6 +565,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "agent-model": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5-pro": HACKERAI_PRO_FALLBACK_CHAIN,
+  "model-grok-4.6-pro": HACKERAI_GROK_4_6_PRO_FALLBACK_CHAIN,
   "model-opus-4.6": ["model-grok-4.5"],
   "model-glm-5.2": KIMI_K3_THEN_GROK_FALLBACK_CHAIN,
   "fallback-agent-model": GROK_4_5_FALLBACK_CHAIN,
@@ -587,6 +596,7 @@ export function isAutoModelSelectionForRetry({
 
 const HIGH_REASONING_MODELS = [
   "model-grok-4.5-pro",
+  "model-grok-4.6-pro",
   "model-glm-5.2",
   "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
@@ -629,6 +639,9 @@ export function getRetryFallbackModel(
   modelName: ModelName,
   _mode: ChatMode,
 ): ModelName {
+  if (modelName === "model-grok-4.6-pro") {
+    return "model-grok-4.5-pro";
+  }
   if (modelName === "model-grok-4.5-pro") {
     return "model-glm-5.2";
   }
@@ -734,6 +747,7 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, string> = {
   "deepseek/deepseek-v4-flash-0731": "agent-model-free",
   "deepseek/deepseek-v4-flash-20260731": "agent-model-free",
   "x-ai/grok-4.5": "model-grok-4.5",
+  "x-ai/grok-4.6": "model-grok-4.6-pro",
   "z-ai/glm-5.2": "model-glm-5.2",
   "z-ai/glm-5.2-20260616": "model-glm-5.2",
   "moonshotai/kimi-k3": "model-kimi-k3",
@@ -804,6 +818,7 @@ export function buildProviderOptions(
     (modelName ? resolveSlug(modelName) : undefined);
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
   const isGrok45 = modelId === GROK_4_5_SLUG;
+  const isGrok46 = modelId === GROK_4_6_SLUG;
   // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this
   // mode-scoped for any future route that does not also include Grok.
   const isAgentDeepSeekV4 = mode === "agent" && isDeepSeekV4;
@@ -815,14 +830,17 @@ export function buildProviderOptions(
       })
     : fallbackSlugs;
   // OpenRouter applies one reasoning configuration to both the primary model
-  // and every provider fallback. Force high whenever Grok 4.5 is reachable so
-  // it cannot inherit less effort.
-  const routesThroughGrok45 =
-    isGrok45 || reasoningFallbackSlugs.includes(GROK_4_5_SLUG);
+  // and every provider fallback. Force high whenever Grok 4.5 or 4.6 is
+  // reachable so neither route can inherit less effort.
+  const routesThroughGrok =
+    isGrok45 ||
+    isGrok46 ||
+    reasoningFallbackSlugs.includes(GROK_4_5_SLUG) ||
+    reasoningFallbackSlugs.includes(GROK_4_6_SLUG);
   const providerRouting = modelId
     ? getOpenRouterProviderRoutingForModel(modelId)
     : undefined;
-  const reasoning = routesThroughGrok45
+  const reasoning = routesThroughGrok
     ? isHighOrGreaterReasoningOverride(options.reasoningOverride)
       ? options.reasoningOverride
       : {

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -154,6 +154,20 @@ describe("limitImageParts", () => {
 // selectModel - Model selection logic
 // ==========================================================================
 describe("selectModel", () => {
+  it("routes the HAC-64 treatment through the Grok 4.6 Pro alias", () => {
+    expect(
+      selectModel("agent", "pro", "hackerai-pro", false, false, {
+        proModelKey: "model-grok-4.6-pro",
+      }),
+    ).toBe("model-grok-4.6-pro");
+  });
+
+  it("keeps HackerAI Pro on Grok 4.5 without an experiment assignment", () => {
+    expect(selectModel("agent", "pro", "hackerai-pro")).toBe(
+      "model-grok-4.5-pro",
+    );
+  });
+
   it.each(["pro", "pro-plus", "ultra", "team"] as const)(
     "routes paid %s Auto/Standard text to DeepSeek V4 Pro in both modes",
     (subscription) => {

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -50,7 +50,10 @@ export function selectModel(
   selectedModel?: SelectedModel,
   hasImageAttachment?: boolean,
   hasPdfAttachment?: boolean,
-  options: { extraUsageAvailable?: boolean } = {},
+  options: {
+    extraUsageAvailable?: boolean;
+    proModelKey?: "model-grok-4.5-pro" | "model-grok-4.6-pro";
+  } = {},
 ): ModelName {
   const isAgent = isAgentMode(mode);
   const allowedSelectedModel = normalizeMaxModelForSubscription(
@@ -104,7 +107,7 @@ export function selectModel(
   }
 
   if (allowedSelectedModel === "hackerai-pro") {
-    return "model-grok-4.5-pro";
+    return options.proModelKey ?? "model-grok-4.5-pro";
   }
 
   const providerKey = resolveTierToProviderKey(allowedSelectedModel, mode);
@@ -646,6 +649,7 @@ export async function processChatMessages({
   uploadBasePath,
   modelOverride,
   extraUsageAvailable = false,
+  proModelKey,
   allowLocalDesktopFiles = false,
 }: {
   messages: UIMessage[];
@@ -655,6 +659,7 @@ export async function processChatMessages({
   uploadBasePath?: string;
   modelOverride?: SelectedModel;
   extraUsageAvailable?: boolean;
+  proModelKey?: "model-grok-4.5-pro" | "model-grok-4.6-pro";
   allowLocalDesktopFiles?: boolean;
 }) {
   const messagesWithoutOpenRouterReasoningMetadata =
@@ -732,7 +737,7 @@ export async function processChatMessages({
     modelOverride,
     mediaAttachmentRouting.hasImage,
     mediaAttachmentRouting.hasPdf,
-    { extraUsageAvailable },
+    { extraUsageAvailable, proModelKey },
   );
 
   // Strip providerMetadata for Anthropic models to prevent cross-model signature errors.

--- a/lib/experiments/__tests__/pro-grok-46.test.ts
+++ b/lib/experiments/__tests__/pro-grok-46.test.ts
@@ -1,0 +1,119 @@
+import {
+  captureProGrok46ExperimentExposure,
+  evaluateProGrok46Experiment,
+  getProGrok46ExperimentContext,
+  isEligibleForProGrok46Experiment,
+  PRO_GROK_46_EXPERIMENT_KEY,
+  PRO_GROK_46_EXPOSURE_EVENT,
+  PRO_GROK_46_FEATURE_PROPERTY,
+} from "@/lib/experiments/pro-grok-46";
+
+describe("Pro Grok 4.6 experiment", () => {
+  it.each(["pro", "pro-plus", "ultra"] as const)(
+    "includes %s users who select HackerAI Pro Agent",
+    (subscription) => {
+      expect(
+        isEligibleForProGrok46Experiment({
+          subscription,
+          mode: "agent",
+          selectedModel: "hackerai-pro",
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    ["free", "agent", "hackerai-pro"],
+    ["team", "agent", "hackerai-pro"],
+    ["pro", "ask", "hackerai-pro"],
+    ["pro", "agent", "auto"],
+    ["pro", "agent", "hackerai-standard"],
+    ["pro", "agent", "hackerai-max"],
+  ] as const)(
+    "excludes subscription=%s mode=%s selectedModel=%s",
+    (subscription, mode, selectedModel) => {
+      expect(
+        isEligibleForProGrok46Experiment({
+          subscription,
+          mode,
+          selectedModel,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it.each([
+    ["control", "model-grok-4.5-pro"],
+    ["grok_4_6", "model-grok-4.6-pro"],
+  ] as const)("maps %s to %s", async (variant, modelKey) => {
+    const evaluateFlags = jest.fn(async () => ({ getFlag: () => variant }));
+
+    await expect(
+      evaluateProGrok46Experiment({
+        posthog: { evaluateFlags } as never,
+        userId: "user-1",
+        subscription: "pro",
+        mode: "agent",
+        selectedModel: "hackerai-pro",
+      }),
+    ).resolves.toEqual({
+      key: PRO_GROK_46_EXPERIMENT_KEY,
+      variant,
+      modelKey,
+    });
+  });
+
+  it("fails closed when evaluation returns an unknown value", async () => {
+    await expect(
+      evaluateProGrok46Experiment({
+        posthog: {
+          evaluateFlags: jest.fn(async () => ({ getFlag: () => true })),
+        } as never,
+        userId: "user-1",
+        subscription: "pro",
+        mode: "agent",
+        selectedModel: "hackerai-pro",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("captures a privacy-safe custom exposure from the provider surface", () => {
+    const capture = jest.fn();
+    const assignment = {
+      key: PRO_GROK_46_EXPERIMENT_KEY,
+      variant: "grok_4_6" as const,
+      modelKey: "model-grok-4.6-pro" as const,
+    };
+
+    captureProGrok46ExperimentExposure({
+      posthog: { capture } as never,
+      userId: "user-1",
+      subscription: "pro",
+      mode: "agent",
+      selectedModel: assignment.modelKey,
+      configuredModel: "x-ai/grok-4.6",
+      assignment,
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user-1",
+      event: PRO_GROK_46_EXPOSURE_EVENT,
+      properties: {
+        experiment_key: PRO_GROK_46_EXPERIMENT_KEY,
+        experiment_variant: "grok_4_6",
+        [PRO_GROK_46_FEATURE_PROPERTY]: "grok_4_6",
+        subscription: "pro",
+        subscription_tier: "pro",
+        mode: "agent",
+        selected_model: "model-grok-4.6-pro",
+        configured_model: "x-ai/grok-4.6",
+        exposure_surface: "agent_provider_request",
+        $process_person_profile: false,
+      },
+    });
+    expect(getProGrok46ExperimentContext(assignment)).toEqual({
+      key: PRO_GROK_46_EXPERIMENT_KEY,
+      variant: "grok_4_6",
+    });
+  });
+});

--- a/lib/experiments/__tests__/pro-grok-46.test.ts
+++ b/lib/experiments/__tests__/pro-grok-46.test.ts
@@ -1,6 +1,7 @@
 import {
   captureProGrok46ExperimentExposure,
   evaluateProGrok46Experiment,
+  getActiveProGrok46ExperimentAssignment,
   getProGrok46ExperimentContext,
   isEligibleForProGrok46Experiment,
   PRO_GROK_46_EXPERIMENT_KEY,
@@ -115,5 +116,11 @@ describe("Pro Grok 4.6 experiment", () => {
       key: PRO_GROK_46_EXPERIMENT_KEY,
       variant: "grok_4_6",
     });
+    expect(
+      getActiveProGrok46ExperimentAssignment(assignment, "model-grok-4.6-pro"),
+    ).toBe(assignment);
+    expect(
+      getActiveProGrok46ExperimentAssignment(assignment, "agent-model"),
+    ).toBeUndefined();
   });
 });

--- a/lib/experiments/pro-grok-46.ts
+++ b/lib/experiments/pro-grok-46.ts
@@ -1,0 +1,131 @@
+import type { PostHog } from "posthog-node";
+import type { ModelName } from "@/lib/ai/providers";
+import type { ChatMode, SelectedModel, SubscriptionTier } from "@/types";
+import { PAID_INDIVIDUAL_SUBSCRIPTION_TIERS } from "@/types";
+import type { ExperimentAnalyticsContext } from "@/lib/analytics/experiment-context";
+
+export const PRO_GROK_46_EXPERIMENT_KEY = "agent_pro_grok_46_model_v1";
+export const PRO_GROK_46_EXPOSURE_EVENT =
+  "hac64_pro_grok_46_model_experiment_exposed";
+export const PRO_GROK_46_FEATURE_PROPERTY = `$feature/${PRO_GROK_46_EXPERIMENT_KEY}`;
+
+export type ProGrok46ExperimentVariant = "control" | "grok_4_6";
+export type ProGrok46ModelKey = "model-grok-4.5-pro" | "model-grok-4.6-pro";
+
+export type ProGrok46ExperimentAssignment = {
+  key: typeof PRO_GROK_46_EXPERIMENT_KEY;
+  variant: ProGrok46ExperimentVariant;
+  modelKey: ProGrok46ModelKey;
+};
+
+export function isEligibleForProGrok46Experiment({
+  subscription,
+  mode,
+  selectedModel,
+}: {
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel?: SelectedModel;
+}): boolean {
+  return (
+    (
+      PAID_INDIVIDUAL_SUBSCRIPTION_TIERS as readonly SubscriptionTier[]
+    ).includes(subscription) &&
+    mode === "agent" &&
+    selectedModel === "hackerai-pro"
+  );
+}
+
+export async function evaluateProGrok46Experiment({
+  posthog,
+  userId,
+  subscription,
+  mode,
+  selectedModel,
+}: {
+  posthog: Pick<PostHog, "evaluateFlags"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel?: SelectedModel;
+}): Promise<ProGrok46ExperimentAssignment | undefined> {
+  if (
+    !posthog ||
+    !isEligibleForProGrok46Experiment({
+      subscription,
+      mode,
+      selectedModel,
+    })
+  ) {
+    return undefined;
+  }
+
+  try {
+    const flags = await posthog.evaluateFlags(userId, {
+      flagKeys: [PRO_GROK_46_EXPERIMENT_KEY],
+    });
+    const variant = flags.getFlag(PRO_GROK_46_EXPERIMENT_KEY);
+
+    if (variant !== "control" && variant !== "grok_4_6") {
+      return undefined;
+    }
+
+    return {
+      key: PRO_GROK_46_EXPERIMENT_KEY,
+      variant,
+      modelKey:
+        variant === "grok_4_6" ? "model-grok-4.6-pro" : "model-grok-4.5-pro",
+    };
+  } catch (error) {
+    console.warn("Pro Grok 4.6 experiment evaluation failed", {
+      event: "pro_grok_46_experiment_evaluation_failed",
+      flag_key: PRO_GROK_46_EXPERIMENT_KEY,
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return undefined;
+  }
+}
+
+export function captureProGrok46ExperimentExposure({
+  posthog,
+  userId,
+  subscription,
+  mode,
+  selectedModel,
+  configuredModel,
+  assignment,
+}: {
+  posthog: Pick<PostHog, "capture"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel: ModelName;
+  configuredModel: string;
+  assignment?: ProGrok46ExperimentAssignment;
+}): void {
+  if (!posthog || !assignment) return;
+
+  posthog.capture({
+    distinctId: userId,
+    event: PRO_GROK_46_EXPOSURE_EVENT,
+    properties: {
+      experiment_key: assignment.key,
+      experiment_variant: assignment.variant,
+      [PRO_GROK_46_FEATURE_PROPERTY]: assignment.variant,
+      subscription,
+      subscription_tier: subscription,
+      mode,
+      selected_model: selectedModel,
+      configured_model: configuredModel,
+      exposure_surface: "agent_provider_request",
+      $process_person_profile: false,
+    },
+  });
+}
+
+export function getProGrok46ExperimentContext(
+  assignment: ProGrok46ExperimentAssignment | undefined,
+): ExperimentAnalyticsContext | undefined {
+  if (!assignment) return undefined;
+  return { key: assignment.key, variant: assignment.variant };
+}

--- a/lib/experiments/pro-grok-46.ts
+++ b/lib/experiments/pro-grok-46.ts
@@ -129,3 +129,10 @@ export function getProGrok46ExperimentContext(
   if (!assignment) return undefined;
   return { key: assignment.key, variant: assignment.variant };
 }
+
+export function getActiveProGrok46ExperimentAssignment(
+  assignment: ProGrok46ExperimentAssignment | undefined,
+  selectedModel: ModelName,
+): ProGrok46ExperimentAssignment | undefined {
+  return assignment?.modelKey === selectedModel ? assignment : undefined;
+}

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -537,6 +537,29 @@ describe("token-bucket", () => {
       expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(90000);
     });
 
+    it("uses Grok 4.6 base pricing below 200k prompt tokens", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 199_999,
+          outputTokens: 10_000,
+          modelName: "model-grok-4.6-pro",
+        }),
+      ).toBeCloseTo(0.459998);
+    });
+
+    it("uses Grok 4.6 doubled pricing from 200k prompt tokens", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 200_000,
+          outputTokens: 10_000,
+          modelName: "x-ai/grok-4.6",
+        }),
+      ).toBeCloseTo(0.92);
+      expect(
+        calculateTokenCost(10_000, "output", "model-grok-4.6-pro", 200_000),
+      ).toBe(1800);
+    });
+
     it("higher-priced models should deplete budget faster", () => {
       const monthlyBudget = getBudgetLimits("pro").monthly;
       // Typical conversation: 2000 input + 500 output tokens

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -45,6 +45,13 @@ const GROK_4_5_PRICING: ModelPricing = {
   cacheRead: 0.5,
   cacheWrite: 2.0,
 };
+const GROK_4_6_LONG_CONTEXT_PRICING: ModelPricing = {
+  input: 4.0,
+  output: 12.0,
+  cacheRead: 1.0,
+  cacheWrite: 4.0,
+};
+const GROK_4_6_LONG_CONTEXT_PROMPT_TOKENS = 200_000;
 const DEEPSEEK_V4_FLASH_PRICING: ModelPricing = {
   input: 0.09,
   output: 0.18,
@@ -88,6 +95,9 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   // Grok 4.5 rates from OpenRouter: $2.00 in / $6.00 out per 1M tokens.
   "model-grok-4.5": GROK_4_5_PRICING,
   "model-grok-4.5-pro": GROK_4_5_PRICING,
+  // Grok 4.6 shares the $2/$6 base rate, with a 2x tier from 200k prompt
+  // tokens handled by getModelPricing when the input size is available.
+  "model-grok-4.6-pro": GROK_4_5_PRICING,
   // Auto and summarization aliases resolve to Grok 4.5.
   "ask-model": GROK_4_5_PRICING,
   "agent-model": GROK_4_5_PRICING,
@@ -105,6 +115,7 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "model-kimi-k3": KIMI_K3_PRICING,
   // Provider response ids can reach accounting before local-key normalization.
   "x-ai/grok-4.5": GROK_4_5_PRICING,
+  "x-ai/grok-4.6": GROK_4_5_PRICING,
   "deepseek/deepseek-v4-flash": DEEPSEEK_V4_FLASH_PRICING,
   "deepseek/deepseek-v4-flash-20260423": DEEPSEEK_V4_FLASH_PRICING,
   "deepseek/deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_PRICING,
@@ -117,8 +128,20 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "moonshotai/kimi-k3-20260715": KIMI_K3_PRICING,
 };
 
-const getModelPricing = (modelName?: string): ModelPricing => {
+const GROK_4_6_MODEL_IDS = new Set(["model-grok-4.6-pro", "x-ai/grok-4.6"]);
+
+const getModelPricing = (
+  modelName?: string,
+  inputTokens?: number,
+): ModelPricing => {
   if (!modelName) return DEFAULT_PRICING;
+
+  if (
+    GROK_4_6_MODEL_IDS.has(modelName) &&
+    normalizeTokenCount(inputTokens ?? 0) >= GROK_4_6_LONG_CONTEXT_PROMPT_TOKENS
+  ) {
+    return GROK_4_6_LONG_CONTEXT_PRICING;
+  }
 
   const exactPricing = MODEL_PRICING_MAP[modelName];
   if (exactPricing) return exactPricing;
@@ -396,9 +419,13 @@ export const calculateTokenCost = (
   tokens: number,
   type: "input" | "output",
   modelName?: string,
+  promptTokens?: number,
 ): number => {
   if (tokens <= 0) return 0;
-  const pricing = getModelPricing(modelName);
+  const pricing = getModelPricing(
+    modelName,
+    type === "input" ? tokens : promptTokens,
+  );
   const price = type === "input" ? pricing.input : pricing.output;
   const costPoints =
     (tokens / 1_000_000) * price * POINTS_PER_DOLLAR * NORMAL_USAGE_MULTIPLIER;
@@ -416,7 +443,10 @@ export const calculateRawTokenCost = (
   modelName?: string,
 ): number => {
   if (tokens <= 0) return 0;
-  const pricing = getModelPricing(modelName);
+  const pricing = getModelPricing(
+    modelName,
+    type === "input" ? tokens : undefined,
+  );
   const price = type === "input" ? pricing.input : pricing.output;
   return Math.ceil((tokens / 1_000_000) * price * POINTS_PER_DOLLAR);
 };
@@ -453,7 +483,7 @@ export const calculateRawModelUsageCostDollars = ({
   );
   const uncachedInput =
     normalizedInput - normalizedCacheRead - normalizedCacheWrite;
-  const pricing = getModelPricing(modelName);
+  const pricing = getModelPricing(modelName, normalizedInput);
 
   return (
     (uncachedInput * pricing.input +
@@ -1242,6 +1272,7 @@ export const deductUsage = async (
         actualOutputTokens,
         "output",
         modelForActualCost,
+        actualInputTokens,
       );
       const nonModelCostPoints =
         nonModelCostDollars > 0

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -44,6 +44,7 @@ import {
   injectNotesIntoMessages,
   getContentFilterRetryModel,
   getRetryFallbackModel,
+  isAutoModelSelectionForRetry,
   resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 import {
@@ -130,6 +131,7 @@ import {
 import { phLogger } from "@/lib/posthog/server";
 import {
   captureProGrok46ExperimentExposure,
+  getActiveProGrok46ExperimentAssignment,
   getProGrok46ExperimentContext,
   type ProGrok46ExperimentAssignment,
 } from "@/lib/experiments/pro-grok-46";
@@ -2067,8 +2069,6 @@ export const agentLongTask = task({
       analyticsRequestContext,
     } = payload;
     let selectedModelOverride = rawSelectedModelOverride;
-    const routingExperimentContext =
-      getProGrok46ExperimentContext(proGrok46Experiment);
     const endpoint = payloadEndpoint ?? LEGACY_AGENT_API_ENDPOINT;
     const freeUsageSubject = freeQuotaSubject ?? userId;
 
@@ -2511,6 +2511,15 @@ export const agentLongTask = task({
                 extra: { selected_model: selectedModel },
               });
             }
+
+            const activeProGrok46Experiment =
+              getActiveProGrok46ExperimentAssignment(
+                proGrok46Experiment,
+                selectedModel,
+              );
+            const routingExperimentContext = getProGrok46ExperimentContext(
+              activeProGrok46Experiment,
+            );
 
             const freeMonthlyBudgetSnapshot =
               subscription === "free"
@@ -3045,12 +3054,10 @@ export const agentLongTask = task({
 
             let isRetryWithFallback = false;
             let retryUsedFallbackModel = false;
-            const isAutoModel = [
-              "ask-model",
-              "ask-model-free",
-              "agent-model",
-              "agent-model-free",
-            ].includes(selectedModel);
+            const isAutoModel = isAutoModelSelectionForRetry({
+              selectedModel,
+              selectedModelOverride,
+            });
             const fallbackModel = getRetryFallbackModel(selectedModel, mode);
             const fallbackModelId =
               trackedProvider.languageModel(fallbackModel).modelId;
@@ -3484,7 +3491,7 @@ export const agentLongTask = task({
                 mode,
                 selectedModel,
                 configuredModel: configuredModelId,
-                assignment: proGrok46Experiment,
+                assignment: activeProGrok46Experiment,
               });
               result = await createStream(selectedModel);
             } catch (error) {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -128,6 +128,11 @@ import {
   type AgentApiEndpoint,
 } from "@/lib/api/agent-endpoints";
 import { phLogger } from "@/lib/posthog/server";
+import {
+  captureProGrok46ExperimentExposure,
+  getProGrok46ExperimentContext,
+  type ProGrok46ExperimentAssignment,
+} from "@/lib/experiments/pro-grok-46";
 import type { AgentAutoReviewAssignment } from "@/lib/experiments/agent-auto-review";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import type { AnalyticsRequestContext } from "@/lib/analytics/request-context";
@@ -1983,6 +1988,7 @@ export type AgentLongPayload = {
   approvalSessionId?: string;
   approvalProtocolVersion?: number;
   selectedModel?: SelectedModel;
+  proGrok46Experiment?: ProGrok46ExperimentAssignment;
   autoReviewAssignment?: AgentAutoReviewAssignment;
   userLocation: Geo;
   isAutoContinue?: boolean;
@@ -2050,6 +2056,7 @@ export const agentLongTask = task({
       approvalSessionId,
       approvalProtocolVersion,
       selectedModel: rawSelectedModelOverride,
+      proGrok46Experiment,
       autoReviewAssignment,
       userLocation,
       isAutoContinue,
@@ -2060,6 +2067,8 @@ export const agentLongTask = task({
       analyticsRequestContext,
     } = payload;
     let selectedModelOverride = rawSelectedModelOverride;
+    const routingExperimentContext =
+      getProGrok46ExperimentContext(proGrok46Experiment);
     const endpoint = payloadEndpoint ?? LEGACY_AGENT_API_ENDPOINT;
     const freeUsageSubject = freeQuotaSubject ?? userId;
 
@@ -2253,6 +2262,7 @@ export const agentLongTask = task({
         uploadBasePath,
         modelOverride: selectedModelOverride,
         extraUsageAvailable,
+        proModelKey: proGrok46Experiment?.modelKey,
         allowLocalDesktopFiles: sandboxPreference === "desktop",
       });
 
@@ -3247,6 +3257,7 @@ export const agentLongTask = task({
                   mode,
                   agentPermissionMode,
                   analyticsRequestContext,
+                  experiment: routingExperimentContext,
                   usage: usageCostRecord,
                   responseModel: state.responseModel,
                   ...(usageSettlementState && {
@@ -3466,6 +3477,15 @@ export const agentLongTask = task({
 
             let result;
             try {
+              captureProGrok46ExperimentExposure({
+                posthog,
+                userId,
+                subscription,
+                mode,
+                selectedModel,
+                configuredModel: configuredModelId,
+                assignment: proGrok46Experiment,
+              });
               result = await createStream(selectedModel);
             } catch (error) {
               if (
@@ -3809,6 +3829,7 @@ export const agentLongTask = task({
                                       state.budgetAbortDetails,
                                     agentPermissionMode,
                                     isAutoContinue: !!isAutoContinue,
+                                    experiment: routingExperimentContext,
                                     stepLimitTelemetry:
                                       buildAgentStepLimitTelemetry({
                                         configuredMaxSteps:
@@ -3981,6 +4002,7 @@ export const agentLongTask = task({
                         budgetAbortDetails: state.budgetAbortDetails,
                         agentPermissionMode,
                         isAutoContinue: !!isAutoContinue,
+                        experiment: routingExperimentContext,
                         stepLimitTelemetry: buildAgentStepLimitTelemetry({
                           configuredMaxSteps: state.configuredMaxSteps,
                           stepCount: state.agentStepCount,


### PR DESCRIPTION
## Summary

- add a server-side PostHog A/B experiment for paid individual users who select HackerAI Pro in Agent mode
- route the treatment to `x-ai/grok-4.6` with Grok 4.5, GLM 5.2, and Kimi K3 fallbacks plus high reasoning
- emit a privacy-safe custom exposure at the provider-request surface and attribute downstream Agent/usage events
- account for Grok 4.6 base and 200k+ prompt pricing, including long-context output pricing

## Experiment

- Linear: HAC-64
- PostHog experiment: 416619
- PostHog feature flag: 816340
- variants: `control` and `grok_4_6`, configured 50/50
- experiment and flag remain draft/inactive
- custom exposure will be bound only after this code is deployed and the exact exposure event is observed

## Validation

- `pnpm test` — 348 suites, 3,576 tests passed
- `pnpm typecheck`
- focused ESLint and Prettier checks
- local dependency guard

## Manual verification

1. Deploy while PostHog experiment 416619 / flag 816340 remain inactive.
2. Assign an internal test user to `grok_4_6`, select HackerAI Pro in Agent mode, and run text and image requests.
3. Confirm the configured provider model is `x-ai/grok-4.6`, reasoning effort is high, and the fallback order is Grok 4.5 → GLM 5.2 → Kimi K3.
4. Confirm `hac64_pro_grok_46_model_experiment_exposed` contains only the expected privacy-safe properties and that downstream Agent/usage events carry the same experiment key and variant.
5. Bind the experiment to that custom exposure event, then launch only after the observed payload is correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Grok 4.6 Pro model.
  - Eligible HackerAI Pro requests may be routed to Grok 4.6 through a controlled experiment.
  - Added fallback routing to maintain availability if the selected model cannot respond.
  - Added high-reasoning support for Grok 4.6.

- **Bug Fixes**
  - Improved model detection, retry handling, and multimodal response compatibility.

- **Chores**
  - Updated usage-cost calculations for Grok 4.6’s long-context pricing tier.
  - Improved experiment and model usage analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->