### PR TITLE
Cache parsed chat draft storage

### DIFF
--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -3,6 +3,7 @@ import {
   CONVERSATION_DRAFTS_STORAGE_KEY,
   getDraftAttachmentsById,
   readOpenSidebarProjectIds,
+  readDraftStore,
   readSelectedModel,
   removeDraftAttachments,
   writeSelectedModel,
@@ -502,5 +503,53 @@ describe("client-storage draft attachments", () => {
 
     expect(getDraftAttachmentsById("chat-1")).toEqual([]);
     expect(hasDraftAttachmentsById("chat-1")).toBe(false);
+  });
+});
+
+describe("client-storage draft cache", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("reuses the parsed draft store while localStorage is unchanged", () => {
+    window.localStorage.setItem(
+      CONVERSATION_DRAFTS_STORAGE_KEY,
+      JSON.stringify({
+        drafts: [{ id: "chat-1", content: "cached", timestamp: 123 }],
+      }),
+    );
+
+    const parseSpy = jest.spyOn(JSON, "parse");
+    const firstRead = readDraftStore();
+    const parseCountAfterFirstRead = parseSpy.mock.calls.length;
+
+    expect(readDraftStore()).toBe(firstRead);
+    expect(parseSpy).toHaveBeenCalledTimes(parseCountAfterFirstRead);
+
+    window.localStorage.setItem(
+      CONVERSATION_DRAFTS_STORAGE_KEY,
+      JSON.stringify({
+        drafts: [{ id: "chat-2", content: "new value", timestamp: 456 }],
+      }),
+    );
+
+    expect(readDraftStore()).not.toBe(firstRead);
+    expect(parseSpy).toHaveBeenCalledTimes(parseCountAfterFirstRead + 1);
+    parseSpy.mockRestore();
+  });
+
+  it("keeps the cached snapshot synchronized with writes and clears", () => {
+    upsertDraft("chat-1", "saved draft", 123);
+
+    const writtenStore = readDraftStore();
+    expect(readDraftStore()).toBe(writtenStore);
+    expect(writtenStore.drafts).toEqual([
+      { id: "chat-1", content: "saved draft", timestamp: 123 },
+    ]);
+
+    window.localStorage.clear();
+
+    expect(readDraftStore()).toEqual({ drafts: [] });
+    expect(readDraftStore()).not.toBe(writtenStore);
   });
 });

--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "@jest/globals";
 import {
   CONVERSATION_DRAFTS_STORAGE_KEY,
+  clearAllDrafts,
   getDraftAttachmentsById,
   readOpenSidebarProjectIds,
   readDraftStore,
@@ -551,5 +552,18 @@ describe("client-storage draft cache", () => {
 
     expect(readDraftStore()).toEqual({ drafts: [] });
     expect(readDraftStore()).not.toBe(writtenStore);
+  });
+
+  it("resets the cached snapshot when all drafts are cleared", () => {
+    upsertDraft("chat-1", "saved draft", 123);
+    const writtenStore = readDraftStore();
+
+    clearAllDrafts();
+
+    expect(readDraftStore()).toEqual({ drafts: [] });
+    expect(readDraftStore()).not.toBe(writtenStore);
+    expect(
+      window.localStorage.getItem(CONVERSATION_DRAFTS_STORAGE_KEY),
+    ).toBeNull();
   });
 });

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -51,6 +51,8 @@ let openSidebarProjectIdsMemorySnapshot =
 const sidebarTaskLastVisitedAtListeners = new Map<string, Set<() => void>>();
 let sidebarTaskLastVisitedAtMemory: Record<string, number> = {};
 let sidebarTaskLastVisitedAtSubscriberCount = 0;
+let draftStoreMemory:
+  { raw: string | null; store: ConversationDraftStore } | undefined;
 
 const isBrowser = (): boolean => typeof window !== "undefined";
 
@@ -360,11 +362,10 @@ export const clearSidebarTaskLastVisitedAt = (): void => {
   taskIds.forEach(notifySidebarTaskLastVisitedAt);
 };
 
