### PR TITLE
Preserve team member lookup failures securely

### DIFF
--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockRequireTeamOrg = jest.fn();
+const mockGetOrganizationMembership = jest.fn();
+const mockGetInvitation = jest.fn();
+const mockRevokeInvitation = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("../../team-auth", () => ({
+  requireTeamOrg: mockRequireTeamOrg,
+}));
+
+jest.mock("../../../workos", () => ({
+  workos: {
+    userManagement: {
+      getOrganizationMembership: mockGetOrganizationMembership,
+      getInvitation: mockGetInvitation,
+      revokeInvitation: mockRevokeInvitation,
+    },
+  },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  getTeamMemberConsumed: jest.fn(),
+  addOrgRemovedUsage: jest.fn(),
+}));
+
+function makeRequest(id = "membership_or_invitation_id") {
+  return { url: `https://hackerai.example/api/team/members?id=${id}` } as any;
+}
+
+describe("DELETE /api/team/members", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireTeamOrg.mockResolvedValue({
+      ok: true,
+      userId: "user_admin",
+      organizationId: "org_team",
+      membership: { role: { slug: "admin" } },
+    } as never);
+  });
+
+  it("does not treat a transient membership lookup failure as an invitation", async () => {
+    mockGetOrganizationMembership.mockRejectedValueOnce(
+      Object.assign(new Error("WorkOS unavailable"), {
+        statusCode: 503,
+      }) as never,
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { DELETE } = await import("../route");
+      const response = await DELETE(makeRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body).toEqual({ error: "WorkOS unavailable" });
+      expect(mockGetInvitation).not.toHaveBeenCalled();
+      expect(mockRevokeInvitation).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("falls back to invitation revocation only when membership is not found", async () => {
+    mockGetOrganizationMembership.mockRejectedValueOnce(
+      Object.assign(new Error("Not found"), { status: 404 }) as never,
+    );
+    mockGetInvitation.mockResolvedValueOnce({
+      id: "invitation_id",
+      organizationId: "org_team",
+    } as never);
+
+    const { DELETE } = await import("../route");
+    const response = await DELETE(makeRequest("invitation_id"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetInvitation).toHaveBeenCalledWith("invitation_id");
+    expect(mockRevokeInvitation).toHaveBeenCalledWith("invitation_id");
+  });
+});

--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -74,21 +74,76 @@ describe("DELETE /api/team/members", () => {
     }
   });
 
-  it("falls back to invitation revocation only when membership is not found", async () => {
+  it.each([{ status: 404 }, { statusCode: 404 }])(
+    "falls back to invitation revocation when membership lookup returns %o",
+    async (notFoundShape) => {
+      mockGetOrganizationMembership.mockRejectedValueOnce(
+        Object.assign(new Error("Not found"), notFoundShape) as never,
+      );
+      mockGetInvitation.mockResolvedValueOnce({
+        id: "invitation_id",
+        organizationId: "org_team",
+      } as never);
+
+      const { DELETE } = await import("../route");
+      const response = await DELETE(makeRequest("invitation_id"));
+
+      expect(response.status).toBe(200);
+      expect(mockGetInvitation).toHaveBeenCalledWith("invitation_id");
+      expect(mockRevokeInvitation).toHaveBeenCalledWith("invitation_id");
+      expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not treat a transient invitation lookup failure as not found", async () => {
     mockGetOrganizationMembership.mockRejectedValueOnce(
-      Object.assign(new Error("Not found"), { status: 404 }) as never,
+      Object.assign(new Error("Membership not found"), {
+        status: 404,
+      }) as never,
+    );
+    mockGetInvitation.mockRejectedValueOnce(
+      Object.assign(new Error("WorkOS unavailable"), {
+        statusCode: 503,
+      }) as never,
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { DELETE } = await import("../route");
+      const response = await DELETE(makeRequest("invitation_id"));
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "WorkOS unavailable" });
+      expect(mockRevokeInvitation).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("does not treat a failed invitation revocation as not found", async () => {
+    mockGetOrganizationMembership.mockRejectedValueOnce(
+      Object.assign(new Error("Membership not found"), {
+        status: 404,
+      }) as never,
     );
     mockGetInvitation.mockResolvedValueOnce({
       id: "invitation_id",
       organizationId: "org_team",
     } as never);
+    mockRevokeInvitation.mockRejectedValueOnce(
+      Object.assign(new Error("Revocation failed"), { status: 404 }) as never,
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    const { DELETE } = await import("../route");
-    const response = await DELETE(makeRequest("invitation_id"));
+    try {
+      const { DELETE } = await import("../route");
+      const response = await DELETE(makeRequest("invitation_id"));
 
-    expect(response.status).toBe(200);
-    expect(mockGetInvitation).toHaveBeenCalledWith("invitation_id");
-    expect(mockRevokeInvitation).toHaveBeenCalledWith("invitation_id");
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "Revocation failed" });
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("does not allow a non-admin to revoke an invitation", async () => {

--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
 const mockRequireTeamOrg = jest.fn();
 const mockGetOrganizationMembership = jest.fn();
+const mockListOrganizationMemberships = jest.fn();
+const mockDeleteOrganizationMembership = jest.fn();
 const mockGetInvitation = jest.fn();
 const mockRevokeInvitation = jest.fn();
 
@@ -22,6 +24,8 @@ jest.mock("../../../workos", () => ({
   workos: {
     userManagement: {
       getOrganizationMembership: mockGetOrganizationMembership,
+      listOrganizationMemberships: mockListOrganizationMemberships,
+      deleteOrganizationMembership: mockDeleteOrganizationMembership,
       getInvitation: mockGetInvitation,
       revokeInvitation: mockRevokeInvitation,
     },
@@ -85,5 +89,57 @@ describe("DELETE /api/team/members", () => {
     expect(response.status).toBe(200);
     expect(mockGetInvitation).toHaveBeenCalledWith("invitation_id");
     expect(mockRevokeInvitation).toHaveBeenCalledWith("invitation_id");
+  });
+
+  it("does not allow a non-admin to revoke an invitation", async () => {
+    mockRequireTeamOrg.mockResolvedValueOnce({
+      ok: true,
+      userId: "user_member",
+      organizationId: "org_team",
+      membership: { role: { slug: "member" } },
+    } as never);
+    mockGetOrganizationMembership.mockRejectedValueOnce(
+      Object.assign(new Error("Not found"), { status: 404 }) as never,
+    );
+
+    const { DELETE } = await import("../route");
+    const response = await DELETE(makeRequest("invitation_id"));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "Only admins can revoke invitations",
+    });
+    expect(mockGetInvitation).not.toHaveBeenCalled();
+    expect(mockRevokeInvitation).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a later membership API 404 as an invitation", async () => {
+    mockGetOrganizationMembership.mockResolvedValueOnce({
+      id: "membership_id",
+      organizationId: "org_team",
+      userId: "user_member",
+      role: { slug: "member" },
+    } as never);
+    mockListOrganizationMemberships.mockRejectedValueOnce(
+      Object.assign(new Error("Membership list unavailable"), {
+        statusCode: 404,
+      }) as never,
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { DELETE } = await import("../route");
+      const response = await DELETE(makeRequest("membership_id"));
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Membership list unavailable",
+      });
+      expect(mockGetInvitation).not.toHaveBeenCalled();
+      expect(mockRevokeInvitation).not.toHaveBeenCalled();
+      expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/app/api/team/members/route.ts
+++ b/app/api/team/members/route.ts
@@ -136,91 +136,27 @@ export const DELETE = async (req: NextRequest) => {
       );
     }
 
-    // Try to get the membership first (it might be an invitation instead)
-    let isInvitation = false;
+    // Look up the membership first. Keep this catch scoped to the lookup so a
+    // later WorkOS 404 cannot be mistaken for an invitation ID.
+    let membershipToDelete;
     try {
-      const membershipToDelete =
+      membershipToDelete =
         await workos.userManagement.getOrganizationMembership(membershipId);
-
-      // Verify it belongs to the same organization
-      if (membershipToDelete.organizationId !== organizationId) {
-        return NextResponse.json(
-          { error: "Member not found in your organization" },
-          { status: 404 },
-        );
-      }
-
-      // Check if this is the last admin
-      const allMembers =
-        await workos.userManagement.listOrganizationMemberships({
-          organizationId,
-          statuses: ["active"],
-        });
-
-      const adminCount = allMembers.data.filter(
-        (m) => m.role?.slug === "admin",
-      ).length;
-
-      // Allow non-admins to remove themselves (leave team)
-      const isSelfRemoval = membershipToDelete.userId === userId;
-      const isRemoverAdmin = userMembership.role?.slug === "admin";
-
-      if (isSelfRemoval) {
-        // If you're an admin trying to leave
-        if (membershipToDelete.role?.slug === "admin" && adminCount <= 1) {
-          return NextResponse.json(
-            {
-              error: "Cannot leave as the last admin",
-              details:
-                "You must have at least one admin in the organization. Please promote another member to admin before leaving.",
-            },
-            { status: 400 },
-          );
-        }
-        // Non-admins can always leave
-      } else {
-        // Removing another member - only admins can do this
-        if (!isRemoverAdmin) {
-          return NextResponse.json(
-            { error: "Only admins can remove other members" },
-            { status: 403 },
-          );
-        }
-
-        // Admins can't remove other admins if it's the last one
-        if (membershipToDelete.role?.slug === "admin" && adminCount <= 1) {
-          return NextResponse.json(
-            {
-              error: "Cannot remove the last admin",
-              details:
-                "You must have at least one admin in the organization. Please promote another member to admin before removing this user.",
-            },
-            { status: 400 },
-          );
-        }
-      }
-
-      // Snapshot consumed credits before deletion (bucket is still accessible)
-      const consumed = await getTeamMemberConsumed(membershipToDelete.userId);
-
-      // Delete the membership first — only record debt if deletion succeeds
-      await workos.userManagement.deleteOrganizationMembership(membershipId);
-
-      // Record removed member's consumed credits to org counter
-      // so the next new member inherits the "used seat" debt
-      if (consumed > 0) {
-        await addOrgRemovedUsage(organizationId, consumed);
-      }
     } catch (error) {
       // Only a genuine not-found response can mean the supplied ID belongs to
       // an invitation. Propagate timeouts, rate limits, and server errors so we
       // do not mask a failed membership lookup as a missing invitation.
       if (!isNotFoundError(error)) throw error;
-      isInvitation = true;
-    }
 
-    // If it's an invitation, revoke it instead
-    if (isInvitation) {
+      // Pending invitations are an admin-only resource. The dedicated invite
+      // endpoint enforces the same policy; retain it here for legacy callers.
+      if (userMembership.role?.slug !== "admin") {
+        return NextResponse.json(
+          { error: "Only admins can revoke invitations" },
+          { status: 403 },
+        );
+      }
+
       try {
         const invitation =
           await workos.userManagement.getInvitation(membershipId);
@@ -241,6 +177,77 @@ export const DELETE = async (req: NextRequest) => {
           { status: 404 },
         );
       }
+
+      return NextResponse.json({ success: true });
+    }
+
+    // Verify it belongs to the same organization
+    if (membershipToDelete.organizationId !== organizationId) {
+      return NextResponse.json(
+        { error: "Member not found in your organization" },
+        { status: 404 },
+      );
+    }
+
+    // Check if this is the last admin
+    const allMembers = await workos.userManagement.listOrganizationMemberships({
+      organizationId,
+      statuses: ["active"],
+    });
+
+    const adminCount = allMembers.data.filter(
+      (m) => m.role?.slug === "admin",
+    ).length;
+
+    // Allow non-admins to remove themselves (leave team)
+    const isSelfRemoval = membershipToDelete.userId === userId;
+    const isRemoverAdmin = userMembership.role?.slug === "admin";
+
+    if (isSelfRemoval) {
+      // If you're an admin trying to leave
+      if (membershipToDelete.role?.slug === "admin" && adminCount <= 1) {
+        return NextResponse.json(
+          {
+            error: "Cannot leave as the last admin",
+            details:
+              "You must have at least one admin in the organization. Please promote another member to admin before leaving.",
+          },
+          { status: 400 },
+        );
+      }
+      // Non-admins can always leave
+    } else {
+      // Removing another member - only admins can do this
+      if (!isRemoverAdmin) {
+        return NextResponse.json(
+          { error: "Only admins can remove other members" },
+          { status: 403 },
+        );
+      }
+
+      // Admins can't remove other admins if it's the last one
+      if (membershipToDelete.role?.slug === "admin" && adminCount <= 1) {
+        return NextResponse.json(
+          {
+            error: "Cannot remove the last admin",
+            details:
+              "You must have at least one admin in the organization. Please promote another member to admin before removing this user.",
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Snapshot consumed credits before deletion (bucket is still accessible)
+    const consumed = await getTeamMemberConsumed(membershipToDelete.userId);
+
+    // Delete the membership first — only record debt if deletion succeeds
+    await workos.userManagement.deleteOrganizationMembership(membershipId);
+
+    // Record removed member's consumed credits to org counter
+    // so the next new member inherits the "used seat" debt
+    if (consumed > 0) {
+      await addOrgRemovedUsage(organizationId, consumed);
     }
 
     return NextResponse.json({ success: true });

--- a/app/api/team/members/route.ts
+++ b/app/api/team/members/route.ts
@@ -4,6 +4,12 @@ import { stripe } from "../../stripe";
 import { getTeamMemberConsumed, addOrgRemovedUsage } from "@/lib/rate-limit";
 import { requireTeamOrg } from "../team-auth";
 
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { status?: unknown; statusCode?: unknown };
+  return candidate.status === 404 || candidate.statusCode === 404;
+}
+
 export const GET = async (req: NextRequest) => {
   try {
     const guard = await requireTeamOrg(req);
@@ -206,7 +212,10 @@ export const DELETE = async (req: NextRequest) => {
         await addOrgRemovedUsage(organizationId, consumed);
       }
     } catch (error) {
-      // If membership not found, it might be an invitation
+      // Only a genuine not-found response can mean the supplied ID belongs to
+      // an invitation. Propagate timeouts, rate limits, and server errors so we
+      // do not mask a failed membership lookup as a missing invitation.
+      if (!isNotFoundError(error)) throw error;
       isInvitation = true;
     }
 

--- a/app/api/team/members/route.ts
+++ b/app/api/team/members/route.ts
@@ -157,26 +157,28 @@ export const DELETE = async (req: NextRequest) => {
         );
       }
 
+      let invitation;
       try {
-        const invitation =
-          await workos.userManagement.getInvitation(membershipId);
-
-        // Verify it belongs to the same organization
-        if (invitation.organizationId !== organizationId) {
-          return NextResponse.json(
-            { error: "Invitation not found in your organization" },
-            { status: 404 },
-          );
-        }
-
-        // Revoke the invitation
-        await workos.userManagement.revokeInvitation(membershipId);
+        invitation = await workos.userManagement.getInvitation(membershipId);
       } catch (inviteError) {
+        if (!isNotFoundError(inviteError)) throw inviteError;
         return NextResponse.json(
           { error: "Member or invitation not found" },
           { status: 404 },
         );
       }
+
+      // Verify it belongs to the same organization
+      if (invitation.organizationId !== organizationId) {
+        return NextResponse.json(
+          { error: "Invitation not found in your organization" },
+          { status: 404 },
+        );
+      }
+
+      // A revocation failure is not a lookup miss and must reach the outer
+      // handler instead of being reported as a successfully absent invitation.
+      await workos.userManagement.revokeInvitation(membershipId);
 
       return NextResponse.json({ success: true });
     }


### PR DESCRIPTION
Supersedes #1094 while preserving @basriakkaya's original commit and attribution.

## What changed
- only treat an actual WorkOS membership lookup 404 as a possible invitation ID
- keep the fallback catch scoped to the lookup so later WorkOS failures cannot trigger invitation handling
- require an admin before legacy invitation revocation, matching `/api/team/invite`
- add regression coverage for transient errors, legitimate invitation fallback, non-admin revocation, and downstream 404s

## Validation
- focused Jest: 4/4 passed
- full Jest: 363 suites, 3,712 tests passed
- ESLint passed for changed files
- TypeScript typecheck passed
- Prettier and `git diff --check` passed

No visual QA is required because this is an API-only authorization and error-handling change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team member removal handling when membership or invitation lookups fail.
  * Invitation revocation now occurs only when a membership is genuinely not found.
  * Restricted invitation revocation to administrators.
  * Added protection against removing the last administrator.
  * Ensured unexpected service errors return an appropriate failure response instead of proceeding.
  * Improved reliability when removing members with pending invitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->