### PR TITLE
Recover desktop relay connections

### DIFF
--- a/app/api/sandbox/presence/route.ts
+++ b/app/api/sandbox/presence/route.ts
@@ -6,7 +6,10 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "@/convex/_generated/api";
 import { phLogger } from "@/lib/posthog/server";
 import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
-import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
+import {
+  LOCAL_SANDBOX_PRESENCE_GRACE_MS,
+  presenceHasConnectionId,
+} from "@/lib/centrifugo/presence";
 
 export async function GET(request: NextRequest) {
   let userId: string;
@@ -132,14 +135,13 @@ export async function GET(request: NextRequest) {
   // Skip rows whose lastSeen is within the grace window — covers the race where a
   // client has just inserted its row but hasn't finished subscribing to Centrifugo,
   // and brief WebSocket reconnects on healthy clients (last_heartbeat is bumped on
-  // every successful Centrifugo token refresh).
-  const PRESENCE_GRACE_MS = 30_000;
+  // a lightweight client heartbeat).
   if (presenceReliable) {
     const now = Date.now();
     const stale = connections.filter(
       (conn) =>
         !onlineConnectionIds.has(conn.connectionId) &&
-        now - conn.lastSeen > PRESENCE_GRACE_MS,
+        now - conn.lastSeen > LOCAL_SANDBOX_PRESENCE_GRACE_MS,
     );
     if (stale.length > 0) {
       const results = await Promise.allSettled(

--- a/app/hooks/__tests__/useSandboxPreference.test.tsx
+++ b/app/hooks/__tests__/useSandboxPreference.test.tsx
@@ -121,28 +121,107 @@ describe("useSandboxPreference", () => {
       expect(result.current.desktopBridgeActive).toBe(true);
     });
 
-    act(() => {
-      bridgeConfigs[1].onTerminated?.("connection_inactive");
-    });
-    await waitFor(() => {
+    jest.useFakeTimers();
+    try {
+      act(() => {
+        bridgeConfigs[1].onTerminated?.("connection_inactive");
+      });
       expect(result.current.desktopBridgeStatus).toBe("connecting");
       expect(result.current.desktopBridgeActive).toBe(false);
-    });
 
-    await waitFor(
-      () => {
-        expect(bridgeInstances).toHaveLength(3);
-        expect(result.current.desktopBridgeStatus).toBe("connected");
-        expect(result.current.desktopBridgeActive).toBe(true);
-      },
-      { timeout: 3_000 },
-    );
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+
+      expect(bridgeInstances).toHaveLength(3);
+      expect(result.current.desktopBridgeStatus).toBe("connected");
+      expect(result.current.desktopBridgeActive).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
 
     rerender({ isAuthenticated: false });
     await waitFor(() => {
       expect(result.current.desktopBridgeStatus).toBe("idle");
       expect(result.current.desktopBridgeActive).toBe(false);
       expect(bridgeInstances[2].stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("stops automatic recovery after six consecutive failures", async () => {
+    const bridgeConfigs: BridgeConfig[] = [];
+    const bridgeInstances: Array<{
+      start: jest.Mock;
+      stop: jest.Mock;
+      getConnectionId: jest.Mock;
+    }> = [];
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    (DesktopSandboxBridge as jest.Mock).mockImplementation(
+      (config: BridgeConfig) => {
+        const instance = {
+          start: jest
+            .fn()
+            .mockResolvedValue(`connection-${bridgeInstances.length + 1}`),
+          stop: jest.fn().mockResolvedValue(undefined),
+          getConnectionId: jest
+            .fn()
+            .mockReturnValue(`connection-${bridgeInstances.length + 1}`),
+        };
+        bridgeConfigs.push(config);
+        bridgeInstances.push(instance);
+        return instance;
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      ({ isAuthenticated }) => useSandboxPreference(isAuthenticated),
+      { initialProps: { isAuthenticated: true } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("connected");
+      expect(bridgeInstances).toHaveLength(1);
+    });
+
+    jest.useFakeTimers();
+    try {
+      const delays = [1_000, 3_000, 8_000, 16_000, 16_000, 16_000];
+      for (const delay of delays) {
+        act(() => {
+          bridgeConfigs.at(-1)?.onTerminated?.("connection_inactive");
+        });
+        expect(result.current.desktopBridgeStatus).toBe("connecting");
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(delay);
+        });
+        expect(result.current.desktopBridgeStatus).toBe("connected");
+      }
+
+      expect(bridgeInstances).toHaveLength(7);
+      act(() => {
+        bridgeConfigs.at(-1)?.onTerminated?.("connection_inactive");
+      });
+
+      expect(result.current.desktopBridgeStatus).toBe("failed");
+      expect(result.current.desktopBridgeActive).toBe(false);
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60_000);
+      });
+      expect(bridgeInstances).toHaveLength(7);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[DesktopSandboxBridge] Automatic recovery exhausted",
+        { reason: "connection_inactive", attempts: 6 },
+      );
+    } finally {
+      jest.useRealTimers();
+      warnSpy.mockRestore();
+    }
+
+    rerender({ isAuthenticated: false });
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("idle");
     });
   });
 });

