### PR TITLE
Route Approve for me through DeepSeek with Grok fallback

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -80,6 +80,13 @@ describe("provider registry", () => {
       (myProvider.languageModel("title-generator-model") as { modelId: string })
         .modelId,
     ).toBe("deepseek/deepseek-v4-flash");
+    expect(
+      (
+        myProvider.languageModel("agent-auto-review-model") as {
+          modelId: string;
+        }
+      ).modelId,
+    ).toBe("deepseek/deepseek-v4-flash-0731");
     expect(getModelCutoffDate("ask-model-free")).toBeUndefined();
     expect(getModelCutoffDate("agent-model-free")).toBeUndefined();
     expect(getModelDisplayName("model-grok-4.6")).toBe("xAI Grok 4.6");
@@ -108,6 +115,10 @@ describe("provider registry", () => {
     expect(getModelDisplayName("title-generator-model")).toBe(
       "DeepSeek V4 Flash",
     );
+    expect(getModelDisplayName("agent-auto-review-model")).toBe(
+      "DeepSeek V4 Flash 0731",
+    );
+    expect(getModelCutoffDate("agent-auto-review-model")).toBe("July 2026");
   });
 
   it("applies Kimi rather than Anthropic provider behavior to HackerAI Max", () => {
@@ -120,6 +131,7 @@ describe("provider registry", () => {
     expect(isDeepSeekModel("model-deepseek-v4-flash-0731")).toBe(true);
     expect(isDeepSeekModel("model-deepseek-v4-pro")).toBe(true);
     expect(isDeepSeekModel("model-deepseek-v4-pro-0813")).toBe(true);
+    expect(isDeepSeekModel("agent-auto-review-model")).toBe(true);
   });
 
   it("keeps tracked free routes split by mode", () => {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -225,8 +225,9 @@ const buildProviderMap = (
     "fallback-ask-model": or(GROK_4_6_SLUG),
     // Titles are a short structured-output task and should never use reasoning.
     "title-generator-model": or(TITLE_GENERATOR_DEEPSEEK_SLUG),
-    // Separate tool-less call used only to review one approval-gated action.
-    "agent-auto-review-model": or(GROK_4_6_SLUG),
+    // Separate text-only, tool-less call used to review one approval-gated
+    // action. The reviewer receives serialized evidence rather than images.
+    "agent-auto-review-model": or(DEEPSEEK_V4_FLASH_SLUG),
   }) as Record<string, any>;
 
 const baseProviders = buildProviderMap(openrouter);
@@ -247,7 +248,7 @@ export const modelCutoffDates: Partial<Record<ModelName, string>> &
   "fallback-agent-model": "August 2026",
   "fallback-ask-model": "August 2026",
   "title-generator-model": "May 2025",
-  "agent-auto-review-model": "August 2026",
+  "agent-auto-review-model": "July 2026",
 };
 
 export const modelDisplayNames: Record<ModelName, string> &
@@ -269,7 +270,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
   "title-generator-model": "DeepSeek V4 Flash",
-  "agent-auto-review-model": "xAI Grok 4.6",
+  "agent-auto-review-model": "DeepSeek V4 Flash 0731",
 };
 
 export const getModelDisplayName = (modelName: ModelName): string => {
@@ -292,6 +293,7 @@ export function isDeepSeekModel(modelName: string): boolean {
   return (
     modelName === "ask-model-free" ||
     modelName === "agent-model-free" ||
+    modelName === "agent-auto-review-model" ||
     modelName === "model-deepseek-v4-flash-0731" ||
     modelName === "model-deepseek-v4-pro" ||
     modelName === "model-deepseek-v4-pro-0813"

--- a/lib/chat/__tests__/agent-auto-review.test.ts
+++ b/lib/chat/__tests__/agent-auto-review.test.ts
@@ -1,6 +1,8 @@
 import type { UIMessage } from "ai";
 
 import {
+  AGENT_AUTO_REVIEW_MODEL,
+  AGENT_AUTO_REVIEW_PROVIDER_OPTIONS,
   AgentAutoReviewDenialTracker,
   extractAgentAutoReviewAuthorizationContext,
   extractAgentAutoReviewConversationContext,
@@ -69,6 +71,17 @@ const authorizationContext = {
 };
 
 describe("Agent Auto review", () => {
+  it("uses DeepSeek with a no-reasoning Grok 4.5 fallback", () => {
+    expect(AGENT_AUTO_REVIEW_MODEL).toBe("agent-auto-review-model");
+    expect(AGENT_AUTO_REVIEW_PROVIDER_OPTIONS).toEqual({
+      openrouter: {
+        reasoning: { enabled: false },
+        models: ["x-ai/grok-4.5"],
+        usage: { include: true },
+      },
+    });
+  });
+
   it.each([
     ["auto_review", "enforce", "terminal_execute", true],
     ["auto_review", "shadow", "file_edit", true],

--- a/lib/chat/agent-auto-review.ts
+++ b/lib/chat/agent-auto-review.ts
@@ -2,7 +2,7 @@ import { generateText, Output, type UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
-import { myProvider } from "@/lib/ai/providers";
+import { GROK_4_5_SLUG, myProvider } from "@/lib/ai/providers";
 import { getProviderUsageRawModelCost } from "@/lib/provider-usage-cost";
 import { isAgentAutoReviewFilesystemDeletionCommand } from "@/lib/chat/agent-auto-review-evidence";
 import type {
@@ -28,6 +28,13 @@ const CONVERSATION_CONTEXT_SEPARATOR =
 const USER_CONTEXT_TRUNCATION_TAG = "user_content_truncated";
 export const AGENT_AUTO_REVIEW_TIMEOUT_MS = 15_000;
 export const AGENT_AUTO_REVIEW_MODEL = "agent-auto-review-model" as const;
+export const AGENT_AUTO_REVIEW_PROVIDER_OPTIONS = {
+  openrouter: {
+    reasoning: { enabled: false },
+    models: [GROK_4_5_SLUG],
+    usage: { include: true },
+  },
+};
 
 const riskCategories = [
   "routine",
@@ -114,12 +121,7 @@ const defaultModelRunner: AutoReviewModelRunner = async ({
     system,
     messages: [{ role: "user", content: prompt }],
     output: Output.object({ schema: agentAutoReviewOutputSchema }),
-    providerOptions: {
-      openrouter: {
-        reasoning: { effort: "minimal" },
-        usage: { include: true },
-      },
-    },
+    providerOptions: AGENT_AUTO_REVIEW_PROVIDER_OPTIONS,
     temperature: 0,
     maxOutputTokens: 1_000,
     maxRetries: 0,

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -534,6 +534,7 @@ describe("token-bucket", () => {
     it.each([
       "ask-model-free",
       "agent-model-free",
+      "agent-auto-review-model",
       "deepseek/deepseek-v4-flash-0731",
       "deepseek/deepseek-v4-flash-20260731",
     ])(
@@ -556,7 +557,6 @@ describe("token-bucket", () => {
       "agent-model",
       "fallback-agent-model",
       "fallback-ask-model",
-      "agent-auto-review-model",
     ])("should use Grok base pricing for %s ($2.00/$6.00)", (modelName) => {
       expect(calculateTokenCost(100_000, "input", modelName)).toBe(2600);
       expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(78000);

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -104,10 +104,10 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "agent-model": GROK_4_6_BASE_PRICING,
   "fallback-agent-model": GROK_4_6_BASE_PRICING,
   "fallback-ask-model": GROK_4_6_BASE_PRICING,
-  "agent-auto-review-model": GROK_4_6_BASE_PRICING,
   // DeepSeek V4 Flash 0731 rates from OpenRouter: $0.14 in / $0.28 out per 1M tokens.
   "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
+  "agent-auto-review-model": DEEPSEEK_V4_FLASH_0731_PRICING,
   "model-deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "model-deepseek-v4-pro-0813": DEEPSEEK_V4_PRO_PRICING,
@@ -142,7 +142,6 @@ const GROK_4_6_MODEL_IDS = new Set([
   "agent-model",
   "fallback-agent-model",
   "fallback-ask-model",
-  "agent-auto-review-model",
   "x-ai/grok-4.6",
 ]);
 


### PR DESCRIPTION
## Summary

- route the separate `Approve for me` reviewer through `deepseek/deepseek-v4-flash-0731`
- disable reasoning for the text-only review call
- fall back to `x-ai/grok-4.5` through OpenRouter when the primary provider fails
- align model metadata and token-cost accounting with the DeepSeek primary route

## Why

Approval review receives bounded serialized text evidence rather than image input, so the lower-cost DeepSeek Flash route is sufficient for the primary decision. Grok 4.5 remains available as a no-reasoning provider fallback while failures and invalid verdicts continue to fail closed to human approval.

## Validation

- 364 Jest suites / 3,731 tests passed via the commit hook
- `pnpm run typecheck`
- `pnpm run lint` (existing warnings only)
- focused provider, auto-review, and rate-limit suites: 145 tests passed
- Prettier and `git diff --check`

## Manual verification

1. Open the Vercel preview with a user assigned to `agent_auto_review_v1`.
2. Select **Approve for me** and ask Agent to perform an approval-gated terminal or file action.
3. Confirm the action shows the automatic-review state, then either executes after an approving verdict or falls through to the human approval prompt for a non-approving or failed verdict.
4. Confirm no reasoning content is surfaced in the approval UI.

The provider fallback chain is covered by the focused configuration test; forcing a primary-provider outage is not required for preview verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated automatic review configuration to use Grok 4.5 with reasoning disabled and usage reporting enabled.
  - Updated the associated model information to identify DeepSeek V4 Flash 0731, including its display name and knowledge cutoff.
  - Adjusted rate-limit and usage accounting to apply the corresponding DeepSeek pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->