### PR TITLE
Fix stale todos after editing stopped Agent responses

### DIFF
--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -312,6 +312,45 @@ describe("useChatHandlers steer todo handoff", () => {
     );
   });
 
+  it("persists and applies cleaned todos when editing a stopped response", async () => {
+    const regenerate = jest.fn();
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate,
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: true },
+        activeTriggerRunRef: { current: undefined },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleEditMessage("user-1", "Edited task");
+    });
+
+    expect(mockRegenerateWithNewContent).toHaveBeenCalledWith({
+      messageId: "user-1",
+      newContent: "Edited task",
+      fileIds: undefined,
+      todos: [],
+    });
+    expect(mockSetTodos).toHaveBeenCalledWith([]);
+    expect(regenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          todos: [],
+          regenerate: true,
+        }),
+      }),
+    );
+  });
+
   it("keeps the queued message when the todo snapshot cannot be persisted", async () => {
     mockCancelStream.mockRejectedValueOnce(new Error("write failed"));
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -792,14 +792,26 @@ export const useChatHandlers = ({
     }
     const agentRunRequestId = uuidv4();
 
-    // Find the edited message index to identify subsequent messages
+    // Compute the todo snapshot before the edit mutation. Stopping a run
+    // persists its latest todos, so the same mutation that removes the old
+    // response must also replace that snapshot to avoid a reactive chat update
+    // restoring todos from the discarded response.
     const editedMessageIndex = messages.findIndex((m) => m.id === messageId);
+    const discardedMessageIds =
+      editedMessageIndex === -1
+        ? []
+        : messages.slice(editedMessageIndex + 1).map((message) => message.id);
+    const cleanedTodosForEdit = removeTodosBySourceMessages(
+      todos,
+      discardedMessageIds,
+    );
 
     try {
       await regenerateWithNewContent({
         messageId: messageId as Id<"messages">,
         newContent,
         fileIds: remainingFileIds,
+        todos: cleanedTodosForEdit,
       });
     } catch (error) {
       if (getConvexErrorCode(error) === "MESSAGE_NOT_EDITABLE") {
@@ -810,23 +822,7 @@ export const useChatHandlers = ({
       throw error;
     }
 
-    if (editedMessageIndex !== -1) {
-      // Get all subsequent messages (both user and assistant) that will be removed
-      const subsequentMessages = messages.slice(editedMessageIndex + 1);
-      const idsToClean = subsequentMessages.map((m) => m.id);
-
-      // Also clean todos from the edited message itself if it's an assistant message
-      const editedMessage = messages[editedMessageIndex];
-      if (editedMessage.role === "assistant") {
-        idsToClean.push(messageId);
-      }
-
-      // Remove todos linked to the edited message and all subsequent messages
-      if (idsToClean.length > 0) {
-        const updatedTodos = removeTodosBySourceMessages(todos, idsToClean);
-        setTodos(updatedTodos);
-      }
-    }
+    setTodos(cleanedTodosForEdit);
 
     // Build updated parts: text + remaining file parts
     const buildUpdatedParts = (currentParts: any[]) => {
@@ -868,17 +864,6 @@ export const useChatHandlers = ({
 
       return updatedMessages;
     });
-
-    // Trigger regeneration of assistant response with cleaned todos
-    const cleanedTodosForEdit = (() => {
-      const editedIndex = messages.findIndex((m) => m.id === messageId);
-      if (editedIndex === -1) return todos;
-      const subsequentMessages = messages.slice(editedIndex + 1);
-      const idsToClean = subsequentMessages.map((m) => m.id);
-      const editedMessage = messages[editedIndex];
-      if (editedMessage.role === "assistant") idsToClean.push(messageId);
-      return removeTodosBySourceMessages(todos, idsToClean);
-    })();
 
     runChatAction("regenerate edited message", () =>
       regenerate({

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -1483,7 +1483,7 @@ describe("regenerateWithNewContent feedback cleanup", () => {
     };
   });
 
-  it("should delete feedback for later messages removed by edit-regenerate", async () => {
+  it("should delete feedback and replace todos for later messages removed by edit-regenerate", async () => {
     const editedUserMessage = {
       _id: "user-doc-1" as Id<"messages">,
       id: "user-msg-1",
@@ -1545,6 +1545,7 @@ describe("regenerateWithNewContent feedback cleanup", () => {
     await regenerateWithNewContent.handler(mockCtx, {
       messageId: editedUserMessage.id,
       newContent: "new prompt",
+      todos: [],
     });
 
     const deleteArgs = mockCtx.db.delete.mock.calls.map(
@@ -1554,6 +1555,10 @@ describe("regenerateWithNewContent feedback cleanup", () => {
     expect(deleteArgs).toContain(laterAssistantMessage._id);
     expect(deleteArgs.indexOf("feedback-2")).toBeLessThan(
       deleteArgs.indexOf(laterAssistantMessage._id),
+    );
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(
+      CHAT_DOC_ID,
+      expect.objectContaining({ todos: [], update_time: expect.any(Number) }),
     );
   });
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1933,6 +1933,21 @@ export const regenerateWithNewContent = mutation({
     messageId: v.string(),
     newContent: v.string(),
     fileIds: v.optional(v.array(v.string())),
+    todos: v.optional(
+      v.array(
+        v.object({
+          id: v.string(),
+          content: v.string(),
+          status: v.union(
+            v.literal("pending"),
+            v.literal("in_progress"),
+            v.literal("completed"),
+            v.literal("cancelled"),
+          ),
+          sourceMessageId: v.optional(v.string()),
+        }),
+      ),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -2100,6 +2115,24 @@ export const regenerateWithNewContent = mutation({
         }
 
         await ctx.db.delete(msg._id);
+      }
+
+      // Keep the persisted todo snapshot consistent with the messages removed
+      // above. In particular, stopping an Agent run persists its todos before
+      // an edit discards that response; without this write, the reactive chat
+      // query can restore those stale todos in the UI.
+      if (args.todos !== undefined) {
+        const chat = await ctx.db
+          .query("chats")
+          .withIndex("by_chat_id", (q) => q.eq("id", message.chat_id))
+          .first();
+
+        if (chat && chat.user_id === user.subject) {
+          await ctx.db.patch(chat._id, {
+            todos: args.todos,
+            update_time: Date.now(),
+          });
+        }
       }
 
       return null;


### PR DESCRIPTION
## Summary

- clear todos attributed to assistant messages removed by a user-message edit
- persist the cleaned todo snapshot in the same Convex mutation that deletes the discarded response
- pass the same cleaned snapshot to local state and the replacement Agent run
- add client and backend regression coverage for the stopped-response edit flow

## Root cause

Stopping an Agent run persisted its latest todo snapshot. Editing the user message deleted the later assistant response, but the edit mutation did not replace the persisted todos. A reactive chat update could therefore restore todos that belonged to the discarded response.

## Validation

- full Jest suite: 365 suites, 3,777 tests
- post-rebase focused Jest: 4 suites, 55 tests
- TypeScript typecheck
- focused ESLint
- Prettier check
- `git diff --check`

## Manual verification

1. Start an Agent run that creates todos.
2. Stop it mid-action.
3. Edit and save the latest user message.
4. Confirm the discarded assistant response and its todos disappear, and the replacement run starts from the cleaned snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a stopped response now correctly saves the updated message.
  * Outdated tasks are cleared when editing, preventing stale todo items from remaining in the conversation.
  * Regenerating edited responses now preserves the latest task details and status.
  * Chat updates and timestamps are refreshed consistently after message edits.
* **Tests**
  * Added coverage for editing stopped responses and replacing associated task data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->