### PR TITLE
Fix active organization scope for entitlements and billing

### DIFF
--- a/app/api/entitlements/route.ts
+++ b/app/api/entitlements/route.ts
@@ -28,44 +28,13 @@ export async function GET(req: NextRequest) {
     // First authenticate to get user and organization info
     const authResult = await session.authenticate();
 
-    let organizationId: string | undefined;
-    if (authResult.authenticated) {
-      // Check if organizationId is already available in the session
-      organizationId = (authResult as any).organizationId;
+    const organizationId = authResult.authenticated
+      ? ((authResult as any).organizationId as string | undefined)
+      : undefined;
 
-      // If organizationId is not in session, fetch it using userId
-      if (!organizationId) {
-        const userId = (authResult as any).user?.id;
-
-        if (userId) {
-          // Get organization membership for this user
-          try {
-            const memberships =
-              await workos.userManagement.listOrganizationMemberships({
-                userId: userId,
-                statuses: ["active"],
-              });
-
-            // Use the first active membership's organization ID
-            if (memberships.data && memberships.data.length > 0) {
-              organizationId = memberships.data[0].organizationId;
-            }
-          } catch (membershipError) {
-            // Rethrow rate-limit errors so the outer catch returns 429
-            // instead of silently falling through to an unscoped refresh
-            if (isRateLimitError(membershipError)) {
-              throw membershipError;
-            }
-            console.error(
-              "Failed to fetch organization memberships:",
-              membershipError,
-            );
-          }
-        }
-      }
-    }
-
-    // Refresh with organization ID to ensure we get entitlements for the correct org
+    // Only scope the refresh when the authenticated session already names an
+    // active organization. Picking the first membership here can silently
+    // switch multi-organization users to an unrelated organization.
     const refreshResult = organizationId
       ? await session.refresh({ organizationId })
       : await session.refresh();

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 
-const mockGetUserID = jest.fn();
+const mockGetUserIDAndPro = jest.fn();
 const mockGetUser = jest.fn();
 const mockListOrganizationMemberships = jest.fn();
 const mockGetOrganization = jest.fn();
@@ -30,7 +30,7 @@ jest.mock("@/lib/posthog/server", () => ({
 }));
 
 jest.mock("@/lib/auth/get-user-id", () => ({
-  getUserID: mockGetUserID,
+  getUserIDAndPro: mockGetUserIDAndPro,
 }));
 
 jest.mock("../../workos", () => ({
@@ -76,7 +76,11 @@ describe("POST /api/subscription-details", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockGetUserID.mockResolvedValue("user_123" as never);
+    mockGetUserIDAndPro.mockResolvedValue({
+      userId: "user_123",
+      subscription: "team",
+      organizationId: "org_team",
+    } as never);
     mockGetUser.mockResolvedValue({
       id: "user_123",
       email: "billing@example.com",
@@ -145,6 +149,36 @@ describe("POST /api/subscription-details", () => {
     expect(mockListPrices).toHaveBeenCalledWith({
       lookup_keys: ["pro-monthly-plan"],
     });
+  });
+
+  it("scopes membership and billing lookup to the active organization", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+
+    expect(response.status).toBe(200);
+    expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
+      userId: "user_123",
+      organizationId: "org_team",
+      statuses: ["active"],
+    });
+    expect(mockGetOrganization).toHaveBeenCalledWith("org_team");
+  });
+
+  it("rejects billing changes when there is no active organization", async () => {
+    mockGetUserIDAndPro.mockResolvedValueOnce({
+      userId: "user_123",
+      subscription: "free",
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: "No active organization" });
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(mockGetOrganization).not.toHaveBeenCalled();
   });
 
   it("rejects non-owner, non-admin members from managing billing", async () => {

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -1,6 +1,6 @@
 import { stripe } from "../stripe";
 import { workos } from "../workos";
-import { getUserID } from "@/lib/auth/get-user-id";
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { after, NextRequest, NextResponse } from "next/server";
 import { SubscriptionTier } from "@/types/chat";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
@@ -92,13 +92,22 @@ export const POST = async (req: NextRequest) => {
         ? requestedPlan
         : "pro-monthly-plan";
 
-    const userId = await getUserID(req);
+    const { userId, organizationId } = await getUserIDAndPro(req);
     const user = await workos.userManagement.getUser(userId);
 
-    // Get user's organization
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "No active organization" },
+        { status: 403 },
+      );
+    }
+
+    // Verify billing permissions in the active organization from the session.
     const existingMemberships =
       await workos.userManagement.listOrganizationMemberships({
         userId,
+        organizationId,
+        statuses: ["active"],
       });
 
     if (!existingMemberships.data || existingMemberships.data.length === 0) {
@@ -116,9 +125,8 @@ export const POST = async (req: NextRequest) => {
       );
     }
 
-    const organization = await workos.organizations.getOrganization(
-      membership.organizationId,
-    );
+    const organization =
+      await workos.organizations.getOrganization(organizationId);
 
     // Find Stripe customer
     const customers = await stripe.customers.list({


### PR DESCRIPTION
## Summary

- preserve the authenticated active organization during entitlement refresh instead of selecting the first WorkOS membership
- scope subscription changes to the active organization and verify an active membership in that exact organization
- fail closed when a billing request has no active organization
- add regression coverage for active-organization scoping and the missing-organization case

## Root cause

Both flows used membership ordering as an implicit organization selector. For multi-organization users, `memberships.data[0]` is not guaranteed to match the organization selected in the application.

The entitlement endpoint could also persist the arbitrarily selected organization into the refreshed sealed session. The subscription endpoint could preview or update the Stripe subscription belonging to that first organization.

## Impact

Multi-organization users no longer risk seeing entitlements from, switching into, or changing billing for the wrong organization because of membership API ordering.

Fixes #1091
Fixes #1092

## Validation

- `pnpm exec jest app/api/subscription-details/__tests__/route.test.ts --runInBand --no-watchman` — 13 tests passed
- ESLint on all three changed files
- Prettier on all three changed files
- `git diff --check`

The repository-wide `pnpm typecheck` is currently blocked by unrelated baseline/local dependency state: stale generated `.next` MFA route types and unresolved `@workos-inc/widgets/user-security` / `workos-widgets` entry points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription and billing details are now scoped to the authenticated session’s active organization.
  * Requests without an active organization are rejected with a clear authorization error.
  * Entitlement refreshes no longer fall back to an unrelated organization.
  * Improved validation ensures organization membership and subscription information match the active organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->