### PR TITLE
Serialize team invitation seat checks

### DIFF
--- a/app/api/team/invite/__tests__/route.test.ts
+++ b/app/api/team/invite/__tests__/route.test.ts
@@ -1,0 +1,160 @@
+import { POST } from "../route";
+import { workos } from "../../../workos";
+import { stripe } from "../../../stripe";
+import { requireAdminOrg } from "../../team-auth";
+import {
+  acquireTeamInvitationLock,
+  TeamInvitationLockUnavailableError,
+} from "@/lib/billing/team-invitation-lock";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("../../team-auth", () => ({
+  requireAdminOrg: jest.fn(),
+}));
+
+jest.mock("@/lib/billing/team-invitation-lock", () => ({
+  acquireTeamInvitationLock: jest.fn(),
+  TeamInvitationLockUnavailableError: class extends Error {},
+}));
+
+jest.mock("../../../workos", () => ({
+  workos: {
+    organizations: { getOrganization: jest.fn() },
+    userManagement: {
+      listOrganizationMemberships: jest.fn(),
+      listInvitations: jest.fn(),
+      listUsers: jest.fn(),
+      sendInvitation: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../../stripe", () => ({
+  stripe: { subscriptions: { list: jest.fn() } },
+}));
+
+const mockRequireAdminOrg = requireAdminOrg as jest.MockedFunction<
+  typeof requireAdminOrg
+>;
+const mockAcquireLock = acquireTeamInvitationLock as jest.MockedFunction<
+  typeof acquireTeamInvitationLock
+>;
+const mockGetOrganization = workos.organizations
+  .getOrganization as jest.MockedFunction<
+  typeof workos.organizations.getOrganization
+>;
+const mockListSubscriptions = stripe.subscriptions.list as jest.MockedFunction<
+  typeof stripe.subscriptions.list
+>;
+const mockListMemberships = workos.userManagement
+  .listOrganizationMemberships as jest.MockedFunction<
+  typeof workos.userManagement.listOrganizationMemberships
+>;
+const mockListInvitations = workos.userManagement
+  .listInvitations as jest.MockedFunction<
+  typeof workos.userManagement.listInvitations
+>;
+const mockListUsers = workos.userManagement.listUsers as jest.MockedFunction<
+  typeof workos.userManagement.listUsers
+>;
+const mockSendInvitation = workos.userManagement
+  .sendInvitation as jest.MockedFunction<
+  typeof workos.userManagement.sendInvitation
+>;
+
+const request = (email = "invitee@example.com") =>
+  ({ json: async () => ({ email }) }) as never;
+
+describe("POST /api/team/invite", () => {
+  const assertOwned = jest.fn();
+  const release = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireAdminOrg.mockResolvedValue({
+      ok: true,
+      userId: "user-admin",
+      organizationId: "org-123",
+      membership: { role: { slug: "admin" } },
+    } as never);
+    assertOwned.mockResolvedValue(undefined);
+    release.mockResolvedValue(undefined);
+    mockAcquireLock.mockResolvedValue({ assertOwned, release });
+    mockGetOrganization.mockResolvedValue({
+      id: "org-123",
+      stripeCustomerId: "cus-123",
+    } as never);
+    mockListSubscriptions.mockResolvedValue({
+      data: [{ items: { data: [{ quantity: 2 }] } }],
+    } as never);
+    mockListMemberships.mockResolvedValue({ data: [{}] } as never);
+    mockListInvitations.mockResolvedValue({ data: [] } as never);
+    mockListUsers.mockResolvedValue({ data: [] } as never);
+    mockSendInvitation.mockResolvedValue({} as never);
+  });
+
+  it("holds the organization lock across the seat check and invitation", async () => {
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mockAcquireLock).toHaveBeenCalledWith("org-123");
+    expect(assertOwned).toHaveBeenCalledTimes(1);
+    expect(mockSendInvitation).toHaveBeenCalledWith({
+      email: "invitee@example.com",
+      organizationId: "org-123",
+      inviterUserId: "user-admin",
+      roleSlug: "member",
+    });
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(assertOwned.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSendInvitation.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("rejects a concurrent invitation before reading seat state", async () => {
+    mockAcquireLock.mockResolvedValueOnce(null);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Another invitation is being processed",
+      message: "Please retry after the current invitation finishes.",
+    });
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockSendInvitation).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when invitation locking is unavailable", async () => {
+    mockAcquireLock.mockRejectedValueOnce(
+      new TeamInvitationLockUnavailableError(),
+    );
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Team invitation service temporarily unavailable",
+    });
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockSendInvitation).not.toHaveBeenCalled();
+  });
+
+  it("releases the lock when the seat limit rejects the invitation", async () => {
+    mockListMemberships.mockResolvedValueOnce({ data: [{}, {}] } as never);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    expect(mockSendInvitation).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/team/invite/route.ts
+++ b/app/api/team/invite/route.ts
@@ -2,8 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { workos } from "../../workos";
 import { stripe } from "../../stripe";
 import { requireAdminOrg } from "../team-auth";
+import {
+  acquireTeamInvitationLock,
+  TeamInvitationLockUnavailableError,
+  type TeamInvitationLock,
+} from "@/lib/billing/team-invitation-lock";
 
 export const POST = async (req: NextRequest) => {
+  let invitationLock: TeamInvitationLock | null = null;
   try {
     const guard = await requireAdminOrg(req);
     if (!guard.ok) return guard.response;
@@ -14,6 +20,17 @@ export const POST = async (req: NextRequest) => {
 
     if (!email || typeof email !== "string") {
       return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    }
+
+    invitationLock = await acquireTeamInvitationLock(organizationId);
+    if (!invitationLock) {
+      return NextResponse.json(
+        {
+          error: "Another invitation is being processed",
+          message: "Please retry after the current invitation finishes.",
+        },
+        { status: 409 },
+      );
     }
 
     // Get organization to access Stripe customer ID
@@ -91,6 +108,7 @@ export const POST = async (req: NextRequest) => {
 
     // Always send an invitation for explicit consent
     // This works for both existing and new users
+    await invitationLock.assertOwned();
     await workos.userManagement.sendInvitation({
       email,
       organizationId,
@@ -103,10 +121,24 @@ export const POST = async (req: NextRequest) => {
       message: "Invitation sent successfully",
     });
   } catch (error: unknown) {
+    if (error instanceof TeamInvitationLockUnavailableError) {
+      return NextResponse.json(
+        { error: "Team invitation service temporarily unavailable" },
+        { status: 503 },
+      );
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An error occurred";
     console.error("Failed to invite team member:", error);
     return NextResponse.json({ error: errorMessage }, { status: 500 });
+  } finally {
+    if (invitationLock) {
+      try {
+        await invitationLock.release();
+      } catch (error) {
+        console.error("Failed to release team invitation lock:", error);
+      }
+    }
   }
 };
 

--- a/lib/billing/__tests__/team-invitation-lock.test.ts
+++ b/lib/billing/__tests__/team-invitation-lock.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+describe("acquireTeamInvitationLock", () => {
+  const mockCreateRedisClient = jest.fn();
+  const mockSet = jest.fn();
+  const mockEval = jest.fn();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockSet.mockResolvedValue("OK");
+    mockEval.mockResolvedValue(1);
+  });
+
+  const getIsolatedModule = () => {
+    let isolatedModule: typeof import("../team-invitation-lock");
+
+    jest.isolateModules(() => {
+      jest.doMock("@/lib/rate-limit/redis", () => ({
+        createRedisClient: mockCreateRedisClient,
+      }));
+      isolatedModule = require("../team-invitation-lock");
+    });
+
+    return isolatedModule!;
+  };
+
+  it("acquires an organization lock and releases only its own token", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    const { acquireTeamInvitationLock } = getIsolatedModule();
+
+    const lock = await acquireTeamInvitationLock("org-123");
+
+    expect(lock).not.toBeNull();
+    expect(mockSet).toHaveBeenCalledWith(
+      "team_invitation_lock:org-123",
+      expect.any(String),
+      { nx: true, ex: 60 },
+    );
+    const token = mockSet.mock.calls[0][1];
+
+    await lock!.assertOwned();
+    expect(mockEval).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("EXPIRE"),
+      ["team_invitation_lock:org-123"],
+      [token, "60"],
+    );
+
+    await lock!.release();
+    await lock!.release();
+    expect(mockEval).toHaveBeenCalledTimes(2);
+    expect(mockEval).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("DEL"),
+      ["team_invitation_lock:org-123"],
+      [token],
+    );
+  });
+
+  it("renews the lease while invitation processing is running", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    const { acquireTeamInvitationLock } = getIsolatedModule();
+    const lock = await acquireTeamInvitationLock("org-123");
+    const token = mockSet.mock.calls[0][1];
+
+    await jest.advanceTimersByTimeAsync(15_000);
+
+    expect(mockEval).toHaveBeenCalledWith(
+      expect.stringContaining("EXPIRE"),
+      ["team_invitation_lock:org-123"],
+      [token, "60"],
+    );
+    await lock!.release();
+  });
+
+  it("returns null while another invitation holds the lock", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    mockSet.mockResolvedValue(null);
+    const { acquireTeamInvitationLock } = getIsolatedModule();
+
+    await expect(acquireTeamInvitationLock("org-123")).resolves.toBeNull();
+    expect(mockEval).not.toHaveBeenCalled();
+  });
+
+  it("maps Redis acquisition errors to lock unavailability", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    mockSet.mockRejectedValueOnce(new Error("Redis unavailable"));
+    const { acquireTeamInvitationLock, TeamInvitationLockUnavailableError } =
+      getIsolatedModule();
+
+    await expect(acquireTeamInvitationLock("org-123")).rejects.toBeInstanceOf(
+      TeamInvitationLockUnavailableError,
+    );
+  });
+});

