### PR TITLE
Update paid model tier routing

### DIFF
--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -106,7 +106,7 @@ describe("ModelSelector", () => {
     );
     expect(
       await screen.findAllByText(
-        "Powered by DeepSeek V4 Pro · xAI Grok 4.6 for vision",
+        "Powered by DeepSeek V4 Flash 0731 · xAI Grok 4.6 for vision",
       ),
     ).not.toHaveLength(0);
 
@@ -115,7 +115,9 @@ describe("ModelSelector", () => {
     );
     await user.hover(screen.getByRole("button", { name: /HackerAI Pro/i }));
     expect(
-      await screen.findAllByText("Powered by xAI Grok 4.6"),
+      await screen.findAllByText(
+        "Powered by DeepSeek V4 Pro 0813 · xAI Grok 4.6 for vision",
+      ),
     ).not.toHaveLength(0);
   });
 

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -31,30 +31,30 @@ describe("ModelSelector tier ↔ provider drift", () => {
     expect([...askIds].sort()).toEqual([...agentIds].sort());
   });
 
-  it("HackerAI Standard resolves to DeepSeek in both modes", () => {
+  it("HackerAI Standard resolves to DeepSeek V4 Flash 0731 in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-standard", "ask")).toBe(
-      "model-deepseek-v4-pro",
+      "model-deepseek-v4-flash-0731",
     );
     expect(resolveTierToProviderKey("hackerai-standard", "agent")).toBe(
-      "model-deepseek-v4-pro",
+      "model-deepseek-v4-flash-0731",
     );
   });
 
-  it("HackerAI Pro resolves to its dedicated Grok route in both modes", () => {
+  it("HackerAI Pro resolves to DeepSeek V4 Pro 0813 in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-pro", "ask")).toBe(
-      "model-grok-4.6-pro",
+      "model-deepseek-v4-pro-0813",
     );
     expect(resolveTierToProviderKey("hackerai-pro", "agent")).toBe(
-      "model-grok-4.6-pro",
+      "model-deepseek-v4-pro-0813",
     );
   });
 
   it("HackerAI Max resolves to the same provider in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-max", "ask")).toBe(
-      "model-opus-4.6",
+      "model-grok-4.6",
     );
     expect(resolveTierToProviderKey("hackerai-max", "agent")).toBe(
-      "model-opus-4.6",
+      "model-grok-4.6",
     );
   });
 
@@ -76,28 +76,28 @@ describe("ModelSelector tier ↔ provider drift", () => {
     expect(
       AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-standard")
         ?.poweredBy,
-    ).toBe("DeepSeek V4 Pro · xAI Grok 4.6 for vision");
+    ).toBe("DeepSeek V4 Flash 0731 · xAI Grok 4.6 for vision");
   });
 
-  it("discloses Grok 4.6 for HackerAI Pro", () => {
+  it("discloses DeepSeek V4 Pro 0813 and Grok vision for HackerAI Pro", () => {
     expect(
       ASK_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
         ?.poweredBy,
-    ).toBe("xAI Grok 4.6");
+    ).toBe("DeepSeek V4 Pro 0813 · xAI Grok 4.6 for vision");
     expect(
       AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
         ?.poweredBy,
-    ).toBe("xAI Grok 4.6");
+    ).toBe("DeepSeek V4 Pro 0813 · xAI Grok 4.6 for vision");
   });
 
-  it("discloses Kimi K3 for HackerAI Max", () => {
+  it("discloses Grok 4.6 for HackerAI Max", () => {
     expect(
       ASK_MODEL_OPTIONS.find((option) => option.id === "hackerai-max")
         ?.poweredBy,
-    ).toBe("Moonshot Kimi K3");
+    ).toBe("xAI Grok 4.6");
     expect(
       AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-max")
         ?.poweredBy,
-    ).toBe("Moonshot Kimi K3");
+    ).toBe("xAI Grok 4.6");
   });
 });

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -16,19 +16,19 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable performance for everyday tasks",
-    poweredBy: "DeepSeek V4 Pro · xAI Grok 4.6 for vision",
+    poweredBy: "DeepSeek V4 Flash 0731 · xAI Grok 4.6 for vision",
   },
   {
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "xAI Grok 4.6",
+    poweredBy: "DeepSeek V4 Pro 0813 · xAI Grok 4.6 for vision",
   },
   {
     id: "hackerai-max",
     label: "HackerAI Max",
     description: "Maximum intelligence for complex work",
-    poweredBy: "Moonshot Kimi K3",
+    poweredBy: "xAI Grok 4.6",
   },
 ];
 
