### PR TITLE
Fix active organization scope for entitlements and billing

### DIFF
--- a/app/api/entitlements/__tests__/route.test.ts
+++ b/app/api/entitlements/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const mockAuthenticate = jest.fn();
 const mockRefresh = jest.fn();
 const mockLoadSealedSession = jest.fn();
 const mockListOrganizationMemberships = jest.fn();
+const mockAutoPagination = jest.fn();
 const mockResponseCookieSet = jest.fn();
 
 jest.mock("next/server", () => ({
@@ -55,6 +56,10 @@ describe("GET /api/entitlements", () => {
       sealedSession: "refreshed-session",
       entitlements: ["pro-plan"],
     } as never);
+    mockListOrganizationMemberships.mockResolvedValue({
+      autoPagination: mockAutoPagination,
+    } as never);
+    mockAutoPagination.mockResolvedValue([] as never);
   });
 
   it("refreshes entitlements for the active organization from the session", async () => {
@@ -87,17 +92,99 @@ describe("GET /api/entitlements", () => {
     );
   });
 
-  it("does not select the first membership when the session has no active organization", async () => {
+  it("recovers entitlements from the only active membership when the session has no organization", async () => {
     mockAuthenticate.mockResolvedValueOnce({
       authenticated: true,
       user: { id: "user_123" },
     } as never);
+    mockAutoPagination.mockResolvedValueOnce([
+      { organizationId: "org_only" },
+    ] as never);
 
     const { GET } = await import("../route");
     const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
+      userId: "user_123",
+      statuses: ["active"],
+    });
+    expect(mockAutoPagination).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledWith({
+      organizationId: "org_only",
+    });
+    expect(body).toEqual({
+      entitlements: ["pro-plan"],
+      subscription: "pro",
+    });
+  });
+
+  it("requires organization selection instead of choosing an arbitrary membership", async () => {
+    mockAuthenticate.mockResolvedValueOnce({
+      authenticated: true,
+      user: { id: "user_123" },
+    } as never);
+    mockAutoPagination.mockResolvedValueOnce([
+      { organizationId: "org_first" },
+      { organizationId: "org_second" },
+    ] as never);
+
+    const { GET } = await import("../route");
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body).toEqual({
+      error: "Organization selection required",
+      code: "organization_selection_required",
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockResponseCookieSet).not.toHaveBeenCalled();
+  });
+
+  it("keeps the unscoped refresh for users with no active memberships", async () => {
+    mockAuthenticate.mockResolvedValueOnce({
+      authenticated: true,
+      user: { id: "user_123" },
+    } as never);
+    mockRefresh.mockResolvedValueOnce({
+      sealedSession: "refreshed-session",
+      entitlements: [],
+    } as never);
+
+    const { GET } = await import("../route");
+    const response = await GET(makeRequest());
+    const body = await response.json();
 
     expect(response.status).toBe(200);
     expect(mockRefresh).toHaveBeenCalledWith();
-    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(body).toEqual({
+      entitlements: [],
+      subscription: "free",
+    });
+  });
+
+  it("does not fall back to an unscoped refresh when membership lookup is rate limited", async () => {
+    mockAuthenticate.mockResolvedValueOnce({
+      authenticated: true,
+      user: { id: "user_123" },
+    } as never);
+    mockAutoPagination.mockRejectedValueOnce(
+      Object.assign(new Error("Rate limit exceeded"), { status: 429 }) as never,
+    );
+
+    const { GET } = await import("../route");
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(body).toEqual({
+      error: "Rate limited",
+      entitlements: [],
+      subscription: "free",
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockResponseCookieSet).not.toHaveBeenCalled();
   });
 });

--- a/app/api/entitlements/__tests__/route.test.ts
+++ b/app/api/entitlements/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockAuthenticate = jest.fn();
+const mockRefresh = jest.fn();
+const mockLoadSealedSession = jest.fn();
+const mockListOrganizationMemberships = jest.fn();
+const mockResponseCookieSet = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+      cookies: {
+        set: mockResponseCookieSet,
+      },
+    })),
+  },
+}));
+
+jest.mock("@/app/api/workos", () => ({
+  workos: {
+    userManagement: {
+      loadSealedSession: mockLoadSealedSession,
+      listOrganizationMemberships: mockListOrganizationMemberships,
+    },
+  },
+}));
+
+function makeRequest(sessionCookie = "sealed-session") {
+  return {
+    cookies: {
+      get: jest.fn((name: string) =>
+        name === "wos-session" ? { value: sessionCookie } : undefined,
+      ),
+    },
+  } as any;
+}
+
+describe("GET /api/entitlements", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.WORKOS_COOKIE_PASSWORD = "cookie-password";
+
+    mockLoadSealedSession.mockReturnValue({
+      authenticate: mockAuthenticate,
+      refresh: mockRefresh,
+    });
+    mockAuthenticate.mockResolvedValue({
+      authenticated: true,
+      user: { id: "user_123" },
+      organizationId: "org_active",
+    } as never);
+    mockRefresh.mockResolvedValue({
+      sealedSession: "refreshed-session",
+      entitlements: ["pro-plan"],
+    } as never);
+  });
+
+  it("refreshes entitlements for the active organization from the session", async () => {
+    const { GET } = await import("../route");
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockLoadSealedSession).toHaveBeenCalledWith({
+      cookiePassword: "cookie-password",
+      sessionData: "sealed-session",
+    });
+    expect(mockRefresh).toHaveBeenCalledWith({
+      organizationId: "org_active",
+    });
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(body).toEqual({
+      entitlements: ["pro-plan"],
+      subscription: "pro",
+    });
+    expect(mockResponseCookieSet).toHaveBeenCalledWith(
+      "wos-session",
+      "refreshed-session",
+      {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: true,
+      },
+    );
+  });
+
+  it("does not select the first membership when the session has no active organization", async () => {
+    mockAuthenticate.mockResolvedValueOnce({
+      authenticated: true,
+      user: { id: "user_123" },
+    } as never);
+
+    const { GET } = await import("../route");
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockRefresh).toHaveBeenCalledWith();
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/entitlements/route.ts
+++ b/app/api/entitlements/route.ts
@@ -28,13 +28,37 @@ export async function GET(req: NextRequest) {
     // First authenticate to get user and organization info
     const authResult = await session.authenticate();
 
-    const organizationId = authResult.authenticated
-      ? ((authResult as any).organizationId as string | undefined)
+    let organizationId = authResult.authenticated
+      ? authResult.organizationId
       : undefined;
 
-    // Only scope the refresh when the authenticated session already names an
-    // active organization. Picking the first membership here can silently
-    // switch multi-organization users to an unrelated organization.
+    if (authResult.authenticated && !organizationId) {
+      const memberships =
+        await workos.userManagement.listOrganizationMemberships({
+          userId: authResult.user.id,
+          statuses: ["active"],
+        });
+      const activeMemberships = await memberships.autoPagination();
+
+      if (activeMemberships.length === 1) {
+        organizationId = activeMemberships[0].organizationId;
+      } else if (activeMemberships.length > 1) {
+        // There is no trustworthy active organization in the session. Refuse
+        // to pick an arbitrarily ordered membership and let the client retain
+        // its current entitlement state until the user selects an organization.
+        return json(
+          {
+            error: "Organization selection required",
+            code: "organization_selection_required",
+          },
+          { status: 409 },
+        );
+      }
+    }
+
+    // A session-selected organization is authoritative. The single-membership
+    // fallback preserves paid access for legacy unscoped sessions without
+    // silently switching users who belong to multiple organizations.
     const refreshResult = organizationId
       ? await session.refresh({ organizationId })
       : await session.refresh();

--- a/app/api/entitlements/route.ts
+++ b/app/api/entitlements/route.ts
@@ -28,44 +28,13 @@ export async function GET(req: NextRequest) {
     // First authenticate to get user and organization info
     const authResult = await session.authenticate();
 
-    let organizationId: string | undefined;
-    if (authResult.authenticated) {
-      // Check if organizationId is already available in the session
-      organizationId = (authResult as any).organizationId;
+    const organizationId = authResult.authenticated
+      ? ((authResult as any).organizationId as string | undefined)
+      : undefined;
 
-      // If organizationId is not in session, fetch it using userId
-      if (!organizationId) {
-        const userId = (authResult as any).user?.id;
-
-        if (userId) {
-          // Get organization membership for this user
-          try {
-            const memberships =
-              await workos.userManagement.listOrganizationMemberships({
-                userId: userId,
-                statuses: ["active"],
-              });
-
-            // Use the first active membership's organization ID
-            if (memberships.data && memberships.data.length > 0) {
-              organizationId = memberships.data[0].organizationId;
-            }
-          } catch (membershipError) {
-            // Rethrow rate-limit errors so the outer catch returns 429
-            // instead of silently falling through to an unscoped refresh
-            if (isRateLimitError(membershipError)) {
-              throw membershipError;
-            }
-            console.error(
-              "Failed to fetch organization memberships:",
-              membershipError,
-            );
-          }
-        }
-      }
-    }
-
-    // Refresh with organization ID to ensure we get entitlements for the correct org
+    // Only scope the refresh when the authenticated session already names an
+    // active organization. Picking the first membership here can silently
+    // switch multi-organization users to an unrelated organization.
     const refreshResult = organizationId
       ? await session.refresh({ organizationId })
       : await session.refresh();

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 
-const mockGetUserID = jest.fn();
+const mockGetUserIDAndPro = jest.fn();
 const mockGetUser = jest.fn();
 const mockListOrganizationMemberships = jest.fn();
 const mockGetOrganization = jest.fn();
@@ -30,7 +30,7 @@ jest.mock("@/lib/posthog/server", () => ({
 }));
 
 jest.mock("@/lib/auth/get-user-id", () => ({
-  getUserID: mockGetUserID,
+  getUserIDAndPro: mockGetUserIDAndPro,
 }));
 
 jest.mock("../../workos", () => ({
@@ -76,7 +76,11 @@ describe("POST /api/subscription-details", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockGetUserID.mockResolvedValue("user_123" as never);
+    mockGetUserIDAndPro.mockResolvedValue({
+      userId: "user_123",
+      subscription: "team",
+      organizationId: "org_team",
+    } as never);
     mockGetUser.mockResolvedValue({
       id: "user_123",
       email: "billing@example.com",
@@ -145,6 +149,36 @@ describe("POST /api/subscription-details", () => {
     expect(mockListPrices).toHaveBeenCalledWith({
       lookup_keys: ["pro-monthly-plan"],
     });
+  });
+
+  it("scopes membership and billing lookup to the active organization", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+
+    expect(response.status).toBe(200);
+    expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
+      userId: "user_123",
+      organizationId: "org_team",
+      statuses: ["active"],
+    });
+    expect(mockGetOrganization).toHaveBeenCalledWith("org_team");
+  });
+
+  it("rejects billing changes when there is no active organization", async () => {
+    mockGetUserIDAndPro.mockResolvedValueOnce({
+      userId: "user_123",
+      subscription: "free",
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: "No active organization" });
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(mockGetOrganization).not.toHaveBeenCalled();
   });
 
   it("rejects non-owner, non-admin members from managing billing", async () => {

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -180,6 +180,9 @@ describe("POST /api/subscription-details", () => {
     expect(mockGetUser).not.toHaveBeenCalled();
     expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
     expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockListCustomers).not.toHaveBeenCalled();
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockUpdateSubscription).not.toHaveBeenCalled();
   });
 
   it("rejects billing changes without an active membership in the session organization", async () => {

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -177,8 +177,31 @@ describe("POST /api/subscription-details", () => {
 
     expect(response.status).toBe(403);
     expect(body).toEqual({ error: "No active organization" });
+    expect(mockGetUser).not.toHaveBeenCalled();
     expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
     expect(mockGetOrganization).not.toHaveBeenCalled();
+  });
+
+  it("rejects billing changes without an active membership in the session organization", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({ error: "No organization found" });
+    expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
+      userId: "user_123",
+      organizationId: "org_team",
+      statuses: ["active"],
+    });
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockListCustomers).not.toHaveBeenCalled();
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockUpdateSubscription).not.toHaveBeenCalled();
   });
 
   it("rejects non-owner, non-admin members from managing billing", async () => {

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -93,14 +93,14 @@ export const POST = async (req: NextRequest) => {
         : "pro-monthly-plan";
 
     const { userId, organizationId } = await getUserIDAndPro(req);
-    const user = await workos.userManagement.getUser(userId);
-
     if (!organizationId) {
       return NextResponse.json(
         { error: "No active organization" },
         { status: 403 },
       );
     }
+
+    const user = await workos.userManagement.getUser(userId);
 
     // Verify billing permissions in the active organization from the session.
     const existingMemberships =

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -1,6 +1,6 @@
 import { stripe } from "../stripe";
 import { workos } from "../workos";
-import { getUserID } from "@/lib/auth/get-user-id";
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { after, NextRequest, NextResponse } from "next/server";
 import { SubscriptionTier } from "@/types/chat";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
@@ -92,13 +92,22 @@ export const POST = async (req: NextRequest) => {
         ? requestedPlan
         : "pro-monthly-plan";
 
-    const userId = await getUserID(req);
+    const { userId, organizationId } = await getUserIDAndPro(req);
     const user = await workos.userManagement.getUser(userId);
 
-    // Get user's organization
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "No active organization" },
+        { status: 403 },
+      );
+    }
+
+    // Verify billing permissions in the active organization from the session.
     const existingMemberships =
       await workos.userManagement.listOrganizationMemberships({
         userId,
+        organizationId,
+        statuses: ["active"],
       });
 
     if (!existingMemberships.data || existingMemberships.data.length === 0) {
@@ -116,9 +125,8 @@ export const POST = async (req: NextRequest) => {
       );
     }
 
-    const organization = await workos.organizations.getOrganization(
-      membership.organizationId,
-    );
+    const organization =
+      await workos.organizations.getOrganization(organizationId);
 
     // Find Stripe customer
     const customers = await stripe.customers.list({

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -906,6 +906,11 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
           );
           setEntitlementApiResolvedUserId(user.id);
         } else {
+          // Multiple active memberships without a selected session org are
+          // ambiguous. Keep the last trustworthy tier instead of displaying a
+          // false downgrade while the user selects an organization.
+          if (response.status === 409) return;
+
           if (response.status === 401) {
             if (typeof window !== "undefined") {
               const { clientLogout } = await import("@/lib/utils/logout");

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -670,4 +670,42 @@ describe("GlobalStateProvider agent defaults", () => {
       );
     });
   });
+
+  it("preserves paid state when checkout refresh requires organization selection", async () => {
+    const refreshAuth = jest.fn().mockResolvedValue(undefined);
+    const refreshAccessToken = jest.fn().mockResolvedValue("paid-token");
+
+    mockAuthUser(["pro-plan"], { refreshAuth });
+    jest.mocked(useAccessToken).mockReturnValue({
+      getAccessToken: jest.fn().mockResolvedValue("paid-token"),
+      accessToken: "paid-token",
+      refresh: refreshAccessToken,
+    } as ReturnType<typeof useAccessToken>);
+    window.history.pushState({}, "", "/?refresh=entitlements");
+    global.fetch = jest.fn((input) => {
+      const url = String(input);
+      if (url === "/api/entitlements") {
+        return Promise.resolve({ ok: false, status: 409 });
+      }
+
+      return Promise.resolve({ ok: false, status: 500 });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent(
+        "false",
+      );
+      expect(window.location.search).toBe("");
+    });
+
+    expect(screen.getByTestId("subscription")).toHaveTextContent("pro");
+    expect(refreshAuth).not.toHaveBeenCalled();
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- preserve the authenticated active organization during entitlement refresh instead of selecting the first WorkOS membership
- recover legacy unscoped sessions only when the user has exactly one active organization; require selection when multiple organizations make the fallback ambiguous
- preserve the last trustworthy paid UI state when organization selection is required instead of showing a false free-tier downgrade
- scope subscription changes to the active organization and verify an active membership in that exact organization
- fail closed before WorkOS user/customer lookups when billing has no active organization
- add route and client regression coverage for entitlement refresh, active membership validation, ambiguous organization context, and missing-organization behavior

## Root cause

Both flows used membership ordering as an implicit organization selector. For multi-organization users, `memberships.data[0]` is not guaranteed to match the organization selected in the application.

The entitlement endpoint could persist an arbitrarily selected organization into the refreshed sealed session. The subscription endpoint could preview or update the Stripe subscription belonging to that first organization.

Removing the entitlement fallback entirely would regress legacy paid sessions where AuthKit omits organization context. The hardened behavior therefore keeps the selected session organization authoritative, permits a deterministic fallback only for exactly one active membership, and returns `409 organization_selection_required` when multiple memberships are ambiguous.

## Attribution

This branch preserves the original fix commit from @basriakkaya as commit `84f7819f` with its original authorship, then adds maintainer hardening and regression coverage in `22c2360f`, `91701514`, and `83413e1c`.

This PR supersedes #1093 because that fork has maintainer edits disabled and its valid review feedback could not be pushed to the contributor branch.

## Validation

- focused Jest: 2 suites / 23 tests passed
- full Jest: 359 suites / 3,673 tests passed
- `pnpm typecheck`
- targeted ESLint
- targeted Prettier
- `git diff --check`

## Manual verification

On the preview:

1. Sign in as a user with admin/owner memberships in organizations A and B, select B, and preview a plan change. Confirm the preview uses B's subscription.
2. Confirm the plan change and verify only B's Stripe subscription changes.
3. Refresh entitlements while B is active and confirm the session remains scoped to B.
4. Use a legacy session without organization context and exactly one active membership. Confirm paid entitlements recover for that organization.
5. Use a session without organization context and multiple active memberships. Confirm the endpoint returns `409`, no organization is switched, no sealed-session cookie is replaced, and the UI does not show a false free-tier downgrade.
6. Use an active B membership without billing permissions and confirm the endpoint returns 403 without touching A.

Fixes #1091
Fixes #1092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Entitlement information now consistently uses the organization selected in the authenticated session.
  * Multiple active memberships prompt organization selection instead of defaulting to an unrelated organization.
  * Subscription details are scoped to the active organization and membership.
  * Requests without an active organization receive a clear access response.
  * Existing paid subscription status is preserved when organization selection is unresolved.

* **Tests**
  * Added coverage for organization context, membership validation, refreshed sessions, rate limits, and response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
