### PR TITLE
Use medium reasoning for Grok 4.6 Auto and Standard

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -32,12 +32,14 @@ const DEEPSEEK_FLASH_CANONICAL_SLUG = "deepseek/deepseek-v4-flash-20260731";
 const DEEPSEEK_FLASH_PREVIOUS_SLUG = "deepseek/deepseek-v4-flash";
 const DEEPSEEK_FLASH_PREVIOUS_CANONICAL_SLUG =
   "deepseek/deepseek-v4-flash-20260423";
-const GROK_PRIMARY_OR_FALLBACK_MODELS = [
+const MEDIUM_GROK_PRIMARY_MODELS = [
   "ask-model",
   "agent-model",
-  "agent-model-free",
   "model-grok-4.6",
   "model-grok-4.5",
+] as const;
+const HIGH_GROK_PRIMARY_OR_FALLBACK_MODELS = [
+  "agent-model-free",
   "model-grok-4.5-pro",
   "model-grok-4.6-pro",
   "model-deepseek-v4-pro",
@@ -86,7 +88,7 @@ describe("buildProviderOptions fallback chain", () => {
     expect(currentRoute.openrouter).not.toHaveProperty("provider");
   });
 
-  it.each(GROK_PRIMARY_OR_FALLBACK_MODELS)(
+  it.each(HIGH_GROK_PRIMARY_OR_FALLBACK_MODELS)(
     "uses high reasoning whenever %s can resolve to Grok",
     (modelName) => {
       for (const mode of ["ask", "agent"] as const) {
@@ -99,6 +101,24 @@ describe("buildProviderOptions fallback chain", () => {
         expect(opts.openrouter.reasoning).toEqual({
           enabled: true,
           effort: "high",
+        });
+      }
+    },
+  );
+
+  it.each(MEDIUM_GROK_PRIMARY_MODELS)(
+    "uses medium reasoning for the Auto/Standard Grok route %s",
+    (modelName) => {
+      for (const mode of ["ask", "agent"] as const) {
+        const opts = buildProviderOptions(
+          mode === "agent",
+          "user-1",
+          modelName,
+          mode,
+        );
+        expect(opts.openrouter.reasoning).toEqual({
+          enabled: true,
+          effort: "medium",
         });
       }
     },
@@ -227,6 +247,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
+      reasoning: { enabled: true, effort: "medium" },
       models: [KIMI_K3_SLUG],
       user: "user-1",
     });
@@ -278,7 +299,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("falls back from paid Ask PDF Grok route to Kimi K3", () => {
     const opts = buildProviderOptions(false, "user-1", "model-grok-4.6", "ask");
     expect(opts.openrouter).toMatchObject({
-      reasoning: { enabled: true, effort: "high" },
+      reasoning: { enabled: true, effort: "medium" },
       models: [KIMI_K3_SLUG],
       user: "user-1",
     });
@@ -418,13 +439,26 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it.each(["model-deepseek-v4-pro", "ask-model", "model-grok-4.6"])(
-    "enables high reasoning for Grok-backed ask mode model %s",
+  it("enables high reasoning for the DeepSeek Pro route with a Grok fallback", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-deepseek-v4-pro",
+      "ask",
+    );
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
+  });
+
+  it.each(["ask-model", "model-grok-4.6"])(
+    "enables medium reasoning for Auto/Standard Grok ask model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
       expect(opts.openrouter.reasoning).toEqual({
         enabled: true,
-        effort: "high",
+        effort: "medium",
       });
     },
   );
@@ -487,7 +521,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(grokReasoning.openrouter).toMatchObject({
-      reasoning: { enabled: true, effort: "high" },
+      reasoning: { enabled: true, effort: "medium" },
       models: [KIMI_K3_SLUG],
     });
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -601,6 +601,13 @@ const isHighReasoningModel = (modelName?: string): boolean =>
   typeof modelName === "string" &&
   (HIGH_REASONING_MODELS as readonly string[]).includes(modelName);
 
+const MEDIUM_GROK_REASONING_MODELS = new Set<string>([
+  "ask-model",
+  "agent-model",
+  "model-grok-4.6",
+  "model-grok-4.5",
+]);
+
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
   reasoningOverride?: ProviderReasoningOverride;
@@ -826,10 +833,15 @@ export function buildProviderOptions(
       })
     : fallbackSlugs;
   // OpenRouter applies one reasoning configuration to both the primary model
-  // and every provider fallback. Force high whenever Grok 4.6 is
-  // reachable so neither route can inherit less effort.
+  // and every provider fallback. Auto and Standard use medium when Grok 4.6 is
+  // the primary route to reduce reasoning-token cost; Pro and routes that can
+  // only reach Grok as a fallback retain high reasoning.
   const routesThroughGrok =
     isGrok46 || reasoningFallbackSlugs.includes(GROK_4_6_SLUG);
+  const usesMediumGrokReasoning =
+    isGrok46 &&
+    typeof modelName === "string" &&
+    MEDIUM_GROK_REASONING_MODELS.has(modelName);
   const providerRouting = modelId
     ? getOpenRouterProviderRoutingForModel(modelId)
     : undefined;
@@ -838,7 +850,7 @@ export function buildProviderOptions(
       ? options.reasoningOverride
       : {
           enabled: true,
-          effort: "high",
+          effort: usesMediumGrokReasoning ? "medium" : "high",
         }
     : (options.reasoningOverride ??
       (isHighReasoningModel(modelName) || isAgentDeepSeekV4


### PR DESCRIPTION
## Summary

- use `medium` reasoning when Grok 4.6 is the primary model for paid Auto and HackerAI Standard
- keep explicit HackerAI Pro on `high` reasoning
- keep DeepSeek-first and other fallback-only Grok routes on `high`
- preserve higher scoped reasoning overrides where explicitly configured

## Why

Grok 4.6 is smarter but uses more reasoning tokens. Medium effort for Auto and Standard reduces token usage and cost while preserving the highest effort for the explicit Pro tier.

## Validation

- `pnpm run typecheck`
- scoped ESLint and Prettier
- full Jest suite: 357 suites, 3,654 tests passed
- `git diff --check`

No UI change; automated validation is sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated supported AI models to use more appropriate medium- or high-reasoning modes based on the selected route.
  * Improved reasoning behavior for Auto, Standard Grok, and agent interactions.
  * Added support for high-reasoning responses with DeepSeek Pro.
  * Preserved high-reasoning behavior for Grok-backed routes that require deeper analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->