### PR TITLE
Fix chat title rename synchronization

### DIFF
--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -189,7 +189,7 @@ import {
   Chat,
   getExistingChatLoadState,
   getStoredAgentApprovalRequest,
-  shouldReleaseStreamedTitle,
+  useStreamedChatTitle,
   useServerMessages,
 } from "../chat";
 import { ChatLayout } from "../ChatLayout";
@@ -234,6 +234,23 @@ const QueueEditingHarness = () => {
   );
 };
 
+const ChatTitleHandoffHarness = ({
+  persistedTitle,
+}: {
+  persistedTitle: string;
+}) => {
+  const [chatTitle, setStreamedTitle] = useStreamedChatTitle(persistedTitle);
+
+  return (
+    <>
+      <div data-testid="chat-title">{chatTitle}</div>
+      <button type="button" onClick={() => setStreamedTitle("Generated title")}>
+        Stream generated title
+      </button>
+    </>
+  );
+};
+
 describe("Chat Component Integration", () => {
   let mockUseChat: jest.Mock;
 
@@ -260,13 +277,26 @@ describe("Chat Component Integration", () => {
 
   describe("Basic Rendering", () => {
     it("releases a persisted streamed title so later manual renames stay visible", () => {
-      expect(
-        shouldReleaseStreamedTitle("Generated title", "Generated title"),
-      ).toBe(true);
-      expect(
-        shouldReleaseStreamedTitle("Generated title", "Original prompt"),
-      ).toBe(false);
-      expect(shouldReleaseStreamedTitle(null, "Renamed title")).toBe(false);
+      const { rerender } = render(
+        <ChatTitleHandoffHarness persistedTitle="Original prompt" />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Stream generated title" }),
+      );
+      expect(screen.getByTestId("chat-title")).toHaveTextContent(
+        "Generated title",
+      );
+
+      rerender(<ChatTitleHandoffHarness persistedTitle="Generated title" />);
+      expect(screen.getByTestId("chat-title")).toHaveTextContent(
+        "Generated title",
+      );
+
+      rerender(<ChatTitleHandoffHarness persistedTitle="Renamed title" />);
+      expect(screen.getByTestId("chat-title")).toHaveTextContent(
+        "Renamed title",
+      );
     });
 
     it("should render new chat with welcome message", () => {

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -189,6 +189,7 @@ import {
   Chat,
   getExistingChatLoadState,
   getStoredAgentApprovalRequest,
+  shouldReleaseStreamedTitle,
   useServerMessages,
 } from "../chat";
 import { ChatLayout } from "../ChatLayout";
@@ -258,6 +259,16 @@ describe("Chat Component Integration", () => {
   });
 
   describe("Basic Rendering", () => {
+    it("releases a persisted streamed title so later manual renames stay visible", () => {
+      expect(
+        shouldReleaseStreamedTitle("Generated title", "Generated title"),
+      ).toBe(true);
+      expect(
+        shouldReleaseStreamedTitle("Generated title", "Original prompt"),
+      ).toBe(false);
+      expect(shouldReleaseStreamedTitle(null, "Renamed title")).toBe(false);
+    });
+
     it("should render new chat with welcome message", () => {
       render(
         <TestWrapper>

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -222,10 +222,25 @@ export function getExistingChatLoadState({
   return { isInitialExistingChatLoad, isChatNotFound };
 }
 
-export const shouldReleaseStreamedTitle = (
+const shouldReleaseStreamedTitle = (
   streamedTitle: string | null,
   persistedTitle: string | null | undefined,
 ): boolean => Boolean(streamedTitle && persistedTitle === streamedTitle);
+
+export function useStreamedChatTitle(
+  persistedTitle: string | null | undefined,
+) {
+  const [streamedTitle, setStreamedTitle] = useState<string | null>(null);
+
+  // The streamed title only bridges the gap until Convex receives the same
+  // generated title. This guarded adjustment restarts the current render
+  // before children commit with a stale title source.
+  if (shouldReleaseStreamedTitle(streamedTitle, persistedTitle)) {
+    setStreamedTitle(null);
+  }
+
+  return [streamedTitle ?? persistedTitle ?? null, setStreamedTitle] as const;
+}
 
 export function useServerMessages(
   paginatedMessageResults: MessageRecord[] | undefined,
@@ -567,9 +582,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     Map<string, FileDetails[]>
   >(new Map());
 
-  // Title streamed mid-response so the header updates before Convex persists it
-  const [streamedTitle, setStreamedTitle] = useState<string | null>(null);
-
   // Use global state ref so streaming callback reads latest value
   const hasUserDismissedWarningRef = useLatestRef(
     hasUserDismissedRateLimitWarning,
@@ -605,21 +617,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     null,
   );
 
-  // Sync local chat state from URL (single source of truth)
-  useEffect(() => {
-    setStreamedTitle(null);
-    lastAppliedTodoOutputRef.current = null;
-    if (routeChatId) {
-      setChatId(routeChatId);
-      setIsExistingChat(true);
-    } else {
-      // Navigated to "/" (new chat) — reset to fresh state
-      setChatId(uuidv4());
-      setIsExistingChat(false);
-      wasNewChatRef.current = true;
-    }
-  }, [routeChatId]);
-
   // Use paginated query to load messages in batches of 14
   const paginatedMessages = usePaginatedQuery(
     api.messages.getMessagesByChatId,
@@ -635,8 +632,26 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   const chatDataForCurrentChat =
     chatData && (chatData as any).id === chatId ? chatData : undefined;
+  const [chatTitle, setStreamedTitle] = useStreamedChatTitle(
+    chatDataForCurrentChat?.title,
+  );
   const loadedChatDocumentId = chatDataForCurrentChat?._id;
   const lastRunFinishedAt = chatDataForCurrentChat?.last_run_finished_at;
+
+  // Sync local chat state from URL (single source of truth)
+  useEffect(() => {
+    setStreamedTitle(null);
+    lastAppliedTodoOutputRef.current = null;
+    if (routeChatId) {
+      setChatId(routeChatId);
+      setIsExistingChat(true);
+    } else {
+      // Navigated to "/" (new chat) — reset to fresh state
+      setChatId(uuidv4());
+      setIsExistingChat(false);
+      wasNewChatRef.current = true;
+    }
+  }, [routeChatId, setStreamedTitle]);
 
   useEffect(() => {
     if (!loadedChatDocumentId) return;
@@ -659,20 +674,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const storedSandboxType = (chatDataForCurrentChat as any)?.sandbox_type as
     string | undefined;
 
-  // Prefer the mid-stream title — the server seeds chatData.title with the
-  // user's first message before generation completes, which would otherwise
-  // flicker into the header on abort.
-  const chatTitle = streamedTitle ?? chatDataForCurrentChat?.title ?? null;
-
-  // The streamed title only bridges the gap until Convex receives the same
-  // generated title. Keeping it afterwards would mask later manual renames.
-  useEffect(() => {
-    if (
-      shouldReleaseStreamedTitle(streamedTitle, chatDataForCurrentChat?.title)
-    ) {
-      setStreamedTitle(null);
-    }
-  }, [chatDataForCurrentChat?.title, streamedTitle]);
   const activeTriggerRunId = (chatDataForCurrentChat as any)
     ?.active_trigger_run_id as string | undefined;
   const storedAgentApprovalRequest = activeTriggerRunId
@@ -1389,6 +1390,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   }, [
     setChatReset,
     setMessages,
+    setStreamedTitle,
     setTodos,
     resetAutoContinueCount,
     stopActiveBrowserStream,

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -222,6 +222,11 @@ export function getExistingChatLoadState({
   return { isInitialExistingChatLoad, isChatNotFound };
 }
 
+export const shouldReleaseStreamedTitle = (
+  streamedTitle: string | null,
+  persistedTitle: string | null | undefined,
+): boolean => Boolean(streamedTitle && persistedTitle === streamedTitle);
+
 export function useServerMessages(
   paginatedMessageResults: MessageRecord[] | undefined,
 ): ChatMessage[] {
@@ -658,6 +663,16 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // user's first message before generation completes, which would otherwise
   // flicker into the header on abort.
   const chatTitle = streamedTitle ?? chatDataForCurrentChat?.title ?? null;
+
+  // The streamed title only bridges the gap until Convex receives the same
+  // generated title. Keeping it afterwards would mask later manual renames.
+  useEffect(() => {
+    if (
+      shouldReleaseStreamedTitle(streamedTitle, chatDataForCurrentChat?.title)
+    ) {
+      setStreamedTitle(null);
+    }
+  }, [chatDataForCurrentChat?.title, streamedTitle]);
   const activeTriggerRunId = (chatDataForCurrentChat as any)
     ?.active_trigger_run_id as string | undefined;
   const storedAgentApprovalRequest = activeTriggerRunId


### PR DESCRIPTION
## Summary

- release the temporary streamed chat title once the identical generated title is persisted in Convex
- let subsequent manual title changes flow from the reactive chat document into the chat header
- add regression coverage for the streamed-title handoff conditions

## Root cause

`streamedTitle` intentionally takes priority over `chatData.title` while a generated title is in flight, preventing the seeded first-message title from flickering into the header. That temporary value was never cleared after Convex persisted it, so it continued masking later user-initiated renames. The sidebar reacted to the updated Convex document while the active chat header kept rendering the stale streamed value.

## User impact

After the generated title is persisted, renaming a task now updates both the sidebar and active chat header consistently. The existing no-flicker behavior during title generation remains unchanged because the streamed value is released only after Convex confirms the exact same title.

## Validation

- `pnpm exec jest app/components/__tests__/chat.integration.test.tsx --runInBand --no-watchman` (15 tests passed)
- repository pre-commit suite (353 suites, 3,621 tests passed)
- `pnpm typecheck`
- targeted ESLint (no errors; three pre-existing hook warnings in `chat.tsx`)
- `git diff --check`

## Manual verification

1. Start a new chat and wait for its generated title to appear.
2. Rename the task from the sidebar options menu.
3. Confirm the new title appears in both the sidebar row and active chat header without reloading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat title updates by clearing temporary streamed titles once the saved title catches up.
  * Ensured later saved title changes display correctly instead of being overridden by stale streamed content.
  * Reset temporary titles when navigating between chats.

* **Tests**
  * Added integration coverage for streamed title handoff, persisted title synchronization, and subsequent renames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->