### PR TITLE
Handle nullish AuthKit refresh action options

### DIFF
--- a/components/__tests__/ConvexClientProvider.contracts.test.ts
+++ b/components/__tests__/ConvexClientProvider.contracts.test.ts
@@ -73,4 +73,17 @@ describe("ConvexClientProvider auth recovery contracts", () => {
     );
     expect(authkitPatchSource).toContain("return { accessToken: undefined };");
   });
+
+  it("normalizes nullish refresh action options before destructuring", () => {
+    expect(authkitPatchSource).toContain(
+      "export const refreshAuthAction = async (options)",
+    );
+    expect(authkitPatchSource).toContain(
+      "export const refreshAuthAction = async (options?: RefreshAuthActionOptions | null)",
+    );
+    expect(authkitPatchSource).toContain(
+      "const { ensureSignedIn, organizationId } = options ?? {};",
+    );
+    expect(authkitPatchSource).toContain("it.each([undefined, null])");
+  });
 });

--- a/patches/@workos-inc__authkit-nextjs@4.2.0.patch
+++ b/patches/@workos-inc__authkit-nextjs@4.2.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/esm/actions.js b/dist/esm/actions.js
-index 48babd8e1868c58577252b8a27660fcb73e7ef98..bb6fefe1447ffed2e06833f3882ab6471aec4a05 100644
+index 48babd8e1868c58577252b8a27660fcb73e7ef98..508678797dee7f5f2c505465e8a652f1fa911dfb 100644
 --- a/dist/esm/actions.js
 +++ b/dist/esm/actions.js
 @@ -13,6 +13,56 @@ function sanitize(value) {
@@ -77,8 +77,13 @@ index 48babd8e1868c58577252b8a27660fcb73e7ef98..bb6fefe1447ffed2e06833f3882ab647
      const sanitized = sanitize(auth);
      if (options?.ensureSignedIn && !auth.user) {
          const signInUrl = await getSignInUrl();
-@@ -54,7 +104,7 @@ export const getAuthAction = async (options) => {
- export const refreshAuthAction = async ({ ensureSignedIn, organizationId, }) => {
+@@ -51,10 +101,11 @@ export const getAuthAction = async (options) => {
+     }
+     return sanitized;
+ };
+-export const refreshAuthAction = async ({ ensureSignedIn, organizationId, }) => {
++export const refreshAuthAction = async (options) => {
++    const { ensureSignedIn, organizationId } = options ?? {};
      // Never pass ensureSignedIn to refreshSession from a server action for the
      // same CORS reason as getAuthAction above.
 -    const auth = await refreshSession({ organizationId });
@@ -86,7 +91,7 @@ index 48babd8e1868c58577252b8a27660fcb73e7ef98..bb6fefe1447ffed2e06833f3882ab647
      const sanitized = sanitize(auth);
      if (ensureSignedIn && !auth.user) {
          const signInUrl = await getSignInUrl();
-@@ -63,14 +113,14 @@ export const refreshAuthAction = async ({ ensureSignedIn, organizationId, }) =>
+@@ -63,14 +114,14 @@ export const refreshAuthAction = async ({ ensureSignedIn, organizationId, }) =>
      return sanitized;
  };
  export const switchToOrganizationAction = async (organizationId, options) => {
@@ -103,7 +108,7 @@ index 48babd8e1868c58577252b8a27660fcb73e7ef98..bb6fefe1447ffed2e06833f3882ab647
      return auth.accessToken;
  }
  /**
-@@ -86,6 +136,9 @@ export async function refreshAccessTokenAction() {
+@@ -86,6 +137,9 @@ export async function refreshAccessTokenAction() {
          return { accessToken: auth.accessToken };
      }
      catch (error) {
@@ -113,8 +118,41 @@ index 48babd8e1868c58577252b8a27660fcb73e7ef98..bb6fefe1447ffed2e06833f3882ab647
          console.warn('Failed to refresh access token:', error instanceof Error ? error.message : String(error));
          return {
              accessToken: undefined,
+diff --git a/dist/esm/types/actions.d.ts b/dist/esm/types/actions.d.ts
+index 631a2e457db56b87b4c295da3fabc2844aba02ae..d5da9b46aa2dcc5f660814fe8437b795222736b0 100644
+--- a/dist/esm/types/actions.d.ts
++++ b/dist/esm/types/actions.d.ts
+@@ -30,10 +30,10 @@ export declare const getAuthAction: (options?: {
+     featureFlags?: string[] | undefined;
+     impersonator?: import("./interfaces.js").Impersonator | undefined;
+ }>;
+-export declare const refreshAuthAction: ({ ensureSignedIn, organizationId, }: {
++export declare const refreshAuthAction: (options?: {
+     ensureSignedIn?: boolean;
+     organizationId?: string;
+-}) => Promise<Omit<UserInfo | NoUserInfo, "accessToken"> | {
++} | null) => Promise<Omit<UserInfo | NoUserInfo, "accessToken"> | {
+     signInUrl: string;
+     organizationId?: string | undefined;
+     role?: string | undefined;
+diff --git a/src/actions.spec.ts b/src/actions.spec.ts
+index ff854d7d749c51a2c07f2b3ee3ef6f88f5aa8a99..619eacf8391e0048fbd5f0c3940d4b664cc97b71 100644
+--- a/src/actions.spec.ts
++++ b/src/actions.spec.ts
+@@ -154,4 +154,11 @@ describe('actions', () => {
+   describe('refreshAuthAction', () => {
++    it.each([undefined, null])('treats a %s options payload as default refresh options', async (options) => {
++      const result = await refreshAuthAction(options);
++
++      expect(refreshSession).toHaveBeenCalledWith({ organizationId: undefined });
++      expect(result).toEqual({ user: 'testUser', sessionId: 'session_123' });
++    });
++
+     it('should refresh session', async () => {
+       const params = { ensureSignedIn: false, organizationId: 'org_123' };
+       const result = await refreshAuthAction(params);
 diff --git a/src/actions.ts b/src/actions.ts
-index dbc84f49ce8960ac2c88d31e6f98d60af4deab90..f1d7a65274daffcfa5716f253460e4b9affc0e1c 100644
+index dbc84f49ce8960ac2c88d31e6f98d60af4deab90..7cf8af95ddd8fa3d65db17cae3505bd1624a4f70 100644
 --- a/src/actions.ts
 +++ b/src/actions.ts
 @@ -22,6 +22,64 @@ function sanitize<T extends UserInfo | NoUserInfo>(value: T) {
@@ -203,8 +241,19 @@ index dbc84f49ce8960ac2c88d31e6f98d60af4deab90..f1d7a65274daffcfa5716f253460e4b9
    const sanitized = sanitize(auth);
  
    if (options?.ensureSignedIn && !auth.user) {
-@@ -76,7 +137,10 @@ export const refreshAuthAction = async ({
- }) => {
+@@ -70,13 +131,16 @@ export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {
+-export const refreshAuthAction = async ({
+-  ensureSignedIn,
+-  organizationId,
+-}: {
++type RefreshAuthActionOptions = {
+   ensureSignedIn?: boolean;
+   organizationId?: string;
+-}) => {
++};
++
++export const refreshAuthAction = async (options?: RefreshAuthActionOptions | null) => {
++  const { ensureSignedIn, organizationId } = options ?? {};
    // Never pass ensureSignedIn to refreshSession from a server action for the
    // same CORS reason as getAuthAction above.
 -  const auth = await refreshSession({ organizationId });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ overrides:
 
 patchedDependencies:
   '@workos-inc/authkit-nextjs@4.2.0':
-    hash: d280094ebf5ae4aec314c2a50eac6a004ce97078f318e4c47741c7b3953e9649
+    hash: 579d75661942a18b46cce288f524aa5f17406f7a6dd5c2e5d640e50c54b6e00c
     path: patches/@workos-inc__authkit-nextjs@4.2.0.patch
   ai@6.0.200:
     hash: 1079dc939735763e1ec40ea672cd70da577a253b731d47f34d1506acb47febf9
@@ -190,7 +190,7 @@ importers:
         version: 3.9.2(@aws-sdk/credential-provider-web-identity@3.972.73)(ws@8.21.0)
       '@workos-inc/authkit-nextjs':
         specifier: 4.2.0
-        version: 4.2.0(patch_hash=d280094ebf5ae4aec314c2a50eac6a004ce97078f318e4c47741c7b3953e9649)(@workos-inc/node@10.9.0)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 4.2.0(patch_hash=579d75661942a18b46cce288f524aa5f17406f7a6dd5c2e5d640e50c54b6e00c)(@workos-inc/node@10.9.0)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@workos-inc/node':
         specifier: ^10.9.0
         version: 10.9.0
@@ -12090,7 +12090,7 @@ snapshots:
 
   '@workos-inc/authkit-js@0.20.0': {}
 
-  '@workos-inc/authkit-nextjs@4.2.0(patch_hash=d280094ebf5ae4aec314c2a50eac6a004ce97078f318e4c47741c7b3953e9649)(@workos-inc/node@10.9.0)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@workos-inc/authkit-nextjs@4.2.0(patch_hash=579d75661942a18b46cce288f524aa5f17406f7a6dd5c2e5d640e50c54b6e00c)(@workos-inc/node@10.9.0)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@sindresorhus/fnv1a': 3.1.0
       '@workos-inc/node': 10.9.0


### PR DESCRIPTION
## Production evidence

The frozen production audit window was `2026-08-15T20:03:32.962Z` through `2026-08-16T20:03:32.962Z`.

Vercel recorded two adjacent `/` 500s on production deployment `dpl_3VzoSEs69HjZaXRi7MTRWhvu7JFW`:

- `TypeError: Cannot destructure property 'ensureSignedIn' of 'undefined' as it is undefined.`
- `TypeError: Cannot destructure property 'ensureSignedIn' of 'object null' as it is null.`

The exact failures match the patched AuthKit `refreshAuthAction` destructuring its Server Action payload before calling `refreshSession`. Current AuthKit clients pass a proper object, so the nullish shapes are consistent with a stale or malformed Server Action payload at the deployment boundary.

## Root cause

`refreshAuthAction` destructured `{ ensureSignedIn, organizationId }` in its parameter list. A null or undefined serialized action payload therefore crashed before authentication could refresh, returning a page-level 500.

## Change

- accept nullish refresh-action options and normalize them to an empty options object before destructuring
- keep `refreshSession` authoritative and preserve the existing rule that `ensureSignedIn` is not forwarded
- update the patched runtime JS, source types, declaration types, and package regression test
- add an application contract test so future patch regeneration preserves both null and undefined compatibility

This does not bypass authentication or turn provider/auth failures into success. Nullish options only mean no optional organization or sign-in redirect flags; the normal session refresh still runs.

## Validation

- `corepack pnpm install --force --frozen-lockfile`
- `corepack pnpm jest components/__tests__/ConvexClientProvider.contracts.test.ts --runInBand` — 4 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint components/__tests__/ConvexClientProvider.contracts.test.ts`
- `corepack pnpm exec prettier --check components/__tests__/ConvexClientProvider.contracts.test.ts`
- `git diff --check`
- commit hooks: 365 suites / 3,771 tests passed

## Manual verification

After deployment, invoke the AuthKit refresh Server Action with both an omitted payload and an explicit null payload. Each should perform a normal session refresh without a 500. Confirm an authenticated session remains authenticated, a signed-out session remains signed out, and unrelated WorkOS/provider failures are still surfaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of expired or ended authentication sessions, providing a signed-out state instead of exposing recoverable refresh errors.
  - Applied consistent behavior across sign-in, organization access, session switching, and access-token flows.
  - Unrelated authentication errors continue to be handled normally.
- **Improvements**
  - Authentication refresh configuration can now be omitted or set to `null` without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->