-export const readDraftStore = (): ConversationDraftStore => {
-  if (!isBrowser()) return { drafts: [] };
+const parseDraftStore = (raw: string | null): ConversationDraftStore => {
+  if (!raw) return { drafts: [] };
+
   try {
-    const raw = window.localStorage.getItem(CONVERSATION_DRAFTS_STORAGE_KEY);
-    if (!raw) return { drafts: [] };
     const parsed = JSON.parse(raw);
     const drafts = Array.isArray(parsed?.drafts) ? parsed.drafts : [];
     const userId =
@@ -375,13 +376,30 @@ export const readDraftStore = (): ConversationDraftStore => {
   }
 };
 
+export const readDraftStore = (): ConversationDraftStore => {
+  if (!isBrowser()) return { drafts: [] };
+
+  try {
+    const raw = window.localStorage.getItem(CONVERSATION_DRAFTS_STORAGE_KEY);
+    // Reuse the parsed snapshot while still noticing replacements from another
+    // tab or direct localStorage writes in this one.
+    if (draftStoreMemory?.raw === raw) return draftStoreMemory.store;
+
+    const store = parseDraftStore(raw);
+    draftStoreMemory = { raw, store };
+    return store;
+  } catch {
+    return draftStoreMemory?.store ?? { drafts: [] };
+  }
+};
+
 export const writeDraftStore = (store: ConversationDraftStore): void => {
   if (!isBrowser()) return;
+
   try {
-    window.localStorage.setItem(
-      CONVERSATION_DRAFTS_STORAGE_KEY,
-      JSON.stringify({ drafts: store.drafts, userId: store.userId }),
-    );
+    const raw = JSON.stringify({ drafts: store.drafts, userId: store.userId });
+    draftStoreMemory = { raw, store };
+    window.localStorage.setItem(CONVERSATION_DRAFTS_STORAGE_KEY, raw);
   } catch {
     // ignore
   }
@@ -673,6 +691,7 @@ export const removeDraft = (id: string): void => {
 
 export const clearAllDrafts = (): void => {
   if (!isBrowser()) return;
+  draftStoreMemory = { raw: null, store: { drafts: [] } };
   try {
     window.localStorage.removeItem(CONVERSATION_DRAFTS_STORAGE_KEY);
   } catch {


### PR DESCRIPTION
## Summary

- Cache the parsed conversation-draft store for as long as its backing localStorage snapshot is unchanged.
- Keep the cache synchronized on draft writes and full clears.
- Detect replacements, cross-tab updates, and direct localStorage changes by comparing the raw backing snapshot before reuse.
- Add regression coverage proving repeated composer reads do not repeatedly parse the same full draft store.

## t3code comparison

t3code keeps composer drafts in memory and treats browser storage as persistence, avoiding repeated full-store decoding during normal composer work. HackerAI already has t3code's larger chat-performance themes—virtualized history, stable timeline rows, composer-state isolation, paginated history, scroll preservation, and streaming throttling—so this PR copies the remaining transferable storage optimization without porting product-specific timeline or server architecture.

HackerAI still writes drafts synchronously after its existing 500 ms autosave debounce. This preserves current durability and timing semantics while removing redundant JSON parsing across text, attachment, restore, and cleanup helpers.

## Validation

- Full Jest suite: 363 suites / 3,735 tests passed.
- Focused client-storage suite: 39 tests passed.
- `pnpm typecheck` passed.
- `pnpm lint` passed with 7 pre-existing warnings and 0 errors.
- Prettier and diff checks passed.

Automated validation is sufficient because this changes internal draft persistence only and has no visual or user-facing behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Draft data loads faster by avoiding unnecessary repeated processing when local storage is unchanged.
  * Repeated draft reads now provide a more responsive experience.

* **Reliability**
  * Drafts remain available when local storage access temporarily fails.
  * Draft data stays synchronized after saving, clearing, or removing all drafts.
  * Updates made outside the app are detected and reflected automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->