### PR TITLE
Skip unchanged default task renames

### DIFF
--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -391,7 +391,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
     const trimmedTitle = editTitle.trim();
 
     // Don't save if title is empty or unchanged
-    if (!trimmedTitle || trimmedTitle === title) {
+    if (!trimmedTitle || trimmedTitle === taskTitle) {
       setShowRenameDialog(false);
       setEditTitle(taskTitle); // Reset to original title
       return;

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/utils/client-storage";
 
 const mockMoveChatToProject = jest.fn<any>();
+const mockRenameChat = jest.fn<any>();
 const mockRouterPush = jest.fn();
 const mockToastSuccess = jest.fn();
 const mockToastInfo = jest.fn();
@@ -47,7 +48,7 @@ jest.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => mockUseIsMobile(),
 }));
 jest.mock("convex/react", () => ({
-  useMutation: () => jest.fn(),
+  useMutation: () => mockRenameChat,
 }));
 jest.mock("@/app/hooks/useChats", () => ({
   usePinChat: () => jest.fn(),
@@ -112,6 +113,7 @@ describe("ChatItem project actions", () => {
     jest.clearAllMocks();
     mockUseIsMobile.mockReturnValue(false);
     mockMoveChatToProject.mockResolvedValue(true);
+    mockRenameChat.mockResolvedValue(null);
     mockProjects = undefined;
     mockPathname = "/";
     clearSidebarTaskLastVisitedAt();
@@ -317,6 +319,23 @@ describe("ChatItem project actions", () => {
     expect(input).toHaveAttribute("name", "taskTitle");
     expect(input).toHaveAttribute("autocomplete", "off");
     expect(input).toHaveAttribute("placeholder", "Task name…");
+  });
+
+  it("does not persist the display-only default title when rename is unchanged", async () => {
+    const user = userEvent.setup();
+    render(<ChatItem id="chat-1" title="New Chat" />);
+
+    fireEvent.focus(screen.getByRole("button", { name: /Open task:/ }));
+    await user.click(screen.getByRole("button", { name: "Open task options" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Rename" }));
+
+    expect(await screen.findByLabelText("Task name")).toHaveValue("New Task");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockRenameChat).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("dialog", { name: "Rename Task" }),
+    ).not.toBeInTheDocument();
   });
 
   it("uses compact side padding for standard and project chat rows", () => {


### PR DESCRIPTION
## Summary

- compare rename input against the title users actually see in the task list
- avoid persisting the display-only `New Task` alias when the rename dialog is saved unchanged
- add regression coverage for the default-title path

## Root cause

The database default is `New Chat`, while `formatTaskTitle` deliberately presents it as `New Task`. The rename dialog is initialized with the formatted value, but the unchanged check compared it against the raw database title. Saving without editing therefore called `renameChat` with `New Task`.

## User impact

An unchanged rename no longer creates a database write, changes `update_time`, or unexpectedly reorders a default task in history.

## Validation

- targeted ChatItem tests (19 passed)
- repository pre-commit suite (353 suites, 3,621 tests passed)
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- `git diff --check`

## Manual verification

1. Open the rename dialog for a task whose displayed title is `New Task`.
2. Click Save without editing the field.
3. Confirm the dialog closes and the task does not move or change in history.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary rename requests when the edited chat title matches its displayed formatting.
  * Saving an unchanged “New Chat” title now closes the dialog without triggering a rename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->