### PR TITLE
Close checkout, Agent, and transport reliability gaps

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -43,6 +43,7 @@ function createRequest({
   userAgent = "BetterStack",
   method = "GET",
   headers = {},
+  cookieNames = [],
 }: {
   pathname: string;
   accept?: string;
@@ -50,6 +51,7 @@ function createRequest({
   userAgent?: string;
   method?: string;
   headers?: Record<string, string>;
+  cookieNames?: string[];
 }): NextRequest {
   const url = new URL(pathname, "https://hackerai.co");
   return {
@@ -62,7 +64,10 @@ function createRequest({
       ...headers,
     }),
     cookies: {
-      has: jest.fn((name: string) => name === "wos-session" && hasSession),
+      has: jest.fn(
+        (name: string) =>
+          (name === "wos-session" && hasSession) || cookieNames.includes(name),
+      ),
     },
   } as unknown as NextRequest;
 }
@@ -111,6 +116,75 @@ describe("proxy", () => {
       expect(mockNextResponseRedirect).not.toHaveBeenCalled();
     },
   );
+
+  it("stores sanitized first-touch attribution before authentication", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://signin.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname:
+          "/?utm_source=github&utm_medium=social&utm_campaign=aug_launch&utm_term=private-target",
+        accept: "text/html",
+        userAgent: "Mozilla/5.0",
+        headers: {
+          referer: "https://github.com/hackerai-tech?secret=value",
+        },
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "next" });
+    const firstTouchCookieCall = response.cookies.set.mock.calls.find(
+      ([name]: [string]) => name === "hackerai_first_touch_attribution",
+    );
+    expect(firstTouchCookieCall).toBeDefined();
+    const [, value, options] = firstTouchCookieCall!;
+    expect(JSON.parse(decodeURIComponent(String(value)))).toMatchObject({
+      version: 1,
+      source: "github",
+      medium: "social",
+      campaign: "aug_launch",
+      referringDomain: "github.com",
+      entrySurface: "home",
+    });
+    expect(String(value)).not.toContain("private-target");
+    expect(String(value)).not.toContain("secret");
+    expect(options).toEqual({
+      httpOnly: true,
+      secure: false,
+      sameSite: "lax",
+      maxAge: 90 * 24 * 60 * 60,
+      path: "/",
+    });
+  });
+
+  it("does not overwrite existing first-touch attribution", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://signin.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/?utm_source=second_touch",
+        accept: "text/html",
+        userAgent: "Mozilla/5.0",
+        cookieNames: ["hackerai_first_touch_attribution"],
+      }),
+    );
+
+    expect(
+      response.cookies.set.mock.calls.some(
+        ([name]: [string]) => name === "hackerai_first_touch_attribution",
+      ),
+    ).toBe(false);
+  });
 
   it("rejects non-action root POSTs before AuthKit", async () => {
     const { default: proxy } = await import("../proxy");

--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -210,6 +210,58 @@ describe("PostHogProvider", () => {
     expect(posthog.identify).toHaveBeenCalledWith("user-deduped", undefined);
   });
 
+  it("sets sanitized first-touch properties once during identification", async () => {
+    const posthog = {
+      __loaded: false,
+      init: jest.fn(),
+      set_config: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      has_opted_out_capturing: jest.fn(() => false),
+      identify: jest.fn(),
+      sessionRecordingStarted: jest.fn(() => false),
+      startSessionRecording: jest.fn(),
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockLoadPostHogClient.mockResolvedValue(posthog);
+
+    render(
+      <PostHogProvider
+        firstTouchAttribution={{
+          version: 1,
+          source: "github",
+          medium: "social",
+          campaign: "aug_launch",
+          referringDomain: "github.com",
+          entrySurface: "home",
+          capturedAt: "2026-08-14T12:00:00.000Z",
+        }}
+      >
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => expect(posthog.identify).toHaveBeenCalledTimes(1));
+    expect(posthog.identify).toHaveBeenCalledWith(
+      "user-123",
+      {
+        email: "user@example.com",
+        name: "Test User",
+        subscription: "pro",
+      },
+      {
+        first_touch_attribution_version: 1,
+        first_touch_source: "github",
+        first_touch_medium: "social",
+        first_touch_campaign: "aug_launch",
+        first_touch_referring_domain: "github.com",
+        first_touch_entry_surface: "home",
+        first_touch_captured_at: "2026-08-14T12:00:00.000Z",
+      },
+    );
+  });
+
   it("applies exception hooks when the shared client is already initialized", async () => {
     const posthog = {
       __loaded: true,

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1828,6 +1828,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     isSendingNowRef,
     hasManuallyStoppedRef,
     activeTriggerRunRef,
+    resumeActiveRun: resumeStream,
     onStopCallback: () => {
       dispatchStreaming({ type: "RESET_ON_FINISH" });
     },

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -616,8 +616,13 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     const now = new Date().toISOString();
     const agentFirstProperties = {
       experiment_key: agentDefaultDecision.experimentKey,
-      first_experience_event_version: 2,
+      first_experience_event_version: 3,
       variant: "agent_first",
+      assignment_type: "deterministic_eligibility",
+      assignment_unit: "authenticated_user",
+      randomized_assignment: false,
+      control_variant_available: false,
+      exposure_trigger: "default_applied",
       subscription: paidAgentSubscription,
       eligible_subscription_tier: agentDefaultDecision.eligibleSubscriptionTier,
       selected_subscription_tier: paidAgentSubscription,

--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -5,6 +5,9 @@ import type { ChatMessage, SelectedModel } from "@/types";
 const mockRegenerate = jest.fn();
 const mockSendMessage = jest.fn();
 const mockSetMessages = jest.fn();
+const mockSetIsAutoResuming = jest.fn();
+const mockCaptureAuthenticatedEvent = jest.fn();
+const mockToastInfo = jest.fn();
 let mockSelectedModel: SelectedModel = "hackerai-standard";
 const originalFetch = globalThis.fetch;
 
@@ -33,7 +36,20 @@ jest.mock("@/app/contexts/GlobalState", () => ({
 }));
 
 jest.mock("@/app/components/DataStreamProvider", () => ({
-  useDataStreamDispatch: () => ({ setIsAutoResuming: jest.fn() }),
+  useDataStreamDispatch: () => ({
+    setIsAutoResuming: mockSetIsAutoResuming,
+  }),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: mockCaptureAuthenticatedEvent,
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+    info: mockToastInfo,
+  },
 }));
 
 jest.mock("@/app/hooks/useTauri", () => ({
@@ -388,5 +404,66 @@ describe("useChatHandlers regenerate model", () => {
     });
 
     expect(stopped).toBe(false);
+  });
+
+  it("reconnects to the persisted run after a stale cancellation", async () => {
+    const fetchMock = jest.fn(async () => {
+      return {
+        ok: false,
+        status: 409,
+        json: jest.fn(async () => ({
+          canceled: false,
+          reason: "stale_run",
+          activeTriggerRunId: "run-2",
+        })),
+      } as unknown as Response;
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+    const activeTriggerRunRef = { current: "run-1" };
+    const hasManuallyStoppedRef = { current: false };
+    const resumeActiveRun = jest.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages: [],
+        sendMessage: mockSendMessage,
+        stop: jest.fn(),
+        regenerate: mockRegenerate,
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef,
+        activeTriggerRunRef,
+        resumeActiveRun,
+      }),
+    );
+
+    let stopped: boolean | undefined;
+    await act(async () => {
+      stopped = await result.current.handleStop();
+    });
+
+    expect(stopped).toBe(false);
+    expect(activeTriggerRunRef.current).toBe("run-2");
+    expect(hasManuallyStoppedRef.current).toBe(false);
+    expect(resumeActiveRun).toHaveBeenCalledTimes(1);
+    expect(mockSetIsAutoResuming).toHaveBeenLastCalledWith(true);
+    expect(mockToastInfo).toHaveBeenCalledWith("Agent run changed", {
+      description: "Reconnecting to the current run instead of cancelling it.",
+    });
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledWith(
+      "agent_cancel_stale_recovery_started",
+      {
+        chat_id: "chat-1",
+        expected_trigger_run_id: "run-1",
+        active_trigger_run_id: "run-2",
+        recovery_action: "resume_stream",
+        cancellation_applied: false,
+      },
+    );
   });
 });

--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -466,4 +466,64 @@ describe("useChatHandlers regenerate model", () => {
       },
     );
   });
+
+  it("clears an obsolete run without resuming when none is active", async () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: jest.fn(async () => {
+        return {
+          ok: false,
+          status: 409,
+          json: jest.fn(async () => ({
+            canceled: false,
+            reason: "stale_run",
+            activeTriggerRunId: null,
+          })),
+        } as unknown as Response;
+      }),
+    });
+    const activeTriggerRunRef: { current: string | undefined } = {
+      current: "run-1",
+    };
+    const resumeActiveRun = jest.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages: [],
+        sendMessage: mockSendMessage,
+        stop: jest.fn(),
+        regenerate: mockRegenerate,
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+        activeTriggerRunRef,
+        resumeActiveRun,
+      }),
+    );
+
+    let stopped: boolean | undefined;
+    await act(async () => {
+      stopped = await result.current.handleStop();
+    });
+
+    expect(stopped).toBe(false);
+    expect(activeTriggerRunRef.current).toBeUndefined();
+    expect(resumeActiveRun).not.toHaveBeenCalled();
+    expect(mockSetIsAutoResuming).toHaveBeenLastCalledWith(false);
+    expect(mockToastInfo).toHaveBeenCalledWith("Agent run already finished", {
+      description: "Nothing is running to cancel. Try the action again.",
+    });
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledWith(
+      "agent_cancel_stale_recovery_started",
+      {
+        chat_id: "chat-1",
+        expected_trigger_run_id: "run-1",
+        active_trigger_run_id: null,
+        recovery_action: "no_active_run",
+        cancellation_applied: false,
+      },
+    );
+  });
 });

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -344,6 +344,52 @@ describe("useChatHandlers steer todo handoff", () => {
     expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
+  it("keeps the queued message and reconnects when cancellation is stale", async () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: jest.fn(async () => {
+        return {
+          ok: false,
+          status: 409,
+          json: jest.fn(async () => ({
+            canceled: false,
+            reason: "stale_run",
+            activeTriggerRunId: "run-2",
+          })),
+        } as unknown as Response;
+      }),
+    });
+    const activeTriggerRunRef = { current: "run-1" };
+    const hasManuallyStoppedRef = { current: false };
+    const resumeActiveRun = jest.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate: jest.fn(),
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "streaming",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef,
+        activeTriggerRunRef,
+        resumeActiveRun,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSendNow("queued-1");
+    });
+
+    expect(activeTriggerRunRef.current).toBe("run-2");
+    expect(hasManuallyStoppedRef.current).toBe(false);
+    expect(resumeActiveRun).toHaveBeenCalledTimes(1);
+    expect(mockRemoveQueuedMessage).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
   it("does not clean local state or regenerate when the server rejects a stale edit", async () => {
     mockRegenerateWithNewContent.mockRejectedValueOnce({
       data: {

--- a/app/hooks/__tests__/useUpgrade.test.ts
+++ b/app/hooks/__tests__/useUpgrade.test.ts
@@ -251,6 +251,37 @@ describe("useUpgrade checkout attempts", () => {
     );
   });
 
+  it("allows an immediate retry when checkout navigation fails", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          ok: true,
+          status: 200,
+          body: { url: "https://[" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({ ok: true, status: 200, body: { error: "cancelled" } }),
+      );
+    mockNewCheckoutAttemptId
+      .mockReturnValueOnce("ca_redirect_failed_123")
+      .mockReturnValueOnce("ca_redirect_retry_456");
+    const { result } = renderHook(() => useUpgrade());
+
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(
+      window.sessionStorage.getItem("hackerai:billing:checkout-navigation:v1"),
+    ).toBeNull();
+  });
+
   it("suppresses a recent checkout redirect after a page reload", async () => {
     window.sessionStorage.setItem(
       "hackerai:billing:checkout-navigation:v1",

--- a/app/hooks/__tests__/useUpgrade.test.ts
+++ b/app/hooks/__tests__/useUpgrade.test.ts
@@ -15,6 +15,7 @@ jest.mock("@workos-inc/authkit-nextjs/components", () => ({
 jest.mock("sonner", () => ({
   toast: {
     error: jest.fn(),
+    info: jest.fn(),
   },
 }));
 
@@ -37,6 +38,7 @@ const mockGetPostHogRequestHeaders =
     typeof getPostHogRequestHeaders
   >;
 const mockToastError = toast.error as jest.MockedFunction<typeof toast.error>;
+const mockToastInfo = toast.info as jest.MockedFunction<typeof toast.info>;
 
 function response({
   ok,
@@ -72,6 +74,7 @@ describe("useUpgrade checkout attempts", () => {
 
   afterEach(() => {
     window.history.replaceState(null, "", "/");
+    window.sessionStorage.clear();
   });
 
   it("coalesces duplicate clicks before React commits the loading state", async () => {
@@ -245,6 +248,45 @@ describe("useUpgrade checkout attempts", () => {
     ]);
     expect(mockToastError).toHaveBeenCalledWith(
       "Checkout temporarily unavailable",
+    );
+  });
+
+  it("suppresses a recent checkout redirect after a page reload", async () => {
+    window.sessionStorage.setItem(
+      "hackerai:billing:checkout-navigation:v1",
+      JSON.stringify({
+        attemptId: "ca_recent_redirect_123",
+        plan: "pro-monthly-plan",
+        startedAt: Date.now(),
+      }),
+    );
+    global.fetch = jest.fn();
+    const { result } = renderHook(() => useUpgrade());
+
+    await act(async () => {
+      await result.current.handleUpgrade(
+        "pro-monthly-plan",
+        undefined,
+        undefined,
+        "free",
+        { source: "sidebar", surface: "pricing_dialog" },
+      );
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockNewCheckoutAttemptId).not.toHaveBeenCalled();
+    expect(mockToastInfo).toHaveBeenCalledWith("Checkout is already opening", {
+      description: "Wait a moment before trying again.",
+    });
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledWith(
+      "checkout_redirect_suppressed",
+      expect.objectContaining({
+        checkout_attempt_id: "ca_recent_redirect_123",
+        plan: "pro-monthly-plan",
+        source: "sidebar",
+        suppression_reason: "recent_navigation",
+        guard_window_ms: 30_000,
+      }),
     );
   });
 

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -189,7 +189,7 @@ export const useChatHandlers = ({
     | {
         outcome: "stale_run";
         expectedTriggerRunId?: string;
-        activeTriggerRunId?: string;
+        activeTriggerRunId?: string | null;
       };
 
   const cancelTriggerRun = async (): Promise<AgentCancellationResult> => {
@@ -209,11 +209,20 @@ export const useChatHandlers = ({
         activeTriggerRunId?: unknown;
       } | null;
       if (payload?.reason === "stale_run") {
+        const hasActiveTriggerRunId = Object.prototype.hasOwnProperty.call(
+          payload,
+          "activeTriggerRunId",
+        );
         return {
           outcome: "stale_run",
           expectedTriggerRunId,
-          ...(typeof payload.activeTriggerRunId === "string"
-            ? { activeTriggerRunId: payload.activeTriggerRunId }
+          ...(hasActiveTriggerRunId
+            ? {
+                activeTriggerRunId:
+                  typeof payload.activeTriggerRunId === "string"
+                    ? payload.activeTriggerRunId
+                    : null,
+              }
             : {}),
         };
       }
@@ -230,17 +239,31 @@ export const useChatHandlers = ({
     result: Extract<AgentCancellationResult, { outcome: "stale_run" }>,
   ): Promise<void> => {
     hasManuallyStoppedRef.current = false;
-    if (result.activeTriggerRunId && activeTriggerRunRef) {
-      activeTriggerRunRef.current = result.activeTriggerRunId;
+    if (activeTriggerRunRef && result.activeTriggerRunId !== undefined) {
+      activeTriggerRunRef.current = result.activeTriggerRunId ?? undefined;
     }
+
+    const hasNoActiveRun = result.activeTriggerRunId === null;
 
     captureAuthenticatedEvent("agent_cancel_stale_recovery_started", {
       chat_id: chatId,
       expected_trigger_run_id: result.expectedTriggerRunId,
       active_trigger_run_id: result.activeTriggerRunId,
-      recovery_action: resumeActiveRun ? "resume_stream" : "persisted_state",
+      recovery_action: hasNoActiveRun
+        ? "no_active_run"
+        : resumeActiveRun
+          ? "resume_stream"
+          : "persisted_state",
       cancellation_applied: false,
     });
+
+    if (hasNoActiveRun) {
+      setIsAutoResuming(false);
+      toast.info("Agent run already finished", {
+        description: "Nothing is running to cancel. Try the action again.",
+      });
+      return;
+    }
 
     toast.info("Agent run changed", {
       description: "Reconnecting to the current run instead of cancelling it.",

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -40,6 +40,7 @@ import { isPastedTextAttachmentAvailableInMode } from "@/lib/utils/pasted-text-a
 import { sanitizeForConvexValue } from "@/lib/db/convex-value-sanitizer";
 import { reconcileSidebarContentAfterRegeneration } from "@/lib/utils/sidebar-utils";
 import { v4 as uuidv4 } from "uuid";
+import { captureAuthenticatedEvent } from "@/lib/analytics/client";
 
 interface UseChatHandlersProps {
   chatId: string;
@@ -58,6 +59,7 @@ interface UseChatHandlersProps {
   isSendingNowRef: RefObject<boolean>;
   hasManuallyStoppedRef: RefObject<boolean>;
   activeTriggerRunRef?: RefObject<string | undefined>;
+  resumeActiveRun?: () => void | Promise<void>;
   onStopCallback?: () => void;
   resetAutoContinueCount?: () => void;
 }
@@ -92,6 +94,7 @@ export const useChatHandlers = ({
   isSendingNowRef,
   hasManuallyStoppedRef,
   activeTriggerRunRef,
+  resumeActiveRun,
   onStopCallback,
   resetAutoContinueCount,
 }: UseChatHandlersProps) => {
@@ -181,8 +184,16 @@ export const useChatHandlers = ({
       isTauri: isTauriEnvironment(),
     });
 
-  const cancelTriggerRun = async (): Promise<void> => {
-    if (!shouldCancelTriggerRun()) return;
+  type AgentCancellationResult =
+    | { outcome: "not_applicable" | "canceled" }
+    | {
+        outcome: "stale_run";
+        expectedTriggerRunId?: string;
+        activeTriggerRunId?: string;
+      };
+
+  const cancelTriggerRun = async (): Promise<AgentCancellationResult> => {
+    if (!shouldCancelTriggerRun()) return { outcome: "not_applicable" };
     const expectedTriggerRunId = activeTriggerRunRef?.current;
     const response = await fetch(AGENT_CANCEL_ENDPOINT, {
       method: "POST",
@@ -192,10 +203,61 @@ export const useChatHandlers = ({
         ...(expectedTriggerRunId ? { expectedTriggerRunId } : {}),
       }),
     });
+    if (response.status === 409) {
+      const payload = (await response.json().catch(() => null)) as {
+        reason?: unknown;
+        activeTriggerRunId?: unknown;
+      } | null;
+      if (payload?.reason === "stale_run") {
+        return {
+          outcome: "stale_run",
+          expectedTriggerRunId,
+          ...(typeof payload.activeTriggerRunId === "string"
+            ? { activeTriggerRunId: payload.activeTriggerRunId }
+            : {}),
+        };
+      }
+    }
     if (!response.ok) {
       throw new Error(
         `Agent cancellation failed with status ${response.status}`,
       );
+    }
+    return { outcome: "canceled" };
+  };
+
+  const recoverStaleAgentRun = async (
+    result: Extract<AgentCancellationResult, { outcome: "stale_run" }>,
+  ): Promise<void> => {
+    hasManuallyStoppedRef.current = false;
+    if (result.activeTriggerRunId && activeTriggerRunRef) {
+      activeTriggerRunRef.current = result.activeTriggerRunId;
+    }
+
+    captureAuthenticatedEvent("agent_cancel_stale_recovery_started", {
+      chat_id: chatId,
+      expected_trigger_run_id: result.expectedTriggerRunId,
+      active_trigger_run_id: result.activeTriggerRunId,
+      recovery_action: resumeActiveRun ? "resume_stream" : "persisted_state",
+      cancellation_applied: false,
+    });
+
+    toast.info("Agent run changed", {
+      description: "Reconnecting to the current run instead of cancelling it.",
+    });
+
+    if (!resumeActiveRun) {
+      setIsAutoResuming(false);
+      return;
+    }
+
+    setIsAutoResuming(true);
+    try {
+      await resumeActiveRun();
+    } catch (error) {
+      setIsAutoResuming(false);
+      console.error("Failed to resume the current Agent run:", error);
+      toast.error("Could not reconnect to the current Agent run.");
     }
   };
 
@@ -286,7 +348,7 @@ export const useChatHandlers = ({
     return normalizedMessages;
   };
 
-  const stopActiveRunForReplacement = async (): Promise<void> => {
+  const stopActiveRunForReplacement = async (): Promise<boolean> => {
     const [triggerCancelResult, streamStopResult] = await Promise.allSettled([
       cancelTriggerRun(),
       stopActiveStream({ skipSave: true }),
@@ -303,13 +365,23 @@ export const useChatHandlers = ({
     if (streamStopResult.status === "rejected") {
       throw streamStopResult.reason;
     }
+    if (triggerCancelResult.value.outcome === "stale_run") {
+      await recoverStaleAgentRun(triggerCancelResult.value);
+      return false;
+    }
+    return true;
   };
 
-  const stopActiveRunForSteer = async (): Promise<void> => {
+  const stopActiveRunForSteer = async (): Promise<boolean> => {
     // Persist the latest message and todo snapshot before canceling the Trigger
     // run. The next run reads the persisted todo snapshot.
     await stopActiveStream({ requireCancelSuccess: true });
-    await cancelTriggerRun();
+    const cancelResult = await cancelTriggerRun();
+    if (cancelResult.outcome === "stale_run") {
+      await recoverStaleAgentRun(cancelResult);
+      return false;
+    }
+    return true;
   };
 
   const hasActiveRunToReplace = () =>
@@ -410,7 +482,7 @@ export const useChatHandlers = ({
         return true;
       } else if (queueBehavior === "stop-and-send") {
         try {
-          await stopActiveRunForSteer();
+          if (!(await stopActiveRunForSteer())) return false;
         } catch (error) {
           console.error(
             "Failed to stop the active run before steering:",
@@ -536,6 +608,14 @@ export const useChatHandlers = ({
       console.error("Error in handleStop:", streamStopResult.reason);
     }
 
+    if (
+      triggerCancelResult.status === "fulfilled" &&
+      triggerCancelResult.value.outcome === "stale_run"
+    ) {
+      await recoverStaleAgentRun(triggerCancelResult.value);
+      return false;
+    }
+
     return triggerCancelResult.status === "fulfilled";
   };
 
@@ -545,7 +625,7 @@ export const useChatHandlers = ({
 
     // Stop any active stream first to prevent message order issues and wasted tokens
     if (hasActiveRunToReplace()) {
-      await stopActiveRunForReplacement();
+      if (!(await stopActiveRunForReplacement())) return;
     }
     const agentRunRequestId = uuidv4();
 
@@ -616,7 +696,7 @@ export const useChatHandlers = ({
 
     // Stop any active stream first to prevent message order issues and wasted tokens
     if (hasActiveRunToReplace()) {
-      await stopActiveRunForReplacement();
+      if (!(await stopActiveRunForReplacement())) return;
     }
     const agentRunRequestId = uuidv4();
 
@@ -685,7 +765,7 @@ export const useChatHandlers = ({
 
     // Stop any active stream first to prevent message order issues and wasted tokens
     if (hasActiveRunToReplace()) {
-      await stopActiveRunForReplacement();
+      if (!(await stopActiveRunForReplacement())) return;
     }
     const agentRunRequestId = uuidv4();
 
@@ -831,7 +911,7 @@ export const useChatHandlers = ({
     try {
       setIsAutoResuming(false);
       if (hasActiveRunToReplace()) {
-        await stopActiveRunForSteer();
+        if (!(await stopActiveRunForSteer())) return;
       }
 
       // Keep the queued message available if stopping fails.

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -149,6 +149,7 @@ export const useUpgrade = () => {
         const { error, url } = data;
 
         if (url) {
+          window.location.href = url;
           rememberCheckoutNavigation({
             attemptId: checkoutAttemptId,
             plan: selectedPlan,
@@ -167,7 +168,6 @@ export const useUpgrade = () => {
             limit_type: analyticsContext.limit_type,
             checkout_type: "new_subscription",
           });
-          window.location.href = url;
           navigationStarted = true;
           return;
         }

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -7,10 +7,16 @@ import {
   newCheckoutAttemptId,
 } from "@/lib/analytics/client";
 import {
+  PAID_FUNNEL_EVENTS,
   planLookupKeyToBillingInterval,
   planLookupKeyToTier,
   type PaidFunnelPlan,
 } from "@/lib/analytics/paid-funnel";
+import {
+  CHECKOUT_NAVIGATION_GUARD_WINDOW_MS,
+  getRecentCheckoutNavigation,
+  rememberCheckoutNavigation,
+} from "@/lib/billing/checkout-navigation-guard";
 
 // Keep a tab's upgrade ownership across pricing dialog remounts. Server routes
 // remain authoritative across page loads and tabs, including open-session reuse.
@@ -44,13 +50,41 @@ export const useUpgrade = () => {
       return;
     }
 
+    const selectedPlan = planKey || "pro-monthly-plan";
+    if (!currentSubscription || currentSubscription === "free") {
+      const recentNavigation = getRecentCheckoutNavigation({
+        plan: selectedPlan,
+      });
+      if (recentNavigation) {
+        captureAuthenticatedEvent(
+          PAID_FUNNEL_EVENTS.checkoutRedirectSuppressed,
+          {
+            checkout_attempt_id: recentNavigation.attemptId,
+            plan: selectedPlan,
+            from_tier: currentSubscription ?? "free",
+            to_tier: planLookupKeyToTier(selectedPlan),
+            billing_interval: planLookupKeyToBillingInterval(selectedPlan),
+            surface: analyticsContext.surface,
+            source: analyticsContext.source,
+            reason: analyticsContext.reason,
+            limit_type: analyticsContext.limit_type,
+            suppression_reason: "recent_navigation",
+            guard_window_ms: CHECKOUT_NAVIGATION_GUARD_WINDOW_MS,
+          },
+        );
+        toast.info("Checkout is already opening", {
+          description: "Wait a moment before trying again.",
+        });
+        return;
+      }
+    }
+
     upgradeInFlight = true;
     setUpgradeLoading(true);
 
     let navigationStarted = false;
 
     try {
-      const selectedPlan = planKey || "pro-monthly-plan";
       const checkoutAttemptId = newCheckoutAttemptId();
       const toTier = planLookupKeyToTier(selectedPlan);
       const billingInterval = planLookupKeyToBillingInterval(selectedPlan);
@@ -115,6 +149,11 @@ export const useUpgrade = () => {
         const { error, url } = data;
 
         if (url) {
+          rememberCheckoutNavigation({
+            attemptId: checkoutAttemptId,
+            plan: selectedPlan,
+            startedAt: Date.now(),
+          });
           captureAuthenticatedEvent("checkout_redirected", {
             checkout_attempt_id: checkoutAttemptId,
             plan: selectedPlan,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import "./globals.css";
 
@@ -15,6 +15,10 @@ import { PostHogProvider } from "./providers";
 import { DataStreamProvider } from "./components/DataStreamProvider";
 import { ChunkLoadRecovery } from "./components/ChunkLoadRecovery";
 import { resolveClientInitialAuth } from "@/lib/auth/initial-auth";
+import {
+  FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME,
+  parseFirstTouchAttribution,
+} from "@/lib/analytics/acquisition";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -115,12 +119,18 @@ export default async function RootLayout({
 }>) {
   // Supplying server-resolved auth prevents AuthKitProvider from invoking its
   // getAuth Server Action on every mount.
-  const initialAuth = await getInitialAuth();
+  const [initialAuth, cookieStore] = await Promise.all([
+    getInitialAuth(),
+    cookies(),
+  ]);
+  const firstTouchAttribution = parseFirstTouchAttribution(
+    cookieStore.get(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME)?.value,
+  );
 
   const content = (
     <GlobalStateProvider>
       <AgentAutoReviewAvailabilityProvider>
-        <PostHogProvider>
+        <PostHogProvider firstTouchAttribution={firstTouchAttribution}>
           <ChunkLoadRecovery />
           <DataStreamProvider>
             <TodoBlockProvider>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -19,10 +19,20 @@ import {
   createPostHogIdentitySignature,
   POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
 } from "@/lib/analytics/identity";
+import {
+  firstTouchPersonProperties,
+  type FirstTouchAttribution,
+} from "@/lib/analytics/acquisition";
 
 let lastIdentifiedSignature: string | null = null;
 
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
+export function PostHogProvider({
+  children,
+  firstTouchAttribution = null,
+}: {
+  children: React.ReactNode;
+  firstTouchAttribution?: FirstTouchAttribution | null;
+}) {
   const { subscription } = useGlobalState();
   const { user } = useAuth();
   const userId = user?.id;
@@ -101,6 +111,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
           email: userEmail,
           name,
           subscription,
+          firstTouchAttribution,
         });
         if (lastIdentifiedSignature !== identitySignature) {
           let persistedIdentitySignature: string | null = null;
@@ -114,16 +125,22 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
           const shouldUpdatePersonProperties =
             persistedIdentitySignature !== identitySignature;
-          posthog.identify(
-            userId!,
-            shouldUpdatePersonProperties
-              ? {
-                  email: userEmail,
-                  name,
-                  subscription,
-                }
-              : undefined,
-          );
+          const personProperties = shouldUpdatePersonProperties
+            ? {
+                email: userEmail,
+                name,
+                subscription,
+              }
+            : undefined;
+          if (shouldUpdatePersonProperties && firstTouchAttribution) {
+            posthog.identify(
+              userId!,
+              personProperties,
+              firstTouchPersonProperties(firstTouchAttribution),
+            );
+          } else {
+            posthog.identify(userId!, personProperties);
+          }
           lastIdentifiedSignature = identitySignature;
 
           if (shouldUpdatePersonProperties) {
@@ -154,7 +171,14 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [subscription, userEmail, userFirstName, userId, userLastName]);
+  }, [
+    firstTouchAttribution,
+    subscription,
+    userEmail,
+    userFirstName,
+    userId,
+    userLastName,
+  ]);
 
   return children;
 }

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -1174,6 +1174,45 @@ describe("forwardChunk", () => {
           recoveryLatencyMs: 250,
         }),
       );
+
+      finishCommand();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(captureAuthenticatedEvent).toHaveBeenNthCalledWith(
+        3,
+        "desktop_stream_command_settled",
+        {
+          connectionId: "conn-123",
+          commandId: "cmd-publish-recovery",
+          outcome: "recovered",
+          observedChunks: 1,
+          publishedChunks: 1,
+          exhaustedChunks: 0,
+          terminalChunkObserved: null,
+          terminalChunkPublished: false,
+          sequenceComplete: true,
+          durationMs: 250,
+        },
+      );
+      expect(
+        infoSpy.mock.calls
+          .map(([value]) => {
+            try {
+              return JSON.parse(String(value)) as Record<string, unknown>;
+            } catch {
+              return null;
+            }
+          })
+          .find((value) => value?.event === "desktop_stream_command_settled"),
+      ).toEqual(
+        expect.objectContaining({
+          level: "info",
+          outcome: "recovered",
+          observed_chunks: 1,
+          published_chunks: 1,
+          exhausted_chunks: 0,
+          sequence_complete: true,
+        }),
+      );
     } finally {
       finishCommand();
       mockSubscription.publish.mockResolvedValue(undefined);

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -1210,7 +1210,10 @@ describe("forwardChunk", () => {
           observed_chunks: 1,
           published_chunks: 1,
           exhausted_chunks: 0,
+          terminal_chunk_observed: null,
+          terminal_chunk_published: false,
           sequence_complete: true,
+          duration_ms: 250,
         }),
       );
     } finally {

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -70,6 +70,11 @@ interface DesktopStreamPublishRecoveryState {
   failureReported: boolean;
   recoveryReported: boolean;
   exhaustionReported: boolean;
+  observedChunks: number;
+  publishedChunks: number;
+  exhaustedChunks: number;
+  terminalChunkObserved: "exit" | "error" | null;
+  terminalChunkPublished: boolean;
 }
 
 function shouldForwardStreamChunk(chunk: StreamChunk): boolean {
@@ -499,16 +504,22 @@ export class DesktopSandboxBridge {
   private async handleCommand(command: CommandMessage): Promise<void> {
     const { commandId } = command;
     this.activeCommands.add(commandId);
+    const commandStartedAt = Date.now();
+    const recoveryState: DesktopStreamPublishRecoveryState = {
+      failureReported: false,
+      recoveryReported: false,
+      exhaustionReported: false,
+      observedChunks: 0,
+      publishedChunks: 0,
+      exhaustedChunks: 0,
+      terminalChunkObserved: null,
+      terminalChunkPublished: false,
+    };
 
     try {
       const { invoke, Channel } = await import("@tauri-apps/api/core");
 
       const channel = new Channel<StreamChunk>();
-      const recoveryState: DesktopStreamPublishRecoveryState = {
-        failureReported: false,
-        recoveryReported: false,
-        exhaustionReported: false,
-      };
       const recoveryDeadlineAt =
         Date.now() +
         (command.timeout ?? 30_000) +
@@ -520,6 +531,10 @@ export class DesktopSandboxBridge {
         if (!shouldForwardStreamChunk(chunk)) return;
 
         const sequence = nextSequence++;
+        recoveryState.observedChunks += 1;
+        if (chunk.type === "exit" || chunk.type === "error") {
+          recoveryState.terminalChunkObserved = chunk.type;
+        }
         const operation = streamPublishTail.then(async () => {
           try {
             await this.forwardChunkWithRetry(
@@ -568,8 +583,67 @@ export class DesktopSandboxBridge {
         message,
       });
     } finally {
+      this.reportDesktopStreamCommandSettlement(
+        commandId,
+        recoveryState,
+        Date.now() - commandStartedAt,
+      );
       this.activeCommands.delete(commandId);
     }
+  }
+
+  private reportDesktopStreamCommandSettlement(
+    commandId: string,
+    recoveryState: DesktopStreamPublishRecoveryState,
+    durationMs: number,
+  ): void {
+    if (!recoveryState.failureReported) return;
+
+    const outcome =
+      recoveryState.exhaustedChunks > 0
+        ? "incomplete"
+        : recoveryState.publishedChunks === recoveryState.observedChunks
+          ? "recovered"
+          : "interrupted";
+    const properties = {
+      connectionId: this.connectionId,
+      commandId,
+      outcome,
+      observedChunks: recoveryState.observedChunks,
+      publishedChunks: recoveryState.publishedChunks,
+      exhaustedChunks: recoveryState.exhaustedChunks,
+      terminalChunkObserved: recoveryState.terminalChunkObserved,
+      terminalChunkPublished: recoveryState.terminalChunkPublished,
+      sequenceComplete:
+        recoveryState.observedChunks === recoveryState.publishedChunks,
+      durationMs,
+    };
+    const log = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: outcome === "recovered" ? "info" : "error",
+      event: "desktop_stream_command_settled",
+      service: "desktop_bridge",
+      environment: process.env.NODE_ENV ?? "unknown",
+      request_id: commandId,
+      connection_id: this.connectionId,
+      command_id: commandId,
+      outcome,
+      observed_chunks: recoveryState.observedChunks,
+      published_chunks: recoveryState.publishedChunks,
+      exhausted_chunks: recoveryState.exhaustedChunks,
+      terminal_chunk_observed: recoveryState.terminalChunkObserved,
+      terminal_chunk_published: recoveryState.terminalChunkPublished,
+      sequence_complete:
+        recoveryState.observedChunks === recoveryState.publishedChunks,
+      duration_ms: durationMs,
+    });
+
+    if (outcome === "recovered") {
+      console.info(log);
+    } else {
+      console.error(log);
+    }
+    captureAuthenticatedEvent("desktop_stream_command_settled", properties);
   }
 
   private getErrorMessage(error: unknown): string {
@@ -915,6 +989,10 @@ export class DesktopSandboxBridge {
 
       try {
         await this.forwardChunk(commandId, chunk, sequence);
+        recoveryState.publishedChunks += 1;
+        if (chunk.type === "exit" || chunk.type === "error") {
+          recoveryState.terminalChunkPublished = true;
+        }
         if (
           firstFailureAt !== null &&
           firstFailureReason !== null &&
@@ -992,6 +1070,7 @@ export class DesktopSandboxBridge {
           if (Date.now() < recoveryDeadlineAt) continue;
         }
 
+        recoveryState.exhaustedChunks += 1;
         if (!recoveryState.exhaustionReported) {
           recoveryState.exhaustionReported = true;
           const recoveryLatencyMs = Date.now() - firstFailureAt;

--- a/lib/analytics/__tests__/acquisition.test.ts
+++ b/lib/analytics/__tests__/acquisition.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  createFirstTouchAttribution,
+  firstTouchPersonProperties,
+  parseFirstTouchAttribution,
+  serializeFirstTouchAttribution,
+} from "../acquisition";
+
+describe("first-touch acquisition attribution", () => {
+  const capturedAt = new Date("2026-08-14T12:00:00.000Z");
+
+  it("keeps bounded campaign metadata without URLs or search terms", () => {
+    const attribution = createFirstTouchAttribution({
+      url: new URL(
+        "https://hackerai.co/?utm_source=newsletter&utm_medium=email&utm_campaign=aug_launch&utm_term=private-target",
+      ),
+      referer: "https://mail.example/path?secret=value",
+      capturedAt,
+    });
+
+    expect(attribution).toEqual({
+      version: 1,
+      source: "newsletter",
+      medium: "email",
+      campaign: "aug_launch",
+      referringDomain: "mail.example",
+      entrySurface: "home",
+      capturedAt: capturedAt.toISOString(),
+    });
+    expect(JSON.stringify(attribution)).not.toContain("private-target");
+    expect(JSON.stringify(attribution)).not.toContain("secret");
+  });
+
+  it("classifies organic, referral, paid, and direct entry", () => {
+    expect(
+      createFirstTouchAttribution({
+        url: new URL("https://hackerai.co/download"),
+        referer: "https://www.google.com/search?q=hackerai",
+        capturedAt,
+      }),
+    ).toMatchObject({
+      source: "google",
+      medium: "organic",
+      referringDomain: "google.com",
+      entrySurface: "download",
+    });
+    expect(
+      createFirstTouchAttribution({
+        url: new URL("https://hackerai.co/?ref=SAFE123"),
+        referer: null,
+        capturedAt,
+      }),
+    ).toMatchObject({ source: "user_referral", medium: "referral" });
+    expect(
+      createFirstTouchAttribution({
+        url: new URL("https://hackerai.co/?gclid=opaque-click-id"),
+        referer: null,
+        capturedAt,
+      }),
+    ).toMatchObject({ source: "google", medium: "paid" });
+    expect(
+      createFirstTouchAttribution({
+        url: new URL("https://hackerai.co/"),
+        referer: "https://signin.hackerai.co/callback",
+        capturedAt,
+      }),
+    ).toMatchObject({
+      source: "$direct",
+      medium: "none",
+      referringDomain: "$direct",
+    });
+  });
+
+  it("round-trips valid values and rejects tampered cookies", () => {
+    const attribution = createFirstTouchAttribution({
+      url: new URL("https://hackerai.co/?utm_source=partner"),
+      referer: "https://partner.example/path",
+      capturedAt,
+    });
+    expect(
+      parseFirstTouchAttribution(serializeFirstTouchAttribution(attribution)),
+    ).toEqual(attribution);
+    expect(parseFirstTouchAttribution("not-json")).toBeNull();
+    expect(
+      parseFirstTouchAttribution(
+        encodeURIComponent(
+          JSON.stringify({ ...attribution, source: "unsafe value" }),
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("maps attribution to set-once person properties", () => {
+    const attribution = createFirstTouchAttribution({
+      url: new URL("https://hackerai.co/trust?utm_source=github"),
+      referer: "https://github.com/hackerai-tech",
+      capturedAt,
+    });
+
+    expect(firstTouchPersonProperties(attribution)).toEqual({
+      first_touch_attribution_version: 1,
+      first_touch_source: "github",
+      first_touch_medium: "campaign",
+      first_touch_referring_domain: "github.com",
+      first_touch_entry_surface: "trust",
+      first_touch_captured_at: capturedAt.toISOString(),
+    });
+  });
+});

--- a/lib/analytics/__tests__/identity.test.ts
+++ b/lib/analytics/__tests__/identity.test.ts
@@ -23,4 +23,20 @@ describe("createPostHogIdentitySignature", () => {
       }),
     ).not.toBe(createPostHogIdentitySignature(identity));
   });
+
+  it("changes when first-touch attribution is added", () => {
+    expect(
+      createPostHogIdentitySignature({
+        ...identity,
+        firstTouchAttribution: {
+          version: 1,
+          source: "google",
+          medium: "organic",
+          referringDomain: "google.com",
+          entrySurface: "home",
+          capturedAt: "2026-08-14T12:00:00.000Z",
+        },
+      }),
+    ).not.toBe(createPostHogIdentitySignature(identity));
+  });
 });

--- a/lib/analytics/acquisition.ts
+++ b/lib/analytics/acquisition.ts
@@ -1,0 +1,201 @@
+export const FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME =
+  "hackerai_first_touch_attribution";
+
+export const FIRST_TOUCH_ATTRIBUTION_VERSION = 1;
+export const FIRST_TOUCH_ATTRIBUTION_MAX_AGE_SECONDS = 90 * 24 * 60 * 60;
+
+const SAFE_CAMPAIGN_LABEL = /^[A-Za-z0-9_$_.:-]{1,80}$/;
+const OWNED_HOST_SUFFIXES = ["hackerai.co"] as const;
+
+export type FirstTouchAttribution = {
+  version: typeof FIRST_TOUCH_ATTRIBUTION_VERSION;
+  source: string;
+  medium: string;
+  campaign?: string;
+  referringDomain: string;
+  entrySurface:
+    | "home"
+    | "download"
+    | "trust"
+    | "signup"
+    | "login"
+    | "shared_chat"
+    | "invite"
+    | "other_public";
+  capturedAt: string;
+};
+
+function normalizeCampaignLabel(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim();
+  return SAFE_CAMPAIGN_LABEL.test(normalized) ? normalized : undefined;
+}
+
+function normalizeHostname(value: string): string | null {
+  const normalized = value.toLowerCase().replace(/^www\./, "");
+  if (
+    !/^[a-z0-9.-]{1,253}$/.test(normalized) ||
+    normalized.startsWith(".") ||
+    normalized.endsWith(".") ||
+    normalized.includes("..")
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function isOwnedHostname(hostname: string): boolean {
+  return OWNED_HOST_SUFFIXES.some(
+    (suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`),
+  );
+}
+
+function getExternalReferringDomain(referer: string | null): string | null {
+  if (!referer) return null;
+
+  try {
+    const hostname = normalizeHostname(new URL(referer).hostname);
+    if (!hostname || isOwnedHostname(hostname)) return null;
+    return hostname;
+  } catch {
+    return null;
+  }
+}
+
+function getEntrySurface(
+  pathname: string,
+): FirstTouchAttribution["entrySurface"] {
+  if (pathname === "/" || pathname === "/index") return "home";
+  if (pathname === "/download") return "download";
+  if (pathname === "/trust") return "trust";
+  if (pathname === "/signup") return "signup";
+  if (pathname === "/login") return "login";
+  if (pathname.startsWith("/share/")) return "shared_chat";
+  if (pathname.startsWith("/invite/")) return "invite";
+  return "other_public";
+}
+
+function classifyReferrer(referringDomain: string | null): {
+  source: string;
+  medium: string;
+} {
+  if (!referringDomain) return { source: "$direct", medium: "none" };
+
+  if (
+    referringDomain === "google.com" ||
+    referringDomain.endsWith(".google.com")
+  ) {
+    return { source: "google", medium: "organic" };
+  }
+  if (referringDomain === "bing.com") {
+    return { source: "bing", medium: "organic" };
+  }
+  if (
+    referringDomain === "duckduckgo.com" ||
+    referringDomain === "search.brave.com"
+  ) {
+    return { source: referringDomain, medium: "organic" };
+  }
+
+  return { source: referringDomain, medium: "referral" };
+}
+
+export function createFirstTouchAttribution({
+  url,
+  referer,
+  capturedAt = new Date(),
+}: {
+  url: URL;
+  referer: string | null;
+  capturedAt?: Date;
+}): FirstTouchAttribution {
+  const utmSource = normalizeCampaignLabel(url.searchParams.get("utm_source"));
+  const utmMedium = normalizeCampaignLabel(url.searchParams.get("utm_medium"));
+  const campaign = normalizeCampaignLabel(url.searchParams.get("utm_campaign"));
+  const referringDomain = getExternalReferringDomain(referer);
+
+  let classified = classifyReferrer(referringDomain);
+  if (utmSource) {
+    classified = { source: utmSource, medium: utmMedium ?? "campaign" };
+  } else if (
+    url.searchParams.has("referral_code") ||
+    url.searchParams.has("ref")
+  ) {
+    classified = { source: "user_referral", medium: "referral" };
+  } else if (url.searchParams.has("gclid")) {
+    classified = { source: "google", medium: "paid" };
+  } else if (url.searchParams.has("msclkid")) {
+    classified = { source: "bing", medium: "paid" };
+  }
+
+  return {
+    version: FIRST_TOUCH_ATTRIBUTION_VERSION,
+    ...classified,
+    ...(campaign ? { campaign } : {}),
+    referringDomain: referringDomain ?? "$direct",
+    entrySurface: getEntrySurface(url.pathname),
+    capturedAt: capturedAt.toISOString(),
+  };
+}
+
+export function serializeFirstTouchAttribution(
+  attribution: FirstTouchAttribution,
+): string {
+  return encodeURIComponent(JSON.stringify(attribution));
+}
+
+export function parseFirstTouchAttribution(
+  value: string | undefined,
+): FirstTouchAttribution | null {
+  if (!value || value.length > 2_048) return null;
+
+  try {
+    const parsed = JSON.parse(
+      decodeURIComponent(value),
+    ) as Partial<FirstTouchAttribution>;
+    if (
+      parsed.version !== FIRST_TOUCH_ATTRIBUTION_VERSION ||
+      !normalizeCampaignLabel(parsed.source ?? null) ||
+      !normalizeCampaignLabel(parsed.medium ?? null) ||
+      (parsed.campaign !== undefined &&
+        !normalizeCampaignLabel(parsed.campaign)) ||
+      !parsed.referringDomain ||
+      (!normalizeHostname(parsed.referringDomain) &&
+        parsed.referringDomain !== "$direct") ||
+      ![
+        "home",
+        "download",
+        "trust",
+        "signup",
+        "login",
+        "shared_chat",
+        "invite",
+        "other_public",
+      ].includes(parsed.entrySurface ?? "") ||
+      typeof parsed.capturedAt !== "string" ||
+      !Number.isFinite(Date.parse(parsed.capturedAt))
+    ) {
+      return null;
+    }
+
+    return parsed as FirstTouchAttribution;
+  } catch {
+    return null;
+  }
+}
+
+export function firstTouchPersonProperties(
+  attribution: FirstTouchAttribution,
+): Record<string, string | number> {
+  return {
+    first_touch_attribution_version: attribution.version,
+    first_touch_source: attribution.source,
+    first_touch_medium: attribution.medium,
+    ...(attribution.campaign
+      ? { first_touch_campaign: attribution.campaign }
+      : {}),
+    first_touch_referring_domain: attribution.referringDomain,
+    first_touch_entry_surface: attribution.entrySurface,
+    first_touch_captured_at: attribution.capturedAt,
+  };
+}

--- a/lib/analytics/identity.ts
+++ b/lib/analytics/identity.ts
@@ -1,4 +1,5 @@
 import { v5 as uuidv5 } from "uuid";
+import type { FirstTouchAttribution } from "@/lib/analytics/acquisition";
 
 export const POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY =
   "hackerai:analytics:identity-signature:v1";
@@ -8,14 +9,22 @@ export function createPostHogIdentitySignature({
   email,
   name,
   subscription,
+  firstTouchAttribution,
 }: {
   userId: string;
   email?: string | null;
   name?: string | null;
   subscription: string;
+  firstTouchAttribution?: FirstTouchAttribution | null;
 }) {
   return uuidv5(
-    JSON.stringify([userId, email ?? null, name ?? null, subscription]),
+    JSON.stringify([
+      userId,
+      email ?? null,
+      name ?? null,
+      subscription,
+      firstTouchAttribution ?? null,
+    ]),
     uuidv5.URL,
   );
 }

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -14,6 +14,7 @@ export const PAID_FUNNEL_EVENTS = {
   addCreditCheckoutSucceeded: "add_credit_checkout_succeeded",
   checkoutStarted: "checkout_started",
   checkoutSucceeded: "checkout_succeeded",
+  checkoutRedirectSuppressed: "checkout_redirect_suppressed",
   cancellationStarted: "cancellation_started",
   cancellationReasonSelected: "cancellation_reason_selected",
   cancellationReasonSubmitted: "cancellation_reason_free_text_submitted",

--- a/lib/api/__tests__/agent-cancel-route.test.ts
+++ b/lib/api/__tests__/agent-cancel-route.test.ts
@@ -183,4 +183,27 @@ describe("agent cancel route", () => {
     expect(mockCancelAgentTriggerRun).not.toHaveBeenCalled();
     expect(mockSetActiveTriggerRun).not.toHaveBeenCalled();
   });
+
+  it("reports an explicit null when a stale cancellation has no active run", async () => {
+    const { createAgentCancelPost } = await import("../agent-cancel-route");
+    mockGetChatById.mockResolvedValue({
+      user_id: "user-1",
+      active_trigger_run_id: null,
+    } as never);
+
+    const response = await createAgentCancelPost({ endpoint: "/api/agent" })(
+      request({
+        chatId: "chat-1",
+        expectedTriggerRunId: "run-1",
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      canceled: false,
+      reason: "stale_run",
+      activeTriggerRunId: null,
+    });
+    expect(mockCancelAgentTriggerRun).not.toHaveBeenCalled();
+  });
 });

--- a/lib/api/__tests__/agent-cancel-route.test.ts
+++ b/lib/api/__tests__/agent-cancel-route.test.ts
@@ -164,6 +164,7 @@ describe("agent cancel route", () => {
     await expect(response.json()).resolves.toEqual({
       canceled: false,
       reason: "stale_run",
+      activeTriggerRunId: "run-2",
     });
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       "Rejected Agent cancellation request",

--- a/lib/api/agent-cancel-route.ts
+++ b/lib/api/agent-cancel-route.ts
@@ -101,7 +101,11 @@ export const createAgentCancelPost =
           reason: "stale_run",
         });
         return NextResponse.json(
-          { canceled: false, reason: "stale_run" },
+          {
+            canceled: false,
+            reason: "stale_run",
+            activeTriggerRunId: runId ?? null,
+          },
           { status: 409 },
         );
       }

--- a/lib/billing/__tests__/checkout-navigation-guard.test.ts
+++ b/lib/billing/__tests__/checkout-navigation-guard.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  CHECKOUT_NAVIGATION_GUARD_WINDOW_MS,
+  getRecentCheckoutNavigation,
+  rememberCheckoutNavigation,
+} from "../checkout-navigation-guard";
+
+describe("checkout navigation guard", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("returns a matching recent navigation", () => {
+    rememberCheckoutNavigation({
+      attemptId: "ca_recent_123",
+      plan: "pro-monthly-plan",
+      startedAt: 10_000,
+    });
+
+    expect(
+      getRecentCheckoutNavigation({
+        plan: "pro-monthly-plan",
+        now: 10_000 + CHECKOUT_NAVIGATION_GUARD_WINDOW_MS,
+      }),
+    ).toEqual({
+      attemptId: "ca_recent_123",
+      plan: "pro-monthly-plan",
+      startedAt: 10_000,
+    });
+  });
+
+  it("expires old, future, and mismatched records", () => {
+    rememberCheckoutNavigation({
+      attemptId: "ca_old_123",
+      plan: "pro-monthly-plan",
+      startedAt: 10_000,
+    });
+    expect(
+      getRecentCheckoutNavigation({
+        plan: "pro-monthly-plan",
+        now: 10_001 + CHECKOUT_NAVIGATION_GUARD_WINDOW_MS,
+      }),
+    ).toBeNull();
+
+    rememberCheckoutNavigation({
+      attemptId: "ca_other_123",
+      plan: "ultra-monthly-plan",
+      startedAt: 20_000,
+    });
+    expect(
+      getRecentCheckoutNavigation({
+        plan: "pro-monthly-plan",
+        now: 20_000,
+      }),
+    ).toBeNull();
+
+    rememberCheckoutNavigation({
+      attemptId: "ca_future_123",
+      plan: "pro-monthly-plan",
+      startedAt: 30_001,
+    });
+    expect(
+      getRecentCheckoutNavigation({
+        plan: "pro-monthly-plan",
+        now: 30_000,
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back when session storage is unavailable", () => {
+    const storageSpy = jest
+      .spyOn(window, "sessionStorage", "get")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+
+    try {
+      expect(
+        getRecentCheckoutNavigation({ plan: "pro-monthly-plan" }),
+      ).toBeNull();
+      expect(() =>
+        rememberCheckoutNavigation({
+          attemptId: "ca_blocked_123",
+          plan: "pro-monthly-plan",
+          startedAt: 10_000,
+        }),
+      ).not.toThrow();
+    } finally {
+      storageSpy.mockRestore();
+    }
+  });
+});

--- a/lib/billing/checkout-navigation-guard.ts
+++ b/lib/billing/checkout-navigation-guard.ts
@@ -1,0 +1,93 @@
+import { normalizeCheckoutAttemptId } from "@/lib/analytics/paid-funnel";
+
+export const CHECKOUT_NAVIGATION_GUARD_WINDOW_MS = 30_000;
+const CHECKOUT_NAVIGATION_STORAGE_KEY =
+  "hackerai:billing:checkout-navigation:v1";
+
+type CheckoutNavigationRecord = {
+  attemptId: string;
+  plan: string;
+  startedAt: number;
+};
+
+function getSessionStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function parseCheckoutNavigationRecord(
+  value: string | null,
+): CheckoutNavigationRecord | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as Partial<CheckoutNavigationRecord>;
+    if (
+      !normalizeCheckoutAttemptId(parsed.attemptId) ||
+      typeof parsed.plan !== "string" ||
+      !/^[A-Za-z0-9_-]{1,80}$/.test(parsed.plan) ||
+      typeof parsed.startedAt !== "number" ||
+      !Number.isFinite(parsed.startedAt)
+    ) {
+      return null;
+    }
+    return parsed as CheckoutNavigationRecord;
+  } catch {
+    return null;
+  }
+}
+
+export function rememberCheckoutNavigation({
+  attemptId,
+  plan,
+  startedAt = Date.now(),
+}: CheckoutNavigationRecord): void {
+  try {
+    getSessionStorage()?.setItem(
+      CHECKOUT_NAVIGATION_STORAGE_KEY,
+      JSON.stringify({ attemptId, plan, startedAt }),
+    );
+  } catch {
+    // Best-effort reload protection only. The in-memory request lock and
+    // server-side checkout-session reuse remain authoritative.
+  }
+}
+
+export function getRecentCheckoutNavigation({
+  plan,
+  now = Date.now(),
+}: {
+  plan: string;
+  now?: number;
+}): CheckoutNavigationRecord | null {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+
+  let record: CheckoutNavigationRecord | null = null;
+  try {
+    record = parseCheckoutNavigationRecord(
+      storage.getItem(CHECKOUT_NAVIGATION_STORAGE_KEY),
+    );
+  } catch {
+    return null;
+  }
+
+  if (
+    !record ||
+    record.plan !== plan ||
+    record.startedAt > now ||
+    now - record.startedAt > CHECKOUT_NAVIGATION_GUARD_WINDOW_MS
+  ) {
+    try {
+      storage.removeItem(CHECKOUT_NAVIGATION_STORAGE_KEY);
+    } catch {
+      // Best-effort cleanup only.
+    }
+    return null;
+  }
+
+  return record;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -8,6 +8,12 @@ import {
   getReferralRewardConfig,
   isValidReferralCode,
 } from "@/lib/referrals/config";
+import {
+  FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME,
+  FIRST_TOUCH_ATTRIBUTION_MAX_AGE_SECONDS,
+  createFirstTouchAttribution,
+  serializeFirstTouchAttribution,
+} from "@/lib/analytics/acquisition";
 
 const AUTHKIT_BYPASS_PATHS = new Set([
   "/api/health/connectivity",
@@ -117,10 +123,44 @@ function isBrowserRequest(request: NextRequest): boolean {
 
 const SESSION_HEADER = "x-workos-session";
 
-function withReferralCookie(
+function withAttributionCookies(
   request: NextRequest,
   response: NextResponse,
 ): NextResponse {
+  const pathname = request.nextUrl.pathname;
+  const shouldCaptureFirstTouch =
+    (request.method === "GET" || request.method === "HEAD") &&
+    isBrowserRequest(request) &&
+    !pathname.startsWith("/api/") &&
+    ![
+      "/callback",
+      "/logout",
+      "/auth-error",
+      "/desktop-callback",
+      "/desktop-login",
+    ].includes(pathname) &&
+    !request.cookies.has("wos-session") &&
+    !request.cookies.has(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME);
+
+  if (shouldCaptureFirstTouch) {
+    response.cookies.set(
+      FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME,
+      serializeFirstTouchAttribution(
+        createFirstTouchAttribution({
+          url: request.nextUrl,
+          referer: request.headers.get("referer"),
+        }),
+      ),
+      {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: FIRST_TOUCH_ATTRIBUTION_MAX_AGE_SECONDS,
+        path: "/",
+      },
+    );
+  }
+
   const referralCode =
     request.nextUrl.searchParams.get("referral_code") ??
     request.nextUrl.searchParams.get("ref");
@@ -175,13 +215,13 @@ function buildEndedSessionResponse(
 
   if (isUnauthenticatedPath(pathname)) {
     return withSessionCookieCleared(
-      withReferralCookie(request, NextResponse.next()),
+      withAttributionCookies(request, NextResponse.next()),
     );
   }
 
   if (!isBrowserRequest(request)) {
     return withSessionCookieCleared(
-      withReferralCookie(
+      withAttributionCookies(
         request,
         NextResponse.json(
           {
@@ -200,7 +240,7 @@ function buildEndedSessionResponse(
     : new URL("/login", request.url);
 
   return withSessionCookieCleared(
-    withReferralCookie(request, NextResponse.redirect(redirectUrl)),
+    withAttributionCookies(request, NextResponse.redirect(redirectUrl)),
   );
 }
 
@@ -259,7 +299,7 @@ export default async function proxy(request: NextRequest) {
     const hasSession = request.cookies.has("wos-session");
 
     if (!hasSession && !isUnauthenticatedPath(pathname)) {
-      return withReferralCookie(
+      return withAttributionCookies(
         request,
         NextResponse.redirect(
           new URL("/desktop-callback?error=unauthenticated", request.url),
@@ -343,7 +383,7 @@ export default async function proxy(request: NextRequest) {
   });
 
   if (session.user || isUnauthenticatedPath(pathname)) {
-    return withReferralCookie(
+    return withAttributionCookies(
       request,
       NextResponse.next({
         request: { headers: requestHeaders },
@@ -357,7 +397,7 @@ export default async function proxy(request: NextRequest) {
     if (!isBrowserRequest(request)) {
       const rateLimitHeaders = new Headers(responseHeaders);
       rateLimitHeaders.set("Retry-After", "5");
-      return withReferralCookie(
+      return withAttributionCookies(
         request,
         NextResponse.json(
           { code: "rate_limited", message: "Please retry shortly." },
@@ -366,7 +406,7 @@ export default async function proxy(request: NextRequest) {
       );
     }
     // For browser requests, let through rather than forcing a confusing login redirect
-    return withReferralCookie(
+    return withAttributionCookies(
       request,
       NextResponse.next({
         request: { headers: requestHeaders },
@@ -376,7 +416,7 @@ export default async function proxy(request: NextRequest) {
   }
 
   if (!isBrowserRequest(request)) {
-    return withReferralCookie(
+    return withAttributionCookies(
       request,
       NextResponse.json(
         {
@@ -396,13 +436,13 @@ export default async function proxy(request: NextRequest) {
     });
     const errorUrl = new URL("/auth-error", request.url);
     errorUrl.searchParams.set("code", "503");
-    return withReferralCookie(
+    return withAttributionCookies(
       request,
       NextResponse.redirect(errorUrl, { headers: responseHeaders }),
     );
   }
 
-  return withReferralCookie(
+  return withAttributionCookies(
     request,
     NextResponse.redirect(authorizationUrl, { headers: responseHeaders }),
   );


### PR DESCRIPTION
## Summary
- suppress repeated subscription checkout redirects across page reloads for 30 seconds while preserving valid retries after failures
- return the active run on stale Agent cancellation conflicts, reconnect the client to persisted state, and keep queued/replacement actions from racing a newer run
- emit one bounded desktop command settlement event after relay failures so recovered, interrupted, and incomplete output can be distinguished
- preserve sanitized first-touch acquisition attribution across authentication with set-once person properties
- mark Agent-first defaults as deterministic exposure rather than randomized assignment

## Why
The August 3-9 review found that the existing checkout lock handled concurrent remounts but did not contain reload loops, stale cancellation 409s were surfaced as generic errors, and desktop relay recovery events did not prove final sequence completeness. Acquisition referrers were also dominated by the authentication handoff, while Agent-first telemetry could be mistaken for experiment assignment.

This PR keeps Stripe session reuse and the stale-run server guard authoritative. It does not change pricing, model routing, limits, sandbox selection, or payment outcome semantics.

## Privacy
First-touch attribution stores only bounded source, medium, campaign, referring domain, entry surface, timestamp, and schema version. It excludes full URLs, paths, UTM term/content, click IDs, prompts, targets, findings, evidence, code, and other user content.

## Validation
- `pnpm test --runInBand` — 362 suites / 3,691 tests passed
- `pnpm lint` — passes with 7 existing warnings
- `pnpm typecheck`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec next build --webpack`

The default Turbopack build path was also attempted; the sandbox-specific CSS worker panicked while binding a local port, so the supported webpack build was used for production-build validation.

## Manual verification
- Start a free-user subscription checkout, return or reload immediately, and click the same plan again. Confirm the existing checkout continues and no second `/api/subscribe` request is sent during the 30-second guard.
- Cause a stale Agent cancellation by replacing the persisted run before Stop/steer completes. Confirm the newer run is not cancelled, the queued action remains, and the client reconnects with the informational toast.
- On Desktop, interrupt Centrifugo while command output is streaming, then reconnect. Confirm the final settlement telemetry reports `recovered` only when every observed sequence was published; exhausted output reports `incomplete`.
- Enter through a tagged landing URL, authenticate, and confirm PostHog receives set-once first-touch properties without URL, path, term/content, or click-ID values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added privacy-conscious first-touch attribution for campaign, referral, organic, and direct visits.
  - Improved analytics profiles with sanitized acquisition details.
  - Prevented duplicate checkout attempts after recent navigation, with an informational notice.
- **Bug Fixes**
  - Improved recovery when chat runs become stale or interrupted while preserving queued messages where possible.
  - Enhanced desktop stream recovery and completion tracking.
- **Analytics**
  - Added clearer reporting for checkout suppression, run recovery, and stream outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->