### PR TITLE
Send PDFs to DeepSeek through OpenRouter OCR

### DIFF
--- a/lib/api/__tests__/agent-stream-runner-rolling-context.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-rolling-context.test.ts
@@ -1,6 +1,8 @@
 import type { ModelMessage } from "ai";
 import {
+  addOpenRouterFileAnnotationsToLastAssistantMessage,
   buildRollingModelMessages,
+  getOpenRouterFileAnnotations,
   isRollingCompactionEffective,
   type RollingModelContextCheckpoint,
 } from "@/lib/api/agent-stream-runner";
@@ -69,5 +71,36 @@ describe("rolling agent model context", () => {
     expect(
       isRollingCompactionEffective(previous, [user("y".repeat(950))]),
     ).toBe(false);
+  });
+});
+
+describe("OpenRouter PDF annotation reuse", () => {
+  it("extracts parsed-file annotations from provider metadata", () => {
+    const annotations = [{ type: "file", file: { hash: "pdf-hash" } }];
+
+    expect(
+      getOpenRouterFileAnnotations({ openrouter: { annotations } }),
+    ).toEqual(annotations);
+    expect(getOpenRouterFileAnnotations({ openrouter: {} })).toBeUndefined();
+  });
+
+  it("adds parsed-file annotations to the last assistant message", () => {
+    const annotations = [{ type: "file", file: { hash: "pdf-hash" } }];
+    const messages = [
+      user("read the report"),
+      assistant("I will inspect it."),
+      user("continue"),
+    ];
+
+    const result = addOpenRouterFileAnnotationsToLastAssistantMessage(
+      messages,
+      annotations,
+    );
+
+    expect((result[1] as any).providerOptions).toEqual({
+      openrouter: { annotations },
+    });
+    expect(result[0]).toBe(messages[0]);
+    expect(result[2]).toBe(messages[2]);
   });
 });

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -290,6 +290,31 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
+  it("enables OpenRouter Mistral OCR for PDFs sent to DeepSeek V4", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-deepseek-v4-pro",
+      "agent",
+      { hasPdfAttachments: true },
+    );
+
+    expect(opts.openrouter.plugins).toEqual([
+      { id: "file-parser", pdf: { engine: "mistral-ocr" } },
+    ]);
+  });
+
+  it("does not enable the PDF parser when a DeepSeek request has no PDF", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-deepseek-v4-pro",
+      "agent",
+    );
+
+    expect(opts.openrouter).not.toHaveProperty("plugins");
+  });
+
   it("falls back from DeepSeek V4 Pro 0813 through the control route, Grok, then Kimi K3", () => {
     const opts = buildProviderOptions(
       false,
@@ -311,13 +336,14 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("falls back from paid Ask PDF Grok route to Kimi K3", () => {
+  it("does not force OCR on the Grok route", () => {
     const opts = buildProviderOptions(false, "user-1", "model-grok-4.6", "ask");
     expect(opts.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "medium" },
       models: [KIMI_K3_SLUG],
       user: "user-1",
     });
+    expect(opts.openrouter).not.toHaveProperty("plugins");
   });
 
   it("does not throw for an unknown registry key — no chain, no slug", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -270,6 +270,53 @@ export const resetServedModelTelemetryForRetry = (
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+export const getOpenRouterFileAnnotations = (
+  providerMetadata: unknown,
+): unknown[] | undefined => {
+  if (!isRecord(providerMetadata)) return undefined;
+  const openrouter = providerMetadata.openrouter;
+  if (!isRecord(openrouter) || !Array.isArray(openrouter.annotations)) {
+    return undefined;
+  }
+  return openrouter.annotations.length > 0
+    ? [...openrouter.annotations]
+    : undefined;
+};
+
+export const addOpenRouterFileAnnotationsToLastAssistantMessage = (
+  messages: ModelMessage[],
+  annotations: unknown[] | undefined,
+): ModelMessage[] => {
+  if (!annotations?.length) return messages;
+
+  const index = messages.findLastIndex(
+    (message) => message.role === "assistant",
+  );
+  if (index < 0) return messages;
+
+  const message = messages[index] as ModelMessage & {
+    providerOptions?: Record<string, unknown>;
+  };
+  const providerOptions = isRecord(message.providerOptions)
+    ? message.providerOptions
+    : {};
+  const openrouter = isRecord(providerOptions.openrouter)
+    ? providerOptions.openrouter
+    : {};
+  const nextMessages = [...messages];
+  nextMessages[index] = {
+    ...message,
+    providerOptions: {
+      ...providerOptions,
+      openrouter: {
+        ...openrouter,
+        annotations,
+      },
+    },
+  } as ModelMessage;
+  return nextMessages;
+};
+
 const ESTIMATED_BYTES_PER_TOKEN = 4;
 
 const incrementCount = (counts: Record<string, number>, key: string): void => {
@@ -697,6 +744,12 @@ export async function createAgentStream(
   let streamHasImageViewResults = uiMessagesContainImageViewResult(
     state.finalMessages,
   );
+  const streamHasPdfAttachments = state.finalMessages.some((message) =>
+    message.parts?.some(
+      (part) => part.type === "file" && part.mediaType === "application/pdf",
+    ),
+  );
+  let openRouterFileAnnotations: unknown[] | undefined;
   const getEffectiveModelName = () =>
     resolveAgentModelForImageToolResults(
       modelName,
@@ -724,9 +777,10 @@ export async function createAgentStream(
       effectiveModelName,
       ctx.mode,
       {
-        hasMultimodalToolResults: streamHasImageViewResults,
-        excludedModelSlugs: ctx.excludedProviderModelSlugs,
         requestedModelSlug,
+        hasMultimodalToolResults: streamHasImageViewResults,
+        hasPdfAttachments: streamHasPdfAttachments,
+        excludedModelSlugs: ctx.excludedProviderModelSlugs,
         ...(ctx.providerReasoningOverride?.modelName === effectiveModelName && {
           reasoningOverride: ctx.providerReasoningOverride.reasoning,
         }),
@@ -754,9 +808,12 @@ export async function createAgentStream(
       repairedMessages = repair.messages as ModelMessage[];
     }
 
-    return appendPlatformAuthorizationToLatestUserMessage(
-      repairedMessages,
-      ctx.platformAuthorized,
+    return addOpenRouterFileAnnotationsToLastAssistantMessage(
+      appendPlatformAuthorizationToLatestUserMessage(
+        repairedMessages,
+        ctx.platformAuthorized,
+      ),
+      openRouterFileAnnotations,
     );
   };
   let latestProviderRequestDiagnostics: ProviderRequestDiagnostics | undefined;
@@ -1300,6 +1357,9 @@ export async function createAgentStream(
     onStepFinish: async ({ usage, response, providerMetadata }) => {
       ctx.onModelStreamFinish?.();
       state.agentStepCount += 1;
+      openRouterFileAnnotations =
+        getOpenRouterFileAnnotations(providerMetadata) ??
+        openRouterFileAnnotations;
       let stepUsageCostIndex: number | undefined;
       if (usage) {
         const stepAccountingModel = resolveServedModelForCostAccounting({

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -618,6 +618,7 @@ const MEDIUM_GROK_REASONING_MODELS = new Set<string>([
 
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
+  hasPdfAttachments?: boolean;
   reasoningOverride?: ProviderReasoningOverride;
   excludedModelSlugs?: readonly string[];
   requestedModelSlug?: string;
@@ -879,6 +880,16 @@ export function buildProviderOptions(
   return {
     openrouter: {
       reasoning,
+      ...(options.hasPdfAttachments && isDeepSeekV4
+        ? {
+            plugins: [
+              {
+                id: "file-parser" as const,
+                pdf: { engine: "mistral-ocr" as const },
+              },
+            ],
+          }
+        : {}),
       ...(userId && { user: userId }),
       ...(providerRouting && { provider: providerRouting }),
       ...(fallbackSlugs.length > 0 && { models: fallbackSlugs }),

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -190,9 +190,9 @@ describe("selectModel", () => {
       );
     });
 
-    it("should return the Grok-backed agent model for paid agent with a PDF", () => {
+    it("should keep paid agent on DeepSeek V4 Pro when a PDF is attached", () => {
       expect(selectModel("agent", "pro", undefined, false, true)).toBe(
-        "agent-model",
+        "model-deepseek-v4-pro",
       );
     });
 
@@ -206,15 +206,15 @@ describe("selectModel", () => {
       );
     });
 
-    it("should return Grok 4.6 for paid ask when a PDF is attached", () => {
+    it("should keep paid ask on DeepSeek V4 Pro when a PDF is attached", () => {
       expect(selectModel("ask", "pro", undefined, false, true)).toBe(
-        "model-grok-4.6",
+        "model-deepseek-v4-pro",
       );
     });
 
-    it("should prefer Grok 4.6 when paid ask has both image and PDF attachments", () => {
+    it("should use the Grok-backed image route when paid ask has both image and PDF attachments", () => {
       expect(selectModel("ask", "pro", undefined, true, true)).toBe(
-        "model-grok-4.6",
+        "ask-model",
       );
     });
 
@@ -269,9 +269,9 @@ describe("selectModel", () => {
       );
     });
 
-    it("should promote HackerAI Standard to Grok 4.6 when a PDF is attached", () => {
+    it("should keep HackerAI Standard on DeepSeek V4 Pro when a PDF is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-standard", false, true)).toBe(
-        "model-grok-4.6",
+        "model-deepseek-v4-pro",
       );
     });
 
@@ -308,7 +308,7 @@ describe("selectModel", () => {
     });
   });
 
-  // Agent mode — Auto/Standard use DeepSeek for text and media-capable routes otherwise.
+  // Agent mode — Auto/Standard use DeepSeek for text/PDF and media-capable routes for images.
   describe("tier override in agent mode", () => {
     it("should map HackerAI Standard to DeepSeek V4 Pro for text-only agent mode", () => {
       expect(selectModel("agent", "pro", "hackerai-standard")).toBe(
@@ -322,10 +322,10 @@ describe("selectModel", () => {
       ).toBe("model-grok-4.6");
     });
 
-    it("should route HackerAI Standard to Grok 4.6 when a PDF is attached", () => {
+    it("should keep HackerAI Standard on DeepSeek V4 Pro when a PDF is attached", () => {
       expect(
         selectModel("agent", "pro", "hackerai-standard", false, true),
-      ).toBe("model-grok-4.6");
+      ).toBe("model-deepseek-v4-pro");
     });
 
     it("should map HackerAI Pro to Grok 4.6 in text-only agent mode", () => {
@@ -403,12 +403,12 @@ describe("selectModel", () => {
       expect(selectModel("agent", "pro", "auto")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should route paid agent Auto media to the Grok-backed agent model", () => {
+    it("should route paid agent Auto images to Grok and PDFs to DeepSeek", () => {
       expect(selectModel("agent", "pro", "auto", true, false)).toBe(
         "agent-model",
       );
       expect(selectModel("agent", "pro", "auto", false, true)).toBe(
-        "agent-model",
+        "model-deepseek-v4-pro",
       );
     });
 
@@ -420,9 +420,9 @@ describe("selectModel", () => {
       expect(selectModel("ask", "pro", "auto", true, false)).toBe("ask-model");
     });
 
-    it("should treat 'auto' as no override in ask mode with PDF -> Grok", () => {
+    it("should treat 'auto' as no override in ask mode with PDF -> DeepSeek", () => {
       expect(selectModel("ask", "pro", "auto", false, true)).toBe(
-        "model-grok-4.6",
+        "model-deepseek-v4-pro",
       );
     });
   });
@@ -440,7 +440,7 @@ describe("selectModel", () => {
         "ask-model",
       );
       expect(selectModel("ask", "pro", undefined, false, true)).toBe(
-        "model-grok-4.6",
+        "model-deepseek-v4-pro",
       );
     });
   });

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -38,9 +38,10 @@ export const getMaxStepsForUser = (mode: ChatMode): number => {
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
  *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
- *   (text-only); image and PDF prompts promote to Grok 4.6. Paid Agent
- *   Auto/Standard routes use DeepSeek V4 Pro for text-only prompts and Grok
- *   4.6 when provider-visible media is attached. HackerAI Pro uses Grok 4.6
+ *   (text-only); image prompts promote to Grok 4.6, while PDF prompts stay on
+ *   DeepSeek and are parsed by OpenRouter. Paid Agent Auto/Standard routes use
+ *   DeepSeek V4 Pro for text/PDF prompts and Grok 4.6 when images are attached.
+ *   HackerAI Pro uses Grok 4.6
  *   for both text and vision; its GLM 5.2 fallback is configured downstream.
  * @returns Model name to use
  */
@@ -49,7 +50,7 @@ export function selectModel(
   subscription: SubscriptionTier,
   selectedModel?: SelectedModel,
   hasImageAttachment?: boolean,
-  hasPdfAttachment?: boolean,
+  _hasPdfAttachment?: boolean,
   options: { extraUsageAvailable?: boolean } = {},
 ): ModelName {
   const isAgent = isAgentMode(mode);
@@ -58,23 +59,20 @@ export function selectModel(
     subscription,
     options,
   );
-  // DeepSeek routes are text-only, so image/PDF prompts promote to a
-  // media-capable route unless the selected tier intentionally uses a
-  // multimodal/file-capable model such as Grok, Kimi, or Opus.
+  // DeepSeek routes are text-only, so image prompts promote to a
+  // media-capable route. PDFs remain on DeepSeek because OpenRouter's file
+  // parser converts them to model-readable text before inference.
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage = !isAgent && !!hasImageAttachment;
-  const hasAskPdf = !isAgent && !!hasPdfAttachment;
-  const hasProviderMedia = !!hasImageAttachment || !!hasPdfAttachment;
-  const paidAskMediaModel: ModelName = hasAskPdf
-    ? "model-grok-4.6"
-    : hasAskImage
-      ? "ask-model"
-      : "model-deepseek-v4-pro";
+  const hasProviderImage = !!hasImageAttachment;
+  const paidAskMediaModel: ModelName = hasAskImage
+    ? "ask-model"
+    : "model-deepseek-v4-pro";
 
   const autoModel: ModelName = isAgent
     ? subscription === "free"
       ? "agent-model-free"
-      : hasProviderMedia
+      : hasProviderImage
         ? "agent-model"
         : "model-deepseek-v4-pro"
     : isFreeAsk
@@ -96,11 +94,9 @@ export function selectModel(
   // the auto-router label.
   if (allowedSelectedModel === "hackerai-standard") {
     if (isAgent) {
-      return hasProviderMedia ? "model-grok-4.6" : "model-deepseek-v4-pro";
+      return hasProviderImage ? "model-grok-4.6" : "model-deepseek-v4-pro";
     }
-    return hasAskImage || hasAskPdf
-      ? "model-grok-4.6"
-      : "model-deepseek-v4-pro";
+    return hasAskImage ? "model-grok-4.6" : "model-deepseek-v4-pro";
   }
 
   if (allowedSelectedModel === "hackerai-pro") {

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -359,6 +359,86 @@ describe("processMessageFiles image size guards", () => {
     ]);
   });
 
+  it("keeps Agent PDFs provider-visible while still staging a sandbox copy", async () => {
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/report.pdf", {
+        sizeBytes: 1024,
+        mediaType: "application/pdf",
+        name: "report.pdf",
+      }),
+    ]);
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "application/pdf",
+        fileId: "file_pdf",
+        name: "report.pdf",
+        url: "https://client.example/report.pdf",
+      }),
+      "agent",
+      "user123",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(result.sandboxFiles).toEqual([
+      {
+        kind: "url",
+        url: "https://storage.example/report.pdf",
+        localPath: "/home/user/upload/report.pdf",
+      },
+    ]);
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
+      expect.objectContaining({
+        type: "file",
+        mediaType: "application/pdf",
+        name: "report.pdf",
+        url: "https://storage.example/report.pdf",
+        size: 1024,
+      }),
+      {
+        type: "text",
+        text: '<attachment filename="report.pdf" local_path="/home/user/upload/report.pdf" />',
+      },
+    ]);
+    expect(result.containsPdfFiles).toBe(true);
+  });
+
+  it("keeps oversized Agent PDFs sandbox-only", async () => {
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/large.pdf", {
+        sizeBytes: 21 * 1024 * 1024,
+        mediaType: "application/pdf",
+        name: "large.pdf",
+      }),
+    ]);
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "application/pdf",
+        fileId: "file_large_pdf",
+        name: "large.pdf",
+      }),
+      "agent",
+      "user123",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(result.sandboxFiles).toHaveLength(1);
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
+      {
+        type: "text",
+        text: '<attachment filename="large.pdf" local_path="/home/user/upload/large.pdf" />',
+      },
+    ]);
+    expect(result.containsPdfFiles).toBe(false);
+  });
+
   it("omits stored images whose storage URL does not return valid image bytes", async () => {
     const notImageBytes = new TextEncoder().encode("<html>not an image</html>");
     mockConvexAction.mockResolvedValue([

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -595,8 +595,9 @@ const applyUrlsToFileParts = async (
   for (const [fileKey, file] of filesToProcess) {
     if (!file.url) continue;
 
-    // Only convert PDFs to base64 in "ask" mode for inline viewing.
-    // In "agent" mode, we want the original URL for sandbox curl download.
+    // Ask mode keeps its existing base64 representation. Agent mode keeps the
+    // original signed URL so the same PDF can be sent to OpenRouter and staged
+    // in the sandbox without downloading it twice on our server.
     const finalUrl =
       mode === "ask" && file.mediaType === "application/pdf"
         ? await convertUrlToBase64DataUrl(file.url, "application/pdf").catch(
@@ -733,11 +734,16 @@ const removeFilePartsWithoutUrls = (messages: UIMessage[]) => {
   });
 };
 
-const isProviderVisibleAgentImagePart = (part: any): boolean => {
+const isProviderVisibleAgentFilePart = (part: any): boolean => {
   if (part?.type !== "file") return false;
   if (providerUnsafeImageParts.has(part)) return false;
   const mediaType = part.mediaType ?? "";
-  if (!isSupportedImageMediaType(mediaType)) return false;
+  if (
+    !isSupportedImageMediaType(mediaType) &&
+    mediaType !== "application/pdf"
+  ) {
+    return false;
+  }
 
   const size =
     typeof part.size === "number"
@@ -768,9 +774,12 @@ const applyModeSpecificTransforms = async (
     collectSandboxFiles(messages, sandboxFiles, uploadBasePath, {
       allowLocalDesktopFiles,
       getAttachmentTagKind: (part) =>
-        isProviderVisibleAgentImagePart(part) ? "inline-image" : "attachment",
+        isProviderVisibleAgentFilePart(part) &&
+        isSupportedImageMediaType(part.mediaType ?? "")
+          ? "inline-image"
+          : "attachment",
     });
-    removeNonMediaAndOversizedImageFileParts(messages);
+    removeNonProviderVisibleAgentFileParts(messages);
   } else {
     const nonMediaFileIds = filterNonMediaFileIds(messages, fileIds);
     if (nonMediaFileIds.length > 0) {
@@ -793,7 +802,7 @@ const applyModeSpecificTransforms = async (
  *
  * Transforms file parts based on chat mode:
  * - **Ask mode**: Converts non-media files to document content, keeps images/PDFs as file parts
- * - **Agent mode**: Prepares all files for sandbox upload, keeps only images as file parts
+ * - **Agent mode**: Prepares all files for sandbox upload and keeps provider-safe images/PDFs as file parts
  *
  * Processing steps:
  * 1. Generates fresh URLs for files (prevents expiration)
@@ -801,7 +810,7 @@ const applyModeSpecificTransforms = async (
  * 3. Detects media files (images/PDFs)
  * 4. Applies mode-specific transforms:
  *    - Ask: Injects document content for text files, removes audio
- *    - Agent: Collects files for sandbox, adds attachment tags, removes non-images
+ *    - Agent: Collects files for sandbox, adds attachment tags, removes files that cannot be sent to the provider
  *
  * @param messages - Messages to process
  * @param mode - Chat mode ("ask" or "agent")
@@ -1005,23 +1014,12 @@ const pruneFileParts = (
   });
 };
 
-const removeNonMediaAndOversizedImageFileParts = (messages: UIMessage[]) => {
+const removeNonProviderVisibleAgentFileParts = (messages: UIMessage[]) => {
   messages.forEach((msg) => {
     if (!msg.parts) return;
     msg.parts = msg.parts.filter((part: any) => {
       if (part?.type !== "file") return true;
-      if (providerUnsafeImageParts.has(part)) return false;
-      if (!isSupportedImageMediaType(part.mediaType ?? "")) return false;
-      return !isSandboxOnlyAgentUpload({
-        mode: "agent",
-        size:
-          typeof part.size === "number"
-            ? part.size
-            : typeof part.sizeBytes === "number"
-              ? part.sizeBytes
-              : 0,
-        mediaType: part.mediaType ?? "",
-      });
+      return isProviderVisibleAgentFilePart(part);
     });
   });
 };


### PR DESCRIPTION
## Summary

- keep PDF-only Auto/Standard requests on DeepSeek V4 Pro instead of switching the entire request to Grok
- preserve provider-safe PDFs in Agent messages while still staging the same files in the sandbox
- enable OpenRouter's `file-parser` plugin with Mistral OCR for DeepSeek PDF requests
- carry OpenRouter file annotations into later tool steps so the parsed PDF can be reused without paying to parse it again
- keep images on the existing vision route and PDFs over 20 MB sandbox-only

## Validation

- `corepack pnpm typecheck`
- focused ESLint on all changed TypeScript files
- Prettier check on all changed files
- full Jest suite: 360 suites / 3,683 tests passed
- commit hooks reran typecheck, lint/format fixes, and the full Jest suite successfully

## Manual verification

1. In Auto or Standard Agent mode, upload a PDF no larger than 20 MB and ask a question about its contents.
2. Confirm the request is served by DeepSeek V4 Pro, the answer uses the PDF contents, and the PDF is also available in the sandbox.
3. Trigger a follow-up tool step and confirm the PDF remains usable without another parse.
4. Upload an image and confirm the existing Grok vision routing is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PDF handling in Agent mode, including support for provider-visible PDFs and sandbox-only processing for oversized files.
  * Added OCR support for DeepSeek V4 PDF requests.
  * Preserved parsed-file annotations in assistant responses.

* **Bug Fixes**
  * Improved model selection for PDF and image attachments.
  * Prevented unnecessary OCR routing for unsupported request types.
  * Ensured unsafe or oversized files are excluded from provider messages while remaining available for processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->