### PR TITLE
Fix desktop file operations on Linux with native IPC

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -470,7 +470,7 @@ describe("command cancellation acknowledgement", () => {
 // ── native desktop file relay ─────────────────────────────────────────
 
 describe("native desktop file relay", () => {
-  it("handles file_read with the local desktop file server", async () => {
+  it("handles file_read through native IPC without loopback HTTP", async () => {
     const config = buildConfig();
     const bridge = new DesktopSandboxBridge(config);
     await bridge.start();
@@ -478,22 +478,19 @@ describe("native desktop file relay", () => {
     const handler = getPublicationHandler();
 
     mockInvokeHandler = async (cmd: string) => {
-      if (cmd === "get_cmd_server_info") {
-        return { port: 49152, token: "file-token" };
+      if (cmd === "desktop_file_request") {
+        return {
+          path: "C:\\repo\\app.ts",
+          sizeBytes: 12,
+          totalLines: 1,
+          content: "hello world\n",
+          startLine: 1,
+          truncated: false,
+        };
       }
       throw new Error(`Unexpected command: ${cmd}`);
     };
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        path: "C:\\repo\\app.ts",
-        sizeBytes: 12,
-        totalLines: 1,
-        content: "hello world\n",
-        startLine: 1,
-        truncated: false,
-      }),
-    } as Response);
+    global.fetch = jest.fn();
 
     handler({
       data: {
@@ -509,22 +506,18 @@ describe("native desktop file relay", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      "http://127.0.0.1:49152/files/read",
-      expect.objectContaining({
-        method: "POST",
-        headers: expect.objectContaining({
-          Authorization: "Bearer file-token",
-        }),
-        body: JSON.stringify({
-          path: "C:\\repo\\app.ts",
-          range_start: 1,
-          range_end: 1,
-          max_full_bytes: 1024,
-          max_result_bytes: 1024,
-        }),
-      }),
-    );
+    const { invoke } = await import("@tauri-apps/api/core");
+    expect(invoke).toHaveBeenCalledWith("desktop_file_request", {
+      request: {
+        path: "C:\\repo\\app.ts",
+        range_start: 1,
+        range_end: 1,
+        max_full_bytes: 1024,
+        max_result_bytes: 1024,
+        type: "file_read",
+      },
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
     expect(mockSubscription.publish).toHaveBeenCalledWith({
       type: "file_read_result",
       requestId: "file-req-1",
@@ -536,6 +529,41 @@ describe("native desktop file relay", () => {
     });
   });
 
+  it("handles file_stat through the same structured native bridge", async () => {
+    const bridge = new DesktopSandboxBridge(buildConfig());
+    await bridge.start();
+    const handler = getPublicationHandler();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "desktop_file_request") {
+        return {
+          kind: "file",
+          path: "C:\\repo\\app.ts",
+          sizeBytes: 12,
+        };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+
+    handler({
+      data: {
+        type: "file_stat",
+        requestId: "file-stat-1",
+        path: "C:\\repo\\app.ts",
+        targetConnectionId: "conn-123",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "file_stat_result",
+      requestId: "file-stat-1",
+      kind: "file",
+      path: "C:\\repo\\app.ts",
+      sizeBytes: 12,
+    });
+  });
+
   it("fragments oversized file_read responses below the relay limit", async () => {
     mockSubscription.publish.mockResolvedValue(undefined);
     const bridge = new DesktopSandboxBridge(buildConfig());
@@ -544,22 +572,19 @@ describe("native desktop file relay", () => {
     const content = "large file line\n".repeat(6_000);
 
     mockInvokeHandler = async (cmd: string) => {
-      if (cmd === "get_cmd_server_info") {
-        return { port: 49152, token: "file-token" };
+      if (cmd === "desktop_file_request") {
+        return {
+          path: "C:\\repo\\large.txt",
+          sizeBytes: content.length,
+          totalLines: 6_000,
+          content,
+          startLine: 1,
+          truncated: false,
+        };
       }
       throw new Error(`Unexpected command: ${cmd}`);
     };
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        path: "C:\\repo\\large.txt",
-        sizeBytes: content.length,
-        totalLines: 6_000,
-        content,
-        startLine: 1,
-        truncated: false,
-      }),
-    } as Response);
+    global.fetch = jest.fn();
 
     handler({
       data: {
@@ -611,15 +636,12 @@ describe("native desktop file relay", () => {
     (invoke as jest.Mock).mockClear();
 
     mockInvokeHandler = async (cmd: string) => {
-      if (cmd === "get_cmd_server_info") {
-        return { port: 49152, token: "file-token" };
+      if (cmd === "desktop_file_request") {
+        return { ok: true };
       }
       throw new Error(`Unexpected command: ${cmd}`);
     };
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ ok: true }),
-    } as Response);
+    global.fetch = jest.fn();
 
     handler({
       data: {
@@ -637,23 +659,23 @@ describe("native desktop file relay", () => {
       "execute_stream_command",
       expect.anything(),
     );
-    expect(global.fetch).toHaveBeenCalledWith(
-      "http://127.0.0.1:49152/files/write",
-      expect.objectContaining({
-        body: JSON.stringify({
-          path: "C:\\repo\\app.ts",
-          content: "updated",
-          is_base64: false,
-        }),
-      }),
-    );
+    expect(invoke).toHaveBeenCalledWith("desktop_file_request", {
+      request: {
+        path: "C:\\repo\\app.ts",
+        content: "updated",
+        is_base64: false,
+        allowed_root: undefined,
+        type: "file_write",
+      },
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
     expect(mockSubscription.publish).toHaveBeenCalledWith({
       type: "file_ok",
       requestId: "file-req-2",
     });
   });
 
-  it("forwards the allowed project root to the local file server", async () => {
+  it("forwards the allowed project root to native IPC", async () => {
     const config = buildConfig();
     const bridge = new DesktopSandboxBridge(config);
     await bridge.start();
@@ -661,15 +683,11 @@ describe("native desktop file relay", () => {
     const handler = getPublicationHandler();
 
     mockInvokeHandler = async (cmd: string) => {
-      if (cmd === "get_cmd_server_info") {
-        return { port: 49152, token: "file-token" };
+      if (cmd === "desktop_file_request") {
+        return { ok: true };
       }
       throw new Error(`Unexpected command: ${cmd}`);
     };
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ ok: true }),
-    } as Response);
 
     handler({
       data: {
@@ -684,20 +702,19 @@ describe("native desktop file relay", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      "http://127.0.0.1:49152/files/write",
-      expect.objectContaining({
-        body: JSON.stringify({
-          path: "C:\\repo\\app.ts",
-          content: "updated",
-          is_base64: false,
-          allowed_root: "C:\\repo",
-        }),
-      }),
-    );
+    const { invoke } = await import("@tauri-apps/api/core");
+    expect(invoke).toHaveBeenCalledWith("desktop_file_request", {
+      request: {
+        path: "C:\\repo\\app.ts",
+        content: "updated",
+        is_base64: false,
+        allowed_root: "C:\\repo",
+        type: "file_write",
+      },
+    });
   });
 
-  it("passes base64 append requests through to the local file server", async () => {
+  it("passes base64 append requests through native IPC", async () => {
     const config = buildConfig();
     const bridge = new DesktopSandboxBridge(config);
     await bridge.start();
@@ -705,15 +722,11 @@ describe("native desktop file relay", () => {
     const handler = getPublicationHandler();
 
     mockInvokeHandler = async (cmd: string) => {
-      if (cmd === "get_cmd_server_info") {
-        return { port: 49152, token: "file-token" };
+      if (cmd === "desktop_file_request") {
+        return { ok: true };
       }
       throw new Error(`Unexpected command: ${cmd}`);
     };
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ ok: true }),
-    } as Response);
 
     handler({
       data: {
@@ -728,19 +741,97 @@ describe("native desktop file relay", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
+    const { invoke } = await import("@tauri-apps/api/core");
+    expect(invoke).toHaveBeenCalledWith("desktop_file_request", {
+      request: {
+        path: "C:\\repo\\asset.bin",
+        content: "AAEC",
+        is_base64: true,
+        allowed_root: undefined,
+        type: "file_append",
+      },
+    });
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "file_ok",
+      requestId: "file-req-3",
+    });
+  });
+
+  it("falls back to the loopback bridge for older desktop binaries", async () => {
+    const bridge = new DesktopSandboxBridge(buildConfig());
+    await bridge.start();
+    const handler = getPublicationHandler();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "desktop_file_request") {
+        throw new Error("Command desktop_file_request not found");
+      }
+      if (cmd === "get_cmd_server_info") {
+        return { port: 49152, token: "file-token" };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    handler({
+      data: {
+        type: "file_write",
+        requestId: "file-legacy-1",
+        path: "C:\\repo\\legacy.txt",
+        content: "compatible",
+        targetConnectionId: "conn-123",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://127.0.0.1:49152/files/append",
+      "http://127.0.0.1:49152/files/write",
       expect.objectContaining({
         body: JSON.stringify({
-          path: "C:\\repo\\asset.bin",
-          content: "AAEC",
-          is_base64: true,
+          path: "C:\\repo\\legacy.txt",
+          content: "compatible",
+          is_base64: false,
         }),
       }),
     );
     expect(mockSubscription.publish).toHaveBeenCalledWith({
       type: "file_ok",
-      requestId: "file-req-3",
+      requestId: "file-legacy-1",
+    });
+  });
+
+  it("does not fall back when native IPC reports a real file error", async () => {
+    const bridge = new DesktopSandboxBridge(buildConfig());
+    await bridge.start();
+    const handler = getPublicationHandler();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "desktop_file_request") {
+        throw new Error("Write error: Permission denied");
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn();
+
+    handler({
+      data: {
+        type: "file_write",
+        requestId: "file-denied-1",
+        path: "/root/denied.txt",
+        content: "nope",
+        targetConnectionId: "conn-123",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "file_error",
+      requestId: "file-denied-1",
+      message: "Write error: Permission denied",
     });
   });
 });

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -208,6 +208,7 @@ export class DesktopSandboxBridge {
   private isStoppingOrStopped = true;
   private config: DesktopBridgeConfig;
   private publishQueue: CentrifugoPublishQueue | null = null;
+  private nativeFileIpcAvailable: boolean | null = null;
 
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
   private consecutiveHeartbeatFailures = 0;
@@ -866,7 +867,17 @@ export class DesktopSandboxBridge {
     });
   }
 
-  private async callLocalFileServer<T>(
+  private isMissingNativeFileCommandError(error: unknown): boolean {
+    const message = this.getErrorMessage(error).toLowerCase();
+    return (
+      message.includes("desktop_file_request") &&
+      (message.includes("not found") ||
+        message.includes("unknown command") ||
+        message.includes("not registered"))
+    );
+  }
+
+  private async callLegacyLocalFileServer<T>(
     route: string,
     body: Record<string, unknown>,
   ): Promise<T> {
@@ -895,6 +906,39 @@ export class DesktopSandboxBridge {
       );
     }
     return payload as T;
+  }
+
+  private async callDesktopFileBridge<T>(
+    requestType:
+      | "file_stat"
+      | "file_read"
+      | "file_write"
+      | "file_append"
+      | "file_remove"
+      | "file_list",
+    legacyRoute: string,
+    body: Record<string, unknown>,
+  ): Promise<T> {
+    if (this.nativeFileIpcAvailable !== false) {
+      const { invoke } = await import("@tauri-apps/api/core");
+      try {
+        const payload = await invoke<T>("desktop_file_request", {
+          request: { ...body, type: requestType },
+        });
+        this.nativeFileIpcAvailable = true;
+        return payload;
+      } catch (error) {
+        if (!this.isMissingNativeFileCommandError(error)) {
+          throw error;
+        }
+        this.nativeFileIpcAvailable = false;
+        console.warn(
+          "[desktop-bridge] Native file IPC is unavailable; using the legacy loopback bridge",
+        );
+      }
+    }
+
+    return this.callLegacyLocalFileServer<T>(legacyRoute, body);
   }
 
   private countLines(content: string): number {
@@ -945,7 +989,7 @@ export class DesktopSandboxBridge {
     }
 
     if (content === undefined) {
-      throw new Error("Desktop file server returned an invalid read payload");
+      throw new Error("Desktop file bridge returned an invalid read payload");
     }
 
     const lines = content.split("\n");
@@ -967,38 +1011,30 @@ export class DesktopSandboxBridge {
   private async handleFileStat(message: FileStatMessage): Promise<void> {
     const { requestId, path } = message;
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      const metadata = await invoke<{ path: string; size: number }>(
-        "get_local_file_metadata",
-        { path },
-      );
+      const payload = await this.callDesktopFileBridge<{
+        kind: "file" | "not_file" | "missing";
+        path: string;
+        sizeBytes?: number;
+      }>("file_stat", "/files/stat", { path });
+      if (
+        typeof payload.path !== "string" ||
+        (payload.kind !== "file" &&
+          payload.kind !== "not_file" &&
+          payload.kind !== "missing")
+      ) {
+        throw new Error("Desktop file bridge returned an invalid stat payload");
+      }
+      if (payload.kind === "file" && typeof payload.sizeBytes !== "number") {
+        throw new Error("Desktop file bridge returned an invalid stat payload");
+      }
       await this.publishResult({
         type: "file_stat_result",
         requestId,
-        kind: "file",
-        path: metadata.path,
-        sizeBytes: metadata.size,
+        kind: payload.kind,
+        path: payload.path,
+        ...(payload.kind === "file" ? { sizeBytes: payload.sizeBytes } : {}),
       });
     } catch (error) {
-      const msg = this.getErrorMessage(error);
-      if (msg.includes("Selected path is not a file")) {
-        await this.publishResult({
-          type: "file_stat_result",
-          requestId,
-          kind: "not_file",
-          path,
-        });
-        return;
-      }
-      if (msg.includes("Metadata error")) {
-        await this.publishResult({
-          type: "file_stat_result",
-          requestId,
-          kind: "missing",
-          path,
-        });
-        return;
-      }
       await this.publishFileError(requestId, error);
     }
   }
@@ -1006,13 +1042,17 @@ export class DesktopSandboxBridge {
   private async handleFileRead(message: FileReadMessage): Promise<void> {
     const { requestId, path, range, maxFullBytes, maxResultBytes } = message;
     try {
-      const payload = await this.callLocalFileServer<unknown>("/files/read", {
-        path,
-        range_start: range?.[0],
-        range_end: range?.[1],
-        max_full_bytes: maxFullBytes,
-        max_result_bytes: maxResultBytes,
-      });
+      const payload = await this.callDesktopFileBridge<unknown>(
+        "file_read",
+        "/files/read",
+        {
+          path,
+          range_start: range?.[0],
+          range_end: range?.[1],
+          max_full_bytes: maxFullBytes,
+          max_result_bytes: maxResultBytes,
+        },
+      );
       await this.publishResult({
         type: "file_read_result",
         requestId,
@@ -1026,7 +1066,7 @@ export class DesktopSandboxBridge {
   private async handleFileWrite(message: FileWriteMessage): Promise<void> {
     const { requestId, path, content, isBase64, allowedRoot } = message;
     try {
-      await this.callLocalFileServer("/files/write", {
+      await this.callDesktopFileBridge("file_write", "/files/write", {
         path,
         content,
         is_base64: Boolean(isBase64),
@@ -1041,7 +1081,7 @@ export class DesktopSandboxBridge {
   private async handleFileAppend(message: FileAppendMessage): Promise<void> {
     const { requestId, path, content, isBase64, allowedRoot } = message;
     try {
-      await this.callLocalFileServer("/files/append", {
+      await this.callDesktopFileBridge("file_append", "/files/append", {
         path,
         content,
         is_base64: Boolean(isBase64),
@@ -1056,7 +1096,9 @@ export class DesktopSandboxBridge {
   private async handleFileRemove(message: FileRemoveMessage): Promise<void> {
     const { requestId, path } = message;
     try {
-      await this.callLocalFileServer("/files/remove", { path });
+      await this.callDesktopFileBridge("file_remove", "/files/remove", {
+        path,
+      });
       await this.publishResult({ type: "file_ok", requestId });
     } catch (error) {
       await this.publishFileError(requestId, error);
@@ -1066,7 +1108,8 @@ export class DesktopSandboxBridge {
   private async handleFileList(message: FileListMessage): Promise<void> {
     const { requestId, path } = message;
     try {
-      const entries = await this.callLocalFileServer<Array<{ name: string }>>(
+      const entries = await this.callDesktopFileBridge<Array<{ name: string }>>(
+        "file_list",
         "/files/list",
         { path },
       );

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1190,6 +1190,41 @@ async fn handle_file_list(body: &str) -> Result<String, String> {
 
 // ── Tauri IPC Commands ────────────────────────────────────────────────
 
+async fn dispatch_desktop_file_request(
+    request: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let request_type = request
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "Desktop file request is missing a type".to_string())?;
+    let body = serde_json::to_string(&request)
+        .map_err(|error| format!("Failed to serialize desktop file request: {}", error))?;
+
+    let response = match request_type {
+        "file_stat" => handle_file_stat(&body).await,
+        "file_read" => handle_file_read(&body).await,
+        "file_write" => handle_file_write(&body).await,
+        "file_append" => handle_file_append(&body).await,
+        "file_remove" => handle_file_remove(&body).await,
+        "file_list" => handle_file_list(&body).await,
+        _ => Err(format!(
+            "Unsupported desktop file request type: {}",
+            request_type
+        )),
+    }?;
+
+    serde_json::from_str(&response)
+        .map_err(|error| format!("Failed to parse desktop file response: {}", error))
+}
+
+/// Executes desktop file operations through Tauri IPC so the HTTPS webview
+/// never needs to fetch an insecure loopback HTTP endpoint. The existing HTTP
+/// handlers remain available for rolling compatibility with older web bundles.
+#[tauri::command]
+async fn desktop_file_request(request: serde_json::Value) -> Result<serde_json::Value, String> {
+    dispatch_desktop_file_request(request).await
+}
+
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 enum StreamEvent {
@@ -1845,6 +1880,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn desktop_file_request_dispatches_write_and_read_over_ipc() {
+        let root = unique_test_dir("ipc-round-trip");
+        fs::create_dir_all(&root).expect("create root");
+        let target = root.join("notes.txt");
+
+        let write_result = dispatch_desktop_file_request(serde_json::json!({
+            "type": "file_write",
+            "path": target.to_string_lossy().to_string(),
+            "content": "written over ipc",
+            "allowed_root": root.to_string_lossy().to_string(),
+        }))
+        .await;
+        assert_eq!(
+            write_result.expect("IPC write should succeed"),
+            serde_json::json!({ "ok": true })
+        );
+
+        let read_result = dispatch_desktop_file_request(serde_json::json!({
+            "type": "file_read",
+            "path": target.to_string_lossy().to_string(),
+            "max_full_bytes": 1024,
+            "max_result_bytes": 1024,
+        }))
+        .await
+        .expect("IPC read should succeed");
+        assert_eq!(read_result["content"], "written over ipc");
+        assert_eq!(read_result["path"], target.to_string_lossy().as_ref());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn desktop_file_request_rejects_unknown_operations() {
+        let result = dispatch_desktop_file_request(serde_json::json!({
+            "type": "file_execute",
+            "path": "/tmp/not-used",
+        }))
+        .await;
+
+        assert_eq!(
+            result.expect_err("unknown operation should fail"),
+            "Unsupported desktop file request type: file_execute"
+        );
+    }
+
+    #[tokio::test]
     async fn file_write_preserves_unscoped_desktop_compatibility() {
         let root = unique_test_dir("unscoped");
         let target = root.join("notes.txt");
@@ -1977,6 +2058,7 @@ pub fn run() {
             get_dev_auth_port,
             prepare_desktop_auth_state,
             get_cmd_server_info,
+            desktop_file_request,
             get_local_file_metadata,
             write_generated_text_attachment,
             read_generated_text_attachment,


### PR DESCRIPTION
## Summary

- route desktop file stat/read/write/append/remove/list operations through a structured Tauri IPC command
- avoid mixed-content failures caused by the production HTTPS WebKitGTK webview fetching `http://127.0.0.1`
- preserve the existing loopback file server only as a rolling-compatibility fallback when an older desktop binary does not register the IPC command
- reuse the existing native file handlers and allowed-root/symlink protections without duplicating filesystem policy

## Why

Terminal execution already moved to Tauri IPC because production webviews can block insecure loopback requests. File operations later reintroduced the same HTTPS-to-HTTP boundary, which is unreliable on EndeavourOS/Arch WebKitGTK and surfaced as `Load failed`.

The desktop boundary also follows the pattern used by t3code: privileged filesystem work stays behind a narrow native bridge instead of being fetched directly from the sandboxed renderer.

## Validation

- `corepack pnpm check:local-dependencies`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (0 errors; 7 pre-existing warnings)
- `corepack pnpm exec jest --runInBand` (365 suites, 3,779 tests)
- added Rust IPC write/read round-trip and unsupported-operation tests (native CI; Cargo is unavailable in the local agent environment)

## Manual verification

1. Install the resulting Linux desktop build on EndeavourOS/Arch and connect a local project.
2. Ask Agent mode to stat, read, write, append, list, and remove files in the project.
3. Confirm each operation succeeds and the agent no longer reports `Load failed`.
4. Run a terminal command whose complete output is saved/read through the file bridge and confirm the generated output is returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native desktop file operations for reading, writing, appending, removing, listing, and retrieving file details.
  * Improved handling of large file responses.
* **Bug Fixes**
  * File status results now accurately distinguish files, directories, and missing paths.
  * Preserved native file errors instead of replacing them with generic fallback errors.
  * Added compatibility fallback for environments where native desktop file operations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->