### PR TITLE
Require active share IDs for shared message reads

### DIFF
--- a/convex/__tests__/messages.shared.test.ts
+++ b/convex/__tests__/messages.shared.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: unknown) => config),
+  query: jest.fn((config: unknown) => config),
+  internalQuery: jest.fn((config: unknown) => config),
+}));
+jest.mock("convex/values", () => {
+  const actualValues =
+    jest.requireActual<typeof import("convex/values")>("convex/values");
+
+  return {
+    v: {
+      any: jest.fn(() => "any"),
+      array: jest.fn(() => "array"),
+      boolean: jest.fn(() => "boolean"),
+      id: jest.fn(() => "id"),
+      literal: jest.fn(() => "literal"),
+      null: jest.fn(() => "null"),
+      number: jest.fn(() => "number"),
+      object: jest.fn(() => "object"),
+      optional: jest.fn(() => "optional"),
+      string: jest.fn(() => "string"),
+      union: jest.fn(() => "union"),
+    },
+    ConvexError: class ConvexError extends Error {},
+    getDocumentSize: actualValues.getDocumentSize,
+  };
+});
+jest.mock("../_generated/api", () => ({ internal: {} }));
+jest.mock("../fileAggregate", () => ({
+  fileCountAggregate: { deleteIfExists: jest.fn() },
+}));
+jest.mock("convex/server", () => ({
+  paginationOptsValidator: "paginationOptsValidator",
+}));
+jest.mock("../lib/sharedChatSnapshot", () => ({
+  getVisibleSharedChatByShareId: jest.fn(),
+  listVisibleSharedMessages: jest.fn(),
+  sharedMessageValidator: "sharedMessageValidator",
+}));
+
+const { getVisibleSharedChatByShareId, listVisibleSharedMessages } =
+  jest.requireMock("../lib/sharedChatSnapshot") as {
+    getVisibleSharedChatByShareId: jest.Mock;
+    listVisibleSharedMessages: jest.Mock;
+  };
+
+describe("getSharedMessages", () => {
+  it("authorizes the read with the active share ID", async () => {
+    const sharedChat = {
+      id: "chat-1",
+      share_id: "new-share-id",
+      share_date: 200,
+    };
+    const messages = [{ id: "message-1" }];
+    getVisibleSharedChatByShareId.mockResolvedValue(sharedChat);
+    listVisibleSharedMessages.mockResolvedValue(messages);
+
+    const { getSharedMessages } = await import("../messages");
+    const ctx = { db: {} };
+
+    await expect(
+      getSharedMessages.handler(ctx as any, { shareId: "new-share-id" }),
+    ).resolves.toEqual(messages);
+
+    expect(getVisibleSharedChatByShareId).toHaveBeenCalledWith(
+      ctx,
+      "new-share-id",
+    );
+    expect(listVisibleSharedMessages).toHaveBeenCalledWith(ctx, sharedChat);
+  });
+
+  it("returns no messages when the supplied share ID is no longer active", async () => {
+    getVisibleSharedChatByShareId.mockResolvedValue(null);
+
+    const { getSharedMessages } = await import("../messages");
+    const ctx = { db: {} };
+
+    await expect(
+      getSharedMessages.handler(ctx as any, { shareId: "revoked-share-id" }),
+    ).resolves.toEqual([]);
+
+    expect(listVisibleSharedMessages).not.toHaveBeenCalled();
+  });
+});

