### PR TITLE
Reject cross-shell reusable command grants

### DIFF
--- a/lib/chat/__tests__/agent-approval-grants.test.ts
+++ b/lib/chat/__tests__/agent-approval-grants.test.ts
@@ -179,6 +179,30 @@ describe("agent approval grants", () => {
   });
 
   it.each([
+    ["an escaped cmd control operator", String.raw`echo harmless\& whoami`],
+    [
+      "a quote interpreted differently by cmd.exe",
+      String.raw`echo "harmless\" & whoami & rem "`,
+    ],
+    ["an ambiguous Windows path", String.raw`type C:\safe.txt`],
+  ])("requires fresh approval for %s", (_description, target) => {
+    const safeGrant = deriveAgentApprovalTargetGrant(
+      request("terminal_execute", "echo harmless"),
+    );
+
+    expect(
+      deriveAgentApprovalTargetGrant(request("terminal_execute", target)),
+    ).toBeNull();
+    expect(
+      safeGrant &&
+        matchesAgentApprovalTargetGrant(
+          request("terminal_execute", target),
+          safeGrant,
+        ),
+    ).toBe(false);
+  });
+
+  it.each([
     ["shell", "bash -c 'npm test && npm publish'"],
     ["absolute shell", "/bin/bash -lc 'npm test'"],
     ["Windows shell", String.raw`"C:\Windows\System32\cmd.exe" /c dir`],

--- a/lib/chat/agent-approval-grants.ts
+++ b/lib/chat/agent-approval-grants.ts
@@ -182,6 +182,14 @@ export const parseStaticCommandArgv = (command: string): string[] | null => {
     // unquoted and double-quoted shell text. Reject them everywhere.
     if (character === "`") return null;
 
+    // A reusable grant can execute under either Bash or the Windows cmd.exe
+    // fallback. Backslashes escape shell syntax in Bash but are ordinary
+    // characters in cmd.exe, so accepting them can make the authorization
+    // parser and the execution shell disagree about argv or command
+    // boundaries. Keep such commands eligible for one-time human approval,
+    // but never derive or reuse a persistent grant from them.
+    if (character === "\\") return null;
+
     if (quote === "single") {
       if (character === "'") {
         quote = null;
@@ -215,23 +223,6 @@ export const parseStaticCommandArgv = (command: string): string[] | null => {
       ) {
         return null;
       }
-      if (character === "\\") {
-        const nextCharacter = command[index + 1];
-        if (
-          !nextCharacter ||
-          nextCharacter === "\n" ||
-          nextCharacter === "\r"
-        ) {
-          return null;
-        }
-        if (["$", "`", '"', "\\"].includes(nextCharacter)) {
-          token += nextCharacter;
-          index += 1;
-        } else {
-          token += character;
-        }
-        continue;
-      }
       token += character;
       continue;
     }
@@ -244,16 +235,6 @@ export const parseStaticCommandArgv = (command: string): string[] | null => {
     if (character === '"') {
       quote = "double";
       tokenStarted = true;
-      continue;
-    }
-    if (character === "\\") {
-      const nextCharacter = command[index + 1];
-      if (!nextCharacter || nextCharacter === "\n" || nextCharacter === "\r") {
-        return null;
-      }
-      tokenStarted = true;
-      token += nextCharacter;
-      index += 1;
       continue;
     }
     if (isShellWhitespace(character)) {


### PR DESCRIPTION
## Summary

- reject reusable terminal-command grants when the command contains backslashes
- keep those commands available through one-time human approval
- add regressions for escaped command separators, quote interpretation differences, and ambiguous Windows paths

## Root cause and impact

Reusable Agent command grants parse a single command representation that may later execute under either Bash or the Windows `cmd.exe` fallback. Backslashes have different quoting and escaping semantics in those shells. The parser could therefore normalize a command into a safe-looking argv prefix while `cmd.exe` interpreted the original text with different command boundaries.

On Windows systems using the `cmd.exe` fallback, a previously approved reusable prefix could consequently match a later command whose runtime interpretation was broader than the authorized argv. This change fails closed for the ambiguous syntax: the command can still be run after a fresh human approval, but it cannot create or reuse a persistent grant.

## Validation

- `pnpm jest --runInBand --no-watchman` — 353 suites / 3,623 tests passed
- `pnpm typecheck`
- focused ESLint and Prettier checks for both changed files
- `git diff --check`

No production service, user data, external target, or harmful command was used during validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command approval security on Windows.
  * Commands containing backslashes, escaped control operators, ambiguous quotes, or ambiguous paths now require fresh approval instead of reusing an existing grant.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->