### PR TITLE
Scope new subscription checkout to the active organization

### DIFF
--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -190,6 +190,70 @@ describe("POST /api/subscribe", () => {
     expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
   });
 
+  it("scopes checkout creation to the active organization", async () => {
+    mockGetUserIDAndPro.mockResolvedValueOnce({
+      userId: "user_123",
+      subscription: "free",
+      organizationId: "org_active",
+      freeQuotaSubject: "free_quota_subject",
+    } as never);
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [
+        {
+          organizationId: "org_active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValueOnce({
+      id: "org_active",
+      stripeCustomerId: "cus_active",
+    } as never);
+    mockRetrieveCustomer.mockResolvedValueOnce({
+      id: "cus_active",
+      metadata: { workOSOrganizationId: "org_active" },
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+
+    expect(response.status).toBe(200);
+    expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
+      userId: "user_123",
+      statuses: ["active"],
+      organizationId: "org_active",
+    });
+    expect(mockGetOrganization).toHaveBeenCalledWith("org_active");
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: "cus_active",
+        metadata: expect.objectContaining({
+          workOSOrganizationId: "org_active",
+        }),
+      }),
+    );
+  });
+
+  it("rejects ambiguous multi-organization checkout without an active organization", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [
+        { organizationId: "org_a", role: { slug: "admin" } },
+        { organizationId: "org_b", role: { slug: "admin" } },
+      ],
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body).toEqual({
+      error: "Select an active organization before subscribing",
+    });
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+  });
+
   it("returns unauthenticated requests as 401 responses", async () => {
     mockGetUserIDAndPro.mockRejectedValueOnce(
       new ChatSDKError("unauthorized:auth") as never,

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -238,7 +238,7 @@ export const POST = async (req: NextRequest) => {
     const fromTier = paidFunnelTierFromUnknown(body?.fromTier);
     const posthogSessionId = req.headers.get("x-posthog-session-id");
     // Get user ID and subscription state from authenticated session
-    const { userId, subscription, freeQuotaSubject } =
+    const { userId, subscription, organizationId, freeQuotaSubject } =
       await getUserIDAndPro(req);
 
     // Get user details from WorkOS to create a personal organization.
@@ -330,12 +330,20 @@ export const POST = async (req: NextRequest) => {
       await workos.userManagement.listOrganizationMemberships({
         userId,
         statuses: ["active"],
+        ...(organizationId && { organizationId }),
       });
 
     let organization;
 
     if (existingMemberships.data && existingMemberships.data.length > 0) {
-      // User already has an organization, use the first one
+      // The authenticated active organization scopes multi-organization users.
+      // Without one, only a single unambiguous membership is safe to select.
+      if (!organizationId && existingMemberships.data.length > 1) {
+        return json(
+          { error: "Select an active organization before subscribing" },
+          { status: 409 },
+        );
+      }
       const membership = existingMemberships.data[0];
       if (!canManageOrganizationBilling(membership)) {
         return json(


### PR DESCRIPTION
## Summary

- scope existing-membership lookup in `POST /api/subscribe` to the authenticated active organization
- retain the existing single-organization fallback for legacy sessions
- reject ambiguous checkout creation when a session has no active organization and the user belongs to multiple organizations
- add regression tests for active-organization checkout and the ambiguous fallback

## Root cause

The new-subscription route ignored the `organizationId` already returned by `getUserIDAndPro`. It listed all active memberships and selected `data[0]`, so WorkOS API ordering could choose a different organization than the one active in the application.

The selected organization controls the Stripe customer, Checkout metadata, subscription metadata, and eventual entitlement assignment.

## Impact

For multi-organization administrators, new Checkout sessions now target the organization selected in the authenticated session. Ambiguous legacy sessions fail safely instead of potentially attaching a paid subscription to the wrong organization.

## Validation

- `pnpm exec jest app/api/subscribe/__tests__/route.test.ts --runInBand --no-watchman` — 14 tests passed
- ESLint on both changed files
- Prettier on both changed files
- `git diff --check`