### PR TITLE
Reduce Trigger API polling during Agent runs

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -64,6 +64,7 @@ import {
 import {
   AGENT_PARTIAL_SAVE_ENDPOINT,
   AGENT_RESUME_ENDPOINT,
+  AGENT_STATUS_ENDPOINT,
   LEGACY_AGENT_RESUME_ENDPOINT,
 } from "@/lib/api/agent-endpoints";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
@@ -110,9 +111,9 @@ import { finalizeNewChatRoute } from "./chat-route";
 
 import { HackingSuggestions } from "./HackingSuggestions";
 
-const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 5_000;
-const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 2_000;
-const AGENT_LONG_COMPLETION_QUIET_MS = 3_000;
+const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 15_000;
+const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 15_000;
+const AGENT_LONG_COMPLETION_QUIET_MS = 10_000;
 const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 6_000;
 type MessagePaginationStatus =
   "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
@@ -1285,6 +1286,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     let stopped = false;
     let pollInterval: ReturnType<typeof setInterval> | undefined;
     let finishTimeout: ReturnType<typeof setTimeout> | undefined;
+    let isCompletionCheckInFlight = false;
     const abortController = new AbortController();
 
     const finishLocally = () => {
@@ -1311,9 +1313,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       if (stopped || finishTimeout !== undefined) return;
       saveAgentLongPartialSnapshot("resume_terminal_204");
 
-      // The transport also polls the resume endpoint and can deliver a
-      // synthetic finish after a terminal 204. Give it a brief chance to close
-      // normally before falling back to stop(), which aborts the active stream.
+      // The transport also polls the status endpoint and can deliver a
+      // synthetic finish after a terminal status. Give it a brief chance to
+      // close normally before falling back to stop(), which aborts the stream.
       finishTimeout = setTimeout(() => {
         finishTimeout = undefined;
         if (
@@ -1327,18 +1329,34 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
     const checkRunCompletion = async () => {
       if (
+        isCompletionCheckInFlight ||
         Date.now() - agentLongLastMessageChangeAtRef.current <
-        AGENT_LONG_COMPLETION_QUIET_MS
+          AGENT_LONG_COMPLETION_QUIET_MS
       ) {
         return;
       }
 
+      const runId =
+        agentLongRunCorrelationRef.current?.runId ??
+        activeTriggerRunRef.current;
+      if (!runId) return;
+
+      isCompletionCheckInFlight = true;
       try {
-        const response = await fetch(
-          `${AGENT_RESUME_ENDPOINT}?chatId=${encodeURIComponent(chatId)}`,
-          { method: "GET", signal: abortController.signal },
-        );
-        if (response.status === 204) {
+        const response = await fetch(AGENT_STATUS_ENDPOINT, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ chatId, runId }),
+          signal: abortController.signal,
+        });
+        if (response.status === 404) {
+          scheduleFinishLocally();
+          return;
+        }
+        if (!response.ok) return;
+
+        const payload = (await response.json()) as { terminal?: unknown };
+        if (payload.terminal === true) {
           scheduleFinishLocally();
         }
       } catch (error) {
@@ -1346,6 +1364,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           // Ignore transient polling failures; the underlying stream still owns
           // the visible error state.
         }
+      } finally {
+        isCompletionCheckInFlight = false;
       }
     };
 
@@ -1368,6 +1388,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
     };
   }, [
+    activeTriggerRunRef,
     chatId,
     isExistingChatRef,
     setIsAutoResuming,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -419,14 +419,33 @@ describe("agent stream runner — empty tool-input recovery", () => {
 });
 
 describe("agent-long chat UI — completion reconciliation", () => {
-  test("polls the resume endpoint and clears useChat state after backend completion", () => {
-    expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_POLL_DELAY_MS/);
-    expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_QUIET_MS/);
+  test("polls status without minting tokens and clears useChat state after backend completion", () => {
+    const reconciliationStart = chatComponentSrc.indexOf(
+      "// Trigger.dev can finish and persist an Agent answer",
+    );
+    const reconciliationEnd = chatComponentSrc.indexOf(
+      "// Ref bridge: StreamEffects exposes resetAutoContinueCount here",
+      reconciliationStart,
+    );
+    const reconciliationSrc = chatComponentSrc.slice(
+      reconciliationStart,
+      reconciliationEnd,
+    );
+
+    expect(reconciliationSrc).toMatch(/AGENT_LONG_COMPLETION_POLL_DELAY_MS/);
+    expect(reconciliationSrc).toMatch(/AGENT_LONG_COMPLETION_QUIET_MS/);
     expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_STOP_GRACE_MS/);
-    expect(chatComponentSrc).toMatch(/AGENT_RESUME_ENDPOINT/);
-    expect(chatComponentSrc).toMatch(/response\.status\s*===\s*204/);
-    expect(chatComponentSrc).toMatch(/scheduleFinishLocally\(\)/);
-    expect(chatComponentSrc).toMatch(/finishLocally\(\)/);
+    expect(chatComponentSrc).toMatch(
+      /AGENT_LONG_COMPLETION_POLL_INTERVAL_MS\s*=\s*15_000/,
+    );
+    expect(reconciliationSrc).toMatch(/AGENT_STATUS_ENDPOINT/);
+    expect(reconciliationSrc).toMatch(/method:\s*"POST"/);
+    expect(reconciliationSrc).toMatch(/isCompletionCheckInFlight/);
+    expect(reconciliationSrc).toMatch(/response\.status\s*===\s*404/);
+    expect(reconciliationSrc).toMatch(/payload\.terminal\s*===\s*true/);
+    expect(reconciliationSrc).not.toMatch(/AGENT_RESUME_ENDPOINT/);
+    expect(reconciliationSrc).toMatch(/scheduleFinishLocally\(\)/);
+    expect(reconciliationSrc).toMatch(/finishLocally\(\)/);
     expect(chatComponentSrc).toMatch(/AGENT_PARTIAL_SAVE_ENDPOINT/);
     expect(chatComponentSrc).toMatch(/saveAgentLongPartialSnapshot/);
     expect(chatComponentSrc).toMatch(
@@ -440,6 +459,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
       /const finishLocally = \(\) => \{[\s\S]*finalizeNewChatRoute/,
     );
     expect(chatComponentSrc).toMatch(/setIsExistingChat\(true\)/);
+    expect(statusSrc).toMatch(
+      /NextResponse\.json\(\{ status: run\.status, terminal \}\)/,
+    );
   });
 
   test("client partial-save endpoint is authenticated and assistant-only", () => {

--- a/lib/api/__tests__/agent-status-route.test.ts
+++ b/lib/api/__tests__/agent-status-route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockGetUserIDAndPro = jest.fn();
+const mockGetChatById = jest.fn();
+const mockSetActiveTriggerRun = jest.fn();
+const mockRunsRetrieve = jest.fn();
+const mockCloseAgentApprovalSession = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: class MockNextResponse {
+    status: number;
+    private body: unknown;
+
+    constructor(body?: unknown, init?: ResponseInit) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+
+    static json(body: unknown, init?: ResponseInit) {
+      return new MockNextResponse(body, init);
+    }
+
+    async json() {
+      return this.body;
+    }
+  },
+}));
+
+jest.mock("@trigger.dev/sdk", () => ({
+  ApiError: class MockApiError extends Error {
+    status?: number;
+  },
+  runs: { retrieve: mockRunsRetrieve },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserIDAndPro: mockGetUserIDAndPro,
+}));
+
+jest.mock("@/lib/db/actions", () => ({
+  getChatById: mockGetChatById,
+  setActiveTriggerRun: mockSetActiveTriggerRun,
+}));
+
+jest.mock("@/lib/api/agent-approval-session", () => ({
+  closeAgentApprovalSession: mockCloseAgentApprovalSession,
+}));
+
+jest.mock("@/lib/api/agent-route-errors", () => ({
+  handleAgentRouteError: jest.fn(() => {
+    throw new Error("unexpected route error");
+  }),
+}));
+
+const requestFor = (chatId: string, runId: string) =>
+  ({
+    headers: { get: () => null },
+    json: async () => ({ chatId, runId }),
+  }) as any;
+
+describe("agent status route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserIDAndPro.mockResolvedValue({ userId: "user-1" } as never);
+  });
+
+  it("reports a nonterminal run without touching persisted lifecycle state", async () => {
+    const { createAgentStatusPost } = await import("../agent-status-route");
+    mockRunsRetrieve.mockResolvedValue({
+      status: "EXECUTING",
+      metadata: { chatId: "chat-1", userId: "user-1" },
+    } as never);
+
+    const response = await createAgentStatusPost({ endpoint: "/api/agent" })(
+      requestFor("chat-1", "run-1"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "EXECUTING",
+      terminal: false,
+    });
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSetActiveTriggerRun).not.toHaveBeenCalled();
+  });
+
+  it("reports terminal status and compare-clears the matching active run", async () => {
+    const { createAgentStatusPost } = await import("../agent-status-route");
+    mockRunsRetrieve.mockResolvedValue({
+      status: "COMPLETED",
+      metadata: { chatId: "chat-1", userId: "user-1" },
+    } as never);
+    mockGetChatById.mockResolvedValue({
+      id: "chat-1",
+      user_id: "user-1",
+      active_trigger_run_id: "run-1",
+      active_agent_approval_session_id: "approval-session-1",
+    } as never);
+
+    const response = await createAgentStatusPost({ endpoint: "/api/agent" })(
+      requestFor("chat-1", "run-1"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "COMPLETED",
+      terminal: true,
+    });
+    expect(mockCloseAgentApprovalSession).toHaveBeenCalledWith(
+      "approval-session-1",
+      "agent-run-terminal",
+    );
+    expect(mockSetActiveTriggerRun).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      triggerRunId: null,
+      approvalSessionId: null,
+      expectedRunId: "run-1",
+      clearApprovalPending: true,
+    });
+  });
+});

