### PR TITLE
Prevent long reasoning blocks from freezing chat

### DIFF
--- a/app/components/ReasoningHandler.tsx
+++ b/app/components/ReasoningHandler.tsx
@@ -53,7 +53,10 @@ const ReasoningBody = memo(function ReasoningBody({
           ? "Showing the latest reasoning while it runs to keep the chat responsive."
           : "Showing the latest section of this long reasoning to keep the chat responsive."}
       </p>
-      <div className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+      <div
+        className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
+        data-testid="long-reasoning-preview-body"
+      >
         {getReasoningTail(content)}
       </div>
       {!isStreamingMessage && (

--- a/app/components/ReasoningHandler.tsx
+++ b/app/components/ReasoningHandler.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
 import { UIMessage } from "@ai-sdk/react";
 import type { ChatStatus } from "@/types";
 import { MemoizedMarkdown } from "./MemoizedMarkdown";
@@ -19,6 +19,55 @@ type ReasoningHandlerProps = {
   suppressAutoOpenDuringStreaming?: boolean;
   deferCollapseUntilParent?: boolean;
 };
+
+const LONG_REASONING_THRESHOLD = 12_000;
+const LONG_REASONING_TAIL_LENGTH = 6_000;
+
+const getReasoningTail = (content: string): string => {
+  const tail = content.slice(-LONG_REASONING_TAIL_LENGTH);
+  const firstNewline = tail.indexOf("\n");
+
+  return firstNewline >= 0 ? tail.slice(firstNewline + 1) : tail;
+};
+
+const ReasoningBody = memo(function ReasoningBody({
+  content,
+  isStreamingMessage,
+}: {
+  content: string;
+  isStreamingMessage: boolean;
+}) {
+  const [showFullReasoning, setShowFullReasoning] = useState(false);
+  const isLongReasoning = content.length > LONG_REASONING_THRESHOLD;
+  const showBoundedPreview =
+    isLongReasoning && (isStreamingMessage || !showFullReasoning);
+
+  if (!showBoundedPreview) {
+    return <MemoizedMarkdown content={content} />;
+  }
+
+  return (
+    <div className="space-y-2" data-testid="long-reasoning-preview">
+      <p className="text-xs text-muted-foreground/80">
+        {isStreamingMessage
+          ? "Showing the latest reasoning while it runs to keep the chat responsive."
+          : "Showing the latest section of this long reasoning to keep the chat responsive."}
+      </p>
+      <div className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+        {getReasoningTail(content)}
+      </div>
+      {!isStreamingMessage && (
+        <button
+          type="button"
+          className="text-xs text-foreground/80 underline-offset-4 hover:text-foreground hover:underline"
+          onClick={() => setShowFullReasoning(true)}
+        >
+          Show full reasoning
+        </button>
+      )}
+    </div>
+  );
+});
 
 const collectReasoningText = (
   parts: UIMessage["parts"],
@@ -176,7 +225,10 @@ export const ReasoningHandler = memo(function ReasoningHandler({
       <ReasoningTrigger />
       {combined && (
         <ReasoningContent>
-          <MemoizedMarkdown content={combined} />
+          <ReasoningBody
+            content={combined}
+            isStreamingMessage={isStreamingMessage}
+          />
         </ReasoningContent>
       )}
     </Reasoning>

--- a/app/components/__tests__/ReasoningHandler.test.tsx
+++ b/app/components/__tests__/ReasoningHandler.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { UIMessage } from "@ai-sdk/react";
 import { ReasoningHandler } from "../ReasoningHandler";
 
@@ -21,6 +21,12 @@ const StreamingReasoningParts = ({ message }: { message: UIMessage }) => (
 );
 
 describe("ReasoningHandler", () => {
+  const longReasoningPrefix = `Unique early reasoning marker.\n${"Filler reasoning line.\n".repeat(
+    800,
+  )}`;
+  const longReasoningTail = "Latest reasoning remains visible.";
+  const longReasoning = `${longReasoningPrefix}${longReasoningTail}`;
+
   it("renders OpenRouter reasoning parts with reasoning_details metadata", () => {
     const message = {
       id: "assistant-1",
@@ -240,5 +246,136 @@ describe("ReasoningHandler", () => {
 
     expect(screen.getByText("Reasoning")).toBeInTheDocument();
     expect(screen.getByText("Reviewing output")).toBeVisible();
+  });
+
+  it("bounds long reasoning while it is streaming", async () => {
+    const message = {
+      id: "assistant-long-stream",
+      role: "assistant",
+      parts: [{ type: "reasoning", state: "streaming", text: longReasoning }],
+    } as unknown as UIMessage;
+
+    render(
+      <ReasoningHandler
+        message={message}
+        partIndex={0}
+        status="streaming"
+        isLastMessage
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("long-reasoning-preview")).toBeVisible();
+    });
+    expect(screen.getByTestId("long-reasoning-preview")).toHaveTextContent(
+      longReasoningTail,
+    );
+    expect(screen.getByTestId("long-reasoning-preview")).not.toHaveTextContent(
+      "Unique early reasoning marker.",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Show full reasoning" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a completed long stream bounded until full reasoning is requested", async () => {
+    const streamingMessage = {
+      id: "assistant-long-complete",
+      role: "assistant",
+      parts: [{ type: "reasoning", state: "streaming", text: longReasoning }],
+    } as unknown as UIMessage;
+    const { rerender } = render(
+      <ReasoningHandler
+        message={streamingMessage}
+        partIndex={0}
+        status="streaming"
+        isLastMessage
+        deferCollapseUntilParent
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("long-reasoning-preview")).toBeVisible();
+    });
+
+    const completedMessage = {
+      ...streamingMessage,
+      parts: [
+        { type: "reasoning", state: "done", text: longReasoning },
+        { type: "text", state: "done", text: "Done" },
+      ],
+    } as unknown as UIMessage;
+    rerender(
+      <ReasoningHandler
+        message={completedMessage}
+        partIndex={0}
+        status="ready"
+        isLastMessage
+        deferCollapseUntilParent
+      />,
+    );
+
+    const showFullButton = screen.getByRole("button", {
+      name: "Show full reasoning",
+    });
+    expect(screen.getByTestId("long-reasoning-preview")).toBeVisible();
+
+    fireEvent.click(showFullButton);
+
+    expect(
+      screen.queryByTestId("long-reasoning-preview"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("streamdown")).toHaveTextContent(
+      "Unique early reasoning marker.",
+    );
+    expect(screen.getByTestId("streamdown")).toHaveTextContent(
+      longReasoningTail,
+    );
+  });
+
+  it("bounds complete historical long reasoning until full content is requested", async () => {
+    const message = {
+      id: "assistant-long-history",
+      role: "assistant",
+      parts: [{ type: "reasoning", state: "done", text: longReasoning }],
+    } as unknown as UIMessage;
+
+    const { rerender } = render(
+      <ReasoningHandler
+        message={message}
+        partIndex={0}
+        status="ready"
+        isLastMessage
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reasoning" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("long-reasoning-preview")).toHaveTextContent(
+        longReasoningTail,
+      );
+    });
+    expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show full reasoning" }),
+    );
+
+    expect(screen.getByTestId("streamdown")).toHaveTextContent(
+      "Unique early reasoning marker.",
+    );
+
+    rerender(
+      <ReasoningHandler
+        message={message}
+        partIndex={0}
+        status="streaming"
+        isLastMessage
+      />,
+    );
+
+    expect(screen.getByTestId("long-reasoning-preview")).toBeVisible();
+    expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
   });
 });

--- a/app/components/__tests__/ReasoningHandler.test.tsx
+++ b/app/components/__tests__/ReasoningHandler.test.tsx
@@ -24,8 +24,13 @@ describe("ReasoningHandler", () => {
   const longReasoningPrefix = `Unique early reasoning marker.\n${"Filler reasoning line.\n".repeat(
     800,
   )}`;
-  const longReasoningTail = "Latest reasoning remains visible.";
-  const longReasoning = `${longReasoningPrefix}${longReasoningTail}`;
+  const longReasoningEnd = "Latest reasoning remains visible.";
+  const longReasoning = `${longReasoningPrefix}${longReasoningEnd}`;
+  const longReasoningCutoff = longReasoning.slice(-6_000);
+  const firstCutoffNewline = longReasoningCutoff.indexOf("\n");
+  const expectedLongReasoningTail = longReasoningCutoff.slice(
+    firstCutoffNewline + 1,
+  );
 
   it("renders OpenRouter reasoning parts with reasoning_details metadata", () => {
     const message = {
@@ -267,11 +272,8 @@ describe("ReasoningHandler", () => {
     await waitFor(() => {
       expect(screen.getByTestId("long-reasoning-preview")).toBeVisible();
     });
-    expect(screen.getByTestId("long-reasoning-preview")).toHaveTextContent(
-      longReasoningTail,
-    );
-    expect(screen.getByTestId("long-reasoning-preview")).not.toHaveTextContent(
-      "Unique early reasoning marker.",
+    expect(screen.getByTestId("long-reasoning-preview-body").textContent).toBe(
+      expectedLongReasoningTail,
     );
     expect(
       screen.queryByRole("button", { name: "Show full reasoning" }),
@@ -329,7 +331,7 @@ describe("ReasoningHandler", () => {
       "Unique early reasoning marker.",
     );
     expect(screen.getByTestId("streamdown")).toHaveTextContent(
-      longReasoningTail,
+      longReasoningEnd,
     );
   });
 
@@ -353,7 +355,7 @@ describe("ReasoningHandler", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("long-reasoning-preview")).toHaveTextContent(
-        longReasoningTail,
+        longReasoningEnd,
       );
     });
     expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Bound active long reasoning rendering to the latest 6,000 characters after a 12,000-character threshold.
- Avoid reparsing the full growing Markdown document on every stream update.
- Keep complete reasoning available after completion through **Show full reasoning**.
- Force resumed streams back into the bounded live preview.

## Root cause

`ReasoningHandler` passed the full accumulated reasoning string to Streamdown on each throttled stream update. The work per update grew with the transcript length, eventually monopolizing the browser main thread for very long reasoning blocks.

## Validation

- Full Jest suite: 363 suites / 3,732 tests passed.
- Focused reasoning tests: 2 suites / 17 tests passed.
- `pnpm typecheck` passed.
- Focused ESLint and Prettier checks passed.
- Local browser shell smoke: HTTP 200, composer rendered, and no overlay or console errors.

## Manual verification

1. Start a response that streams more than 12,000 characters of reasoning.
2. Confirm chat remains responsive and the latest reasoning tail stays visible.
3. After completion, click **Show full reasoning** and confirm the full formatted content appears.
4. Resume an interrupted long response and confirm the view returns to the bounded live preview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long reasoning content exceeding the display limit now shows a concise latest-section preview by default.
  * Completed reasoning can be expanded with a **“Show full reasoning”** option.

* **Improvements**
  * Reasoning previews remain available while content is streaming and after completion.
  * Returning to streaming automatically reapplies the preview limit for a consistent viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->