@@ -37,21 +37,21 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable agent for everyday automation",
-    poweredBy: "DeepSeek V4 Pro · xAI Grok 4.6 for vision",
+    poweredBy: "DeepSeek V4 Flash 0731 · xAI Grok 4.6 for vision",
     thinking: true,
   },
   {
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "xAI Grok 4.6",
+    poweredBy: "DeepSeek V4 Pro 0813 · xAI Grok 4.6 for vision",
     thinking: true,
   },
   {
     id: "hackerai-max",
     label: "HackerAI Max",
     description: "Maximum intelligence for complex work",
-    poweredBy: "Moonshot Kimi K3",
+    poweredBy: "xAI Grok 4.6",
     thinking: true,
   },
 ];

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -44,6 +44,13 @@ describe("provider registry", () => {
     ).toBe("x-ai/grok-4.6");
     expect(
       (
+        myProvider.languageModel("model-deepseek-v4-flash-0731") as {
+          modelId: string;
+        }
+      ).modelId,
+    ).toBe("deepseek/deepseek-v4-flash-0731");
+    expect(
+      (
         myProvider.languageModel("model-deepseek-v4-pro-0813") as {
           modelId: string;
         }
@@ -80,6 +87,12 @@ describe("provider registry", () => {
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.6");
     expect(getModelDisplayName("model-grok-4.6-pro")).toBe("xAI Grok 4.6");
     expect(getModelCutoffDate("model-grok-4.6-pro")).toBe("August 2026");
+    expect(getModelDisplayName("model-deepseek-v4-flash-0731")).toBe(
+      "DeepSeek V4 Flash 0731",
+    );
+    expect(getModelCutoffDate("model-deepseek-v4-flash-0731")).toBe(
+      "July 2026",
+    );
     expect(getModelDisplayName("model-deepseek-v4-pro-0813")).toBe(
       "DeepSeek V4 Pro 0813",
     );
@@ -101,7 +114,8 @@ describe("provider registry", () => {
     expect(isAnthropicModel("anthropic/claude-opus-4.6")).toBe(true);
   });
 
-  it("classifies both DeepSeek V4 Pro experiment routes as DeepSeek", () => {
+  it("classifies the active DeepSeek tier routes as DeepSeek", () => {
+    expect(isDeepSeekModel("model-deepseek-v4-flash-0731")).toBe(true);
     expect(isDeepSeekModel("model-deepseek-v4-pro")).toBe(true);
     expect(isDeepSeekModel("model-deepseek-v4-pro-0813")).toBe(true);
   });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -211,9 +211,8 @@ const buildProviderMap = (
     "model-grok-4.5": or(GROK_4_6_SLUG),
     "model-grok-4.5-pro": or(GROK_4_6_SLUG),
     "model-grok-4.6-pro": or(GROK_4_6_SLUG),
+    "model-deepseek-v4-flash-0731": or(DEEPSEEK_V4_FLASH_SLUG),
     "model-deepseek-v4-pro": or(DEEPSEEK_V4_PRO_SLUG),
-    // HAC-68 treatment alias. Auto and Standard keep their persisted tier
-    // while the server-side experiment chooses the provider route per user.
     "model-deepseek-v4-pro-0813": or(DEEPSEEK_V4_PRO_0813_SLUG),
     // Keep the persisted Max compatibility key while routing new requests to
     // Kimi K3. Renaming the key would invalidate existing stored selections.
@@ -240,6 +239,7 @@ export const modelCutoffDates: Partial<Record<ModelName, string>> &
   "model-grok-4.5": "August 2026",
   "model-grok-4.5-pro": "August 2026",
   "model-grok-4.6-pro": "August 2026",
+  "model-deepseek-v4-flash-0731": "July 2026",
   "model-deepseek-v4-pro": "May 2025",
   "model-deepseek-v4-pro-0813": "August 2026",
   "model-opus-4.6": "July 2026",
@@ -260,6 +260,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-grok-4.5": "xAI Grok 4.6",
   "model-grok-4.5-pro": "xAI Grok 4.6",
   "model-grok-4.6-pro": "xAI Grok 4.6",
+  "model-deepseek-v4-flash-0731": "DeepSeek V4 Flash 0731",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-deepseek-v4-pro-0813": "DeepSeek V4 Pro 0813",
   "model-opus-4.6": "Moonshot Kimi K3",
@@ -286,10 +287,12 @@ export function isAnthropicModel(modelName: string): boolean {
   return normalized.startsWith("anthropic/") || normalized.includes("claude");
 }
 
+/** Returns whether a provider key uses a DeepSeek V4 route. */
 export function isDeepSeekModel(modelName: string): boolean {
   return (
     modelName === "ask-model-free" ||
     modelName === "agent-model-free" ||
+    modelName === "model-deepseek-v4-flash-0731" ||
     modelName === "model-deepseek-v4-pro" ||
     modelName === "model-deepseek-v4-pro-0813"
   );
@@ -343,8 +346,9 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
 /**
  * Map a HackerAI tier id to the underlying provider key for a given mode.
  * Returns `null` for `"auto"` (the caller routes to the auto-router model
- * key instead). Standard maps to DeepSeek, Pro to Grok, and Max to Kimi K3 in
- * both modes; media-aware promotion happens in `selectModel`.
+ * key instead). Standard maps to DeepSeek V4 Flash 0731, Pro to DeepSeek V4
+ * Pro 0813, and Max to Grok 4.6 in both modes; media-aware promotion happens
+ * in `selectModel`.
  */
 export function resolveTierToProviderKey(
   tier: SelectedModel,
@@ -353,11 +357,11 @@ export function resolveTierToProviderKey(
   if (tier === "auto") return null;
   switch (tier) {
     case "hackerai-standard":
-      return "model-deepseek-v4-pro";
+      return "model-deepseek-v4-flash-0731";
     case "hackerai-pro":
-      return "model-grok-4.6-pro";
+      return "model-deepseek-v4-pro-0813";
     case "hackerai-max":
-      return "model-opus-4.6";
+      return "model-grok-4.6";
   }
 }
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -32,17 +32,16 @@ const DEEPSEEK_FLASH_CANONICAL_SLUG = "deepseek/deepseek-v4-flash-20260731";
 const DEEPSEEK_FLASH_PREVIOUS_SLUG = "deepseek/deepseek-v4-flash";
 const DEEPSEEK_FLASH_PREVIOUS_CANONICAL_SLUG =
   "deepseek/deepseek-v4-flash-20260423";
-const DEEPSEEK_V4_PRO_SLUG = "deepseek/deepseek-v4-pro";
-const MEDIUM_GROK_PRIMARY_MODELS = [
+const DEEPSEEK_V4_PRO_0813_SLUG = "deepseek/deepseek-v4-pro-0813";
+const HIGH_GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "ask-model",
   "agent-model",
-  "model-grok-4.6",
-  "model-grok-4.5",
-] as const;
-const HIGH_GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "agent-model-free",
+  "model-grok-4.5",
   "model-grok-4.5-pro",
+  "model-grok-4.6",
   "model-grok-4.6-pro",
+  "model-deepseek-v4-flash-0731",
   "model-deepseek-v4-pro",
   "model-deepseek-v4-pro-0813",
   "model-opus-4.6",
@@ -103,24 +102,6 @@ describe("buildProviderOptions fallback chain", () => {
         expect(opts.openrouter.reasoning).toEqual({
           enabled: true,
           effort: "high",
-        });
-      }
-    },
-  );
-
-  it.each(MEDIUM_GROK_PRIMARY_MODELS)(
-    "uses medium reasoning for the Auto/Standard Grok route %s",
-    (modelName) => {
-      for (const mode of ["ask", "agent"] as const) {
-        const opts = buildProviderOptions(
-          mode === "agent",
-          "user-1",
-          modelName,
-          mode,
-        );
-        expect(opts.openrouter.reasoning).toEqual({
-          enabled: true,
-          effort: "medium",
         });
       }
     },
@@ -249,7 +230,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      reasoning: { enabled: true, effort: "medium" },
+      reasoning: { enabled: true, effort: "high" },
       models: [KIMI_K3_SLUG],
       user: "user-1",
     });
@@ -290,32 +271,48 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("enables OpenRouter Mistral OCR for PDFs sent to DeepSeek V4", () => {
-    const opts = buildProviderOptions(
-      false,
-      "user-1",
-      "model-deepseek-v4-pro",
-      "agent",
-      { hasPdfAttachments: true },
-    );
+  it.each([
+    "model-deepseek-v4-flash-0731",
+    "model-deepseek-v4-pro-0813",
+  ] as const)(
+    "enables OpenRouter Mistral OCR for PDFs sent to %s",
+    (modelName) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, "agent", {
+        hasPdfAttachments: true,
+      });
 
-    expect(opts.openrouter.plugins).toEqual([
-      { id: "file-parser", pdf: { engine: "mistral-ocr" } },
-    ]);
-  });
+      expect(opts.openrouter.plugins).toEqual([
+        { id: "file-parser", pdf: { engine: "mistral-ocr" } },
+      ]);
+    },
+  );
 
   it("does not enable the PDF parser when a DeepSeek request has no PDF", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
-      "model-deepseek-v4-pro",
+      "model-deepseek-v4-flash-0731",
       "agent",
     );
 
     expect(opts.openrouter).not.toHaveProperty("plugins");
   });
 
-  it("falls back from DeepSeek V4 Pro 0813 through the control route, Grok, then Kimi K3", () => {
+  it("falls back from DeepSeek V4 Flash 0731 through Pro 0813, Grok, then Kimi K3", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-deepseek-v4-flash-0731",
+      "ask",
+    );
+    expect(opts.openrouter).toMatchObject({
+      reasoning: { enabled: true, effort: "high" },
+      models: [DEEPSEEK_V4_PRO_0813_SLUG, GROK_SLUG, KIMI_K3_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("falls back from DeepSeek V4 Pro 0813 through Grok then Kimi K3", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -323,7 +320,8 @@ describe("buildProviderOptions fallback chain", () => {
       "ask",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [DEEPSEEK_V4_PRO_SLUG, GROK_SLUG, KIMI_K3_SLUG],
+      reasoning: { enabled: true, effort: "high" },
+      models: [GROK_SLUG, KIMI_K3_SLUG],
       user: "user-1",
     });
   });
@@ -339,7 +337,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("does not force OCR on the Grok route", () => {
     const opts = buildProviderOptions(false, "user-1", "model-grok-4.6", "ask");
     expect(opts.openrouter).toMatchObject({
-      reasoning: { enabled: true, effort: "medium" },
+      reasoning: { enabled: true, effort: "high" },
       models: [KIMI_K3_SLUG],
       user: "user-1",
     });
@@ -494,12 +492,12 @@ describe("buildProviderOptions fallback chain", () => {
   });
 
   it.each(["ask-model", "model-grok-4.6"])(
-    "enables medium reasoning for Auto/Standard Grok ask model %s",
+    "enables high reasoning for Auto/Standard Grok ask model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
       expect(opts.openrouter.reasoning).toEqual({
         enabled: true,
-        effort: "medium",
+        effort: "high",
       });
     },
   );
@@ -562,7 +560,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(grokReasoning.openrouter).toMatchObject({
-      reasoning: { enabled: true, effort: "medium" },
+      reasoning: { enabled: true, effort: "high" },
       models: [KIMI_K3_SLUG],
     });
 
@@ -673,9 +671,15 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
-  it("retries the DeepSeek 0813 treatment with the current DeepSeek route", () => {
+  it("retries DeepSeek V4 Flash 0731 with DeepSeek V4 Pro 0813", () => {
+    expect(getRetryFallbackModel("model-deepseek-v4-flash-0731", "ask")).toBe(
+      "model-deepseek-v4-pro-0813",
+    );
+  });
+
+  it("retries DeepSeek V4 Pro 0813 with Grok", () => {
     expect(getRetryFallbackModel("model-deepseek-v4-pro-0813", "ask")).toBe(
-      "model-deepseek-v4-pro",
+      "model-grok-4.6",
     );
   });
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -520,8 +520,9 @@ export class SummarizationTracker {
  * stream, OpenRouter rolls forward through this list and bills at the served
  * model's rate (response.modelId reflects what actually ran).
  *
- * The persisted Max key now resolves to Kimi K3 and falls back to Grok 4.6 in
- * every mode. Historical Opus response ids remain recognized for accounting.
+ * Paid Auto/Standard use DeepSeek V4 Flash 0731, Pro uses DeepSeek V4 Pro
+ * 0813, and Max uses Grok 4.6. Historical aliases remain recognized for
+ * in-flight requests and cost accounting.
  *
  * Keys and values are registry names (see lib/ai/providers.ts) — the actual
  * OpenRouter slugs are resolved at request-build time so this stays in sync
@@ -541,16 +542,17 @@ const AGENT_TEXT_FALLBACK_CHAIN = [
   "model-kimi-k3",
 ] as const satisfies readonly ModelName[];
 
-// HAC-68 treatment falls back through today's DeepSeek route before the
-// existing Grok/Kimi recovery chain.
-const DEEPSEEK_V4_PRO_0813_FALLBACK_CHAIN = [
-  "model-deepseek-v4-pro",
+const DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN = [
+  "model-deepseek-v4-pro-0813",
   ...AGENT_TEXT_FALLBACK_CHAIN,
 ] as const satisfies readonly ModelName[];
 
-// HackerAI Pro uses Grok 4.6 for every request. GLM 5.2 remains its first
-// fallback, followed by Kimi K3 so media requests still have a multimodal final
-// recovery path if both primary providers are unavailable.
+const DEEPSEEK_V4_PRO_0813_FALLBACK_CHAIN = [
+  ...AGENT_TEXT_FALLBACK_CHAIN,
+] as const satisfies readonly ModelName[];
+
+// Preserve the historical Grok-backed Pro aliases for in-flight requests.
+// GLM 5.2 remains their first fallback, followed by Kimi K3.
 const HACKERAI_PRO_FALLBACK_CHAIN = [
   "model-glm-5.2",
   "model-kimi-k3",
@@ -559,6 +561,7 @@ const HACKERAI_PRO_FALLBACK_CHAIN = [
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "agent-model-free": AGENT_TEXT_FALLBACK_CHAIN,
+  "model-deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN,
   "model-deepseek-v4-pro": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-pro-0813": DEEPSEEK_V4_PRO_0813_FALLBACK_CHAIN,
   "ask-model": GROK_4_6_FALLBACK_CHAIN,
@@ -601,6 +604,8 @@ const HIGH_REASONING_MODELS = [
   "model-grok-4.5-pro",
   "model-grok-4.6",
   "model-grok-4.6-pro",
+  "model-deepseek-v4-flash-0731",
+  "model-deepseek-v4-pro-0813",
   "model-glm-5.2",
   "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
@@ -608,13 +613,6 @@ const HIGH_REASONING_MODELS = [
 const isHighReasoningModel = (modelName?: string): boolean =>
   typeof modelName === "string" &&
   (HIGH_REASONING_MODELS as readonly string[]).includes(modelName);
-
-const MEDIUM_GROK_REASONING_MODELS = new Set<string>([
-  "ask-model",
-  "agent-model",
-  "model-grok-4.6",
-  "model-grok-4.5",
-]);
 
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
@@ -651,8 +649,11 @@ export function getRetryFallbackModel(
   modelName: ModelName,
   _mode: ChatMode,
 ): ModelName {
+  if (modelName === "model-deepseek-v4-flash-0731") {
+    return "model-deepseek-v4-pro-0813";
+  }
   if (modelName === "model-deepseek-v4-pro-0813") {
-    return "model-deepseek-v4-pro";
+    return "model-grok-4.6";
   }
   if (
     modelName === "model-grok-4.6-pro" ||
@@ -762,6 +763,8 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, string> = {
   "deepseek/deepseek-v4-flash-20260423": "deepseek/deepseek-v4-flash",
   "deepseek/deepseek-v4-flash-0731": "agent-model-free",
   "deepseek/deepseek-v4-flash-20260731": "agent-model-free",
+  "deepseek/deepseek-v4-pro-0813": "model-deepseek-v4-pro-0813",
+  "deepseek/deepseek-v4-pro-20260813": "model-deepseek-v4-pro-0813",
   "x-ai/grok-4.5": "model-grok-4.5",
   "x-ai/grok-4.6": "model-grok-4.6",
   "z-ai/glm-5.2": "model-glm-5.2",
@@ -845,15 +848,10 @@ export function buildProviderOptions(
       })
     : fallbackSlugs;
   // OpenRouter applies one reasoning configuration to both the primary model
-  // and every provider fallback. Auto and Standard use medium when Grok 4.6 is
-  // the primary route to reduce reasoning-token cost; Pro and routes that can
-  // only reach Grok as a fallback retain high reasoning.
+  // and every provider fallback. All paid Auto/Standard, Pro, and Max routes
+  // use high reasoning, including media requests promoted to Grok 4.6.
   const routesThroughGrok =
     isGrok46 || reasoningFallbackSlugs.includes(GROK_4_6_SLUG);
-  const usesMediumGrokReasoning =
-    isGrok46 &&
-    typeof modelName === "string" &&
-    MEDIUM_GROK_REASONING_MODELS.has(modelName);
   const providerRouting = modelId
     ? getOpenRouterProviderRoutingForModel(modelId)
     : undefined;
@@ -862,7 +860,7 @@ export function buildProviderOptions(
       ? options.reasoningOverride
       : {
           enabled: true,
-          effort: usesMediumGrokReasoning ? "medium" : "high",
+          effort: "high",
         }
     : (options.reasoningOverride ??
       (isHighReasoningModel(modelName) || isAgentDeepSeekV4

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -645,6 +645,7 @@ const getFallbackKeys = (
   return MODEL_FALLBACK_CHAIN[modelName as ModelName];
 };
 
+/** Returns the first app-side retry model for a failed provider route. */
 export function getRetryFallbackModel(
   modelName: ModelName,
   _mode: ChatMode,

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -154,19 +154,19 @@ describe("limitImageParts", () => {
 // selectModel - Model selection logic
 // ==========================================================================
 describe("selectModel", () => {
-  it("routes HackerAI Pro through Grok 4.6 without experiment assignment", () => {
+  it("routes HackerAI Pro through DeepSeek V4 Pro 0813", () => {
     expect(selectModel("agent", "pro", "hackerai-pro")).toBe(
-      "model-grok-4.6-pro",
+      "model-deepseek-v4-pro-0813",
     );
   });
 
   it.each(["pro", "pro-plus", "ultra", "team"] as const)(
-    "routes paid %s Auto/Standard text to DeepSeek V4 Pro in both modes",
+    "routes paid %s Auto/Standard text to DeepSeek V4 Flash 0731 in both modes",
     (subscription) => {
       for (const mode of ["ask", "agent"] as const) {
         for (const selectedModel of ["auto", "hackerai-standard"] as const) {
           expect(selectModel(mode, subscription, selectedModel)).toBe(
-            "model-deepseek-v4-pro",
+            "model-deepseek-v4-flash-0731",
           );
         }
       }
@@ -176,45 +176,45 @@ describe("selectModel", () => {
   // Default model selection by mode
   describe("default models (no override)", () => {
     it.each(["pro", "pro-plus", "ultra", "team"] as const)(
-      "should return DeepSeek V4 Pro for paid agent text on %s",
+      "should return DeepSeek V4 Flash 0731 for paid agent text on %s",
       (subscription) => {
         expect(selectModel("agent", subscription)).toBe(
-          "model-deepseek-v4-pro",
+          "model-deepseek-v4-flash-0731",
         );
       },
     );
 
     it("should return the Grok-backed agent model for paid agent with an image", () => {
       expect(selectModel("agent", "pro", undefined, true, false)).toBe(
-        "agent-model",
+        "model-grok-4.6",
       );
     });
 
-    it("should keep paid agent on DeepSeek V4 Pro when a PDF is attached", () => {
+    it("should keep paid agent on DeepSeek V4 Flash 0731 when a PDF is attached", () => {
       expect(selectModel("agent", "pro", undefined, false, true)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
 
-    it("should return DeepSeek V4 Pro for paid ask with no image/PDF", () => {
-      expect(selectModel("ask", "pro")).toBe("model-deepseek-v4-pro");
+    it("should return DeepSeek V4 Flash 0731 for paid ask with no image/PDF", () => {
+      expect(selectModel("ask", "pro")).toBe("model-deepseek-v4-flash-0731");
     });
 
     it("should return the Grok-backed ask model when an image is attached", () => {
       expect(selectModel("ask", "pro", undefined, true, false)).toBe(
-        "ask-model",
+        "model-grok-4.6",
       );
     });
 
-    it("should keep paid ask on DeepSeek V4 Pro when a PDF is attached", () => {
+    it("should keep paid ask on DeepSeek V4 Flash 0731 when a PDF is attached", () => {
       expect(selectModel("ask", "pro", undefined, false, true)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
 
     it("should use the Grok-backed image route when paid ask has both image and PDF attachments", () => {
       expect(selectModel("ask", "pro", undefined, true, true)).toBe(
-        "ask-model",
+        "model-grok-4.6",
       );
     });
 
@@ -222,44 +222,44 @@ describe("selectModel", () => {
       expect(selectModel("ask", "free")).toBe("ask-model-free");
     });
 
-    it("should return DeepSeek V4 Pro for ultra subscription with no image/PDF", () => {
-      expect(selectModel("ask", "ultra")).toBe("model-deepseek-v4-pro");
+    it("should return DeepSeek V4 Flash 0731 for ultra subscription with no image/PDF", () => {
+      expect(selectModel("ask", "ultra")).toBe("model-deepseek-v4-flash-0731");
     });
 
-    it("should return DeepSeek V4 Pro for team subscription with no image/PDF", () => {
-      expect(selectModel("ask", "team")).toBe("model-deepseek-v4-pro");
+    it("should return DeepSeek V4 Flash 0731 for team subscription with no image/PDF", () => {
+      expect(selectModel("ask", "team")).toBe("model-deepseek-v4-flash-0731");
     });
   });
 
   // Tier override — Standard is content-aware in ask mode; Max maps to Opus in both modes
   describe("tier override for ask mode (paid users)", () => {
-    it("should map HackerAI Pro to Grok 4.6 for text-only ask mode", () => {
+    it("should map HackerAI Pro to DeepSeek V4 Pro 0813 for text-only ask mode", () => {
       expect(selectModel("ask", "ultra", "hackerai-pro")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
     });
 
-    it("should map HackerAI Pro to Grok 4.6 for team users", () => {
+    it("should map HackerAI Pro to DeepSeek V4 Pro 0813 for team users", () => {
       expect(selectModel("ask", "team", "hackerai-pro")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
     });
 
     it("should keep HackerAI Pro on Grok 4.6 when an image is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-pro", true, false)).toBe(
-        "model-grok-4.6-pro",
+        "model-grok-4.6",
       );
     });
 
-    it("should keep HackerAI Pro on Grok 4.6 when a PDF is attached", () => {
+    it("should keep HackerAI Pro on DeepSeek V4 Pro 0813 when a PDF is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-pro", false, true)).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
     });
 
-    it("should map HackerAI Standard to DeepSeek V4 Pro when no image/PDF", () => {
+    it("should map HackerAI Standard to DeepSeek V4 Flash 0731 when no image/PDF", () => {
       expect(selectModel("ask", "pro", "hackerai-standard")).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
 
@@ -269,9 +269,9 @@ describe("selectModel", () => {
       );
     });
 
-    it("should keep HackerAI Standard on DeepSeek V4 Pro when a PDF is attached", () => {
+    it("should keep HackerAI Standard on DeepSeek V4 Flash 0731 when a PDF is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-standard", false, true)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
 
@@ -281,38 +281,38 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to its Kimi K3 compatibility route for Ultra", () => {
+    it("should map HackerAI Max to Grok 4.6 for Ultra", () => {
       expect(selectModel("ask", "ultra", "hackerai-max")).toBe(
-        "model-opus-4.6",
+        "model-grok-4.6",
       );
     });
 
     it("should downgrade HackerAI Max to Pro outside Ultra", () => {
       expect(selectModel("ask", "pro", "hackerai-max")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
       expect(selectModel("ask", "pro-plus", "hackerai-max")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
       expect(selectModel("ask", "team", "hackerai-max")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
     });
 
-    it("should map HackerAI Max to its Kimi K3 compatibility route for paid users with extra usage", () => {
+    it("should map HackerAI Max to Grok 4.6 for paid users with extra usage", () => {
       expect(
         selectModel("ask", "pro", "hackerai-max", false, false, {
           extraUsageAvailable: true,
         }),
-      ).toBe("model-opus-4.6");
+      ).toBe("model-grok-4.6");
     });
   });
 
   // Agent mode — Auto/Standard use DeepSeek for text/PDF and media-capable routes for images.
   describe("tier override in agent mode", () => {
-    it("should map HackerAI Standard to DeepSeek V4 Pro for text-only agent mode", () => {
+    it("should map HackerAI Standard to DeepSeek V4 Flash 0731 for text-only agent mode", () => {
       expect(selectModel("agent", "pro", "hackerai-standard")).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
 
@@ -322,59 +322,61 @@ describe("selectModel", () => {
       ).toBe("model-grok-4.6");
     });
 
-    it("should keep HackerAI Standard on DeepSeek V4 Pro when a PDF is attached", () => {
+    it("should keep HackerAI Standard on DeepSeek V4 Flash 0731 when a PDF is attached", () => {
       expect(
         selectModel("agent", "pro", "hackerai-standard", false, true),
-      ).toBe("model-deepseek-v4-pro");
+      ).toBe("model-deepseek-v4-flash-0731");
     });
 
-    it("should map HackerAI Pro to Grok 4.6 in text-only agent mode", () => {
+    it("should map HackerAI Pro to DeepSeek V4 Pro 0813 in text-only agent mode", () => {
       expect(selectModel("agent", "pro", "hackerai-pro")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
     });
 
     it("should route HackerAI Pro to Grok 4.6 in agent mode when an image is attached", () => {
       expect(selectModel("agent", "pro", "hackerai-pro", true, false)).toBe(
-        "model-grok-4.6-pro",
+        "model-grok-4.6",
       );
     });
 
-    it("should route HackerAI Pro to Grok 4.6 in agent mode when a PDF is attached", () => {
+    it("should keep HackerAI Pro on DeepSeek V4 Pro 0813 when a PDF is attached", () => {
       expect(selectModel("agent", "pro", "hackerai-pro", false, true)).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
     });
 
-    it("should map HackerAI Max to its Kimi K3 compatibility route in agent mode for Ultra", () => {
+    it("should map HackerAI Max to Grok 4.6 in agent mode for Ultra", () => {
       expect(selectModel("agent", "ultra", "hackerai-max")).toBe(
-        "model-opus-4.6",
+        "model-grok-4.6",
       );
     });
 
     it("should downgrade HackerAI Max to Pro in agent mode outside Ultra", () => {
       expect(selectModel("agent", "pro", "hackerai-max")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
       expect(selectModel("agent", "pro-plus", "hackerai-max")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
       expect(selectModel("agent", "team", "hackerai-max")).toBe(
-        "model-grok-4.6-pro",
+        "model-deepseek-v4-pro-0813",
       );
     });
 
-    it("should map HackerAI Max to its Kimi K3 compatibility route in agent mode for paid users with extra usage", () => {
+    it("should map HackerAI Max to Grok 4.6 in agent mode for paid users with extra usage", () => {
       expect(
         selectModel("agent", "pro-plus", "hackerai-max", false, false, {
           extraUsageAvailable: true,
         }),
-      ).toBe("model-opus-4.6");
+      ).toBe("model-grok-4.6");
     });
 
-    it("should default to DeepSeek V4 Pro when no model is selected", () => {
-      expect(selectModel("agent", "pro")).toBe("model-deepseek-v4-pro");
-      expect(selectModel("agent", "pro", "auto")).toBe("model-deepseek-v4-pro");
+    it("should default to DeepSeek V4 Flash 0731 when no model is selected", () => {
+      expect(selectModel("agent", "pro")).toBe("model-deepseek-v4-flash-0731");
+      expect(selectModel("agent", "pro", "auto")).toBe(
+        "model-deepseek-v4-flash-0731",
+      );
     });
   });
 
@@ -399,30 +401,36 @@ describe("selectModel", () => {
 
   // "auto" override
   describe("auto override", () => {
-    it("should route paid agent Auto text to DeepSeek V4 Pro", () => {
-      expect(selectModel("agent", "pro", "auto")).toBe("model-deepseek-v4-pro");
+    it("should route paid agent Auto text to DeepSeek V4 Flash 0731", () => {
+      expect(selectModel("agent", "pro", "auto")).toBe(
+        "model-deepseek-v4-flash-0731",
+      );
     });
 
     it("should route paid agent Auto images to Grok and PDFs to DeepSeek", () => {
       expect(selectModel("agent", "pro", "auto", true, false)).toBe(
-        "agent-model",
+        "model-grok-4.6",
       );
       expect(selectModel("agent", "pro", "auto", false, true)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
 
-    it("should treat 'auto' as no override in paid ask mode (text-only → DeepSeek Pro)", () => {
-      expect(selectModel("ask", "pro", "auto")).toBe("model-deepseek-v4-pro");
+    it("should treat 'auto' as no override in paid ask mode (text-only → DeepSeek Flash)", () => {
+      expect(selectModel("ask", "pro", "auto")).toBe(
+        "model-deepseek-v4-flash-0731",
+      );
     });
 
     it("should treat 'auto' as no override in ask mode with image -> Grok", () => {
-      expect(selectModel("ask", "pro", "auto", true, false)).toBe("ask-model");
+      expect(selectModel("ask", "pro", "auto", true, false)).toBe(
+        "model-grok-4.6",
+      );
     });
 
     it("should treat 'auto' as no override in ask mode with PDF -> DeepSeek", () => {
       expect(selectModel("ask", "pro", "auto", false, true)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
   });
@@ -431,16 +439,16 @@ describe("selectModel", () => {
   describe("undefined override", () => {
     it("should use default when override is undefined", () => {
       expect(selectModel("agent", "pro", undefined)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
       expect(selectModel("ask", "pro", undefined)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
       expect(selectModel("ask", "pro", undefined, true, false)).toBe(
-        "ask-model",
+        "model-grok-4.6",
       );
       expect(selectModel("ask", "pro", undefined, false, true)).toBe(
-        "model-deepseek-v4-pro",
+        "model-deepseek-v4-flash-0731",
       );
     });
   });

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -37,12 +37,10 @@ export const getMaxStepsForUser = (mode: ChatMode): number => {
  * @param mode - Chat mode (ask or agent)
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
- *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
- *   (text-only); image prompts promote to Grok 4.6, while PDF prompts stay on
- *   DeepSeek and are parsed by OpenRouter. Paid Agent Auto/Standard routes use
- *   DeepSeek V4 Pro for text/PDF prompts and Grok 4.6 when images are attached.
- *   HackerAI Pro uses Grok 4.6
- *   for both text and vision; its GLM 5.2 fallback is configured downstream.
+ *   Paid Auto/Standard routes use DeepSeek V4 Flash 0731 for text/PDF prompts,
+ *   Pro uses DeepSeek V4 Pro 0813, and Max uses Grok 4.6. Images promote Auto,
+ *   Standard, and Pro to Grok 4.6; PDFs stay on DeepSeek and are parsed by
+ *   OpenRouter before inference.
  * @returns Model name to use
  */
 export function selectModel(
@@ -66,15 +64,15 @@ export function selectModel(
   const hasAskImage = !isAgent && !!hasImageAttachment;
   const hasProviderImage = !!hasImageAttachment;
   const paidAskMediaModel: ModelName = hasAskImage
-    ? "ask-model"
-    : "model-deepseek-v4-pro";
+    ? "model-grok-4.6"
+    : "model-deepseek-v4-flash-0731";
 
   const autoModel: ModelName = isAgent
     ? subscription === "free"
       ? "agent-model-free"
       : hasProviderImage
-        ? "agent-model"
-        : "model-deepseek-v4-pro"
+        ? "model-grok-4.6"
+        : "model-deepseek-v4-flash-0731"
     : isFreeAsk
       ? "ask-model-free"
       : paidAskMediaModel;
@@ -93,14 +91,11 @@ export function selectModel(
   // any UI that reads `getModelDisplayName` shows the picked model rather than
   // the auto-router label.
   if (allowedSelectedModel === "hackerai-standard") {
-    if (isAgent) {
-      return hasProviderImage ? "model-grok-4.6" : "model-deepseek-v4-pro";
-    }
-    return hasAskImage ? "model-grok-4.6" : "model-deepseek-v4-pro";
+    return hasProviderImage ? "model-grok-4.6" : "model-deepseek-v4-flash-0731";
   }
 
   if (allowedSelectedModel === "hackerai-pro") {
-    return "model-grok-4.6-pro";
+    return hasProviderImage ? "model-grok-4.6" : "model-deepseek-v4-pro-0813";
   }
 
   const providerKey = resolveTierToProviderKey(allowedSelectedModel, mode);
@@ -108,8 +103,7 @@ export function selectModel(
 }
 
 /**
- * Media file parts used by selectModel to decide whether the text-only
- * DeepSeek ask route is viable.
+ * Media file parts used by selectModel and OpenRouter PDF parser setup.
  */
 function getMediaAttachmentRouting(messages: UIMessage[]): {
   hasImage: boolean;

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -494,6 +494,15 @@ describe("token-bucket", () => {
       ).toBe(11310);
     });
 
+    it("should use DeepSeek V4 Flash 0731 pricing ($0.14/$0.28)", () => {
+      expect(
+        calculateTokenCost(1_000_000, "input", "model-deepseek-v4-flash-0731"),
+      ).toBe(1820);
+      expect(
+        calculateTokenCost(1_000_000, "output", "model-deepseek-v4-flash-0731"),
+      ).toBe(3640);
+    });
+
     it("should use GLM 5.2 baseline pricing ($0.76/$2.42)", () => {
       expect(calculateTokenCost(1_000_000, "input", "model-glm-5.2")).toBe(
         9880,

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -108,6 +108,7 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   // DeepSeek V4 Flash 0731 rates from OpenRouter: $0.14 in / $0.28 out per 1M tokens.
   "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
+  "model-deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "model-deepseek-v4-pro-0813": DEEPSEEK_V4_PRO_PRICING,
   // Persisted Max compatibility key; the active provider route is Kimi K3.


### PR DESCRIPTION
## Summary

- route paid Auto and Standard text/PDF requests to `deepseek/deepseek-v4-flash-0731`
- route Pro text/PDF requests to `deepseek/deepseek-v4-pro-0813`
- route Max requests to `x-ai/grok-4.6`
- use `high` reasoning across these paid routes, including Grok image promotion
- preserve OpenRouter Mistral OCR parsing for PDFs on DeepSeek
- update provider labels, fallback chains, and pricing metadata
- keep the existing Max Ultra/Extra Usage access and billing gate unchanged

## Validation

- `corepack pnpm typecheck`
- focused ESLint on changed files
- focused Jest: 300 tests passed
- full Jest: 362 suites / 3,708 tests passed

## Manual verification

1. Open the model selector in Ask and Agent mode.
2. Hover Standard, Pro, and Max.
3. Confirm the provider labels show DeepSeek V4 Flash 0731, DeepSeek V4 Pro 0813, and xAI Grok 4.6 respectively.
4. On a non-Ultra paid account without usable Extra Usage, confirm Max remains locked; on Ultra or with usable Extra Usage, confirm Max remains selectable.
5. Upload a PDF on Standard or Pro and confirm it stays on the selected DeepSeek tier; upload an image and confirm the request promotes to Grok 4.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for DeepSeek V4 Flash 0731.
  - Updated model routing: Standard uses DeepSeek V4 Flash, Pro uses DeepSeek V4 Pro, and Max uses Grok 4.6.
  - Continued support for image and PDF requests through compatible models.

- **Improvements**
  - Enhanced fallback and retry behavior for improved availability.
  - Updated provider disclosures and model descriptions.
  - Added pricing support for DeepSeek V4 Flash 0731.
  - Improved high-reasoning routing where required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->