### PR TITLE
Prevent concurrent PentestGPT migrations

### DIFF
--- a/app/api/migrate-pentestgpt/__tests__/route.test.ts
+++ b/app/api/migrate-pentestgpt/__tests__/route.test.ts
@@ -126,6 +126,7 @@ const mockAcquireMigrationLock =
   acquirePentestgptMigrationLock as jest.MockedFunction<
     typeof acquirePentestgptMigrationLock
   >;
+const mockAssertMigrationLockOwned = jest.fn<() => Promise<void>>();
 const mockReleaseMigrationLock = jest.fn<() => Promise<void>>();
 
 const request = () => ({ url: "https://hackerai.test/api/migrate-pentestgpt" });
@@ -134,8 +135,10 @@ describe("POST /api/migrate-pentestgpt", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    mockAssertMigrationLockOwned.mockResolvedValue();
     mockReleaseMigrationLock.mockResolvedValue();
     mockAcquireMigrationLock.mockResolvedValue({
+      assertOwned: mockAssertMigrationLockOwned,
       release: mockReleaseMigrationLock,
     });
 
@@ -231,6 +234,7 @@ describe("POST /api/migrate-pentestgpt", () => {
       { idempotencyKey: "pentestgpt-migration:sub_legacy" },
     );
     expect(mockReleaseMigrationLock).toHaveBeenCalledTimes(1);
+    expect(mockAssertMigrationLockOwned).toHaveBeenCalledTimes(8);
   });
 
   it("rejects a concurrent migration before creating side effects", async () => {

--- a/app/api/migrate-pentestgpt/__tests__/route.test.ts
+++ b/app/api/migrate-pentestgpt/__tests__/route.test.ts
@@ -7,6 +7,10 @@ import {
   PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
 } from "@/lib/billing/included-usage";
 import { capCurrentCycleAllocation } from "@/lib/rate-limit";
+import {
+  acquirePentestgptMigrationLock,
+  PentestgptMigrationLockUnavailableError,
+} from "@/lib/billing/pentestgpt-migration-lock";
 
 jest.mock("next/server", () => ({
   NextResponse: {
@@ -23,6 +27,11 @@ jest.mock("@/lib/auth/get-user-id", () => ({
 
 jest.mock("@/lib/rate-limit", () => ({
   capCurrentCycleAllocation: jest.fn(),
+}));
+
+jest.mock("@/lib/billing/pentestgpt-migration-lock", () => ({
+  acquirePentestgptMigrationLock: jest.fn(),
+  PentestgptMigrationLockUnavailableError: class extends Error {},
 }));
 
 jest.mock("../../stripe", () => ({
@@ -113,12 +122,22 @@ const mockCapCurrentCycleAllocation =
   capCurrentCycleAllocation as jest.MockedFunction<
     typeof capCurrentCycleAllocation
   >;
+const mockAcquireMigrationLock =
+  acquirePentestgptMigrationLock as jest.MockedFunction<
+    typeof acquirePentestgptMigrationLock
+  >;
+const mockReleaseMigrationLock = jest.fn<() => Promise<void>>();
 
 const request = () => ({ url: "https://hackerai.test/api/migrate-pentestgpt" });
 
 describe("POST /api/migrate-pentestgpt", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockReleaseMigrationLock.mockResolvedValue();
+    mockAcquireMigrationLock.mockResolvedValue({
+      release: mockReleaseMigrationLock,
+    });
 
     mockGetUserIDAndPro.mockResolvedValue({
       userId: "user_123",
@@ -209,7 +228,43 @@ describe("POST /api/migrate-pentestgpt", () => {
         customer: "cus_legacy",
         items: [{ price: "price_destination", quantity: 1 }],
       }),
+      { idempotencyKey: "pentestgpt-migration:sub_legacy" },
     );
+    expect(mockReleaseMigrationLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a concurrent migration before creating side effects", async () => {
+    mockAcquireMigrationLock.mockResolvedValueOnce(null);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body).toEqual({
+      error: "Migration already in progress",
+      message: "A PentestGPT migration is already running for this account.",
+    });
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+    expect(mockUpdateCustomer).not.toHaveBeenCalled();
+    expect(mockCreateSubscription).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the migration lock is unavailable", async () => {
+    mockAcquireMigrationLock.mockRejectedValueOnce(
+      new PentestgptMigrationLockUnavailableError(),
+    );
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({
+      error: "Migration service temporarily unavailable",
+    });
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateSubscription).not.toHaveBeenCalled();
   });
 
   it("migrates legacy PentestGPT Pro customers with old userId metadata to HackerAI Pro", async () => {
@@ -253,6 +308,7 @@ describe("POST /api/migrate-pentestgpt", () => {
         collection_method: "charge_automatically",
         cancel_at_period_end: false,
       }),
+      { idempotencyKey: "pentestgpt-migration:sub_legacy" },
     );
     expect(mockCancelSubscription).toHaveBeenCalledWith("sub_legacy");
   });
@@ -299,6 +355,7 @@ describe("POST /api/migrate-pentestgpt", () => {
       expect.objectContaining({
         items: [{ price: HACKERAI_PRO_20_MONTHLY_PRICE_ID, quantity: 1 }],
       }),
+      { idempotencyKey: "pentestgpt-migration:sub_legacy_20" },
     );
     expect(mockCapCurrentCycleAllocation).toHaveBeenCalledWith(
       "user_123",

--- a/app/api/migrate-pentestgpt/route.ts
+++ b/app/api/migrate-pentestgpt/route.ts
@@ -7,9 +7,15 @@ import {
   PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
 } from "@/lib/billing/included-usage";
 import { capCurrentCycleAllocation } from "@/lib/rate-limit";
+import {
+  acquirePentestgptMigrationLock,
+  PentestgptMigrationLockUnavailableError,
+  type PentestgptMigrationLock,
+} from "@/lib/billing/pentestgpt-migration-lock";
 import { NextRequest, NextResponse } from "next/server";
 
 export const POST = async (req: NextRequest) => {
+  let migrationLock: PentestgptMigrationLock | null = null;
   try {
     // Get user ID and subscription status
     const { userId, subscription } = await getUserIDAndPro(req);
@@ -22,6 +28,18 @@ export const POST = async (req: NextRequest) => {
           message: "You must be on the free tier to migrate from PentestGPT",
         },
         { status: 400 },
+      );
+    }
+
+    migrationLock = await acquirePentestgptMigrationLock(userId);
+    if (!migrationLock) {
+      return NextResponse.json(
+        {
+          error: "Migration already in progress",
+          message:
+            "A PentestGPT migration is already running for this account.",
+        },
+        { status: 409 },
       );
     }
 
@@ -343,20 +361,27 @@ export const POST = async (req: NextRequest) => {
       }
 
       // Create the new subscription using the same default payment method
-      await stripe.subscriptions.create({
-        customer: pentestGPTCustomer.id,
-        items: [
-          {
-            price: destinationPriceId,
-            quantity,
-          },
-        ],
-        ...(paymentMethodId ? { default_payment_method: paymentMethodId } : {}),
-        ...(defaultSourceId ? { default_source: defaultSourceId } : {}),
-        trial_end: trialEnd,
-        collection_method: "charge_automatically",
-        cancel_at_period_end: false,
-      });
+      await stripe.subscriptions.create(
+        {
+          customer: pentestGPTCustomer.id,
+          items: [
+            {
+              price: destinationPriceId,
+              quantity,
+            },
+          ],
+          ...(paymentMethodId
+            ? { default_payment_method: paymentMethodId }
+            : {}),
+          ...(defaultSourceId ? { default_source: defaultSourceId } : {}),
+          trial_end: trialEnd,
+          collection_method: "charge_automatically",
+          cancel_at_period_end: false,
+        },
+        {
+          idempotencyKey: `pentestgpt-migration:${pentestGPTSubscription.id}`,
+        },
+      );
     } catch (createErr) {
       console.error("Failed to create destination subscription:", createErr);
       return NextResponse.json(
@@ -380,9 +405,26 @@ export const POST = async (req: NextRequest) => {
       showTeamWelcome,
     });
   } catch (error: unknown) {
+    if (error instanceof PentestgptMigrationLockUnavailableError) {
+      return NextResponse.json(
+        { error: "Migration service temporarily unavailable" },
+        { status: 503 },
+      );
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An error occurred";
     console.error("Migration error:", errorMessage, error);
     return NextResponse.json({ error: errorMessage }, { status: 500 });
+  } finally {
+    if (migrationLock) {
+      try {
+        await migrationLock.release();
+      } catch (releaseError) {
+        console.error(
+          "Failed to release PentestGPT migration lock:",
+          releaseError,
+        );
+      }
+    }
   }
 };

--- a/app/api/migrate-pentestgpt/route.ts
+++ b/app/api/migrate-pentestgpt/route.ts
@@ -298,11 +298,13 @@ export const POST = async (req: NextRequest) => {
 
     // Create new organization with a WorkOS-safe display name only after all
     // migration prerequisites have been validated.
+    await migrationLock.assertOwned();
     const organization = await workos.organizations.createOrganization({
       name: buildWorkOSOrganizationName(user),
     });
 
     // Create organization membership for user as admin
+    await migrationLock.assertOwned();
     await workos.userManagement.createOrganizationMembership({
       organizationId: organization.id,
       userId,
@@ -310,6 +312,7 @@ export const POST = async (req: NextRequest) => {
     });
 
     // Update Stripe customer metadata to link to new WorkOS organization
+    await migrationLock.assertOwned();
     await stripe.customers.update(pentestGPTCustomer.id, {
       metadata: {
         workOSOrganizationId: organization.id,
@@ -319,48 +322,52 @@ export const POST = async (req: NextRequest) => {
 
     // Update WorkOS organization with Stripe customer ID
     // This will allow WorkOS to automatically add entitlements to the access token
+    await migrationLock.assertOwned();
     await workos.organizations.updateOrganization({
       organization: organization.id,
       stripeCustomerId: pentestGPTCustomer.id,
     });
 
     // Always reuse the old subscription's payment method for the new subscription
-    try {
-      // Ensure the payment method is attached to the destination customer
-      if (paymentMethodId) {
-        try {
-          const pm = await stripe.paymentMethods.retrieve(paymentMethodId);
-          const attachedCustomer = (pm as any).customer;
-          if (!attachedCustomer) {
-            await stripe.paymentMethods.attach(paymentMethodId, {
-              customer: pentestGPTCustomer.id,
-            });
-          } else if (attachedCustomer !== pentestGPTCustomer.id) {
-            // If attached to another customer, try to attach (Stripe will error if not allowed)
-            await stripe.paymentMethods.attach(paymentMethodId, {
-              customer: pentestGPTCustomer.id,
-            });
-          }
-        } catch (attachErr) {
-          console.warn("Payment method attach attempt result:", attachErr);
-        }
-      }
-
-      // Set as customer's default to mirror legacy behavior
-      if (paymentMethodId) {
-        try {
-          await stripe.customers.update(pentestGPTCustomer.id, {
-            invoice_settings: { default_payment_method: paymentMethodId },
+    // Ensure the payment method is attached to the destination customer
+    if (paymentMethodId) {
+      await migrationLock.assertOwned();
+      try {
+        const pm = await stripe.paymentMethods.retrieve(paymentMethodId);
+        const attachedCustomer = (pm as any).customer;
+        if (!attachedCustomer) {
+          await stripe.paymentMethods.attach(paymentMethodId, {
+            customer: pentestGPTCustomer.id,
           });
-        } catch (custErr) {
-          console.warn(
-            "Failed setting customer default payment method:",
-            custErr,
-          );
+        } else if (attachedCustomer !== pentestGPTCustomer.id) {
+          // If attached to another customer, try to attach (Stripe will error if not allowed)
+          await stripe.paymentMethods.attach(paymentMethodId, {
+            customer: pentestGPTCustomer.id,
+          });
         }
+      } catch (attachErr) {
+        console.warn("Payment method attach attempt result:", attachErr);
       }
+    }
 
-      // Create the new subscription using the same default payment method
+    // Set as customer's default to mirror legacy behavior
+    if (paymentMethodId) {
+      await migrationLock.assertOwned();
+      try {
+        await stripe.customers.update(pentestGPTCustomer.id, {
+          invoice_settings: { default_payment_method: paymentMethodId },
+        });
+      } catch (custErr) {
+        console.warn(
+          "Failed setting customer default payment method:",
+          custErr,
+        );
+      }
+    }
+
+    // Create the new subscription using the same default payment method
+    await migrationLock.assertOwned();
+    try {
       await stripe.subscriptions.create(
         {
           customer: pentestGPTCustomer.id,
@@ -391,6 +398,7 @@ export const POST = async (req: NextRequest) => {
     }
 
     // Cancel the old PentestGPT subscription immediately
+    await migrationLock.assertOwned();
     try {
       await stripe.subscriptions.cancel(pentestGPTSubscription.id);
     } catch (cancelErr) {

--- a/lib/billing/__tests__/pentestgpt-migration-lock.test.ts
+++ b/lib/billing/__tests__/pentestgpt-migration-lock.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+describe("acquirePentestgptMigrationLock", () => {
+  const mockCreateRedisClient = jest.fn();
+  const mockSet = jest.fn();
+  const mockEval = jest.fn();
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockSet.mockResolvedValue("OK");
+    mockEval.mockResolvedValue(1);
+  });
+
+  const getIsolatedModule = () => {
+    let isolatedModule: typeof import("../pentestgpt-migration-lock");
+
+    jest.isolateModules(() => {
+      jest.doMock("@/lib/rate-limit/redis", () => ({
+        createRedisClient: mockCreateRedisClient,
+      }));
+      isolatedModule = require("../pentestgpt-migration-lock");
+    });
+
+    return isolatedModule!;
+  };
+
+  it("acquires a per-user lock and releases only its own token", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    const { acquirePentestgptMigrationLock } = getIsolatedModule();
+
+    const lock = await acquirePentestgptMigrationLock("user-123");
+
+    expect(lock).not.toBeNull();
+    expect(mockSet).toHaveBeenCalledWith(
+      "pentestgpt_migration_lock:user-123",
+      expect.any(String),
+      { nx: true, ex: 900 },
+    );
+
+    await lock!.release();
+    await lock!.release();
+
+    expect(mockEval).toHaveBeenCalledTimes(1);
+    expect(mockEval).toHaveBeenCalledWith(
+      expect.any(String),
+      ["pentestgpt_migration_lock:user-123"],
+      [expect.any(String)],
+    );
+  });
+
+  it("returns null while another migration holds the lock", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    mockSet.mockResolvedValue(null);
+    const { acquirePentestgptMigrationLock } = getIsolatedModule();
+
+    await expect(
+      acquirePentestgptMigrationLock("user-123"),
+    ).resolves.toBeNull();
+    expect(mockEval).not.toHaveBeenCalled();
+  });
+
+  it("allows lock release to be retried after a Redis error", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    mockEval
+      .mockRejectedValueOnce(new Error("temporary Redis error"))
+      .mockResolvedValueOnce(1);
+    const { acquirePentestgptMigrationLock } = getIsolatedModule();
+    const lock = await acquirePentestgptMigrationLock("user-123");
+
+    await expect(lock!.release()).rejects.toThrow("temporary Redis error");
+    await expect(lock!.release()).resolves.toBeUndefined();
+    expect(mockEval).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/billing/__tests__/pentestgpt-migration-lock.test.ts
+++ b/lib/billing/__tests__/pentestgpt-migration-lock.test.ts
@@ -6,6 +6,7 @@ describe("acquirePentestgptMigrationLock", () => {
   const mockEval = jest.fn();
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.resetModules();
     jest.clearAllMocks();
     mockSet.mockResolvedValue("OK");
@@ -37,16 +38,42 @@ describe("acquirePentestgptMigrationLock", () => {
       expect.any(String),
       { nx: true, ex: 900 },
     );
+    const acquiredToken = mockSet.mock.calls[0][1];
 
-    await lock!.release();
-    await lock!.release();
-
-    expect(mockEval).toHaveBeenCalledTimes(1);
-    expect(mockEval).toHaveBeenCalledWith(
-      expect.any(String),
+    await lock!.assertOwned();
+    expect(mockEval).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("EXPIRE"),
       ["pentestgpt_migration_lock:user-123"],
-      [expect.any(String)],
+      [acquiredToken, "900"],
     );
+
+    await lock!.release();
+    await lock!.release();
+
+    expect(mockEval).toHaveBeenCalledTimes(2);
+    expect(mockEval).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("DEL"),
+      ["pentestgpt_migration_lock:user-123"],
+      [acquiredToken],
+    );
+  });
+
+  it("renews the token-owned lease while the migration is running", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    const { acquirePentestgptMigrationLock } = getIsolatedModule();
+    const lock = await acquirePentestgptMigrationLock("user-123");
+    const acquiredToken = mockSet.mock.calls[0][1];
+
+    await jest.advanceTimersByTimeAsync(60_000);
+
+    expect(mockEval).toHaveBeenCalledWith(
+      expect.stringContaining("EXPIRE"),
+      ["pentestgpt_migration_lock:user-123"],
+      [acquiredToken, "900"],
+    );
+    await lock!.release();
   });
 
   it("returns null while another migration holds the lock", async () => {
@@ -71,5 +98,18 @@ describe("acquirePentestgptMigrationLock", () => {
     await expect(lock!.release()).rejects.toThrow("temporary Redis error");
     await expect(lock!.release()).resolves.toBeUndefined();
     expect(mockEval).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps Redis acquisition errors to lock unavailability", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    mockSet.mockRejectedValueOnce(new Error("Redis unavailable"));
+    const {
+      acquirePentestgptMigrationLock,
+      PentestgptMigrationLockUnavailableError,
+    } = getIsolatedModule();
+
+    await expect(
+      acquirePentestgptMigrationLock("user-123"),
+    ).rejects.toBeInstanceOf(PentestgptMigrationLockUnavailableError);
   });
 });

--- a/lib/billing/pentestgpt-migration-lock.ts
+++ b/lib/billing/pentestgpt-migration-lock.ts
@@ -1,6 +1,18 @@
 import { createRedisClient } from "@/lib/rate-limit/redis";
 
 const MIGRATION_LOCK_TTL_SECONDS = 15 * 60;
+const MIGRATION_LOCK_RENEW_INTERVAL_MS = 60 * 1000;
+const RENEW_MIGRATION_LOCK_SCRIPT = `
+local key = KEYS[1]
+local token = ARGV[1]
+local ttl = ARGV[2]
+
+if redis.call("GET", key) == token then
+  return redis.call("EXPIRE", key, ttl)
+end
+
+return 0
+`;
 const RELEASE_MIGRATION_LOCK_SCRIPT = `
 local key = KEYS[1]
 local token = ARGV[1]
@@ -20,6 +32,7 @@ export class PentestgptMigrationLockUnavailableError extends Error {
 }
 
 export type PentestgptMigrationLock = {
+  assertOwned: () => Promise<void>;
   release: () => Promise<void>;
 };
 
@@ -30,24 +43,70 @@ export async function acquirePentestgptMigrationLock(
 
   if (!redis) {
     if (process.env.NODE_ENV !== "production") {
-      return { release: async () => {} };
+      return { assertOwned: async () => {}, release: async () => {} };
     }
     throw new PentestgptMigrationLockUnavailableError();
   }
 
   const lockKey = `pentestgpt_migration_lock:${userId}`;
   const lockToken = crypto.randomUUID();
-  const acquired = await redis.set(lockKey, lockToken, {
-    nx: true,
-    ex: MIGRATION_LOCK_TTL_SECONDS,
-  });
+  let acquired: string | null;
+  try {
+    acquired = await redis.set(lockKey, lockToken, {
+      nx: true,
+      ex: MIGRATION_LOCK_TTL_SECONDS,
+    });
+  } catch {
+    throw new PentestgptMigrationLockUnavailableError();
+  }
 
   if (acquired !== "OK") return null;
 
   let released = false;
+  let renewalFailure: PentestgptMigrationLockUnavailableError | null = null;
+  let renewalInFlight: Promise<void> | null = null;
+
+  const renew = async () => {
+    if (released) return;
+    try {
+      const renewed = await redis.eval(
+        RENEW_MIGRATION_LOCK_SCRIPT,
+        [lockKey],
+        [lockToken, String(MIGRATION_LOCK_TTL_SECONDS)],
+      );
+      if (renewed !== 1) {
+        throw new PentestgptMigrationLockUnavailableError();
+      }
+    } catch {
+      renewalFailure = new PentestgptMigrationLockUnavailableError();
+      throw renewalFailure;
+    }
+  };
+
+  const startRenewal = () => {
+    if (released || renewalInFlight) return;
+    renewalInFlight = renew()
+      .catch(() => {})
+      .finally(() => {
+        renewalInFlight = null;
+      });
+  };
+  const renewalTimer = setInterval(
+    startRenewal,
+    MIGRATION_LOCK_RENEW_INTERVAL_MS,
+  );
+
   return {
+    assertOwned: async () => {
+      if (renewalFailure) throw renewalFailure;
+      if (renewalInFlight) await renewalInFlight;
+      if (renewalFailure) throw renewalFailure;
+      await renew();
+    },
     release: async () => {
       if (released) return;
+      clearInterval(renewalTimer);
+      if (renewalInFlight) await renewalInFlight.catch(() => {});
       await redis.eval(RELEASE_MIGRATION_LOCK_SCRIPT, [lockKey], [lockToken]);
       released = true;
     },

--- a/lib/billing/pentestgpt-migration-lock.ts
+++ b/lib/billing/pentestgpt-migration-lock.ts
@@ -1,0 +1,55 @@
+import { createRedisClient } from "@/lib/rate-limit/redis";
+
+const MIGRATION_LOCK_TTL_SECONDS = 15 * 60;
+const RELEASE_MIGRATION_LOCK_SCRIPT = `
+local key = KEYS[1]
+local token = ARGV[1]
+
+if redis.call("GET", key) == token then
+  return redis.call("DEL", key)
+end
+
+return 0
+`;
+
+export class PentestgptMigrationLockUnavailableError extends Error {
+  constructor() {
+    super("PentestGPT migration locking is unavailable");
+    this.name = "PentestgptMigrationLockUnavailableError";
+  }
+}
+
+export type PentestgptMigrationLock = {
+  release: () => Promise<void>;
+};
+
+export async function acquirePentestgptMigrationLock(
+  userId: string,
+): Promise<PentestgptMigrationLock | null> {
+  const redis = createRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") {
+      return { release: async () => {} };
+    }
+    throw new PentestgptMigrationLockUnavailableError();
+  }
+
+  const lockKey = `pentestgpt_migration_lock:${userId}`;
+  const lockToken = crypto.randomUUID();
+  const acquired = await redis.set(lockKey, lockToken, {
+    nx: true,
+    ex: MIGRATION_LOCK_TTL_SECONDS,
+  });
+
+  if (acquired !== "OK") return null;
+
+  let released = false;
+  return {
+    release: async () => {
+      if (released) return;
+      await redis.eval(RELEASE_MIGRATION_LOCK_SCRIPT, [lockKey], [lockToken]);
+      released = true;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- serialize PentestGPT migrations per user with a token-owned, automatically renewed Redis lock
- revalidate lock ownership before each WorkOS and Stripe side effect
- fail closed when production migration locking or renewal is unavailable
- add a stable Stripe idempotency key derived from the legacy subscription
- cover contention, renewal, ownership-safe release, Redis failures, and Stripe idempotency

## Why

The migration previously relied on a client-side loading state. Concurrent server requests could both pass the pre-migration checks before either request updated the legacy customer, allowing duplicate WorkOS and Stripe side effects.

## Impact

Only one migration can mutate an account at a time, the lease remains owned throughout long external-service waits, and repeated subscription creation attempts for the same legacy subscription are deduplicated by Stripe. Normal migration behavior and responses remain unchanged.

## Validation

- `pnpm exec jest --runInBand --watchman=false` — 354 suites, 3,627 tests passed
- `pnpm typecheck`
- targeted ESLint and Prettier checks for all changed files
- `git diff --check`
- all CodeRabbit review threads addressed and resolved