--- a/lib/api/agent-status-route.ts
+++ b/lib/api/agent-status-route.ts
@@ -112,11 +112,14 @@ export const createAgentStatusPost =
         return new NextResponse("Forbidden", { status: 403 });
       }
 
-      if (run.status && TERMINAL_RUN_STATUSES.has(run.status)) {
+      const terminal = Boolean(
+        run.status && TERMINAL_RUN_STATUSES.has(run.status),
+      );
+      if (terminal) {
         await clearTerminalAgentRun({ chatId, userId, runId });
       }
 
-      return NextResponse.json({ status: run.status });
+      return NextResponse.json({ status: run.status, terminal });
     } catch (error) {
       if (isMissingTriggerRunError(error)) {
         if (chatId && userId && runId) {

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -164,8 +164,11 @@ const STREAM_TIMEOUT_MS = 5 * 60 * 1000;
 const STREAM_IDLE_TIMEOUT_SECONDS = STREAM_TIMEOUT_MS / 1000;
 const POST_FINISH_DRAIN_TIMEOUT_MS = 2_000;
 const COMPLETED_RUN_DRAIN_TIMEOUT_MS = 5_000;
-const QUIET_STREAM_STATUS_POLL_INTERVAL_MS = 2_000;
-const QUIET_STREAM_STATUS_POLL_AFTER_MS = 5_000;
+// The task emits a hidden heartbeat every 25 seconds. Poll at most once during
+// that quiet window so fallback status checks cannot exhaust Trigger's shared
+// API token bucket when many Agent runs are active at the same time.
+const QUIET_STREAM_STATUS_POLL_INTERVAL_MS = 10_000;
+const QUIET_STREAM_STATUS_POLL_AFTER_MS = 15_000;
 
 const getChatIdFromRequestInit = (
   init: RequestInit | undefined,


### PR DESCRIPTION
## Summary
- replace the Agent completion health check's `/api/agent/resume` calls with status-only requests so polling no longer mints six-hour Trigger public tokens
- make client completion checks single-flight and move both fallback status loops to bounded intervals that fit below the production API refill rate
- return an explicit terminal signal from the authenticated status route and add route-level lifecycle coverage

## Root cause
Trigger's production API bucket was pinned at `0/1,500` with a refill of 250 requests per 10 seconds. A ten-minute production sample contained roughly 10.1k successful `/api/agent/resume` requests and 3.9k `/api/agent/status` requests.

The completion reconciliation effect called the expensive resume route every two seconds while a message was quiet. Each resume request retrieved the run and minted at least one new public token even though the caller only needed terminal status. A second two-second status loop ran in the realtime transport, and the completion loop allowed overlapping requests when latency exceeded its interval.

## Impact
Realtime stream delivery remains the primary completion path. The fallback now:
- starts after 15 seconds and checks at most every 15 seconds
- performs one `runs.retrieve` call instead of retrieving plus minting tokens
- never overlaps a prior completion request
- preserves missing-run and terminal-run cleanup behavior

The transport's secondary quiet-stream check now runs at most once between the task's 25-second heartbeats.

## Validation
- `corepack pnpm run check:local-dependencies`
- `corepack pnpm jest --runInBand` — 359 suites / 3,666 tests
- `corepack pnpm typecheck`
- changed-file ESLint — zero errors, three pre-existing warnings in `app/components/chat.tsx`
- changed-file Prettier
- `git diff --check`

## Manual verification
1. Start an Agent run that has a tool/terminal phase quiet for more than 15 seconds. Streaming should continue and the UI should leave Working when the task finishes.
2. Reload an active Agent chat. Realtime resume should still reconstruct the in-progress response and finish normally.
3. After production deployment, monitor the Trigger Limits page and Vercel request counts. `/api/agent/resume` should no longer be used for periodic completion checks, `/api/agent/status` volume should fall substantially, and the API bucket should recover burst capacity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent completion handling with reliable status checks and protection against overlapping requests.
  * Recognizes completed runs even when status records are unavailable.
  * Allows active responses additional time to finish before stopping.
  * Improved handling of terminal and nonterminal run states.
* **Performance**
  * Reduced unnecessary status polling while waiting for messages to become quiet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->