--- a/convex/__tests__/sharedChats.fork.test.ts
+++ b/convex/__tests__/sharedChats.fork.test.ts
@@ -30,8 +30,6 @@ jest.mock("../lib/suspensionGuards", () => ({
 
 const { forkSharedChat, getSharedSnapshot } =
   require("../sharedChats") as typeof import("../sharedChats");
-const { getVisibleSharedChatByChatId } =
-  require("../lib/sharedChatSnapshot") as typeof import("../lib/sharedChatSnapshot");
 
 describe("getSharedSnapshot", () => {
   it("returns frozen, anonymous chat data with one shared-chat lookup", async () => {
@@ -250,18 +248,6 @@ describe("getSharedSnapshot", () => {
       expect.any(Error),
     );
     consoleError.mockRestore();
-  });
-});
-
-describe("shared chat visibility helpers", () => {
-  it("rejects an invalid legacy chat ID without reading the database", async () => {
-    const query = jest.fn<any>();
-
-    await expect(
-      getVisibleSharedChatByChatId({ db: { query } } as any, "not-a-uuid"),
-    ).resolves.toBeNull();
-
-    expect(query).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/lib/sharedChatSnapshot.ts
+++ b/convex/lib/sharedChatSnapshot.ts
@@ -31,9 +31,6 @@ export const sharedMessageValidator = v.object({
   update_time: v.number(),
 });
 
-const UUID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 const resolveVisibleSharedChat = async (
   ctx: SharedChatReaderCtx,
   chat: Doc<"chats"> | null,
@@ -56,22 +53,6 @@ export const getVisibleSharedChatByShareId = async (
   const chat = await ctx.db
     .query("chats")
     .withIndex("by_share_id", (q) => q.eq("share_id", shareId))
-    .first();
-
-  return resolveVisibleSharedChat(ctx, chat);
-};
-
-export const getVisibleSharedChatByChatId = async (
-  ctx: SharedChatReaderCtx,
-  chatId: string,
-): Promise<VisibleSharedChat | null> => {
-  if (!UUID_REGEX.test(chatId)) {
-    return null;
-  }
-
-  const chat = await ctx.db
-    .query("chats")
-    .withIndex("by_chat_id", (q) => q.eq("id", chatId))
     .first();
 
   return resolveVisibleSharedChat(ctx, chat);

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -14,7 +14,7 @@ import { convexLogger } from "./lib/logger";
 import type { RetainedTailDoc } from "./lib/retainedTail";
 import { assertUserCanAccessChatHistory } from "./lib/suspensionGuards";
 import {
-  getVisibleSharedChatByChatId,
+  getVisibleSharedChatByShareId,
   listVisibleSharedMessages,
   sharedMessageValidator,
 } from "./lib/sharedChatSnapshot";
@@ -2140,15 +2140,15 @@ export const regenerateWithNewContent = mutation({
  * the shared link only shows messages that existed at share time.
  * New messages added after sharing are NOT visible until user updates the share.
  *
- * @param chatId - The ID of the chat to get messages for
+ * @param shareId - The active public share ID
  * @returns Array of messages (up to share_date) with files/images as placeholders
  */
 export const getSharedMessages = query({
-  args: { chatId: v.string() },
+  args: { shareId: v.string() },
   returns: v.array(sharedMessageValidator),
   handler: async (ctx, args) => {
     try {
-      const chat = await getVisibleSharedChatByChatId(ctx, args.chatId);
+      const chat = await getVisibleSharedChatByShareId(ctx, args.shareId);
       return chat ? await listVisibleSharedMessages(ctx, chat) : [];
     } catch (error) {
       console.error("Failed to get shared messages:", error);


### PR DESCRIPTION
## Summary

- authorize legacy shared-message reads with the active `shareId` instead of the underlying chat ID
- remove the public chat-ID visibility helper
- add regression coverage for active and revoked share IDs

## Why

A chat ID is a resource identifier, not the capability that grants public access. Requiring the current share ID keeps public message reads aligned with share revocation and link rotation.

## Impact

Revoked share IDs can no longer regain access if the same chat is shared again under a new link. The current share page already uses the secure snapshot query, so its UI behavior is unchanged.

## Validation

- `pnpm exec jest --runInBand --watchman=false` — 354 suites, 3,621 tests passed
- `pnpm typecheck`
- targeted ESLint and Prettier checks for all changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-message access by validating public share IDs before retrieving messages.
  * Revoked or inactive shares now safely return no messages.
  * Removed legacy chat-ID lookup behavior for shared chats.

* **Tests**
  * Added coverage for active, inactive, and revoked share access.
  * Updated shared-chat tests to reflect the current share-ID-based flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->