### PR TITLE
Harden web search rendering and transport filtering

### DIFF
--- a/app/components/tools/WebToolHandler.tsx
+++ b/app/components/tools/WebToolHandler.tsx
@@ -83,7 +83,7 @@ export const WebToolHandler = memo(function WebToolHandler({
     }
 
     const searchInput = input as WebSearchInput;
-    if (searchInput.queries && searchInput.queries.length > 0) {
+    if (Array.isArray(searchInput.queries) && searchInput.queries.length > 0) {
       return searchInput.queries.join(", ");
     }
 
@@ -99,7 +99,7 @@ export const WebToolHandler = memo(function WebToolHandler({
     if (!input) return "";
 
     const searchInput = input as WebSearchInput;
-    if (searchInput.queries && searchInput.queries.length > 0) {
+    if (Array.isArray(searchInput.queries) && searchInput.queries.length > 0) {
       return searchInput.queries.join(", ");
     }
 

--- a/app/components/tools/__tests__/WebToolHandler.test.tsx
+++ b/app/components/tools/__tests__/WebToolHandler.test.tsx
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/app/hooks/useToolSidebar", () => ({
+  useToolSidebar: () => ({
+    handleOpenInSidebar: jest.fn(),
+    handleKeyDown: jest.fn(),
+  }),
+}));
+
+const { WebToolHandler } =
+  require("../WebToolHandler") as typeof import("../WebToolHandler");
+
+describe("WebToolHandler", () => {
+  it("falls back to the legacy query when queries is not an array", () => {
+    render(
+      <WebToolHandler
+        status="ready"
+        part={{
+          toolCallId: "call-1",
+          state: "output-available",
+          input: {
+            queries: { 0: "unexpected", length: 1 },
+            query: "fallback query",
+          } as never,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Searched web")).toBeInTheDocument();
+    expect(screen.getByText("fallback query")).toBeInTheDocument();
+  });
+});

--- a/app/share/[shareId]/__tests__/SharedMessages.test.tsx
+++ b/app/share/[shareId]/__tests__/SharedMessages.test.tsx
@@ -294,6 +294,32 @@ describe("SharedMessages", () => {
         screen.getByText("best practices for testing"),
       ).toBeInTheDocument();
     });
+
+    it("falls back to the legacy query when queries is not an array", () => {
+      const messages = [
+        {
+          id: "1",
+          role: "assistant" as const,
+          parts: [
+            {
+              type: "tool-web_search",
+              state: "output-available",
+              input: {
+                queries: { 0: "unexpected", length: 1 },
+                query: "fallback shared query",
+              },
+            },
+          ],
+          update_time: mockShareDate,
+        },
+      ];
+
+      renderWithContext(
+        <SharedMessages messages={messages} shareDate={mockShareDate} />,
+      );
+      expect(screen.getByText("Searched web")).toBeInTheDocument();
+      expect(screen.getByText("fallback shared query")).toBeInTheDocument();
+    });
   });
 
   describe("Tool Execution - Todo", () => {

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -550,7 +550,7 @@ function renderWebSearchTool(part: MessagePart, idx: number) {
   };
 
   let target: string | undefined;
-  if (webInput?.queries && webInput.queries.length > 0) {
+  if (Array.isArray(webInput?.queries) && webInput.queries.length > 0) {
     target = webInput.queries.join(", ");
   } else if (webInput?.query) {
     target = webInput.query;

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -147,6 +147,45 @@ describe("shouldDropExpectedFrontendException", () => {
     ).toBe(true);
   });
 
+  it("drops transport failures with mixed Next 16.3 server action frames", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Failed to fetch"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source:
+                      "turbopack:///[project]/node_modules/next/src/client/components/router-reducer/reducers/server-action-reducer.ts",
+                    junk_drawer: {
+                      raw_frame: {
+                        filename:
+                          "/_next/static/immutable/chunks/0ro0tl16w8mcs.js",
+                      },
+                    },
+                  },
+                  {
+                    source:
+                      "turbopack:///[project]/node_modules/next/src/client/components/segment-cache/fetch.ts",
+                    junk_drawer: {
+                      raw_frame: {
+                        filename:
+                          "/_next/static/immutable/chunks/0ro0tl16w8mcs.js",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("keeps generic network failures when a server action failure has app frames", () => {
     expect(
       shouldDropExpectedFrontendException({
@@ -157,6 +196,30 @@ describe("shouldDropExpectedFrontendException", () => {
             {
               stacktrace: {
                 frames: [
+                  {
+                    source: "turbopack:///[project]/app/actions/example.ts",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Failed to fetch"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source:
+                      "turbopack:///[project]/node_modules/next/src/client/components/segment-cache/fetch.ts",
+                  },
                   {
                     source: "turbopack:///[project]/app/actions/example.ts",
                   },

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -60,11 +60,12 @@ const CHUNK_LOAD_MESSAGE_FRAGMENTS = [
 
 const NEXT_SERVER_ACTION_SOURCE_FRAGMENTS = [
   "next/src/client/components/router-reducer/reducers/server-action-reducer.ts",
+  "next/src/client/components/segment-cache/fetch.ts",
   "/docs/messages/failed-to-find-server-action",
 ];
 
 const NEXT_GENERATED_CHUNK_SOURCE_PATTERN =
-  /^(?:https?:\/\/[^/]+)?\/_next\/static\/chunks\/[^?\s]+\.js(?:\?[^#\s]*)?(?::\d+){0,2}$/i;
+  /^(?:https?:\/\/[^/]+)?\/_next\/static\/(?:immutable\/)?chunks\/[^?\s]+\.js(?:\?[^#\s]*)?(?::\d+){0,2}$/i;
 const VERCEL_DEPLOYMENT_ID_PATTERN = /[?&]dpl=(dpl_[A-Za-z0-9]+)/;
 
 const INJECTED_THIRD_PARTY_SOURCE_PREFIXES = [
@@ -166,19 +167,10 @@ const hasChunkLoadMessage = (strings: string[]): boolean =>
 const hasStaleServerActionMessage = (strings: string[]): boolean =>
   includesAny(strings, STALE_SERVER_ACTION_MESSAGE_FRAGMENTS);
 
-const hasOnlyNextServerActionFrames = (frameSources: string[]): boolean =>
-  frameSources.length > 0 &&
-  frameSources.every((source) =>
-    NEXT_SERVER_ACTION_SOURCE_FRAGMENTS.some((fragment) =>
-      source.includes(fragment),
-    ),
-  );
-
-const hasOnlyNextGeneratedChunkFrames = (frameSources: string[]): boolean =>
-  frameSources.length > 0 &&
-  frameSources.every((source) =>
-    NEXT_GENERATED_CHUNK_SOURCE_PATTERN.test(source),
-  );
+const isExpectedNextServerActionFrame = (source: string): boolean =>
+  NEXT_SERVER_ACTION_SOURCE_FRAGMENTS.some((fragment) =>
+    source.includes(fragment),
+  ) || NEXT_GENERATED_CHUNK_SOURCE_PATTERN.test(source);
 
 const hasOnlyInjectedThirdPartyFrames = (frameSources: string[]): boolean =>
   frameSources.length > 0 &&
@@ -191,8 +183,8 @@ const hasOnlyInjectedThirdPartyFrames = (frameSources: string[]): boolean =>
 const hasOnlyExpectedNextServerActionFrames = (
   frameSources: string[],
 ): boolean =>
-  hasOnlyNextServerActionFrames(frameSources) ||
-  hasOnlyNextGeneratedChunkFrames(frameSources);
+  frameSources.length > 0 &&
+  frameSources.every(isExpectedNextServerActionFrame);
 
 const hasStackOverflowMessage = (strings: string[]): boolean =>
   hasExactStringFrom(strings, STACK_OVERFLOW_MESSAGES);

--- a/lib/utils/__tests__/sidebar-utils.test.ts
+++ b/lib/utils/__tests__/sidebar-utils.test.ts
@@ -84,3 +84,28 @@ describe("terminal sidebar output", () => {
     });
   });
 });
+
+describe("web search sidebar output", () => {
+  it("falls back to the legacy query when queries has an invalid shape", () => {
+    const [webSearch] = extractSidebarContentFromMessage({
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-web_search",
+          toolCallId: "call-search",
+          state: "input-available",
+          input: {
+            queries: { 0: "unexpected", length: 1 },
+            query: "fallback sidebar query",
+          },
+        },
+      ],
+    });
+
+    expect(webSearch).toMatchObject({
+      query: "fallback sidebar query",
+      isSearching: true,
+      toolCallId: "call-search",
+    });
+  });
+});

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -34,6 +34,17 @@ export interface Message {
 // per-part forEach below.
 const STREAMS_DURING_INPUT = new Set<string>(["tool-file"]);
 
+const getWebSearchQuery = (input: unknown): string => {
+  if (!input || typeof input !== "object") return "";
+  const { queries, query } = input as {
+    queries?: unknown;
+    query?: unknown;
+  };
+  if (Array.isArray(queries)) return queries.join(", ");
+  if (typeof queries === "string") return queries;
+  return typeof query === "string" ? query : "";
+};
+
 /**
  * Extract sidebar content from a single message. Exported for incremental processing
  * (e.g. only reprocess the last message during streaming).
@@ -281,8 +292,7 @@ export function extractSidebarContentFromMessage(
 
     // Web Search - extract at input-available for auto-follow, and output-available for results
     if (part.type === "tool-web_search" && part.state === "input-available") {
-      const queries = part.input?.queries || [];
-      const query = Array.isArray(queries) ? queries.join(", ") : queries;
+      const query = getWebSearchQuery(part.input);
       if (query) {
         contentList.push({
           query,
@@ -294,8 +304,7 @@ export function extractSidebarContentFromMessage(
     }
 
     if (part.type === "tool-web_search" && part.state === "output-available") {
-      const queries = part.input?.queries || [];
-      const query = Array.isArray(queries) ? queries.join(", ") : queries;
+      const query = getWebSearchQuery(part.input);
 
       let results: WebSearchResult[] = [];
       if (part.output) {


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-08-12T20:01:22.579Z` through `2026-08-13T20:01:22.579Z`.

PostHog Error Tracking found two unhandled `queries.join is not a function` exceptions across two sessions and two users. Both resolved to `WebToolHandler.tsx:86`; the runtime value had a truthy length but no callable `join`.

PostHog also showed a new `Failed to fetch` fingerprint after the `posthog-js` 1.415.1 update: 2,717 occurrences in the window. Representative frames were entirely Next internals, but the existing source-aware filter missed them because one event mixed resolved server-action frames with generated chunk filenames and Next 16.3's new `segment-cache/fetch.ts` and immutable chunk path.

The same audit isolated 3,345 Vercel 504 rows in a bounded Trigger API/control-plane incident from about 16:33Z to 16:53Z, with quiet adjacent hours and representative Trigger 429s. That incident remains visible and is not changed by this PR.

## Root cause

- Live and shared web-tool renderers trusted the TypeScript-only `queries?: string[]` shape and called `.join()` after only a truthy length check.
- Sidebar extraction accepted arbitrary non-array `queries` values and could later pass an object into React.
- The expected-transport predicate accepted either all known Next sources or all generated chunks, but not a safe mixture of the two.

## Change

- Require arrays before joining web-search queries in live and shared rendering.
- Preserve legacy string and `query` fallbacks in sidebar extraction while rejecting unknown objects.
- Treat each frame independently as expected only when it is a recognized Next server-action/segment-cache source or a generated Next chunk, including immutable chunks.
- Keep any event with an application frame visible.
- Add focused regression coverage for live rendering, shared rendering, sidebar extraction, the production-shaped Next 16.3 frame mix, and mixed framework/application stacks.

No provider request, retry, billing, auth, task, deployment, analytics payload, or broad suppression behavior changes.

## Validation

- `corepack pnpm jest --runTestsByPath app/components/tools/__tests__/WebToolHandler.test.tsx app/share/[shareId]/__tests__/SharedMessages.test.tsx lib/utils/__tests__/sidebar-utils.test.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts app/__tests__/providers.test.tsx --runInBand` — 5 suites / 51 tests
- `corepack pnpm typecheck`
- changed-file ESLint
- changed-file Prettier
- `corepack pnpm run check:local-dependencies`
- commit hooks — 359 suites / 3,655 tests plus typecheck
- `git diff --check`

## Manual verification

On the preview:

1. Open a chat containing a completed web-search tool call and confirm its query label and sidebar results still render.
2. Open a shared copy of that chat and confirm the web-search label still renders.
3. Reload both views and confirm no `queries.join` exception appears.
4. Confirm an application-attributed `Failed to fetch` fixture remains retained while the exact framework-only Next 16.3 fixture is dropped.

Chrome visual verification will be completed on the registered Vercel preview before final handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web search handling for malformed or legacy query formats.
  * Preserved fallback support for single-query search inputs across search results, shared messages, and sidebar displays.
  * Improved filtering of expected frontend errors from generated server-action frames.

* **Tests**
  * Added coverage for legacy query fallback, invalid query lists, web-search rendering, and frontend error filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->