### PR TITLE
Polish chat composer controls

### DIFF
--- a/app/components/AttachmentButton.tsx
+++ b/app/components/AttachmentButton.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/ui/popover";
 import { TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import { Paperclip } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useGlobalState } from "../contexts/GlobalState";
 import { useEffect, useRef, useState } from "react";
 import { redirectToPricing } from "../hooks/usePricingDialog";
@@ -67,12 +67,12 @@ export const AttachmentButton = ({
             onClick={onAttachClick}
             variant="ghost"
             size="sm"
-            className="rounded-full p-0 w-8 h-8 min-w-0"
+            className="h-8 w-8 min-w-0 rounded-md p-0 hover:bg-muted/30"
             aria-label="Attach files"
             data-testid="attach-files-button"
             disabled={disabled || isCheckingProPlan}
           >
-            <Paperclip className="w-[15px] h-[15px]" />
+            <Plus className="size-[18px]" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
@@ -91,12 +91,12 @@ export const AttachmentButton = ({
           onClick={handleClick}
           variant="ghost"
           size="sm"
-          className="rounded-full p-0 w-8 h-8 min-w-0"
+          className="h-8 w-8 min-w-0 rounded-md p-0 hover:bg-muted/30"
           aria-label="Attach files"
           data-testid="attach-files-button"
           disabled={disabled}
         >
-          <Paperclip className="w-[15px] h-[15px]" />
+          <Plus className="size-[18px]" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/app/components/AttachmentButton.tsx
+++ b/app/components/AttachmentButton.tsx
@@ -72,7 +72,7 @@ export const AttachmentButton = ({
             data-testid="attach-files-button"
             disabled={disabled || isCheckingProPlan}
           >
-            <Plus className="size-[18px]" />
+            <Plus className="size-5" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
@@ -96,7 +96,7 @@ export const AttachmentButton = ({
           data-testid="attach-files-button"
           disabled={disabled}
         >
-          <Plus className="size-[18px]" />
+          <Plus className="size-5" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -87,7 +87,7 @@ const ChatInputLoadingState = ({
   >
     <div className="mx-auto w-full min-w-0 max-w-full sm:min-w-[390px] sm:max-w-[768px]">
       <div
-        className="flex h-[98px] flex-col justify-center gap-2 rounded-[22px] border border-black/8 bg-input-chat px-4 shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] dark:border-border"
+        className="chat-input-glass-surface relative z-10 flex h-[98px] flex-col justify-center gap-2 rounded-[22px] border border-black/8 px-4 shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] dark:border-border"
         data-testid="chat-input-loading-surface"
       >
         <div className="h-3 w-32 animate-pulse rounded-full bg-muted-foreground/15 motion-reduce:animate-none" />
@@ -96,7 +96,7 @@ const ChatInputLoadingState = ({
       {showAgentControls ? (
         <div
           aria-hidden="true"
-          className="h-10 md:h-9"
+          className="chat-input-glass-context relative z-0 mx-6 -mt-2 h-10 rounded-b-[18px] border border-t-0 border-black/8 md:hidden dark:border-border/70"
           data-testid="chat-input-loading-controls"
         />
       ) : null}
@@ -801,7 +801,8 @@ export const ChatInput = ({
           />
         ) : (
           <div
-            className={`order-2 sm:order-1 flex flex-col gap-3 transition-colors relative bg-input-chat py-3 max-h-[300px] min-w-0 overflow-hidden shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border ${uploadedFiles && uploadedFiles.length > 0 ? "rounded-b-[22px] border-t-0" : "rounded-[22px]"}`}
+            className={`chat-input-glass-surface relative z-10 order-2 flex max-h-[300px] min-w-0 flex-col gap-3 overflow-hidden border border-black/8 py-3 shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] transition-colors sm:order-1 dark:border-border ${uploadedFiles && uploadedFiles.length > 0 ? "rounded-b-[22px] border-t-0" : "rounded-[22px]"}`}
+            data-testid="chat-input-surface"
           >
             <ChatInputTextarea
               draftId={draftId}
@@ -828,23 +829,21 @@ export const ChatInput = ({
           </div>
         )}
 
-        {/* Agent controls below input.
-            Desktop centered new chats (no messages yet): absolutely positioned to avoid
-            shifting the centered layout.
-            On mobile, permission approval sits beside the sandbox selector. */}
+        {/* Compact mobile Agent controls below the input. Desktop keeps these
+            selectors in the main toolbar where there is room for them. */}
         {isAgent && !showAgentApprovalPrompt && (
           <div
-            className={`order-3 flex items-center gap-2 px-1 pt-2 min-w-0 ${
-              isNewChat && !hasMessages
-                ? "md:absolute md:left-4 md:right-4 md:top-full"
-                : ""
-            }`}
+            className="chat-input-glass-context relative z-0 order-3 mx-6 -mt-2 flex h-10 min-w-0 items-center gap-2 rounded-b-[18px] border border-t-0 border-black/8 px-3 pt-2 md:hidden dark:border-border/70"
+            data-testid="chat-input-agent-context"
           >
             <SandboxSelector
               value={sandboxPreference}
               onChange={setSandboxPreference}
             />
-            <div className="min-w-0 md:hidden">
+            <div
+              className="ml-auto min-w-0 md:hidden"
+              data-testid="chat-input-mobile-permission"
+            >
               <AgentPermissionSelector analyticsSurface="chat_input" />
             </div>
           </div>

--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AttachmentButton } from "@/app/components/AttachmentButton";
+import { SandboxSelector } from "@/app/components/SandboxSelector";
 import { ChatModeSelector } from "./ChatModeSelector";
 import { ModelSelector } from "@/app/components/ModelSelector";
 import { AgentPermissionSelector } from "@/app/components/AgentPermissionSelector";
@@ -28,7 +29,9 @@ export function ChatInputToolbar({
     freeDesktopAgentOnlyActive,
     hasLocalSandbox,
     paidAgentOnlyActive,
+    sandboxPreference,
     selectedModel,
+    setSandboxPreference,
     setSelectedModel,
     subscription,
   } = useGlobalState();
@@ -53,9 +56,24 @@ export function ChatInputToolbar({
       ) : null}
       {showFreeAskComputerActivation ? <FreeAskComputerActivation /> : null}
       {isAgentMode(chatMode) ? (
-        <div className="hidden md:block">
-          <AgentPermissionSelector analyticsSurface="chat_input" />
-        </div>
+        <>
+          <div
+            className="hidden md:block"
+            data-testid="chat-input-desktop-permission"
+          >
+            <AgentPermissionSelector analyticsSurface="chat_input" />
+          </div>
+          <div
+            className="hidden md:block"
+            data-testid="chat-input-desktop-sandbox"
+          >
+            <SandboxSelector
+              value={sandboxPreference}
+              onChange={setSandboxPreference}
+              size="toolbar"
+            />
+          </div>
+        </>
       ) : null}
       <div className="ml-auto shrink-0 flex items-center gap-2.5">
         {user ? (

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -34,6 +34,12 @@ jest.mock("@/app/components/AgentPermissionSelector", () => ({
   ),
 }));
 
+jest.mock("@/app/components/SandboxSelector", () => ({
+  SandboxSelector: ({ size }: { size?: string }) => (
+    <div data-testid="sandbox-selector" data-size={size} />
+  ),
+}));
+
 jest.mock("../SubmitStopButton", () => ({
   SubmitStopButton: ({
     isPaid,
@@ -61,6 +67,8 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     hasLocalSandbox: mockHasLocalSandbox,
     paidAgentOnlyActive: mockPaidAgentOnlyActive,
     freeDesktopAgentOnlyActive: mockFreeDesktopAgentOnlyActive,
+    sandboxPreference: "e2b",
+    setSandboxPreference: jest.fn(),
   }),
 }));
 
@@ -157,7 +165,7 @@ describe("ChatInputToolbar", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows the permission selector only in agent mode", () => {
+  it("shows desktop permission and sandbox selectors only in agent mode", () => {
     mockAuthUser({ id: "user_123" });
 
     const { rerender } = render(
@@ -166,9 +174,23 @@ describe("ChatInputToolbar", () => {
     expect(
       screen.queryByTestId("agent-permission-selector"),
     ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("sandbox-selector")).not.toBeInTheDocument();
 
     rerender(<ChatInputToolbar {...defaultProps} chatMode="agent" />);
     expect(screen.getByTestId("agent-permission-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("sandbox-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("sandbox-selector")).toHaveAttribute(
+      "data-size",
+      "toolbar",
+    );
+    expect(screen.getByTestId("chat-input-desktop-permission")).toHaveClass(
+      "hidden",
+      "md:block",
+    );
+    expect(screen.getByTestId("chat-input-desktop-sandbox")).toHaveClass(
+      "hidden",
+      "md:block",
+    );
   });
 
   it("removes only the mode selector for paid Agent-only mode", () => {

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import type { SubscriptionTier } from "@/types";
@@ -9,6 +9,7 @@ let mockChatModeAccessResolved = true;
 let mockPaidAgentOnlyActive = false;
 let mockFreeDesktopAgentOnlyActive = false;
 let mockHasLocalSandbox = false;
+const mockSetSandboxPreference = jest.fn();
 
 jest.mock("@/app/components/AttachmentButton", () => ({
   AttachmentButton: () => <button type="button">Attach</button>,
@@ -35,8 +36,22 @@ jest.mock("@/app/components/AgentPermissionSelector", () => ({
 }));
 
 jest.mock("@/app/components/SandboxSelector", () => ({
-  SandboxSelector: ({ size }: { size?: string }) => (
-    <div data-testid="sandbox-selector" data-size={size} />
+  SandboxSelector: ({
+    size,
+    value,
+    onChange,
+  }: {
+    size?: string;
+    value?: string;
+    onChange?: (value: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="sandbox-selector"
+      data-size={size}
+      data-value={value}
+      onClick={() => onChange?.("local")}
+    />
   ),
 }));
 
@@ -68,7 +83,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     paidAgentOnlyActive: mockPaidAgentOnlyActive,
     freeDesktopAgentOnlyActive: mockFreeDesktopAgentOnlyActive,
     sandboxPreference: "e2b",
-    setSandboxPreference: jest.fn(),
+    setSandboxPreference: mockSetSandboxPreference,
   }),
 }));
 
@@ -106,6 +121,7 @@ describe("ChatInputToolbar", () => {
     mockPaidAgentOnlyActive = false;
     mockFreeDesktopAgentOnlyActive = false;
     mockHasLocalSandbox = false;
+    mockSetSandboxPreference.mockClear();
     mockAuthUser(null);
   });
 
@@ -183,6 +199,12 @@ describe("ChatInputToolbar", () => {
       "data-size",
       "toolbar",
     );
+    expect(screen.getByTestId("sandbox-selector")).toHaveAttribute(
+      "data-value",
+      "e2b",
+    );
+    fireEvent.click(screen.getByTestId("sandbox-selector"));
+    expect(mockSetSandboxPreference).toHaveBeenCalledWith("local");
     expect(screen.getByTestId("chat-input-desktop-permission")).toHaveClass(
       "hidden",
       "md:block",

--- a/app/components/SandboxSelector.tsx
+++ b/app/components/SandboxSelector.tsx
@@ -26,7 +26,7 @@ interface SandboxSelectorProps {
   value: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
-  size?: "sm" | "md";
+  size?: "sm" | "toolbar" | "md";
 }
 
 interface ConnectionOption {
@@ -119,7 +119,9 @@ export function SandboxSelector({
   const buttonClassName =
     size === "md"
       ? "h-9 px-3 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
-      : "h-7 px-2 gap-1 text-xs font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink";
+      : size === "toolbar"
+        ? "h-7 px-2 gap-1 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
+        : "h-7 px-2 gap-1 text-xs font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink";
 
   const iconClassName = size === "md" ? "h-4 w-4 shrink-0" : "h-3 w-3 shrink-0";
 

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -181,9 +181,7 @@ describe("ChatInput - Integration Tests", () => {
         screen.getByTestId("attach-files-button").querySelector(".lucide-plus"),
       ).toBeInTheDocument();
       expect(
-        screen
-          .getByTestId("attach-files-button")
-          .querySelector(".size-\\[18px\\]"),
+        screen.getByTestId("attach-files-button").querySelector(".size-5"),
       ).toBeInTheDocument();
       expect(screen.getByTestId("attach-files-button")).toHaveClass(
         "h-8",

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -10,6 +10,7 @@ import {
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ReactNode, useEffect } from "react";
 import {
+  CHAT_MODE_STORAGE_KEY,
   CONVERSATION_DRAFTS_STORAGE_KEY,
   getDraftAttachmentsById,
   getDraftContentById,
@@ -176,6 +177,23 @@ describe("ChatInput - Integration Tests", () => {
         screen.getByPlaceholderText("Ask, learn, brainstorm"),
       ).toBeInTheDocument();
       expect(screen.getByText("Ask")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("attach-files-button").querySelector(".lucide-plus"),
+      ).toBeInTheDocument();
+      expect(
+        screen
+          .getByTestId("attach-files-button")
+          .querySelector(".size-\\[18px\\]"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("attach-files-button")).toHaveClass(
+        "h-8",
+        "w-8",
+        "rounded-md",
+        "hover:bg-muted/30",
+      );
+      expect(screen.getByTestId("attach-files-button")).not.toHaveClass(
+        "rounded-full",
+      );
     });
 
     it("should show only submit button when ready in ask mode", () => {
@@ -398,6 +416,45 @@ describe("ChatInput - Integration Tests", () => {
   });
 
   describe("Agent Mode Integration", () => {
+    it("renders a glass composer with a narrower sandbox context strip", () => {
+      window.localStorage.setItem(CHAT_MODE_STORAGE_KEY, "agent");
+      mockUseQuery.mockReturnValue([
+        {
+          connectionId: "local-sandbox",
+          name: "Local sandbox",
+          isDesktop: false,
+        },
+      ]);
+
+      render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            hasMessages
+          />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId("chat-input-surface")).toHaveClass(
+        "chat-input-glass-surface",
+        "z-10",
+      );
+      expect(screen.getByTestId("chat-input-agent-context")).toHaveClass(
+        "chat-input-glass-context",
+        "mx-6",
+        "-mt-2",
+        "h-10",
+        "rounded-b-[18px]",
+        "md:hidden",
+      );
+      expect(screen.getByTestId("chat-input-mobile-permission")).toHaveClass(
+        "ml-auto",
+        "md:hidden",
+      );
+    });
+
     it("does not show a late approval after the composer stop button is clicked", async () => {
       let resolveStop: ((stopped: boolean) => void) | undefined;
       const pendingStop = new Promise<boolean>((resolve) => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -179,6 +179,35 @@
   box-shadow: 0 18px 44px -18px rgb(0 0 0 / 80%);
 }
 
+.chat-input-glass-surface {
+  background: color-mix(in srgb, var(--fill-input-chat) 86%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  backdrop-filter: blur(18px) saturate(140%);
+}
+
+.chat-input-glass-context {
+  background: color-mix(in srgb, var(--fill-input-chat) 76%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  backdrop-filter: blur(18px) saturate(140%);
+}
+
+.dark .chat-input-glass-surface {
+  background: color-mix(in srgb, var(--fill-input-chat) 90%, transparent);
+}
+
+.dark .chat-input-glass-context {
+  background: color-mix(in srgb, var(--fill-input-chat) 82%, transparent);
+}
+
+@supports not (
+  (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
+) {
+  .chat-input-glass-surface,
+  .chat-input-glass-context {
+    background: var(--fill-input-chat);
+  }
+}
+
 @keyframes shimmer {
   0% {
     background-position: 200% 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -180,22 +180,26 @@
 }
 
 .chat-input-glass-surface {
+  background: var(--fill-input-chat);
   background: color-mix(in srgb, var(--fill-input-chat) 86%, transparent);
   -webkit-backdrop-filter: blur(18px) saturate(140%);
   backdrop-filter: blur(18px) saturate(140%);
 }
 
 .chat-input-glass-context {
+  background: var(--fill-input-chat);
   background: color-mix(in srgb, var(--fill-input-chat) 76%, transparent);
   -webkit-backdrop-filter: blur(18px) saturate(140%);
   backdrop-filter: blur(18px) saturate(140%);
 }
 
 .dark .chat-input-glass-surface {
+  background: var(--fill-input-chat);
   background: color-mix(in srgb, var(--fill-input-chat) 90%, transparent);
 }
 
 .dark .chat-input-glass-context {
+  background: var(--fill-input-chat);
   background: color-mix(in srgb, var(--fill-input-chat) 82%, transparent);
 }
 


### PR DESCRIPTION
## Summary
- add a translucent backdrop blur to the chat composer and a compact mobile context strip
- move the sandbox selector into the desktop toolbar while keeping mobile sandbox and permission controls on opposite sides
- replace the attachment paperclip with an aligned plus icon and normalize selector sizing and hover geometry

## Why
The transparent composer let timeline content read straight through it, while the desktop-only lower sandbox bar felt visually disconnected. This keeps the composer light while restoring hierarchy across desktop and mobile.

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm test` — 358 suites, 3,652 tests passed
- staged-file Prettier and ESLint hooks
- Google Chrome at 1440×900 and 375×667: selector placement, blur/context surfaces, control sizing, hover styling, and console

## Manual verification
- On desktop, open an Agent task and confirm permission and sandbox selectors are inline in the composer with no lower context strip.
- At a mobile width, confirm sandbox is left and permission is right in the lower strip with no duplicate selectors.
- Hover the plus, permission, sandbox, and mode controls and confirm their rounded background treatment is consistent.
- Click the plus and confirm the attachment flow still opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact sandbox selector to the agent-mode chat toolbar.
  * Updated attachment controls with a plus icon and rounded styling.
  * Introduced glass-style chat input surfaces with responsive mobile and desktop layouts.
  * Added theme-aware styling and a solid-color fallback for unsupported visual effects.
* **Tests**
  * Expanded coverage for attachment controls, sandbox selection, responsive layouts, and glass styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->