--- a/app/hooks/__tests__/useSandboxPreference.test.tsx
+++ b/app/hooks/__tests__/useSandboxPreference.test.tsx
@@ -31,8 +31,10 @@ type BridgeConfig = {
       | "unauthenticated"
       | "connection_not_found"
       | "ownership_mismatch"
-      | "connection_inactive",
+      | "connection_inactive"
+      | "transport_disconnected",
   ) => void;
+  onConnectionState?: (state: "connecting" | "connected") => void;
 };
 
 describe("useSandboxPreference", () => {
@@ -53,7 +55,7 @@ describe("useSandboxPreference", () => {
     expect(DesktopSandboxBridge).not.toHaveBeenCalled();
   });
 
-  it("invalidates bridge startup and connected state when authentication is lost", async () => {
+  it("invalidates on auth loss and automatically recovers a stale connection", async () => {
     let resolveFirstStart: ((connectionId: string) => void) | undefined;
     const firstStart = new Promise<string>((resolve) => {
       resolveFirstStart = resolve;
@@ -123,17 +125,18 @@ describe("useSandboxPreference", () => {
       bridgeConfigs[1].onTerminated?.("connection_inactive");
     });
     await waitFor(() => {
-      expect(result.current.desktopBridgeStatus).toBe("failed");
+      expect(result.current.desktopBridgeStatus).toBe("connecting");
       expect(result.current.desktopBridgeActive).toBe(false);
     });
 
-    act(() => {
-      result.current.retryDesktopBridge();
-    });
-    await waitFor(() => {
-      expect(result.current.desktopBridgeStatus).toBe("connected");
-      expect(result.current.desktopBridgeActive).toBe(true);
-    });
+    await waitFor(
+      () => {
+        expect(bridgeInstances).toHaveLength(3);
+        expect(result.current.desktopBridgeStatus).toBe("connected");
+        expect(result.current.desktopBridgeActive).toBe(true);
+      },
+      { timeout: 3_000 },
+    );
 
     rerender({ isAuthenticated: false });
     await waitFor(() => {

--- a/app/hooks/useSandboxPreference.ts
+++ b/app/hooks/useSandboxPreference.ts
@@ -27,6 +27,8 @@ let bridgeStateListener:
   ((active: boolean, status: DesktopBridgeStatus) => void) | null = null;
 const PERSISTABLE_SANDBOX_PREFERENCES = new Set(["e2b", "desktop"]);
 const DESKTOP_BRIDGE_RECOVERY_DELAYS_MS = [1_000, 3_000, 8_000, 16_000];
+const DESKTOP_BRIDGE_MAX_RECOVERY_ATTEMPTS = 6;
+const DESKTOP_BRIDGE_STABLE_RESET_MS = 60_000;
 const RECOVERABLE_DESKTOP_TERMINATIONS = new Set([
   "connection_not_found",
   "connection_inactive",
@@ -34,15 +36,29 @@ const RECOVERABLE_DESKTOP_TERMINATIONS = new Set([
 ]);
 let bridgeRecoveryAttempt = 0;
 let bridgeRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+let bridgeStableResetTimer: ReturnType<typeof setTimeout> | null = null;
 
 function clearBridgeRecovery(resetAttempt: boolean): void {
   if (bridgeRecoveryTimer) {
     clearTimeout(bridgeRecoveryTimer);
     bridgeRecoveryTimer = null;
   }
+  if (bridgeStableResetTimer) {
+    clearTimeout(bridgeStableResetTimer);
+    bridgeStableResetTimer = null;
+  }
   if (resetAttempt) {
     bridgeRecoveryAttempt = 0;
   }
+}
+
+function scheduleStableRecoveryReset(generation: number): void {
+  if (bridgeStableResetTimer) clearTimeout(bridgeStableResetTimer);
+  bridgeStableResetTimer = setTimeout(() => {
+    bridgeStableResetTimer = null;
+    if (generation !== bridgeGeneration) return;
+    bridgeRecoveryAttempt = 0;
+  }, DESKTOP_BRIDGE_STABLE_RESET_MS);
 }
 
 export function useSandboxPreference(
@@ -152,7 +168,7 @@ export function useSandboxPreference(
                   onConnectionState: (state) => {
                     if (generation !== bridgeGeneration) return;
                     if (state === "connected") {
-                      clearBridgeRecovery(true);
+                      scheduleStableRecoveryReset(generation);
                     }
                     bridgeStateListener?.(state === "connected", state);
                   },
@@ -165,8 +181,24 @@ export function useSandboxPreference(
                       return;
                     }
 
-                    bridgeStateListener?.(false, "connecting");
                     clearBridgeRecovery(false);
+                    if (
+                      bridgeRecoveryAttempt >=
+                      DESKTOP_BRIDGE_MAX_RECOVERY_ATTEMPTS
+                    ) {
+                      console.warn(
+                        "[DesktopSandboxBridge] Automatic recovery exhausted",
+                        {
+                          reason,
+                          attempts: bridgeRecoveryAttempt,
+                        },
+                      );
+                      clearBridgeRecovery(true);
+                      bridgeStateListener?.(false, "failed");
+                      return;
+                    }
+
+                    bridgeStateListener?.(false, "connecting");
                     const delay =
                       DESKTOP_BRIDGE_RECOVERY_DELAYS_MS[
                         Math.min(
@@ -216,12 +248,12 @@ export function useSandboxPreference(
         // Keep Cloud selected by default; user can switch to Local if desired
         // setSandboxPreferenceState(connectionId);
       } catch (error) {
+        if (cancelled) return;
         if (bridgeRecoveryTimer) {
           setDesktopBridgeActive(false);
           setDesktopBridgeStatus("connecting");
           return;
         }
-        if (cancelled) return;
         console.error("[DesktopSandboxBridge] Failed to start:", error);
         setDesktopBridgeActive(false);
         setDesktopBridgeStatus("failed");

--- a/app/hooks/useSandboxPreference.ts
+++ b/app/hooks/useSandboxPreference.ts
@@ -26,6 +26,24 @@ let bridgeGeneration = 0;
 let bridgeStateListener:
   ((active: boolean, status: DesktopBridgeStatus) => void) | null = null;
 const PERSISTABLE_SANDBOX_PREFERENCES = new Set(["e2b", "desktop"]);
+const DESKTOP_BRIDGE_RECOVERY_DELAYS_MS = [1_000, 3_000, 8_000, 16_000];
+const RECOVERABLE_DESKTOP_TERMINATIONS = new Set([
+  "connection_not_found",
+  "connection_inactive",
+  "transport_disconnected",
+]);
+let bridgeRecoveryAttempt = 0;
+let bridgeRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearBridgeRecovery(resetAttempt: boolean): void {
+  if (bridgeRecoveryTimer) {
+    clearTimeout(bridgeRecoveryTimer);
+    bridgeRecoveryTimer = null;
+  }
+  if (resetAttempt) {
+    bridgeRecoveryAttempt = 0;
+  }
+}
 
 export function useSandboxPreference(
   isAuthenticated: boolean,
@@ -52,14 +70,22 @@ export function useSandboxPreference(
   );
   const disconnectMutation = useMutation(api.localSandbox.disconnectDesktop);
 
+  const heartbeatMutation = useMutation(api.localSandbox.heartbeatDesktop);
   const connectDesktopRef = useRef(connectDesktopMutation);
   const refreshTokenRef = useRef(refreshTokenMutation);
   const disconnectRef = useRef(disconnectMutation);
+  const heartbeatRef = useRef(heartbeatMutation);
   useEffect(() => {
     connectDesktopRef.current = connectDesktopMutation;
     refreshTokenRef.current = refreshTokenMutation;
     disconnectRef.current = disconnectMutation;
-  }, [connectDesktopMutation, refreshTokenMutation, disconnectMutation]);
+    heartbeatRef.current = heartbeatMutation;
+  }, [
+    connectDesktopMutation,
+    refreshTokenMutation,
+    disconnectMutation,
+    heartbeatMutation,
+  ]);
 
   useEffect(() => {
     let cancelled = false;
@@ -83,6 +109,7 @@ export function useSandboxPreference(
       bridgeStartPromise = null;
       const bridgeToStop = activeBridge;
       activeBridge = null;
+      clearBridgeRecovery(true);
       void bridgeToStop?.stop();
       syncBridgeState(false, "idle");
       return () => {
@@ -121,10 +148,40 @@ export function useSandboxPreference(
                   refreshCentrifugoTokenDesktop: (args) =>
                     refreshTokenRef.current(args),
                   disconnectDesktop: (args) => disconnectRef.current(args),
-                  onTerminated: () => {
+                  heartbeatDesktop: (args) => heartbeatRef.current(args),
+                  onConnectionState: (state) => {
+                    if (generation !== bridgeGeneration) return;
+                    if (state === "connected") {
+                      clearBridgeRecovery(true);
+                    }
+                    bridgeStateListener?.(state === "connected", state);
+                  },
+                  onTerminated: (reason) => {
                     if (generation !== bridgeGeneration) return;
                     if (activeBridge === bridge) activeBridge = null;
-                    bridgeStateListener?.(false, "failed");
+                    if (!RECOVERABLE_DESKTOP_TERMINATIONS.has(reason)) {
+                      clearBridgeRecovery(true);
+                      bridgeStateListener?.(false, "failed");
+                      return;
+                    }
+
+                    bridgeStateListener?.(false, "connecting");
+                    clearBridgeRecovery(false);
+                    const delay =
+                      DESKTOP_BRIDGE_RECOVERY_DELAYS_MS[
+                        Math.min(
+                          bridgeRecoveryAttempt,
+                          DESKTOP_BRIDGE_RECOVERY_DELAYS_MS.length - 1,
+                        )
+                      ];
+                    bridgeRecoveryAttempt += 1;
+                    bridgeRecoveryTimer = setTimeout(() => {
+                      bridgeRecoveryTimer = null;
+                      if (generation !== bridgeGeneration) return;
+                      bridgeGeneration += 1;
+                      bridgeStartPromise = null;
+                      setDesktopBridgeRetryAttempt((attempt) => attempt + 1);
+                    }, delay);
                   },
                 });
 
@@ -159,6 +216,11 @@ export function useSandboxPreference(
         // Keep Cloud selected by default; user can switch to Local if desired
         // setSandboxPreferenceState(connectionId);
       } catch (error) {
+        if (bridgeRecoveryTimer) {
+          setDesktopBridgeActive(false);
+          setDesktopBridgeStatus("connecting");
+          return;
+        }
         if (cancelled) return;
         console.error("[DesktopSandboxBridge] Failed to start:", error);
         setDesktopBridgeActive(false);
@@ -174,6 +236,7 @@ export function useSandboxPreference(
     // Cleanup on beforeunload (page close/refresh)
     const handleBeforeUnload = () => {
       bridgeGeneration += 1;
+      clearBridgeRecovery(true);
       bridgeStartPromise = null;
       bridgeStateListener = null;
       try {
@@ -217,6 +280,7 @@ export function useSandboxPreference(
   const retryDesktopBridge = useCallback(() => {
     if (!isAuthenticated || !isTauriEnvironment()) return;
     bridgeGeneration += 1;
+    clearBridgeRecovery(true);
     bridgeStartPromise = null;
     setDesktopBridgeActive(false);
     setDesktopBridgeStatus("connecting");

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -84,8 +84,27 @@ function buildConfig(overrides: Record<string, unknown> = {}) {
       .fn()
       .mockResolvedValue({ ok: true, centrifugoToken: "new-token" }),
     disconnectDesktop: jest.fn().mockResolvedValue({ success: true }),
+    heartbeatDesktop: jest.fn().mockResolvedValue({ success: true }),
     ...overrides,
   };
+}
+
+function getClientHandler(
+  eventName: string,
+): (ctx: Record<string, unknown>) => void {
+  const call = mockClient.on.mock.calls.find(([event]) => event === eventName);
+  if (!call) throw new Error(`No client ${eventName} handler registered`);
+  return call[1];
+}
+
+function getSubscriptionHandler(
+  eventName: string,
+): (ctx: Record<string, unknown>) => void {
+  const call = mockSubscription.on.mock.calls.find(
+    ([event]) => event === eventName,
+  );
+  if (!call) throw new Error(`No subscription ${eventName} handler registered`);
+  return call[1];
 }
 
 function getPublicationHandler(): (ctx: { data: unknown }) => void {
@@ -136,6 +155,71 @@ describe("desktop capability registration", () => {
       }),
     );
   });
+});
+
+it("waits for the relay and subscription before reporting ready", async () => {
+  const onConnectionState = jest.fn();
+  const config = buildConfig({ onConnectionState });
+  const bridge = new DesktopSandboxBridge(config);
+
+  await bridge.start();
+  await Promise.resolve();
+
+  expect(mockClient.ready).toHaveBeenCalledWith(15_000);
+  expect(mockSubscription.ready).toHaveBeenCalledWith(15_000);
+  expect(config.heartbeatDesktop).toHaveBeenCalledWith({
+    connectionId: "conn-123",
+  });
+  expect(onConnectionState).toHaveBeenCalledWith("connected");
+
+  await bridge.stop();
+});
+
+it("reports reconnecting and restored subscription state", async () => {
+  const onConnectionState = jest.fn();
+  const config = buildConfig({ onConnectionState });
+  const bridge = new DesktopSandboxBridge(config);
+  await bridge.start();
+
+  getClientHandler("connecting")({ code: 1, reason: "transport closed" });
+  getSubscriptionHandler("subscribing")({
+    code: 1,
+    reason: "transport closed",
+  });
+  getSubscriptionHandler("subscribed")({
+    recovered: true,
+    wasRecovering: true,
+  });
+
+  expect(onConnectionState).toHaveBeenNthCalledWith(2, "connecting");
+  expect(onConnectionState).toHaveBeenNthCalledWith(3, "connecting");
+  expect(onConnectionState).toHaveBeenLastCalledWith("connected");
+  expect(captureAuthenticatedEvent).toHaveBeenCalledWith(
+    "desktop_bridge_relay_state_changed",
+    expect.objectContaining({
+      state: "connected",
+      source: "subscription",
+      recovered: true,
+    }),
+  );
+
+  await bridge.stop();
+});
+
+it("requests a fresh bridge after a terminal transport disconnect", async () => {
+  const onTerminated = jest.fn();
+  const config = buildConfig({ onTerminated });
+  const bridge = new DesktopSandboxBridge(config);
+  await bridge.start();
+
+  getClientHandler("disconnected")({ code: 3500, reason: "transport closed" });
+
+  expect(onTerminated).toHaveBeenCalledWith("transport_disconnected");
+  expect(bridge.getConnectionId()).toBeNull();
+  expect(captureAuthenticatedEvent).toHaveBeenCalledWith(
+    "desktop_bridge_relay_state_changed",
+    expect.objectContaining({ state: "disconnected", code: 3500 }),
+  );
 });
 
 describe("terminal connection state", () => {
@@ -1245,14 +1329,14 @@ describe("forwardChunk", () => {
       new Promise<void>((_, reject) => {
         setTimeout(() => reject(new Error("ready timeout")), timeoutMs);
       });
-    mockClient.ready.mockImplementationOnce(rejectAtTimeout);
-    mockSubscription.ready.mockImplementationOnce(rejectAtTimeout);
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
     try {
       const bridge = new DesktopSandboxBridge(buildConfig());
       await bridge.start();
+      mockClient.ready.mockImplementationOnce(rejectAtTimeout);
+      mockSubscription.ready.mockImplementationOnce(rejectAtTimeout);
       const handler = getPublicationHandler();
       handler({
         data: {

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_PTY_ROWS,
 } from "@/lib/ai/tools/utils/pty-session-manager";
 import { CentrifugoPublishQueue } from "@/packages/local/src/centrifugo-transport";
+import { LOCAL_SANDBOX_HEARTBEAT_INTERVAL_MS } from "@/lib/centrifugo/presence";
 
 type RefreshTokenResult =
   | { ok: true; centrifugoToken: string }
@@ -50,7 +51,10 @@ type DesktopBridgeTerminationReason =
   | "unauthenticated"
   | "connection_not_found"
   | "ownership_mismatch"
-  | "connection_inactive";
+  | "connection_inactive"
+  | "transport_disconnected";
+
+type DesktopBridgeConnectionState = "connecting" | "connected";
 
 type DesktopStreamPublishFailureReason = "connection_closed" | "timeout";
 
@@ -58,6 +62,7 @@ const DESKTOP_STREAM_PUBLISH_MAX_ATTEMPTS = 3;
 const DESKTOP_STREAM_PUBLISH_RETRY_BASE_DELAY_MS = 250;
 const DESKTOP_STREAM_RECONNECT_WAIT_MS = 5_000;
 const DESKTOP_STREAM_RECOVERY_DEADLINE_BUFFER_MS = 3_000;
+const DESKTOP_BRIDGE_READY_TIMEOUT_MS = 15_000;
 
 interface StreamChunk {
   type: "stdout" | "stderr" | "exit" | "error";
@@ -188,6 +193,10 @@ interface DesktopBridgeConfig {
   disconnectDesktop: (args: {
     connectionId: string;
   }) => Promise<{ success: boolean }>;
+  heartbeatDesktop: (args: {
+    connectionId: string;
+  }) => Promise<{ success: boolean }>;
+  onConnectionState?: (state: DesktopBridgeConnectionState) => void;
   onTerminated?: (reason: DesktopBridgeTerminationReason) => void;
 }
 
@@ -200,6 +209,10 @@ export class DesktopSandboxBridge {
   private config: DesktopBridgeConfig;
   private publishQueue: CentrifugoPublishQueue | null = null;
 
+  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  private consecutiveHeartbeatFailures = 0;
+  private relayUnavailableAt: number | null = null;
+  private successfulRelayConnections = 0;
   constructor(config: DesktopBridgeConfig) {
     this.config = config;
   }
@@ -208,9 +221,100 @@ export class DesktopSandboxBridge {
     return this.connectionId;
   }
 
+  private logRelayState(
+    state: "connecting" | "connected" | "disconnected" | "error",
+    details: Record<string, unknown> = {},
+  ): void {
+    const properties = {
+      connectionId: this.connectionId,
+      clientSurface: "desktop_bridge",
+      state,
+      reconnectAttempt: Math.max(0, this.successfulRelayConnections - 1),
+      ...details,
+    };
+    const message = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      event: "desktop_bridge_relay_state_changed",
+      ...properties,
+    });
+    if (state === "connected") {
+      console.info("[desktop-bridge]", message);
+    } else {
+      console.warn("[desktop-bridge]", message);
+    }
+    captureAuthenticatedEvent(
+      state === "error"
+        ? "desktop_bridge_relay_error"
+        : "desktop_bridge_relay_state_changed",
+      properties,
+    );
+  }
+
+  private async sendHeartbeat(): Promise<void> {
+    const connectionId = this.connectionId;
+    if (this.isStoppingOrStopped || !connectionId) return;
+
+    try {
+      const result = await this.config.heartbeatDesktop({ connectionId });
+      if (this.isStoppingOrStopped || this.connectionId !== connectionId)
+        return;
+      if (!result.success) {
+        this.logRelayState("disconnected", {
+          reason: "heartbeat_connection_inactive",
+        });
+        this.terminateClient("connection_inactive");
+        return;
+      }
+      if (this.consecutiveHeartbeatFailures > 0) {
+        this.logRelayState("connected", {
+          source: "heartbeat",
+          recoveredAfterFailures: this.consecutiveHeartbeatFailures,
+        });
+        this.consecutiveHeartbeatFailures = 0;
+      }
+    } catch (error) {
+      if (this.isStoppingOrStopped) return;
+      if (isUnauthenticatedError(error)) {
+        this.logRelayState("disconnected", {
+          reason: "heartbeat_unauthenticated",
+        });
+        this.terminateClient("unauthenticated");
+        return;
+      }
+      this.consecutiveHeartbeatFailures += 1;
+      if (
+        this.consecutiveHeartbeatFailures === 1 ||
+        this.consecutiveHeartbeatFailures % 4 === 0
+      ) {
+        this.logRelayState("error", {
+          errorType: "heartbeat",
+          consecutiveFailures: this.consecutiveHeartbeatFailures,
+          error:
+            error instanceof Error ? error.message : String(error ?? "unknown"),
+        });
+      }
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    void this.sendHeartbeat();
+    this.heartbeatInterval = setInterval(() => {
+      void this.sendHeartbeat();
+    }, LOCAL_SANDBOX_HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+  }
+
   private terminateClient(reason: DesktopBridgeTerminationReason): void {
     if (this.isStoppingOrStopped) return;
     this.isStoppingOrStopped = true;
+    this.stopHeartbeat();
     const client = this.client;
     const subscription = this.subscription;
     this.client = null;
@@ -308,6 +412,7 @@ export class DesktopSandboxBridge {
         throw new Error(`Centrifugo refresh aborted: ${result.reason}`);
       },
     });
+    const client = this.client;
 
     const userId = this.extractUserIdFromToken(centrifugoToken);
     const channel = sandboxConnectionChannel(userId, connectionId);
@@ -319,6 +424,87 @@ export class DesktopSandboxBridge {
       if (this.isStoppingOrStopped || this.subscription !== subscription)
         return;
       await subscription.publish(message);
+    });
+
+    client.on("connecting", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      if (this.relayUnavailableAt === null) {
+        this.relayUnavailableAt = Date.now();
+      }
+      this.config.onConnectionState?.("connecting");
+      this.logRelayState("connecting", {
+        code: ctx.code,
+        reason: ctx.reason,
+      });
+    });
+    client.on("connected", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      this.successfulRelayConnections += 1;
+      this.logRelayState("connected", {
+        transport: ctx.transport,
+        outageDurationMs:
+          this.relayUnavailableAt === null
+            ? 0
+            : Date.now() - this.relayUnavailableAt,
+      });
+      this.relayUnavailableAt = null;
+    });
+    client.on("disconnected", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      this.logRelayState("disconnected", {
+        code: ctx.code,
+        reason: ctx.reason,
+      });
+      this.terminateClient("transport_disconnected");
+    });
+    client.on("error", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      this.logRelayState("error", {
+        errorType: ctx.type,
+        code: ctx.error.code,
+        reason: ctx.error.message,
+        transport: ctx.transport,
+      });
+    });
+
+    subscription.on("subscribing", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      if (this.relayUnavailableAt === null) {
+        this.relayUnavailableAt = Date.now();
+      }
+      this.config.onConnectionState?.("connecting");
+      this.logRelayState("connecting", {
+        source: "subscription",
+        code: ctx.code,
+        reason: ctx.reason,
+      });
+    });
+    subscription.on("subscribed", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      this.config.onConnectionState?.("connected");
+      this.logRelayState("connected", {
+        source: "subscription",
+        recovered: ctx.recovered,
+        wasRecovering: ctx.wasRecovering,
+      });
+    });
+    subscription.on("unsubscribed", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      this.logRelayState("disconnected", {
+        source: "subscription",
+        code: ctx.code,
+        reason: ctx.reason,
+      });
+      this.terminateClient("transport_disconnected");
+    });
+    subscription.on("error", (ctx) => {
+      if (this.isStoppingOrStopped) return;
+      this.logRelayState("error", {
+        source: "subscription",
+        errorType: ctx.type,
+        code: ctx.error.code,
+        reason: ctx.error.message,
+      });
     });
 
     this.subscription.on("publication", (ctx) => {
@@ -415,7 +601,26 @@ export class DesktopSandboxBridge {
     });
 
     this.subscription.subscribe();
-    this.client.connect();
+    client.connect();
+
+    try {
+      await Promise.all([
+        client.ready(DESKTOP_BRIDGE_READY_TIMEOUT_MS),
+        subscription.ready(DESKTOP_BRIDGE_READY_TIMEOUT_MS),
+      ]);
+    } catch (error) {
+      this.logRelayState("error", {
+        errorType: "startup_readiness",
+        error:
+          error instanceof Error ? error.message : String(error ?? "unknown"),
+      });
+      throw error;
+    }
+    if (this.isStoppingOrStopped || this.connectionId !== connectionId) {
+      throw new Error("Desktop bridge stopped before relay became ready");
+    }
+    this.config.onConnectionState?.("connected");
+    this.startHeartbeat();
 
     return connectionId;
   }
@@ -1345,6 +1550,7 @@ export class DesktopSandboxBridge {
 
   async stop(): Promise<void> {
     this.isStoppingOrStopped = true;
+    this.stopHeartbeat();
     this.publishQueue = null;
     if (this.connectionId) {
       try {

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -538,6 +538,41 @@ export const refreshCentrifugoTokenDesktop = mutation({
   },
 });
 
+export const heartbeatDesktop = mutation({
+  args: {
+    connectionId: v.string(),
+  },
+  returns: v.object({
+    success: v.boolean(),
+  }),
+  handler: async (ctx, { connectionId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Unauthorized: User not authenticated",
+      });
+    }
+
+    const connection = await ctx.db
+      .query("local_sandbox_connections")
+      .withIndex("by_connection_id", (q) => q.eq("connection_id", connectionId))
+      .first();
+
+    if (
+      !connection ||
+      connection.user_id !== identity.subject ||
+      connection.client_version !== "desktop" ||
+      connection.status !== "connected"
+    ) {
+      return { success: false };
+    }
+
+    await ctx.db.patch(connection._id, { last_heartbeat: Date.now() });
+    return { success: true };
+  },
+});
+
 export const disconnectDesktop = mutation({
   args: {
     connectionId: v.string(),

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -22,7 +22,10 @@ import { SANDBOX_ENVIRONMENT_TOOLS } from "./sandbox-tools";
 import { getPlatformDisplayName } from "./platform-utils";
 import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
 import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
-import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
+import {
+  LOCAL_SANDBOX_PRESENCE_GRACE_MS,
+  presenceHasConnectionId,
+} from "@/lib/centrifugo/presence";
 import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
 
 type SandboxInstance = Sandbox | CentrifugoSandbox;
@@ -54,7 +57,7 @@ export interface SandboxFallbackInfo {
 // initial readiness check and one reconnect both fail. E2B reset remains
 // connection-only and never kills the shared per-user sandbox.
 const MAX_SANDBOX_HEALTH_FAILURES = 2;
-export const LOCAL_SANDBOX_PRESENCE_GRACE_MS = 30_000;
+export { LOCAL_SANDBOX_PRESENCE_GRACE_MS };
 const LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS = 2_000;
 
 interface PresenceProbeResult {

--- a/lib/centrifugo/presence.ts
+++ b/lib/centrifugo/presence.ts
@@ -8,6 +8,12 @@ type PresenceResultLike = {
   presence?: Record<string, unknown>;
 };
 
+// Clients refresh this timestamp independently from Centrifugo token refreshes
+// so a brief relay outage remains recoverable. The grace window tolerates four
+// missed heartbeats before backend cleanup can make the connection terminal.
+export const LOCAL_SANDBOX_HEARTBEAT_INTERVAL_MS = 30_000;
+export const LOCAL_SANDBOX_PRESENCE_GRACE_MS = 120_000;
+
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   typeof value === "object" && value !== null
     ? (value as Record<string, unknown>)


### PR DESCRIPTION
## Summary

- keep Desktop connection liveness fresh with an authenticated 30-second heartbeat and a 120-second presence recovery window
- wait for both the Centrifugo transport and subscription before reporting the Desktop sandbox as connected
- reflect transient reconnects in Desktop state and automatically create a fresh bridge after terminal transport or stale-connection failures using bounded backoff
- add privacy-safe structured telemetry for transport transitions, subscription recovery, readiness failures, heartbeat failures, retry counts, and outage duration

## Root cause

The Desktop bridge returned success immediately after calling `connect()` and `subscribe()`, before either was ready. Connection rows were only refreshed during the one-hour Centrifugo token refresh, so a brief WebSocket absence could look stale and be permanently disconnected by presence cleanup. Once that happened, token refresh rejected the inactive row and the UI required a manual retry.

This change gives healthy reconnects time to recover, keeps the server-side liveness timestamp current, and restarts the bridge automatically when the existing connection is genuinely terminal.

## Validation

- `pnpm exec jest app/services/__tests__/desktop-sandbox-bridge.test.ts app/hooks/__tests__/useSandboxPreference.test.tsx lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts --runInBand` — 67 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with 7 pre-existing warnings
- commit hook full Jest suite — 363 suites / 3,728 tests passed
- Prettier and `git diff --check` — passed

## Manual verification

1. Open HackerAI Desktop on Linux/Kali and select the Desktop sandbox for Agent mode.
2. Start a long-running terminal command, then interrupt network access for 30-60 seconds and restore it.
3. Confirm the UI shows the temporary connecting state, the relay resubscribes automatically, Agent mode remains local, and a subsequent terminal command succeeds.
4. Leave the connection unavailable past the recovery window and confirm the bridge creates a fresh Desktop connection automatically rather than remaining permanently disconnected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for disconnected desktop sandbox connections with bounded retry attempts.
  * Added connection heartbeats to detect inactive or unauthenticated sessions.
  * Added readiness tracking and connection-state updates during startup, reconnection, and shutdown.

* **Bug Fixes**
  * Improved stale-connection detection using a consistent presence grace period.
  * Prevented recoverable interruptions from immediately appearing as permanent failures.
  * Stopped recovery after repeated unsuccessful attempts and reported the connection as failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->