### PR TITLE
Fix Desktop project file symlink escapes

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -569,6 +569,50 @@ describe("native desktop file relay", () => {
     });
   });
 
+  it("forwards the allowed project root to the local file server", async () => {
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    const handler = getPublicationHandler();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "get_cmd_server_info") {
+        return { port: 49152, token: "file-token" };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    handler({
+      data: {
+        type: "file_write",
+        requestId: "file-req-root",
+        path: "C:\\repo\\app.ts",
+        content: "updated",
+        allowedRoot: "C:\\repo",
+        targetConnectionId: "conn-123",
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:49152/files/write",
+      expect.objectContaining({
+        body: JSON.stringify({
+          path: "C:\\repo\\app.ts",
+          content: "updated",
+          is_base64: false,
+          allowed_root: "C:\\repo",
+        }),
+      }),
+    );
+  });
+
   it("passes base64 append requests through to the local file server", async () => {
     const config = buildConfig();
     const bridge = new DesktopSandboxBridge(config);

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -745,12 +745,13 @@ export class DesktopSandboxBridge {
   }
 
   private async handleFileWrite(message: FileWriteMessage): Promise<void> {
-    const { requestId, path, content, isBase64 } = message;
+    const { requestId, path, content, isBase64, allowedRoot } = message;
     try {
       await this.callLocalFileServer("/files/write", {
         path,
         content,
         is_base64: Boolean(isBase64),
+        allowed_root: allowedRoot,
       });
       await this.publishResult({ type: "file_ok", requestId });
     } catch (error) {
@@ -759,12 +760,13 @@ export class DesktopSandboxBridge {
   }
 
   private async handleFileAppend(message: FileAppendMessage): Promise<void> {
-    const { requestId, path, content, isBase64 } = message;
+    const { requestId, path, content, isBase64, allowedRoot } = message;
     try {
       await this.callLocalFileServer("/files/append", {
         path,
         content,
         is_base64: Boolean(isBase64),
+        allowed_root: allowedRoot,
       });
       await this.publishResult({ type: "file_ok", requestId });
     } catch (error) {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1068,6 +1068,35 @@ describe("CentrifugoSandbox", () => {
       await expect(promise).resolves.toBeUndefined();
     });
 
+    it("includes the project folder as the allowed root for native writes", async () => {
+      const sandbox = createDesktopSandbox("C:\\work\\hackerai");
+      const promise = sandbox.files.write("src\\app.ts", "updated");
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(sub.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "file_write",
+          path: "C:\\work\\hackerai\\src\\app.ts",
+          allowedRoot: "C:\\work\\hackerai",
+          targetConnectionId: "conn-1",
+          requestId: expect.any(String),
+        }),
+      );
+
+      const request = (sub.publish as jest.Mock).mock.calls[0][0] as {
+        requestId: string;
+      };
+      sub.emit("publication", {
+        data: { type: "file_ok", requestId: request.requestId },
+      });
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+
     it("chunks large native writes into file_write then file_append requests", async () => {
       const sandbox = createDesktopSandbox();
       const content = "x".repeat(70 * 1024);

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -494,6 +494,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
             ...input,
             path: this.resolveWorkingPath(input.path),
             requestId,
+            ...(this.workingDirectory &&
+            (input.type === "file_write" || input.type === "file_append")
+              ? { allowedRoot: this.workingDirectory }
+              : {}),
             targetConnectionId: this.connectionInfo.connectionId,
           } as FileRequestMessage;
 

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -76,6 +76,7 @@ export interface FileWriteMessage {
   path: string;
   content: string;
   isBase64?: boolean;
+  allowedRoot?: string;
   targetConnectionId: string;
 }
 
@@ -85,6 +86,7 @@ export interface FileAppendMessage {
   path: string;
   content: string;
   isBase64?: boolean;
+  allowedRoot?: string;
   targetConnectionId: string;
 }
 

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +449,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
 ]
 
 [[package]]
@@ -1268,6 +1316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1755,8 @@ name = "hackerai-desktop"
 version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
+ "cap-fs-ext",
+ "cap-std",
  "env_logger",
  "libc",
  "log",
@@ -2078,6 +2139,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2525,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -3884,6 +3967,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -6453,6 +6546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.10.0",
  "windows-sys 0.59.0",
 ]
 

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 reqwest = { version = "0.12", features = ["json"] }
 portable-pty = "0.8"
+cap-std = "3.4.5"
+cap-fs-ext = "3.4.5"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1,10 +1,14 @@
 mod platform;
 mod pty;
 
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions as CapOpenOptions};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::Manager;
@@ -413,6 +417,7 @@ struct FileReadRequest {
 struct FileWriteRequest {
     path: String,
     content: String,
+    allowed_root: Option<String>,
     #[serde(default)]
     is_base64: bool,
 }
@@ -426,6 +431,7 @@ struct FileRemoveRequest {
 struct FileAppendRequest {
     path: String,
     content: String,
+    allowed_root: Option<String>,
     #[serde(default)]
     is_base64: bool,
 }
@@ -862,6 +868,110 @@ async fn count_file_lines(path: &std::path::Path, file_size: u64) -> Result<u64,
     Ok(lines)
 }
 
+fn scoped_mutation_target(path: &Path, allowed_root: &str) -> Result<(Dir, PathBuf), String> {
+    let root = Path::new(allowed_root);
+    if !root.is_absolute() || !path.is_absolute() {
+        return Err("Desktop project file mutations require absolute paths".to_string());
+    }
+
+    let relative_path = path.strip_prefix(root).map_err(|_| {
+        format!(
+            "Path is outside the allowed project folder: {}",
+            path.display()
+        )
+    })?;
+    if relative_path.as_os_str().is_empty()
+        || relative_path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(format!(
+            "Path is outside the allowed project folder: {}",
+            path.display()
+        ));
+    }
+
+    let dir = Dir::open_ambient_dir(root, ambient_authority()).map_err(|error| {
+        format!(
+            "Allowed root error: could not open project folder '{}': {}",
+            root.display(),
+            error
+        )
+    })?;
+    Ok((dir, relative_path.to_path_buf()))
+}
+
+fn open_scoped_mutation_file(
+    path: &Path,
+    allowed_root: &str,
+    append: bool,
+) -> Result<cap_std::fs::File, String> {
+    let (dir, relative_path) = scoped_mutation_target(path, allowed_root)?;
+    if let Some(parent) = relative_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        dir.create_dir_all(parent)
+            .map_err(|error| format!("Mkdir error: {}", error))?;
+    }
+
+    let mut options = CapOpenOptions::new();
+    options.create(true).follow(FollowSymlinks::No);
+    if append {
+        options.append(true);
+    } else {
+        options.write(true).truncate(true);
+    }
+
+    dir.open_with(&relative_path, &options)
+        .map_err(|error| format!("Open error: {}", error))
+}
+
+fn open_unscoped_mutation_file(path: &Path, append: bool) -> Result<fs::File, String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| format!("Mkdir error: {}", error))?;
+    }
+
+    let mut options = fs::OpenOptions::new();
+    options.create(true);
+    if append {
+        options.append(true);
+    } else {
+        options.write(true).truncate(true);
+    }
+    options
+        .open(path)
+        .map_err(|error| format!("Open error: {}", error))
+}
+
+fn write_desktop_file(
+    path: &Path,
+    allowed_root: Option<&str>,
+    bytes: &[u8],
+    append: bool,
+) -> Result<(), String> {
+    let allowed_root = allowed_root.filter(|root| !root.trim().is_empty());
+    if let Some(allowed_root) = allowed_root {
+        let mut file = open_scoped_mutation_file(path, allowed_root, append)?;
+        file.write_all(bytes)
+            .map_err(|error| format!("Write error: {}", error))?;
+        file.flush()
+            .map_err(|error| format!("Flush error: {}", error))?;
+    } else {
+        let mut file = open_unscoped_mutation_file(path, append)?;
+        file.write_all(bytes)
+            .map_err(|error| format!("Write error: {}", error))?;
+        file.flush()
+            .map_err(|error| format!("Flush error: {}", error))?;
+    }
+    Ok(())
+}
+
 async fn handle_file_stat(body: &str) -> Result<String, String> {
     let req: FileStatRequest =
         serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
@@ -997,26 +1107,21 @@ async fn handle_file_read(body: &str) -> Result<String, String> {
 async fn handle_file_write(body: &str) -> Result<String, String> {
     let req: FileWriteRequest =
         serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
-
-    // Ensure parent directory exists
-    if let Some(parent) = std::path::Path::new(&req.path).parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| format!("Mkdir error: {}", e))?;
-    }
+    let path = std::path::Path::new(&req.path);
 
     if req.is_base64 {
         use base64::Engine;
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(&req.content)
             .map_err(|e| format!("Base64 decode error: {}", e))?;
-        tokio::fs::write(&req.path, bytes)
-            .await
-            .map_err(|e| format!("Write error: {}", e))?;
+        write_desktop_file(path, req.allowed_root.as_deref(), &bytes, false)?;
     } else {
-        tokio::fs::write(&req.path, &req.content)
-            .await
-            .map_err(|e| format!("Write error: {}", e))?;
+        write_desktop_file(
+            path,
+            req.allowed_root.as_deref(),
+            req.content.as_bytes(),
+            false,
+        )?;
     }
 
     Ok(r#"{"ok":true}"#.to_string())
@@ -1025,35 +1130,22 @@ async fn handle_file_write(body: &str) -> Result<String, String> {
 async fn handle_file_append(body: &str) -> Result<String, String> {
     let req: FileAppendRequest =
         serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let path = std::path::Path::new(&req.path);
 
-    if let Some(parent) = std::path::Path::new(&req.path).parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| format!("Mkdir error: {}", e))?;
-    }
-
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&req.path)
-        .await
-        .map_err(|e| format!("Open error: {}", e))?;
     if req.is_base64 {
         use base64::Engine;
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(&req.content)
             .map_err(|e| format!("Base64 decode error: {}", e))?;
-        file.write_all(&bytes)
-            .await
-            .map_err(|e| format!("Append error: {}", e))?;
+        write_desktop_file(path, req.allowed_root.as_deref(), &bytes, true)?;
     } else {
-        file.write_all(req.content.as_bytes())
-            .await
-            .map_err(|e| format!("Append error: {}", e))?;
+        write_desktop_file(
+            path,
+            req.allowed_root.as_deref(),
+            req.content.as_bytes(),
+            true,
+        )?;
     }
-    file.flush()
-        .await
-        .map_err(|e| format!("Flush error: {}", e))?;
 
     Ok(r#"{"ok":true}"#.to_string())
 }
@@ -1718,6 +1810,164 @@ async fn execute_pty_kill(
 ) -> Result<(), String> {
     let mut manager = state.lock().map_err(|e| format!("Lock poisoned: {}", e))?;
     manager.kill(&session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_test_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "hackerai-desktop-{}-{}",
+            label,
+            uuid::Uuid::new_v4().simple()
+        ))
+    }
+
+    #[tokio::test]
+    async fn file_write_allows_nested_paths_inside_allowed_root() {
+        let root = unique_test_dir("allowed-root");
+        fs::create_dir_all(&root).expect("create allowed root");
+        let target = root.join("src").join("app.ts");
+        let body = serde_json::json!({
+            "path": target.to_string_lossy().to_string(),
+            "content": "updated",
+            "allowed_root": root.to_string_lossy().to_string(),
+        })
+        .to_string();
+
+        let result = handle_file_write(&body).await;
+
+        assert!(result.is_ok(), "{result:?}");
+        let content = fs::read_to_string(&target).expect("written file should exist");
+        assert_eq!(content, "updated");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn file_write_preserves_unscoped_desktop_compatibility() {
+        let root = unique_test_dir("unscoped");
+        let target = root.join("notes.txt");
+        let body = serde_json::json!({
+            "path": target.to_string_lossy().to_string(),
+            "content": "updated",
+        })
+        .to_string();
+
+        let result = handle_file_write(&body).await;
+
+        assert!(result.is_ok(), "{result:?}");
+        assert_eq!(
+            fs::read_to_string(&target).expect("written file should exist"),
+            "updated"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn file_append_allows_existing_files_inside_allowed_root() {
+        let root = unique_test_dir("allowed-append-root");
+        fs::create_dir_all(&root).expect("create allowed root");
+        let target = root.join("notes.txt");
+        fs::write(&target, "first").expect("seed target");
+        let body = serde_json::json!({
+            "path": target.to_string_lossy().to_string(),
+            "content": " second",
+            "allowed_root": root.to_string_lossy().to_string(),
+        })
+        .to_string();
+
+        let result = handle_file_append(&body).await;
+
+        assert!(result.is_ok(), "{result:?}");
+        assert_eq!(
+            fs::read_to_string(&target).expect("appended file should exist"),
+            "first second"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn file_write_rejects_parent_traversal_from_allowed_root() {
+        let root = unique_test_dir("traversal-root");
+        let external = unique_test_dir("traversal-external");
+        fs::create_dir_all(&root).expect("create root");
+        let external_target = root
+            .join("..")
+            .join(external.file_name().expect("external basename"))
+            .join("outside.txt");
+        let body = serde_json::json!({
+            "path": external_target.to_string_lossy().to_string(),
+            "content": "overwritten",
+            "allowed_root": root.to_string_lossy().to_string(),
+        })
+        .to_string();
+
+        let result = handle_file_write(&body).await;
+
+        assert!(result.is_err(), "{result:?}");
+        assert!(!external_target.exists());
+        let _ = fs::remove_dir_all(&root);
+        let _ = fs::remove_dir_all(&external);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn file_write_rejects_symlink_escape_from_allowed_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_test_dir("symlink-root");
+        let external = unique_test_dir("symlink-external");
+        fs::create_dir_all(&root).expect("create root");
+        fs::create_dir_all(&external).expect("create external");
+        let external_target = external.join("secret.txt");
+        fs::write(&external_target, "secret").expect("seed external target");
+        let project_link = root.join("linked-secret.txt");
+        symlink(&external_target, &project_link).expect("create symlink");
+        let body = serde_json::json!({
+            "path": project_link.to_string_lossy().to_string(),
+            "content": "overwritten",
+            "allowed_root": root.to_string_lossy().to_string(),
+        })
+        .to_string();
+
+        let result = handle_file_write(&body).await;
+
+        assert!(result.is_err(), "{result:?}");
+        assert_eq!(
+            fs::read_to_string(&external_target).expect("external target should remain"),
+            "secret"
+        );
+        let _ = fs::remove_dir_all(&root);
+        let _ = fs::remove_dir_all(&external);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn file_write_rejects_parent_symlink_escape_from_allowed_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_test_dir("parent-symlink-root");
+        let external = unique_test_dir("parent-symlink-external");
+        fs::create_dir_all(&root).expect("create root");
+        fs::create_dir_all(&external).expect("create external");
+        let project_link = root.join("linked-directory");
+        symlink(&external, &project_link).expect("create directory symlink");
+        let target = project_link.join("secret.txt");
+        let body = serde_json::json!({
+            "path": target.to_string_lossy().to_string(),
+            "content": "overwritten",
+            "allowed_root": root.to_string_lossy().to_string(),
+        })
+        .to_string();
+
+        let result = handle_file_write(&body).await;
+
+        assert!(result.is_err(), "{result:?}");
+        assert!(!external.join("secret.txt").exists());
+        let _ = fs::remove_dir_all(&root);
+        let _ = fs::remove_dir_all(&external);
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]


### PR DESCRIPTION
## Summary

- bind Desktop write and append requests to the linked project root
- enforce filesystem containment at the native Rust mutation sink with capability-based path resolution
- reject parent traversal, final symlinks, and symlinked parent directories while preserving normal scoped and unscoped Desktop behavior
- add TypeScript relay/bridge coverage and native Rust regression tests

## Root cause

Automatic review authorized a lexical project path, but the Desktop native file server later opened that path with ambient filesystem APIs. A repository-controlled symlink or junction could therefore redirect an approved write or append outside the linked project.

This addresses the High finding from Codex Security scan `f9a01a81-2ac6-4ab4-9517-2fc5bcdb62e0`.

## Fix

The web relay now carries the linked project root with native write/append requests. The Desktop bridge forwards that boundary, and the Rust file server opens the project root as a capability directory. Mutations are resolved relative to that directory, disallow `..`, and use no-follow opens for the final target. This keeps the authorization boundary attached to the actual OS-level mutation and avoids a check-then-open race.

Unlinked Desktop operations retain their existing behavior because they have no project-scoped authorization boundary.

## Validation

- `pnpm typecheck`
- `pnpm test` — 354 suites, 3,624 tests passed on current `main`
- `cargo +stable test --manifest-path packages/desktop/src-tauri/Cargo.toml --locked --offline --lib` — 6/6 passed
- `cargo +stable check --manifest-path packages/desktop/src-tauri/Cargo.toml --locked`
- `cargo +stable fmt --manifest-path packages/desktop/src-tauri/Cargo.toml -- --check`
- `cargo +stable clippy --manifest-path packages/desktop/src-tauri/Cargo.toml --locked --lib` — passed with three pre-existing warnings outside this change
- focused relay, bridge, file-tool, and hybrid-sandbox tests — 145 passed
- `git diff --check`

## Manual verification

1. Link a Desktop project containing a symlink to a temporary file outside the project.
2. Ask Agent mode to write or append through that project symlink.
3. Confirm the operation fails and the external file is unchanged.
4. Write and append to a normal nested project file; confirm both succeed.
5. Exercise an unlinked Desktop file flow; confirm compatibility is unchanged.
6. On Windows, repeat with a directory junction after the Windows Desktop build completes.

## Release note

Older installed Desktop binaries do not enforce the new native sink boundary. Coordinate the web change with a Desktop release and treat client upgrade adoption as part of remediation completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File write and append operations can now be safely scoped to the project folder.
  * Relative paths are resolved within the configured project area.
* **Bug Fixes**
  * Prevented file operations from accessing paths outside the permitted folder, including through directory traversal or symbolic links.
  * Preserved existing behavior for requests without a configured folder restriction.
* **Tests**
  * Added coverage for nested paths, append operations, compatibility, traversal attempts, and symbolic-link escapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->