### PR TITLE
Fix WorkOS security dialog layering

### DIFF
--- a/app/components/SecurityTab.tsx
+++ b/app/components/SecurityTab.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { UserSecurity } from "@workos-inc/widgets/user-security";
 import { WorkOsWidgets } from "@workos-inc/widgets/workos-widgets";
+import { LogOut, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 
@@ -53,6 +54,7 @@ const SecurityTab = () => {
     <div className="space-y-6">
       <div data-testid="workos-user-security">
         <WorkOsWidgets
+          style={{ blockSize: "auto", minBlockSize: "auto" }}
           theme={{
             appearance: "dark",
             accentColor: "gray",
@@ -65,9 +67,20 @@ const SecurityTab = () => {
         </WorkOsWidgets>
       </div>
 
-      <div className="border-t">
-        <div className="flex items-center justify-between py-3 border-b">
-          <div className="font-medium text-base">Log out of this device</div>
+      <div
+        data-testid="security-session-actions"
+        className="overflow-hidden rounded-lg border bg-card text-card-foreground"
+      >
+        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 border-b p-4">
+          <div
+            aria-hidden="true"
+            className="flex size-8 items-center justify-center rounded-md border bg-muted/50"
+          >
+            <Monitor className="size-4" />
+          </div>
+          <div className="min-w-0 text-sm font-semibold">
+            Log out of this device
+          </div>
           <Button
             data-testid="logout-button-device"
             variant="outline"
@@ -78,10 +91,16 @@ const SecurityTab = () => {
           </Button>
         </div>
 
-        <div className="flex items-start justify-between py-3">
-          <div className="flex-1 pr-4">
-            <div className="font-medium text-base">Log out of all devices</div>
-            <div className="text-sm text-muted-foreground mt-1">
+        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 p-4">
+          <div
+            aria-hidden="true"
+            className="flex size-8 items-center justify-center rounded-md border bg-muted/50"
+          >
+            <LogOut className="size-4" />
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-semibold">Log out of all devices</div>
+            <div className="mt-1 text-sm text-muted-foreground">
               Log out of all active sessions across all devices, including your
               current session. It may take up to 10 minutes for other devices to
               be logged out.
@@ -92,7 +111,7 @@ const SecurityTab = () => {
             variant="destructive"
             size="sm"
             onClick={handleLogoutAll}
-            className="bg-red-600 hover:bg-red-700 text-white shrink-0"
+            className="shrink-0 bg-red-600 text-white hover:bg-red-700"
           >
             Log out all
           </Button>

--- a/app/components/__tests__/SecurityTab.test.tsx
+++ b/app/components/__tests__/SecurityTab.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 const mockGetAccessToken = jest.fn<() => Promise<string | undefined>>();
 let mockWidgetAuthToken: (() => Promise<string>) | undefined;
@@ -10,8 +10,16 @@ jest.mock("@workos-inc/authkit-nextjs/components", () => ({
 }));
 
 jest.mock("@workos-inc/widgets/workos-widgets", () => ({
-  WorkOsWidgets: ({ children }: { children: ReactNode }) => (
-    <div data-testid="workos-widgets-provider">{children}</div>
+  WorkOsWidgets: ({
+    children,
+    style,
+  }: {
+    children: ReactNode;
+    style?: CSSProperties;
+  }) => (
+    <div data-testid="workos-widgets-provider" style={style}>
+      {children}
+    </div>
   ),
 }));
 
@@ -34,6 +42,9 @@ describe("SecurityTab", () => {
     render(<SecurityTab />);
 
     expect(screen.getByTestId("workos-widgets-provider")).toBeInTheDocument();
+    expect(screen.getByTestId("workos-widgets-provider")).toHaveStyle(
+      "block-size: auto; min-block-size: auto",
+    );
     expect(
       screen.getByTestId("workos-user-security-widget"),
     ).toBeInTheDocument();
@@ -51,5 +62,26 @@ describe("SecurityTab", () => {
     await expect(mockWidgetAuthToken?.()).rejects.toThrow(
       "Unable to load security settings",
     );
+  });
+
+  it("keeps both session logout actions in a shared card", async () => {
+    const { SecurityTab } = await import("../SecurityTab");
+    render(<SecurityTab />);
+
+    expect(screen.getByTestId("security-session-actions")).toHaveClass(
+      "rounded-lg",
+      "border",
+    );
+    expect(screen.getByText("Log out of this device")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
+    expect(screen.getByText("Log out of all devices")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Log out of all active sessions across all devices, including your current session/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Log out all" }),
+    ).toBeInTheDocument();
   });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,11 @@
 @import "@workos-inc/widgets/styles.css";
 @source "../node_modules/streamdown/dist/index.js";
 
+/* Keep WorkOS widget dialogs above HackerAI's z-50 dialog portals. */
+.woswidgets-dialog-overlay {
+  z-index: 60;
+}
+
 @custom-variant dark (&:is(.dark *));
 @custom-variant desktop (@media (min-width: 950px));
 @custom-variant touch-device (@media (hover: none));


### PR DESCRIPTION
## Summary

- place WorkOS widget dialogs above HackerAI's existing Settings dialog layer
- scope the override to WorkOS's namespaced dialog overlay class
- preserve the shared fix for MFA setup/elevated-access and Password dialogs
- keep both session logout actions directly below WorkOS controls in a matching two-row card
- constrain the embedded WorkOS root theme to content height so the logout actions are not pushed below a viewport-sized gap

## Root cause

HackerAI's shadcn/Radix Settings overlay and content portal directly to `document.body` at `z-index: 50`. WorkOS 1.16.0 also portals its Radix Themes dialog to `document.body`, but its `.woswidgets-dialog-overlay` computes to `z-index: auto`. Even though the WorkOS portal is later in DOM order, HackerAI's explicit z-index wins, so hit-testing at the WorkOS dialog center lands on the Settings backdrop.

WorkOS's internal Radix Themes content supports a portal `container`, but neither `UserSecurity` nor `WorkOsWidgets` exposes it. The smallest supported integration fix is therefore a namespaced WorkOS overlay layer above Settings, without changing global dialog z-index behavior.

The WorkOS provider is also a Radix root theme with `min-height: 100dvh`. In the embedded Settings panel this inserted a viewport-sized gap before HackerAI's session actions, so this instance now opts into content sizing through the provider's supported `style` prop.

## Validation

- `pnpm jest app/components/__tests__/SecurityTab.test.tsx --runInBand` (3 tests)
- `pnpm exec eslint app/components/SecurityTab.tsx app/components/__tests__/SecurityTab.test.tsx`
- `pnpm typecheck`
- `pnpm exec prettier --check app/components/SecurityTab.tsx app/components/__tests__/SecurityTab.test.tsx app/globals.css`
- commit hook: 358 test suites / 3,656 tests passed
- `git diff --check`

## Visual verification

Verified in Google Chrome against the real WorkOS UserSecurity widget using the dedicated free-tier test account:

- reproduced MFA identity dialog hidden behind Settings before the fix
- confirmed computed layers: Settings `z-index: 50`, WorkOS `z-index: auto`
- after the fix, WorkOS computes to `z-index: 60` and hit-testing resolves inside the WorkOS dialog
- MFA identity dialog: visible, clickable Cancel, focus returns to “Set up authenticator app,” Settings remains open
- Change Password dialog: visible, fields receive hit-testing, clickable Cancel, focus returns to “Change,” Settings remains open
- Password/MFA and both logout actions now render together without scrolling or a blank viewport-height gap
- session actions retain the exact device/all-devices copy and buttons in a WorkOS-aligned card layout

No MFA factor was completed, reset, or disabled.

## Manual verification

1. Open **Settings → Security** in a production or CORS-enabled environment.
2. Confirm Password/MFA and the **Log out of this device** / **Log out of all devices** rows are visible together in matching card layouts.
3. Click **Set up authenticator app** and confirm the WorkOS identity/MFA dialog appears above Settings, accepts interaction, and returns focus to the trigger when closed.
4. Click **Change** in Password and confirm the same layer, click, close, and focus behavior.
5. Confirm **Log out** and **Log out all** still invoke their existing flows; do not complete the all-devices action on a customer account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned security session controls with clearer icon-based actions for signing out from the current device or all devices.
  * Improved the layout and sizing of the security widget.
* **Bug Fixes**
  * Improved the visibility and layering of WorkOS widget dialogs so they appear correctly above other interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->