### PR TITLE
Preserve WorkOS errors when removing team members

### DIFF
--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockRequireTeamOrg = jest.fn();
+const mockGetOrganizationMembership = jest.fn();
+const mockGetInvitation = jest.fn();
+const mockRevokeInvitation = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("../../team-auth", () => ({
+  requireTeamOrg: mockRequireTeamOrg,
+}));
+
+jest.mock("../../../workos", () => ({
+  workos: {
+    userManagement: {
+      getOrganizationMembership: mockGetOrganizationMembership,
+      getInvitation: mockGetInvitation,
+      revokeInvitation: mockRevokeInvitation,
+    },
+  },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  getTeamMemberConsumed: jest.fn(),
+  addOrgRemovedUsage: jest.fn(),
+}));
+
+function makeRequest(id = "membership_or_invitation_id") {
+  return { url: `https://hackerai.example/api/team/members?id=${id}` } as any;
+}
+
+describe("DELETE /api/team/members", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireTeamOrg.mockResolvedValue({
+      ok: true,
+      userId: "user_admin",
+      organizationId: "org_team",
+      membership: { role: { slug: "admin" } },
+    } as never);
+  });
+
+  it("does not treat a transient membership lookup failure as an invitation", async () => {
+    mockGetOrganizationMembership.mockRejectedValueOnce(
+      Object.assign(new Error("WorkOS unavailable"), {
+        statusCode: 503,
+      }) as never,
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { DELETE } = await import("../route");
+      const response = await DELETE(makeRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body).toEqual({ error: "WorkOS unavailable" });
+      expect(mockGetInvitation).not.toHaveBeenCalled();
+      expect(mockRevokeInvitation).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("falls back to invitation revocation only when membership is not found", async () => {
+    mockGetOrganizationMembership.mockRejectedValueOnce(
+      Object.assign(new Error("Not found"), { status: 404 }) as never,
+    );
+    mockGetInvitation.mockResolvedValueOnce({
+      id: "invitation_id",
+      organizationId: "org_team",
+    } as never);
+
+    const { DELETE } = await import("../route");
+    const response = await DELETE(makeRequest("invitation_id"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetInvitation).toHaveBeenCalledWith("invitation_id");
+    expect(mockRevokeInvitation).toHaveBeenCalledWith("invitation_id");
+  });
+});

--- a/app/api/team/members/route.ts
+++ b/app/api/team/members/route.ts
@@ -4,6 +4,12 @@ import { stripe } from "../../stripe";
 import { getTeamMemberConsumed, addOrgRemovedUsage } from "@/lib/rate-limit";
 import { requireTeamOrg } from "../team-auth";
 
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { status?: unknown; statusCode?: unknown };
+  return candidate.status === 404 || candidate.statusCode === 404;
+}
+
 export const GET = async (req: NextRequest) => {
   try {
     const guard = await requireTeamOrg(req);
@@ -206,7 +212,10 @@ export const DELETE = async (req: NextRequest) => {
         await addOrgRemovedUsage(organizationId, consumed);
       }
     } catch (error) {
-      // If membership not found, it might be an invitation
+      // Only a genuine not-found response can mean the supplied ID belongs to
+      // an invitation. Propagate timeouts, rate limits, and server errors so we
+      // do not mask a failed membership lookup as a missing invitation.
+      if (!isNotFoundError(error)) throw error;
       isInvitation = true;
     }
 


### PR DESCRIPTION
## Summary

- fall back from membership deletion to invitation revocation only when WorkOS returns a genuine 404
- propagate transient membership lookup failures instead of disguising them as missing invitations
- add regression coverage for both a transient WorkOS failure and the intended invitation fallback

## Root cause

The team-member deletion route wrapped the entire membership lookup and deletion path in a broad `catch`. Every error — including timeouts, rate limits, and WorkOS server failures — set `isInvitation = true`.

The route then queried the same identifier as an invitation and usually returned a misleading `Member or invitation not found` response. This hid the real failure and made it difficult for administrators to know whether retrying was safe.

## Impact

Team administrators now receive the original operational failure when WorkOS membership operations are unavailable. Invitation revocation behavior remains unchanged for actual not-found membership IDs.

## Validation

- `pnpm exec jest app/api/team/members/__tests__/route.test.ts --runInBand --no-watchman` — 2 tests passed
- ESLint on both changed files
- Prettier on both changed files
- `git diff --check`