--- a/lib/billing/team-invitation-lock.ts
+++ b/lib/billing/team-invitation-lock.ts
@@ -1,0 +1,115 @@
+import { createRedisClient } from "@/lib/rate-limit/redis";
+
+const INVITATION_LOCK_TTL_SECONDS = 60;
+const INVITATION_LOCK_RENEW_INTERVAL_MS = 15 * 1000;
+
+const RENEW_INVITATION_LOCK_SCRIPT = `
+local key = KEYS[1]
+local token = ARGV[1]
+local ttl = ARGV[2]
+
+if redis.call("GET", key) == token then
+  return redis.call("EXPIRE", key, ttl)
+end
+
+return 0
+`;
+
+const RELEASE_INVITATION_LOCK_SCRIPT = `
+local key = KEYS[1]
+local token = ARGV[1]
+
+if redis.call("GET", key) == token then
+  return redis.call("DEL", key)
+end
+
+return 0
+`;
+
+export class TeamInvitationLockUnavailableError extends Error {
+  constructor() {
+    super("Team invitation locking is unavailable");
+    this.name = "TeamInvitationLockUnavailableError";
+  }
+}
+
+export type TeamInvitationLock = {
+  assertOwned: () => Promise<void>;
+  release: () => Promise<void>;
+};
+
+export async function acquireTeamInvitationLock(
+  organizationId: string,
+): Promise<TeamInvitationLock | null> {
+  const redis = createRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") {
+      return { assertOwned: async () => {}, release: async () => {} };
+    }
+    throw new TeamInvitationLockUnavailableError();
+  }
+
+  const lockKey = `team_invitation_lock:${organizationId}`;
+  const lockToken = crypto.randomUUID();
+  let acquired: string | null;
+
+  try {
+    acquired = await redis.set(lockKey, lockToken, {
+      nx: true,
+      ex: INVITATION_LOCK_TTL_SECONDS,
+    });
+  } catch {
+    throw new TeamInvitationLockUnavailableError();
+  }
+
+  if (acquired !== "OK") return null;
+
+  let released = false;
+  let renewalFailure: TeamInvitationLockUnavailableError | null = null;
+  let renewalInFlight: Promise<void> | null = null;
+
+  const renew = async () => {
+    if (released) return;
+    try {
+      const renewed = await redis.eval(
+        RENEW_INVITATION_LOCK_SCRIPT,
+        [lockKey],
+        [lockToken, String(INVITATION_LOCK_TTL_SECONDS)],
+      );
+      if (renewed !== 1) throw new TeamInvitationLockUnavailableError();
+    } catch {
+      renewalFailure = new TeamInvitationLockUnavailableError();
+      throw renewalFailure;
+    }
+  };
+
+  const startRenewal = () => {
+    if (released || renewalInFlight) return;
+    renewalInFlight = renew()
+      .catch(() => {})
+      .finally(() => {
+        renewalInFlight = null;
+      });
+  };
+  const renewalTimer = setInterval(
+    startRenewal,
+    INVITATION_LOCK_RENEW_INTERVAL_MS,
+  );
+
+  return {
+    assertOwned: async () => {
+      if (renewalFailure) throw renewalFailure;
+      if (renewalInFlight) await renewalInFlight;
+      if (renewalFailure) throw renewalFailure;
+      await renew();
+    },
+    release: async () => {
+      if (released) return;
+      clearInterval(renewalTimer);
+      if (renewalInFlight) await renewalInFlight.catch(() => {});
+      await redis.eval(RELEASE_INVITATION_LOCK_SCRIPT, [lockKey], [lockToken]);
+      released = true;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- serialize team invitation seat checks per organization with a token-owned Redis lease
- reject concurrent invitation attempts before they can reuse the same available seat
- fail closed when invitation locking is unavailable in production
- add route and lock coverage for contention, ownership, renewal, release, and service failure

## Root cause

The invite route counted active memberships and pending invitations, then created the WorkOS invitation in a separate operation. Concurrent requests could all observe the same available Stripe seat before any invitation became visible, allowing an organization to create more invitations than its paid seat quantity.

## Impact

Only one invitation for an organization can now pass through the seat-count-and-create critical section at a time. Contending requests receive `409` and can be retried; Redis lock failures return `503` instead of bypassing enforcement.

## Validation

- `pnpm exec jest --ci --maxWorkers=2 --watchman=false` — 355 suites, 3,628 tests passed
- `pnpm typecheck`
- ESLint on changed files
- Prettier check on changed files
- `pnpm exec next build --webpack` — successful production build

The default Turbopack build was also attempted, but the local sandbox denied Turbopack permission to bind an internal helper port. The webpack production build completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards to prevent concurrent team invitations from exceeding available seats.
  * Invitations now handle temporary service unavailability with an appropriate error response.
  * Invitation locks automatically renew during processing and are safely released afterward.

* **Bug Fixes**
  * Prevented invitations from proceeding when another invitation process holds the lock.
  * Ensured locks are released when seat limits reject an invitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->