### PR TITLE
Fix legacy Windows attachment shell detection

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1228,7 +1228,14 @@ describe("CentrifugoSandbox", () => {
       });
 
       try {
-        const sandbox = createSandbox();
+        const sandbox = createSandbox({
+          osInfo: {
+            platform: "linux",
+            arch: "x86_64",
+            release: "6.1",
+            hostname: "linux-dev",
+          },
+        });
         await sandbox.files.write("/tmp/hackerai/test.txt", "hello world");
 
         // files.write runs mkdir -p then cat > ... heredoc.
@@ -1310,6 +1317,78 @@ describe("CentrifugoSandbox", () => {
       });
       return { sandbox, runs };
     }
+
+    it("probes legacy connections without OS info before building file commands", async () => {
+      const sandbox = createSandbox();
+      (sandbox as any).httpClient = "curl";
+      (sandbox as any).curlCaps = {
+        retryAllErrors: true,
+        retryConnrefused: true,
+        sslNoRevoke: true,
+      };
+      const runs: string[] = [];
+      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
+        runs.push(cmd);
+        if (cmd === "echo $BASH_VERSION") {
+          return {
+            stdout: "$BASH_VERSION\r\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
+
+      await sandbox.files.downloadFromUrl(
+        "https://example.com/image.png?X-Amz-Algorithm=test&X-Amz-Credential=opaque&X-Amz-Signature=opaque",
+        "/tmp/hackerai-upload/image.png",
+      );
+
+      expect(runs[0]).toBe("echo $BASH_VERSION");
+      expect(runs[1]).toContain(
+        'if not exist "C:\\temp\\hackerai-upload" mkdir "C:\\temp\\hackerai-upload"',
+      );
+      expect(runs[1]).toContain(
+        '"https://example.com/image.png?X-Amz-Algorithm=test&X-Amz-Credential=opaque&X-Amz-Signature=opaque"',
+      );
+      expect(runs[1]).not.toContain("mkdir -p");
+      expect(sandbox.isWindows()).toBe(true);
+    });
+
+    it("keeps Bash semantics for legacy connections without OS info", async () => {
+      const sandbox = createSandbox();
+      (sandbox as any).httpClient = "curl";
+      (sandbox as any).curlCaps = {
+        retryAllErrors: true,
+        retryConnrefused: true,
+        sslNoRevoke: false,
+      };
+      const runs: string[] = [];
+      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
+        runs.push(cmd);
+        if (cmd === "echo $BASH_VERSION") {
+          return {
+            stdout: "5.2.37(1)-release\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
+
+      await sandbox.files.downloadFromUrl(
+        "https://example.com/image.png?X-Amz-Algorithm=test&X-Amz-Signature=opaque",
+        "/tmp/hackerai-upload/image.png",
+      );
+
+      expect(runs[0]).toBe("echo $BASH_VERSION");
+      expect(runs[1]).toContain("mkdir -p '/tmp/hackerai-upload'");
+      expect(runs[1]).toContain(
+        "'https://example.com/image.png?X-Amz-Algorithm=test&X-Amz-Signature=opaque'",
+      );
+      expect(runs[1]).not.toContain("if not exist");
+      expect(sandbox.isWindows()).toBe(false);
+    });
 
     it("downloadFromUrl emits POSIX mkdir + curl with MSYS paths", async () => {
       const { sandbox, runs, runOptions } = createWindowsBashSandbox();

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1019,7 +1019,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
    * Docker containers are always Linux regardless of host OS.
    */
   isWindows(): boolean {
-    return this.connectionInfo.osInfo?.platform === "win32";
+    return (
+      this.connectionInfo.osInfo?.platform === "win32" ||
+      this.shellKind === "cmd"
+    );
   }
 
   /**
@@ -1042,7 +1045,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
    * Uses double quotes on Windows (cmd.exe), single quotes on POSIX.
    */
   private escapeForTarget(value: string): string {
-    return escapeShellValue(value, this.connectionInfo.osInfo?.platform);
+    return escapeShellValue(
+      value,
+      this.isWindows() ? "win32" : this.connectionInfo.osInfo?.platform,
+    );
   }
 
   /**
@@ -1071,7 +1077,11 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
    */
   private async detectShell(): Promise<"bash" | "cmd"> {
     if (this.shellKind) return this.shellKind;
-    if (!this.isWindows()) {
+    const declaredPlatform = this.connectionInfo.osInfo?.platform;
+    // Older desktop clients did not publish osInfo. Probe those connections
+    // instead of assuming Bash: a Windows cmd relay would otherwise receive
+    // single-quoted signed URLs and split their `&` query fields into commands.
+    if (declaredPlatform && declaredPlatform !== "win32") {
       this.shellKind = "bash";
       return "bash";
     }


### PR DESCRIPTION
## Summary
- probe legacy Desktop sandbox connections that omit `osInfo` before selecting shell syntax
- treat a detected `cmd.exe` relay as Windows for path conversion and argument quoting
- preserve declared Linux/macOS and detected Bash behavior

## Production evidence
The frozen production audit window was `2026-08-13T20:02:32.302Z`–`2026-08-14T20:02:32.302Z`.

Trigger run `run_06fvreogb7vrp407qs5e25sc01` failed while staging a URL attachment through a legacy Windows Desktop relay. Its safe stderr first reported the Portuguese cmd syntax error, then treated every `X-Amz-*` / `x-id` query field as a separate command. The run was on worker `20260813.16`; current main had no later fix.

The same window had 12 attachment failures in total, but the other inspected failures were E2B placement, missing-curl, disconnected relay, or HTTP 404 cases. This PR changes only the proven legacy Windows shell-selection path.

## Root cause
`ConnectionInfo.osInfo` is optional for deploy-skew compatibility with older Desktop clients. `detectShell()` previously treated missing metadata as non-Windows and selected Bash without probing. When that older client actually used the `cmd.exe` fallback, Bash single quotes did not protect the presigned URL and its ampersands split the command.

## Change
Connections with a declared non-Windows platform still select Bash directly. Connections declaring Windows or omitting platform metadata run the existing bounded shell probe once and cache the result. A detected cmd relay now drives Windows path conversion and quoting; a detected Bash relay keeps POSIX behavior.

No retry, attachment payload, signed URL, sandbox selection, logging, or user-content behavior changed.

## Validation
- `corepack pnpm jest lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand` — 2 suites / 89 tests
- `corepack pnpm typecheck`
- changed-file ESLint and Prettier
- `corepack pnpm run check:local-dependencies`
- `git diff --check`
- commit hooks: 360 suites / 3,677 tests

## Manual verification
1. Connect a legacy Windows Desktop client that omits `osInfo` and falls back to `cmd.exe`.
2. Start an Agent run with a stored file attachment.
3. Confirm staging uses a Windows destination, the presigned URL remains one curl argument, and no `X-Amz-*` field is executed as a command.
4. Repeat with a current Windows Git Bash client and a Linux client; both should retain their existing path and quoting behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows environment detection when platform information is unavailable or inconsistent.
  * Corrected command escaping for Windows command shells.
  * Improved shell detection for connections without platform metadata, including Bash and Windows command shells.
  * Fixed download command generation for legacy connections across Windows and POSIX environments.
* **Tests**
  * Added regression coverage for legacy connections and platform-specific download commands.
  * Updated sandbox file-write testing to use an explicit Linux environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->