### PR TITLE
Keep auxiliary image descriptions out of chat titles

### DIFF
--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -53,6 +53,21 @@ const makeImageOnlyMessage = (): UIMessage[] =>
     },
   ] as UIMessage[];
 
+const makeDescribedImageMessage = (text?: string): UIMessage[] =>
+  [
+    {
+      id: "message-1",
+      role: "user",
+      parts: [
+        ...(text ? [{ type: "text" as const, text }] : []),
+        {
+          type: "text",
+          text: '<image_description filename="screenshot.png" trust="untrusted">\nA terminal screenshot.\n</image_description>',
+        },
+      ],
+    },
+  ] as UIMessage[];
+
 describe("generateTitleFromUserMessage", () => {
   beforeEach(() => {
     mockGenerateText.mockReset();
@@ -93,6 +108,32 @@ describe("generateTitleFromUserMessage", () => {
 
     expect(mockLanguageModel).not.toHaveBeenCalled();
     expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("keeps the default title when auxiliary preprocessing replaced the only image", async () => {
+    await expect(
+      generateTitleFromUserMessage(makeDescribedImageMessage()),
+    ).resolves.toBe("New chat");
+
+    expect(mockLanguageModel).not.toHaveBeenCalled();
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("generates a title from user text without auxiliary image markup", async () => {
+    mockGenerateText.mockResolvedValue({
+      output: { title: "Explain This Screenshot" },
+    });
+
+    await expect(
+      generateTitleFromUserMessage(
+        makeDescribedImageMessage("Tell me about this image"),
+      ),
+    ).resolves.toBe("Explain This Screenshot");
+
+    const prompt = mockGenerateText.mock.calls[0][0].messages[0]
+      .content as string;
+    expect(prompt).toContain("### User Message:\nTell me about this image");
+    expect(prompt).not.toContain("<image_description");
   });
 
   it("constrains generated titles to non-empty strings under the chat title limit", async () => {

--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -134,6 +134,7 @@ describe("generateTitleFromUserMessage", () => {
       .content as string;
     expect(prompt).toContain("### User Message:\nTell me about this image");
     expect(prompt).not.toContain("<image_description");
+    expect(prompt).not.toContain("A terminal screenshot.");
   });
 
   it("constrains generated titles to non-empty strings under the chat title limit", async () => {

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -11,6 +11,8 @@ const MAX_GENERATED_TITLE_LENGTH = 100;
 const TITLE_GENERATION_MAX_OUTPUT_TOKENS = 64;
 const FALLBACK_TITLE_WORD_LIMIT = 5;
 const IMAGE_ONLY_CHAT_TITLE = "New chat";
+const AUXILIARY_IMAGE_DESCRIPTION_PATTERN =
+  /^<image_description\b(?=[^>]*\btrust="untrusted")[^>]*>[\s\S]*<\/image_description>$/;
 
 const truncateMiddle = (text: string, maxLength: number): string => {
   if (text.length <= maxLength) return text;
@@ -60,12 +62,24 @@ export const generateTitleFromUserMessage = async (
   truncatedMessages: UIMessage[],
 ): Promise<string | undefined> => {
   const firstMessage = truncatedMessages[0];
-  const textContent = (firstMessage?.parts ?? [])
-    .filter((part: { type: string; text?: string }) => part.type === "text")
+  const firstMessageParts = firstMessage?.parts ?? [];
+  const isAuxiliaryImageDescription = (part: {
+    type: string;
+    text?: string;
+  }): boolean =>
+    part.type === "text" &&
+    AUXILIARY_IMAGE_DESCRIPTION_PATTERN.test((part.text ?? "").trim());
+  const textContent = firstMessageParts
+    .filter(
+      (part: { type: string; text?: string }) =>
+        part.type === "text" && !isAuxiliaryImageDescription(part),
+    )
     .map((part: { type: string; text?: string }) => part.text || "")
     .join(" ");
-  const hasImage = (firstMessage?.parts ?? []).some(
-    (part) => part.type === "file" && part.mediaType.startsWith("image/"),
+  const hasImage = firstMessageParts.some(
+    (part) =>
+      (part.type === "file" && part.mediaType.startsWith("image/")) ||
+      isAuxiliaryImageDescription(part),
   );
 
   if (!textContent.trim() && hasImage) {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1702,7 +1702,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(dbActionsSrc).toMatch(/export async function updateChatTitle/);
     expect(dbActionsSrc).toMatch(/api\.chats\.updateChatTitle/);
     expect(chatHandlerSrc).toMatch(
-      /generateTitleFromUserMessageWithWriter\(\s*truncatedMessages,[\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
+      /generateTitleFromUserMessageWithWriter\(\s*fetched\.truncatedMessages,[\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
     );
     expect(taskSrc).toMatch(
       /generateTitleFromUserMessageWithWriter\(\s*messagesForProcessing,[\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1702,10 +1702,10 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(dbActionsSrc).toMatch(/export async function updateChatTitle/);
     expect(dbActionsSrc).toMatch(/api\.chats\.updateChatTitle/);
     expect(chatHandlerSrc).toMatch(
-      /generateTitleFromUserMessageWithWriter\([\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
+      /generateTitleFromUserMessageWithWriter\(\s*truncatedMessages,[\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
     );
     expect(taskSrc).toMatch(
-      /generateTitleFromUserMessageWithWriter\([\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
+      /generateTitleFromUserMessageWithWriter\(\s*messagesForProcessing,[\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
     );
   });
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -895,7 +895,7 @@ export const createChatHandler = () => {
             // Generate the title in parallel for new tasks.
             const titlePromise = isNewChat
               ? generateTitleFromUserMessageWithWriter(
-                  processedMessages,
+                  truncatedMessages,
                   writer,
                   (title) => updateChatTitle({ chatId, title }),
                 )

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -895,7 +895,7 @@ export const createChatHandler = () => {
             // Generate the title in parallel for new tasks.
             const titlePromise = isNewChat
               ? generateTitleFromUserMessageWithWriter(
-                  truncatedMessages,
+                  fetched.truncatedMessages,
                   writer,
                   (title) => updateChatTitle({ chatId, title }),
                 )

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -3056,7 +3056,7 @@ export const agentLongTask = task({
 
             const titlePromise = isNewChat
               ? generateTitleFromUserMessageWithWriter(
-                  processedMessages,
+                  messagesForProcessing,
                   writer,
                   (title) => updateChatTitle({ chatId, title }),
                 )


### PR DESCRIPTION
## Summary

- generate chat titles from the original user message instead of the auxiliary-vision-processed message
- ignore internal `<image_description ... trust="untrusted">` parts as defense in depth
- keep image-only conversations titled exactly `New chat`
- keep text-plus-image conversations titled from only the user-written text

## Why

Follow-up to #1113. Auxiliary vision replaces an image part with an internal text description before DeepSeek sees it. Title generation was also receiving that processed message, so image-only chats could expose internal markup such as `<image_description filename="...">` in the title.

The active DeepSeek request still receives the auxiliary description. Only the title-generation input now stays on the original user message.

## User impact

- image plus `Tell me about this image` produces a title based on that text
- image without user text remains `New chat`
- internal auxiliary markup never becomes visible as a chat title

## Validation

- full Jest suite: 365 suites / 3,772 tests passed
- `corepack pnpm run typecheck`
- ESLint on all changed TypeScript files
- Prettier on all changed TypeScript files
- `git diff --check`

## Manual verification

1. Start a new paid DeepSeek chat with only an image. Confirm its title is `New chat`.
2. Start another chat with an image and `Tell me about this image`. Confirm the title is derived from that text and contains no `image_description` markup.
3. Confirm DeepSeek still receives and answers from the MiMo-generated visual description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic chat title generation for image-only messages.
  * Image descriptions are now excluded from generated titles when they are auxiliary content.
  * Messages combining images and user text now generate titles from the user’s text without including image-description markup.
  * Preserved the default title when no meaningful text is available.
  * Improved title generation consistency for new chats and agent conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->