### PR TITLE
Fail over auxiliary vision to direct vision

### DIFF
--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -808,6 +808,70 @@ describe("file tool image view", () => {
     expect(commandRun).toHaveBeenCalledTimes(1);
   });
 
+  test("hands the original image to direct vision after auxiliary failover", async () => {
+    mockUploadSandboxFileToConvex.mockResolvedValue({
+      fileId: "file-1" as never,
+      name: "screenshot.png",
+      mediaType: "image/png",
+    });
+    const commandRun = jest.fn(async (_command, opts) => {
+      expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("1");
+      return {
+        stdout: JSON.stringify({
+          path: "/tmp/screenshot.png",
+          mediaType: "image/png",
+          sizeBytes: 68,
+          kind: "image",
+          data: VALID_PNG_BASE64,
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    });
+    let auxiliaryVisionEnabled = true;
+    const describeImage = jest.fn(async () => {
+      auxiliaryVisionEnabled = false;
+      throw new Error("provider failed");
+    });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(
+      makeContext(sandbox, {
+        modelName: "model-deepseek-v4-pro-0813",
+        auxiliaryVision: {
+          isEnabled: () => auxiliaryVisionEnabled,
+          describeImage,
+        },
+      }),
+    );
+
+    const result = await runTool(tool, {
+      action: "view",
+      path: "/tmp/screenshot.png",
+      brief: "Inspect the screenshot",
+    });
+
+    expect(result).toMatchObject({
+      action: "view",
+      visionDescriptionError: expect.any(String),
+    });
+    await expect(runToModelOutput(tool, result)).resolves.toEqual({
+      type: "content",
+      value: [
+        {
+          type: "text",
+          text: "Viewing image file: screenshot.png (image/png, 68 bytes).",
+        },
+        {
+          type: "image-data",
+          data: VALID_PNG_BASE64,
+          mediaType: "image/png",
+        },
+      ],
+    });
+    expect(describeImage).toHaveBeenCalledTimes(1);
+    expect(commandRun).toHaveBeenCalledTimes(2);
+  });
+
   test("propagates a user stop during an auxiliary file-view description", async () => {
     mockUploadSandboxFileToConvex.mockResolvedValue({
       fileId: "file-1" as never,

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -1275,6 +1275,10 @@ async function uploadViewPreviewFiles(args: {
 
 export const createFile = (context: ToolContext) => {
   const { sandboxManager, modelName, getCurrentModelName } = context;
+  const getAuxiliaryVision = () =>
+    context.auxiliaryVision?.isEnabled?.() === false
+      ? undefined
+      : context.auxiliaryVision;
   const getSandboxForFileTool = (
     expectedSandboxIdentity?: AgentApprovalSandboxIdentity,
   ) =>
@@ -1286,18 +1290,19 @@ export const createFile = (context: ToolContext) => {
     supportsMultimodalToolResults(getCurrentModelName?.() ?? modelName);
   const canHandoffMultimodalFiles = context.mode === "agent";
   const canReturnMultimodalFiles = () =>
-    !!context.auxiliaryVision ||
+    !!getAuxiliaryVision() ||
     canHandoffMultimodalFiles ||
     canViewMultimodalFiles();
   const auxiliaryDescriptionCache = new Map<string, Promise<string>>();
   const describeViewPayload = (
     viewPayload: SandboxViewPayload,
     filename: string,
+    auxiliaryVision: NonNullable<ToolContext["auxiliaryVision"]>,
   ): Promise<string> => {
     const existing = auxiliaryDescriptionCache.get(viewPayload.path);
     if (existing) return existing;
-    const description = context
-      .auxiliaryVision!.describeImage({
+    const description = auxiliaryVision
+      .describeImage({
         image: viewPayload.data!,
         mediaType: viewPayload.mediaType,
         filename,
@@ -1397,7 +1402,7 @@ export const createFile = (context: ToolContext) => {
               viewPayload = await readSandboxFileForView(
                 sandbox,
                 path,
-                !!context.auxiliaryVision,
+                !!getAuxiliaryVision(),
               );
             } catch (error) {
               const classification = classifyFileViewError(error);
@@ -1452,7 +1457,8 @@ export const createFile = (context: ToolContext) => {
 
             let visionDescription: string | undefined;
             let visionDescriptionError: string | undefined;
-            if (context.auxiliaryVision) {
+            const auxiliaryVision = getAuxiliaryVision();
+            if (auxiliaryVision) {
               try {
                 // A new explicit view may observe changed file contents and is
                 // also the retry boundary after a prior descriptor failure.
@@ -1460,9 +1466,10 @@ export const createFile = (context: ToolContext) => {
                 visionDescription = await describeViewPayload(
                   viewPayload,
                   filename,
+                  auxiliaryVision,
                 );
               } catch (error) {
-                if (context.auxiliaryVision.isAborted?.()) throw error;
+                if (auxiliaryVision.isAborted?.()) throw error;
                 visionDescriptionError =
                   "The auxiliary vision model could not inspect this image. Retry the view action.";
               }
@@ -1749,7 +1756,8 @@ export const createFile = (context: ToolContext) => {
             };
           }
 
-          if (context.auxiliaryVision) {
+          const auxiliaryVision = getAuxiliaryVision();
+          if (auxiliaryVision) {
             if (viewOutput.visionDescription) {
               return {
                 type: "text" as const,
@@ -1780,6 +1788,7 @@ export const createFile = (context: ToolContext) => {
               const description = await describeViewPayload(
                 viewPayload,
                 viewOutput.filename,
+                auxiliaryVision,
               );
               return {
                 type: "text" as const,
@@ -1790,7 +1799,7 @@ export const createFile = (context: ToolContext) => {
                 ),
               };
             } catch (error) {
-              if (context.auxiliaryVision.isAborted?.()) throw error;
+              if (auxiliaryVision.isAborted?.()) throw error;
               return {
                 type: "text" as const,
                 value:

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -1288,6 +1288,8 @@ export const createFile = (context: ToolContext) => {
     });
   const canViewMultimodalFiles = () =>
     supportsMultimodalToolResults(getCurrentModelName?.() ?? modelName);
+  // Agent streams consume image-data as a handoff boundary: prepareStep
+  // promotes the active text model before the provider sees the tool result.
   const canHandoffMultimodalFiles = context.mode === "agent";
   const canReturnMultimodalFiles = () =>
     !!getAuxiliaryVision() ||

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -206,6 +206,25 @@ const toolExecutionSources = [
   },
 ];
 
+describe("auxiliary vision failover contracts", () => {
+  test.each([
+    ["agent-long", taskSrc],
+    ["chat handler", chatHandlerSrc],
+  ])("%s switches attachment failures to direct vision", (_name, source) => {
+    expect(source).toContain("createAuxiliaryVisionFailoverController");
+    expect(source).toMatch(
+      /auxiliaryVisionFailover\.activate\(\{\s*error,\s*source: "attachment",\s*\}\);/,
+    );
+    expect(source).toMatch(
+      /selectedModel = selectModel\([\s\S]*?auxiliaryVisionEnabled: false[\s\S]*?\);/,
+    );
+    expect(source).toMatch(
+      /get auxiliaryVisionEnabled\(\) \{\s*return auxiliaryVisionFailover\.isEnabled\(\);\s*\}/,
+    );
+    expect(source).not.toContain("AUXILIARY_VISION_UNAVAILABLE_MESSAGE");
+  });
+});
+
 describe("agent tool schemas — Head Start bundle boundary", () => {
   test("schema-only tool catalog imports only ai and zod", () => {
     const importSources = Array.from(

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -216,7 +216,10 @@ describe("auxiliary vision failover contracts", () => {
       /auxiliaryVisionFailover\.activate\(\{\s*error,\s*source: "attachment",\s*\}\);/,
     );
     expect(source).toMatch(
-      /selectedModel = selectModel\([\s\S]*?auxiliaryVisionEnabled: false[\s\S]*?\);/,
+      /selectedModel = [\s\S]*?resolveAgentModelForImageToolResults\([\s\S]*?selectedModel[\s\S]*?true[\s\S]*?false[\s\S]*?\);/,
+    );
+    expect(source).toMatch(
+      /activeDeepSeekV4Pro0813Experiment =\s*getActiveDeepSeekV4Pro0813ExperimentAssignment\([\s\S]*?selectedModel[\s\S]*?\);/,
     );
     expect(source).toMatch(
       /get auxiliaryVisionEnabled\(\) \{\s*return auxiliaryVisionFailover\.isEnabled\(\);\s*\}/,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -188,6 +188,7 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 import {
   createAgentStream,
   initAgentStreamState,
+  resolveAgentModelForImageToolResults,
   resetServedModelTelemetryForRetry,
   retryUsesDifferentModel,
   type AgentStreamContext,
@@ -598,12 +599,12 @@ export const createChatHandler = () => {
         });
       }
 
-      const activeDeepSeekV4Pro0813Experiment =
+      let activeDeepSeekV4Pro0813Experiment =
         getActiveDeepSeekV4Pro0813ExperimentAssignment(
           deepSeekV4Pro0813Experiment,
           selectedModel,
         );
-      const routingExperimentContext = getDeepSeekV4Pro0813ExperimentContext(
+      let routingExperimentContext = getDeepSeekV4Pro0813ExperimentContext(
         activeDeepSeekV4Pro0813Experiment,
       );
 
@@ -898,14 +899,31 @@ export const createChatHandler = () => {
                   error,
                   source: "attachment",
                 });
-                selectedModel = selectModel(
-                  mode,
-                  subscription,
-                  selectedModelOverride,
-                  true,
-                  false,
-                  { extraUsageAvailable, auxiliaryVisionEnabled: false },
-                );
+                selectedModel = isAgentMode(mode)
+                  ? resolveAgentModelForImageToolResults(
+                      selectedModel,
+                      mode,
+                      true,
+                      selectedModelOverride,
+                      false,
+                    )
+                  : selectModel(
+                      mode,
+                      subscription,
+                      selectedModelOverride,
+                      true,
+                      false,
+                      { extraUsageAvailable, auxiliaryVisionEnabled: false },
+                    );
+                activeDeepSeekV4Pro0813Experiment =
+                  getActiveDeepSeekV4Pro0813ExperimentAssignment(
+                    deepSeekV4Pro0813Experiment,
+                    selectedModel,
+                  );
+                routingExperimentContext =
+                  getDeepSeekV4Pro0813ExperimentContext(
+                    activeDeepSeekV4Pro0813Experiment,
+                  );
                 chatLogger?.setChat(chatLogContext, selectedModel);
               }
             }

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -114,10 +114,10 @@ import {
   createPreemptiveTimeout,
 } from "@/lib/utils/stream-cancellation";
 import { v4 as uuidv4 } from "uuid";
-import { processChatMessages } from "@/lib/chat/chat-processor";
+import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
 import { cacheAuxiliaryVisionDescription } from "@/lib/utils/file-transform-utils";
 import {
-  AUXILIARY_VISION_UNAVAILABLE_MESSAGE,
+  createAuxiliaryVisionFailoverController,
   describeImageAttachmentsWithAuxiliaryVision,
   describeImageWithAuxiliaryVision,
 } from "@/lib/chat/auxiliary-vision";
@@ -639,6 +639,14 @@ export const createChatHandler = () => {
       });
 
       const summarizationTracker = new SummarizationTracker();
+      const auxiliaryVisionFailover = createAuxiliaryVisionFailoverController({
+        enabled: !!auxiliaryVisionAssignment,
+        service: "chat-handler",
+        requestId: req.headers.get("x-vercel-id") ?? undefined,
+        userId,
+        chatId,
+        isUserAborted: () => userStopSignal.signal.aborted,
+      });
       const captureAuxiliaryVisionExposure =
         createAuxiliaryVisionExposureRecorder({
           posthog,
@@ -666,28 +674,38 @@ export const createChatHandler = () => {
         execute: async ({ writer }) => {
           try {
             const usageTracker = new UsageTracker();
-            const auxiliaryVision = auxiliaryVisionAssignment
+            const auxiliaryVision = auxiliaryVisionFailover.isEnabled()
               ? {
+                  isEnabled: auxiliaryVisionFailover.isEnabled,
                   isAborted: () => userStopSignal.signal.aborted,
-                  describeImage: (args: {
+                  describeImage: async (args: {
                     image: string;
                     mediaType: string;
                     filename?: string;
                     source: "file_view";
-                  }) =>
-                    describeImageWithAuxiliaryVision({
-                      ...args,
-                      requestId: req.headers.get("x-vercel-id") ?? undefined,
-                      userId,
-                      chatId,
-                      abortSignal: userStopSignal.signal,
-                      onExposure: captureAuxiliaryVisionExposure,
-                      onCost: (costDollars) => {
-                        usageTracker.providerCost += costDollars;
-                        usageTracker.nonModelCost += costDollars;
-                        chatLogger?.getBuilder().addToolCost(costDollars);
-                      },
-                    }),
+                  }) => {
+                    try {
+                      return await describeImageWithAuxiliaryVision({
+                        ...args,
+                        requestId: req.headers.get("x-vercel-id") ?? undefined,
+                        userId,
+                        chatId,
+                        abortSignal: userStopSignal.signal,
+                        onExposure: captureAuxiliaryVisionExposure,
+                        onCost: (costDollars) => {
+                          usageTracker.providerCost += costDollars;
+                          usageTracker.nonModelCost += costDollars;
+                          chatLogger?.getBuilder().addToolCost(costDollars);
+                        },
+                      });
+                    } catch (error) {
+                      auxiliaryVisionFailover.activate({
+                        error,
+                        source: "file_view",
+                      });
+                      throw error;
+                    }
+                  },
                 }
               : undefined;
             sendRateLimitWarnings(writer, {
@@ -857,7 +875,7 @@ export const createChatHandler = () => {
               );
             }
 
-            if (auxiliaryVisionAssignment) {
+            if (auxiliaryVisionFailover.isEnabled()) {
               try {
                 processedMessages =
                   await describeImageAttachmentsWithAuxiliaryVision({
@@ -875,20 +893,20 @@ export const createChatHandler = () => {
                     cacheDescription: cacheAuxiliaryVisionDescription,
                   });
               } catch (error) {
-                if (
-                  userStopSignal.signal.aborted ||
-                  (error instanceof DOMException && error.name === "AbortError")
-                ) {
-                  throw error;
-                }
-                const auxiliaryVisionError = new ChatSDKError(
-                  "bad_request:api",
-                  AUXILIARY_VISION_UNAVAILABLE_MESSAGE,
+                if (userStopSignal.signal.aborted) throw error;
+                auxiliaryVisionFailover.activate({
+                  error,
+                  source: "attachment",
+                });
+                selectedModel = selectModel(
+                  mode,
+                  subscription,
+                  selectedModelOverride,
+                  true,
+                  false,
+                  { extraUsageAvailable, auxiliaryVisionEnabled: false },
                 );
-                preemptiveTimeout?.clear();
-                await usageRefundTracker.refund();
-                chatLogger?.emitChatError(auxiliaryVisionError);
-                throw auxiliaryVisionError;
+                chatLogger?.setChat(chatLogContext, selectedModel);
               }
             }
 
@@ -1383,7 +1401,9 @@ export const createChatHandler = () => {
               contextUsageOn,
               isReasoningModel,
               platformAuthorized,
-              auxiliaryVisionEnabled: !!auxiliaryVisionAssignment,
+              get auxiliaryVisionEnabled() {
+                return auxiliaryVisionFailover.isEnabled();
+              },
               maxDurationMs: AGENT_MAX_STREAM_DURATION_MS,
               writer,
               abortController: userStopSignal,

--- a/lib/chat/__tests__/auxiliary-vision.test.ts
+++ b/lib/chat/__tests__/auxiliary-vision.test.ts
@@ -4,6 +4,7 @@ import { AUXILIARY_VISION_SLUG } from "@/lib/ai/providers";
 import {
   AUXILIARY_VISION_MAX_CONCURRENCY,
   AUXILIARY_VISION_MAX_IMAGES_PER_TURN,
+  createAuxiliaryVisionFailoverController,
   describeImageAttachmentsWithAuxiliaryVision,
   describeImageWithAuxiliaryVision,
   type AuxiliaryVisionModelRunner,
@@ -59,10 +60,91 @@ describe("auxiliary vision", () => {
     });
   });
 
+  it("activates direct vision failover once with bounded diagnostics", () => {
+    const controller = createAuxiliaryVisionFailoverController({
+      enabled: true,
+      service: "chat-handler",
+      requestId: "request-1",
+      userId: "user-1",
+      chatId: "chat-1",
+    });
+    const providerError = new Error("sensitive provider details");
+
+    expect(
+      controller.activate({ error: providerError, source: "attachment" }),
+    ).toBe(true);
+    expect(controller.isEnabled()).toBe(false);
+    expect(
+      controller.activate({ error: providerError, source: "file_view" }),
+    ).toBe(false);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(
+      (console.warn as jest.Mock).mock.calls[0][0] as string,
+    );
+    expect(payload).toMatchObject({
+      event: "auxiliary_vision_failover_activated",
+      service: "chat-handler",
+      request_id: "request-1",
+      user_id: "user-1",
+      chat_id: "chat-1",
+      source: "attachment",
+      fallback_route: "direct_vision",
+      failure_reason: "provider_error",
+      error_name: "Error",
+      failed_image_count: 1,
+    });
+    expect(JSON.stringify(payload)).not.toContain("sensitive provider details");
+  });
+
+  it("does not activate failover for a user cancellation", () => {
+    const controller = createAuxiliaryVisionFailoverController({
+      enabled: true,
+      service: "agent-long",
+      isUserAborted: () => true,
+    });
+
+    expect(
+      controller.activate({
+        error: new DOMException("Stopped", "AbortError"),
+        source: "attachment",
+      }),
+    ).toBe(false);
+    expect(controller.isEnabled()).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("classifies a descriptor timeout without logging its message", () => {
+    const controller = createAuxiliaryVisionFailoverController({
+      enabled: true,
+      service: "agent-long",
+    });
+
+    controller.activate({
+      error: new AggregateError([
+        new DOMException("provider timeout details", "AbortError"),
+      ]),
+      source: "attachment",
+    });
+
+    const payload = JSON.parse(
+      (console.warn as jest.Mock).mock.calls[0][0] as string,
+    );
+    expect(payload).toMatchObject({
+      service: "agent-long",
+      failure_reason: "timeout",
+      error_name: "AggregateError",
+      failed_image_count: 1,
+    });
+    expect(JSON.stringify(payload)).not.toContain("provider timeout details");
+  });
+
   it("replaces image files with untrusted descriptions and keeps other parts", async () => {
     const modelRunner = jest.fn(async () => ({
       text: "Visible login form with a red invalid-password warning.",
+      usage: { raw: { cost: 0.003 } },
     })) as jest.MockedFunction<AuxiliaryVisionModelRunner>;
+    const onCost = jest.fn();
 
     const messages = await describeImageAttachmentsWithAuxiliaryVision({
       messages: [
@@ -86,6 +168,7 @@ describe("auxiliary vision", () => {
           ],
         },
       ],
+      onCost,
       modelRunner,
     });
 
@@ -100,6 +183,8 @@ describe("auxiliary vision", () => {
         mediaType: "application/pdf",
       }),
     ]);
+    expect(onCost).toHaveBeenCalledTimes(1);
+    expect(onCost).toHaveBeenCalledWith(0.003);
   });
 
   it("reuses matching owned-file descriptions without another model call", async () => {
@@ -256,9 +341,13 @@ describe("auxiliary vision", () => {
 
   it("settles all calls and caches successes before reporting a partial failure", async () => {
     const cacheDescription = jest.fn(async () => undefined);
+    const onCost = jest.fn();
     const modelRunner = jest.fn(async ({ filename }) => {
       if (filename === "bad.png") throw new Error("provider failed");
-      return { text: "Successful description" };
+      return {
+        text: "Successful description",
+        usage: { raw: { cost: 0.004 } },
+      };
     }) as jest.MockedFunction<AuxiliaryVisionModelRunner>;
 
     await expect(
@@ -287,6 +376,7 @@ describe("auxiliary vision", () => {
         ],
         userId: "user-1",
         cacheDescription,
+        onCost,
         modelRunner,
       }),
     ).rejects.toThrow("failed for 1 image request");
@@ -296,6 +386,7 @@ describe("auxiliary vision", () => {
     expect(cacheDescription).toHaveBeenCalledWith(
       expect.objectContaining({ fileId: "file-good" }),
     );
+    expect(onCost).not.toHaveBeenCalled();
   });
 
   it("fails explicitly when the auxiliary model returns no description", async () => {

--- a/lib/chat/auxiliary-vision.ts
+++ b/lib/chat/auxiliary-vision.ts
@@ -10,10 +10,81 @@ export const AUXILIARY_VISION_TIMEOUT_MS = 20_000;
 export const AUXILIARY_VISION_MAX_OUTPUT_TOKENS = 1_200;
 export const AUXILIARY_VISION_MAX_IMAGES_PER_TURN = 10;
 export const AUXILIARY_VISION_MAX_CONCURRENCY = 3;
-export const AUXILIARY_VISION_UNAVAILABLE_MESSAGE =
-  "We couldn't inspect the image right now. Please retry. DeepSeek was not replaced by another model.";
 
 export type AuxiliaryVisionSource = "attachment" | "file_view";
+
+export type AuxiliaryVisionFailoverController = {
+  activate: (args: {
+    error: unknown;
+    source: AuxiliaryVisionSource;
+  }) => boolean;
+  isEnabled: () => boolean;
+};
+
+const getAuxiliaryVisionFailureDetails = (
+  error: unknown,
+): {
+  errorName: string;
+  failedImageCount: number;
+  reason: "provider_error" | "timeout";
+} => {
+  const errors = error instanceof AggregateError ? error.errors : [error];
+  const errorNames = errors.map((entry) =>
+    entry instanceof Error ? entry.name : "UnknownError",
+  );
+  return {
+    errorName:
+      error instanceof Error ? error.name : (errorNames[0] ?? "UnknownError"),
+    failedImageCount: Math.max(errors.length, 1),
+    reason: errorNames.includes("AbortError") ? "timeout" : "provider_error",
+  };
+};
+
+export function createAuxiliaryVisionFailoverController({
+  enabled,
+  service,
+  requestId,
+  userId,
+  chatId,
+  isUserAborted,
+}: {
+  enabled: boolean;
+  service: "agent-long" | "chat-handler";
+  requestId?: string;
+  userId?: string;
+  chatId?: string;
+  isUserAborted?: () => boolean;
+}): AuxiliaryVisionFailoverController {
+  let active = enabled;
+
+  return {
+    isEnabled: () => active,
+    activate: ({ error, source }) => {
+      if (!active || isUserAborted?.()) return false;
+      active = false;
+      const failure = getAuxiliaryVisionFailureDetails(error);
+      console.warn(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: "warn",
+          event: "auxiliary_vision_failover_activated",
+          service,
+          environment:
+            process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+          request_id: requestId ?? "unavailable",
+          user_id: userId,
+          chat_id: chatId,
+          source,
+          fallback_route: "direct_vision",
+          failure_reason: failure.reason,
+          error_name: failure.errorName,
+          failed_image_count: failure.failedImageCount,
+        }),
+      );
+      return true;
+    },
+  };
+}
 
 export type AuxiliaryVisionResult = {
   description: string;
@@ -317,6 +388,7 @@ export async function describeImageAttachmentsWithAuxiliaryVision({
 
   const requestCache = new Map<string, Promise<AuxiliaryVisionResult>>();
   const failures: unknown[] = [];
+  let pendingCostDollars = 0;
   let nextTaskIndex = 0;
   const runWorker = async (): Promise<void> => {
     while (nextTaskIndex < tasks.length) {
@@ -334,7 +406,9 @@ export async function describeImageAttachmentsWithAuxiliaryVision({
               userId,
               chatId,
               abortSignal,
-              onCost,
+              onCost: (costDollars) => {
+                pendingCostDollars += costDollars;
+              },
               onExposure,
               modelRunner,
             });
@@ -379,5 +453,6 @@ export async function describeImageAttachmentsWithAuxiliaryVision({
       `Auxiliary vision failed for ${failures.length} image request(s)`,
     );
   }
+  if (pendingCostDollars > 0) onCost?.(pendingCostDollars);
   return updatedMessages;
 }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -25,10 +25,10 @@ import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { createTrackedProvider } from "@/lib/ai/providers";
-import { processChatMessages } from "@/lib/chat/chat-processor";
+import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
 import { cacheAuxiliaryVisionDescription } from "@/lib/utils/file-transform-utils";
 import {
-  AUXILIARY_VISION_UNAVAILABLE_MESSAGE,
+  createAuxiliaryVisionFailoverController,
   describeImageAttachmentsWithAuxiliaryVision,
   describeImageWithAuxiliaryVision,
 } from "@/lib/chat/auxiliary-vision";
@@ -2428,6 +2428,14 @@ export const agentLongTask = task({
         PaidDailyFreeAllowanceReservation | undefined;
 
       let streamError: unknown;
+      const auxiliaryVisionFailover = createAuxiliaryVisionFailoverController({
+        enabled: !!auxiliaryVisionAssignment,
+        service: "agent-long",
+        requestId: ctx.run.id,
+        userId,
+        chatId,
+        isUserAborted: () => userStopSignal.signal.aborted,
+      });
       const captureAuxiliaryVisionExposure =
         createAuxiliaryVisionExposureRecorder({
           posthog,
@@ -2450,28 +2458,38 @@ export const agentLongTask = task({
           try {
             const usageTracker = new UsageTracker();
             observedUsageTracker = usageTracker;
-            const auxiliaryVision = auxiliaryVisionAssignment
+            const auxiliaryVision = auxiliaryVisionFailover.isEnabled()
               ? {
+                  isEnabled: auxiliaryVisionFailover.isEnabled,
                   isAborted: () => userStopSignal.signal.aborted,
-                  describeImage: (args: {
+                  describeImage: async (args: {
                     image: string;
                     mediaType: string;
                     filename?: string;
                     source: "file_view";
-                  }) =>
-                    describeImageWithAuxiliaryVision({
-                      ...args,
-                      requestId: ctx.run.id,
-                      userId,
-                      chatId,
-                      abortSignal: userStopSignal.signal,
-                      onExposure: captureAuxiliaryVisionExposure,
-                      onCost: (costDollars) => {
-                        usageTracker.providerCost += costDollars;
-                        usageTracker.nonModelCost += costDollars;
-                        chatLogger?.getBuilder().addToolCost(costDollars);
-                      },
-                    }),
+                  }) => {
+                    try {
+                      return await describeImageWithAuxiliaryVision({
+                        ...args,
+                        requestId: ctx.run.id,
+                        userId,
+                        chatId,
+                        abortSignal: userStopSignal.signal,
+                        onExposure: captureAuxiliaryVisionExposure,
+                        onCost: (costDollars) => {
+                          usageTracker.providerCost += costDollars;
+                          usageTracker.nonModelCost += costDollars;
+                          chatLogger?.getBuilder().addToolCost(costDollars);
+                        },
+                      });
+                    } catch (error) {
+                      auxiliaryVisionFailover.activate({
+                        error,
+                        source: "file_view",
+                      });
+                      throw error;
+                    }
+                  },
                 }
               : undefined;
             writeAgentLongFastStart(writer, "setup");
@@ -3020,7 +3038,7 @@ export const agentLongTask = task({
               );
             }
 
-            if (auxiliaryVisionAssignment) {
+            if (auxiliaryVisionFailover.isEnabled()) {
               try {
                 processedMessages =
                   await describeImageAttachmentsWithAuxiliaryVision({
@@ -3038,19 +3056,20 @@ export const agentLongTask = task({
                     cacheDescription: cacheAuxiliaryVisionDescription,
                   });
               } catch (error) {
-                if (
-                  userStopSignal.signal.aborted ||
-                  (error instanceof DOMException && error.name === "AbortError")
-                ) {
-                  throw error;
-                }
-                const auxiliaryVisionError = new ChatSDKError(
-                  "bad_request:api",
-                  AUXILIARY_VISION_UNAVAILABLE_MESSAGE,
+                if (userStopSignal.signal.aborted) throw error;
+                auxiliaryVisionFailover.activate({
+                  error,
+                  source: "attachment",
+                });
+                selectedModel = selectModel(
+                  mode,
+                  subscription,
+                  selectedModelOverride,
+                  true,
+                  false,
+                  { extraUsageAvailable, auxiliaryVisionEnabled: false },
                 );
-                await usageRefundTracker.refund();
-                chatLogger?.emitChatError(auxiliaryVisionError);
-                throw auxiliaryVisionError;
+                chatLogger?.setChat(chatLogContext, selectedModel);
               }
             }
 
@@ -3523,7 +3542,9 @@ export const agentLongTask = task({
               contextUsageOn,
               isReasoningModel: true, // long mode is always agent mode
               platformAuthorized,
-              auxiliaryVisionEnabled: !!auxiliaryVisionAssignment,
+              get auxiliaryVisionEnabled() {
+                return auxiliaryVisionFailover.isEnabled();
+              },
               maxDurationMs: agentLongMaxDurationMs,
               getActiveElapsedTimeMs: runtimeBudget.getElapsedTimeMs,
               writer,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -25,7 +25,7 @@ import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { createTrackedProvider } from "@/lib/ai/providers";
-import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
+import { processChatMessages } from "@/lib/chat/chat-processor";
 import { cacheAuxiliaryVisionDescription } from "@/lib/utils/file-transform-utils";
 import {
   createAuxiliaryVisionFailoverController,
@@ -198,6 +198,7 @@ import {
 import {
   createAgentStream,
   initAgentStreamState,
+  resolveAgentModelForImageToolResults,
   resetServedModelTelemetryForRetry,
   retryUsesDifferentModel,
   type AgentStreamContext,
@@ -2597,12 +2598,12 @@ export const agentLongTask = task({
               });
             }
 
-            const activeDeepSeekV4Pro0813Experiment =
+            let activeDeepSeekV4Pro0813Experiment =
               getActiveDeepSeekV4Pro0813ExperimentAssignment(
                 deepSeekV4Pro0813Experiment,
                 selectedModel,
               );
-            const routingExperimentContext =
+            let routingExperimentContext =
               getDeepSeekV4Pro0813ExperimentContext(
                 activeDeepSeekV4Pro0813Experiment,
               );
@@ -3061,14 +3062,22 @@ export const agentLongTask = task({
                   error,
                   source: "attachment",
                 });
-                selectedModel = selectModel(
+                selectedModel = resolveAgentModelForImageToolResults(
+                  selectedModel,
                   mode,
-                  subscription,
-                  selectedModelOverride,
                   true,
+                  selectedModelOverride,
                   false,
-                  { extraUsageAvailable, auxiliaryVisionEnabled: false },
                 );
+                activeDeepSeekV4Pro0813Experiment =
+                  getActiveDeepSeekV4Pro0813ExperimentAssignment(
+                    deepSeekV4Pro0813Experiment,
+                    selectedModel,
+                  );
+                routingExperimentContext =
+                  getDeepSeekV4Pro0813ExperimentContext(
+                    activeDeepSeekV4Pro0813Experiment,
+                  );
                 chatLogger?.setChat(chatLogContext, selectedModel);
               }
             }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -702,6 +702,8 @@ export interface ToolContext {
   onSandboxResourceMetrics?: SandboxResourceMetricsObserver;
   /** Optional Hermes-style image descriptor for text-only active models. */
   auxiliaryVision?: {
+    /** Returns false after the request has failed over to direct vision. */
+    isEnabled?: () => boolean;
     /** Distinguishes a user stop from a descriptor timeout/provider failure. */
     isAborted?: () => boolean;
     describeImage: (args: {


### PR DESCRIPTION
## Summary

- fail over from auxiliary MiMo image description to the existing direct-vision route when attachment preprocessing or a later file-view description fails
- keep user cancellation terminal while limiting failover to once per request
- preserve original image data for the fallback model and emit one bounded structured failover event
- stage auxiliary batch cost accounting so a partially failed batch is not charged to the request

## Root cause

The `auxiliary-deepseek-vision` treatment made successful MiMo image descriptions a hard dependency before DeepSeek inference. A MiMo timeout or provider failure therefore terminated the entire chat or Agent run with `We couldn't inspect the image right now` instead of using the existing image-capable model route.

## User impact

Image-based chat and Agent requests now continue through direct vision when the auxiliary descriptor is unavailable. Explicit user Stop actions still cancel normally, and the request cannot loop between auxiliary and direct vision.

## Validation

- `pnpm typecheck`
- focused ESLint and Prettier checks for all changed files
- focused auxiliary vision, file tool, and Agent contract tests: 126 passed
- full pre-commit suite: 365 suites and 3,785 tests passed
- `git diff --check`

## Manual verification

1. In production or a production-like Trigger.dev environment, start a paid Agent run with an image while `auxiliary-deepseek-vision` is enabled.
2. Force or observe a MiMo timeout/provider failure.
3. Confirm the run continues through direct Grok vision and emits one `auxiliary_vision_failover_activated` event with `service: "agent-long"`.
4. Trigger a later image `file.view` failure and confirm the original image is handed to direct vision.
5. Press Stop during auxiliary vision and confirm the run cancels without activating failover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic fallback to a non-vision model when auxiliary image processing fails.
  * Preserved original image data and continued processing instead of immediately returning an error.
  * Improved handling of cancellations, timeouts, and partial image-processing failures.
  * Added accurate usage-cost reporting for successful image-description requests.
  * Updated availability dynamically during ongoing requests and streaming responses.
* **Tests**
  * Added regression and contract coverage for vision failover, cancellation, and cost handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->