### PR TITLE
Protect file lookup errors from private content

### DIFF
--- a/convex/__tests__/fileStorage.validators.test.ts
+++ b/convex/__tests__/fileStorage.validators.test.ts
@@ -40,7 +40,7 @@ function getObjectFields(validator: { json: ValidatorJson }) {
 }
 
 describe("file storage lookup validators", () => {
-  it("accepts cached auxiliary vision fields on single and batch lookups", async () => {
+  it("returns only URL lookup metadata for single and batch lookups", async () => {
     const { getFileById, getFilesByIds } = await import("../fileStorage");
     const singleValidator = (
       getFileById as unknown as { returns: { json: ValidatorJson } }
@@ -65,6 +65,80 @@ describe("file storage lookup validators", () => {
         fieldType: { type: "string" },
         optional: true,
       });
+      expect(fields.content).toBeUndefined();
+      expect(fields.file_token_size).toBeUndefined();
     }
+
+    const storedFile = {
+      _id: "file-1",
+      _creationTime: 1,
+      s3_key: "users/user-1/file.txt",
+      user_id: "user-1",
+      name: "file.txt",
+      media_type: "text/plain",
+      size: 42,
+      file_token_size: 8,
+      content: "private file contents",
+      auxiliary_vision_description: "safe cached description",
+      auxiliary_vision_model: "vision-model",
+      is_attached: true,
+      future_private_field: "must not cross the action boundary",
+    };
+    const db = { get: jest.fn().mockResolvedValue(storedFile) };
+
+    await expect(
+      (getFileById as unknown as { handler: Function }).handler(
+        { db },
+        { fileId: "file-1" },
+      ),
+    ).resolves.toEqual({
+      s3_key: "users/user-1/file.txt",
+      user_id: "user-1",
+      name: "file.txt",
+      media_type: "text/plain",
+      size: 42,
+      auxiliary_vision_description: "safe cached description",
+      auxiliary_vision_model: "vision-model",
+    });
+
+    await expect(
+      (getFilesByIds as unknown as { handler: Function }).handler(
+        { db },
+        { fileIds: ["file-1"] },
+      ),
+    ).resolves.toEqual([
+      {
+        s3_key: "users/user-1/file.txt",
+        user_id: "user-1",
+        name: "file.txt",
+        media_type: "text/plain",
+        size: 42,
+        auxiliary_vision_description: "safe cached description",
+        auxiliary_vision_model: "vision-model",
+      },
+    ]);
+
+    db.get.mockResolvedValueOnce({
+      _id: "file-2",
+      _creationTime: 2,
+      user_id: "user-1",
+      name: "legacy.txt",
+      media_type: "text/plain",
+      size: 7,
+      file_token_size: 2,
+      content: "private legacy contents",
+      is_attached: false,
+    });
+    await expect(
+      (getFileById as unknown as { handler: Function }).handler(
+        { db },
+        { fileId: "file-2" },
+      ),
+    ).resolves.toEqual({
+      user_id: "user-1",
+      name: "legacy.txt",
+      media_type: "text/plain",
+      size: 7,
+    });
   });
 });

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -672,6 +672,41 @@ describe("s3Actions", () => {
         getFileUrlAction.handler(mockCtx, { fileId: mockFileId }),
       ).rejects.toThrow("Failed to get file URL");
     });
+
+    it("does not expose return-validation values to logs or callers", async () => {
+      const privateValue = "private auxiliary description";
+      const validationError = new Error(
+        `ReturnsValidationError: Value does not match validator: ${privateValue}`,
+      );
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const { getFileUrlAction } = await import("../s3Actions");
+      const mockCtx = {
+        auth: {
+          getUserIdentity: jest.fn().mockResolvedValue({
+            subject: "user123",
+          }),
+        },
+        runQuery: jest.fn().mockRejectedValue(validationError),
+      } as any;
+
+      try {
+        await expect(
+          getFileUrlAction.handler(mockCtx, { fileId: "file123" as any }),
+        ).rejects.toThrow(/^Failed to get file URL$/);
+
+        const serializedLog = consoleError.mock.calls
+          .flat()
+          .map(String)
+          .join("\n");
+        expect(serializedLog).toContain('"reason":"returns_validation"');
+        expect(serializedLog).not.toContain(privateValue);
+        expect(serializedLog).not.toContain("Value does not match validator");
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
   });
 
   describe("getFileUrlsBatchAction", () => {

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -7,6 +7,7 @@ import {
 import { v, ConvexError } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
 import { isSupportedImageMediaType } from "../lib/utils/file-utils";
 import { fileCountAggregate } from "./fileAggregate";
 import { convexLogger } from "./lib/logger";
@@ -343,21 +344,37 @@ export const purgeExpiredUnattachedFiles = internalMutation({
 
 const fileForStorageLookupValidator = v.union(
   v.object({
-    _id: v.id("files"),
     s3_key: v.optional(v.string()),
     user_id: v.string(),
     name: v.string(),
     media_type: v.string(),
     size: v.number(),
-    file_token_size: v.number(),
-    content: v.optional(v.string()),
     auxiliary_vision_description: v.optional(v.string()),
     auxiliary_vision_model: v.optional(v.string()),
-    is_attached: v.boolean(),
-    _creationTime: v.number(),
   }),
   v.null(),
 );
+
+const toFileForStorageLookup = (file: Doc<"files"> | null) => {
+  if (!file) return null;
+
+  // Return only the metadata consumed by the URL actions. Returning the raw
+  // document lets future schema fields reach Convex return-validation errors,
+  // whose diagnostic values can include user-authored file content.
+  return {
+    ...(file.s3_key !== undefined ? { s3_key: file.s3_key } : {}),
+    user_id: file.user_id,
+    name: file.name,
+    media_type: file.media_type,
+    size: file.size,
+    ...(file.auxiliary_vision_description !== undefined
+      ? { auxiliary_vision_description: file.auxiliary_vision_description }
+      : {}),
+    ...(file.auxiliary_vision_model !== undefined
+      ? { auxiliary_vision_model: file.auxiliary_vision_model }
+      : {}),
+  };
+};
 
 /**
  * Internal query to get a file by ID
@@ -370,7 +387,7 @@ export const getFileById = internalQuery({
   returns: fileForStorageLookupValidator,
   handler: async (ctx, args) => {
     const file = await ctx.db.get(args.fileId);
-    return file;
+    return toFileForStorageLookup(file);
   },
 });
 
@@ -384,7 +401,10 @@ export const getFilesByIds = internalQuery({
   },
   returns: v.array(fileForStorageLookupValidator),
   handler: async (ctx, args) => {
-    return await Promise.all(args.fileIds.map((fileId) => ctx.db.get(fileId)));
+    const files = await Promise.all(
+      args.fileIds.map((fileId) => ctx.db.get(fileId)),
+    );
+    return files.map(toFileForStorageLookup);
   },
 });
 

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -7,7 +7,6 @@ import { internal } from "./_generated/api";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
 import { checkFileUploadRateLimit } from "./fileActions";
-import { Doc } from "./_generated/dataModel";
 import { validateUploadPolicy } from "../lib/utils/upload-policy";
 import { hasPaidEntitlement } from "../lib/auth/entitlements";
 
@@ -18,7 +17,27 @@ type StorageUsage = {
 } | null;
 
 /** File record returned by internal.fileStorage.getFileById */
-type FileRecord = Doc<"files"> | null;
+type FileRecord = {
+  s3_key?: string;
+  user_id: string;
+  name: string;
+  media_type: string;
+  size: number;
+  auxiliary_vision_description?: string;
+  auxiliary_vision_model?: string;
+} | null;
+
+const getFileLookupErrorFields = (error: unknown) => {
+  const errorMessage = error instanceof Error ? error.message : "";
+  const reason =
+    (error instanceof Error && error.name === "ReturnsValidationError") ||
+    errorMessage.includes("ReturnsValidationError") ||
+    errorMessage.includes("Value does not match validator")
+      ? "returns_validation"
+      : "unknown";
+
+  return { reason };
+};
 
 const serviceFileUrlInfoValidator = v.object({
   url: v.string(),
@@ -268,15 +287,9 @@ export const getFileUrlAction = action({
       convexLogger.error("file_get_url_failed", {
         userId: identity.subject,
         fileId: args.fileId,
-        error:
-          error instanceof Error
-            ? { name: error.name, message: error.message, stack: error.stack }
-            : String(error),
+        ...getFileLookupErrorFields(error),
       });
-      throw new Error(
-        "Failed to get file URL: " +
-          (error instanceof Error ? error.message : "Unknown error"),
-      );
+      throw new Error("Failed to get file URL");
     }
   },
 });
@@ -328,10 +341,7 @@ export const getFileUrlsByFileIdsAction = action({
       convexLogger.error("file_batch_lookup_failed", {
         caller: "service",
         fileCount: args.fileIds.length,
-        error:
-          error instanceof Error
-            ? { name: error.name, message: error.message }
-            : String(error),
+        ...getFileLookupErrorFields(error),
       });
       return args.fileIds.map(() => null);
     }
@@ -404,10 +414,7 @@ export const getFileUrlInfosByFileIdsAction = action({
       convexLogger.error("file_batch_lookup_failed", {
         caller: "service-info",
         fileCount: args.fileIds.length,
-        error:
-          error instanceof Error
-            ? { name: error.name, message: error.message }
-            : String(error),
+        ...getFileLookupErrorFields(error),
       });
       return args.fileIds.map(() => null);
     }
@@ -502,10 +509,7 @@ export const getFileUrlsBatchAction = action({
         userId: identity.subject,
         caller: "user",
         fileCount: args.fileIds.length,
-        error:
-          error instanceof Error
-            ? { name: error.name, message: error.message }
-            : String(error),
+        ...getFileLookupErrorFields(error),
       });
       return urlMap;
     }


### PR DESCRIPTION
## Production evidence

The frozen audit window was `2026-08-16T20:01:35.497Z` through `2026-08-17T20:01:35.497Z`.

PostHog issue `019f62b8-7959-70f3-8ad9-519175c36d7a` contained 188 Convex `ReturnsValidationError` events affecting 48 users. The immediate return-validator mismatch ended at `2026-08-17T03:12:18.361Z`; commit `69ab3632` became READY in production at `03:14:42.046Z`, and no later matching event occurred.

Representative exception properties showed a separate privacy gap: the return-validation diagnostic included the returned file record, including user-derived file metadata. `getFileUrlAction` logged the raw error and appended its message to the thrown client error, after which the Convex PostHog integration captured it.

## Root cause

The internal file lookup queries returned entire `files` documents even though URL actions need only ownership and URL-generation metadata. Any future schema/validator skew could therefore include private document fields in a return-validation diagnostic. The action catch then propagated that diagnostic verbatim.

## Change

- project only URL-generation metadata from single and batch file lookups;
- exclude file contents, token counts, attachment state, timestamps, and future fields from the internal action boundary;
- keep failures visible with the bounded reason `returns_validation` or `unknown` plus existing opaque identifiers;
- return a generic client error instead of raw Convex validator values.

No error suppression, retry, routing, billing, machine, or public success-response behavior changes.

## Validation

- focused Convex suites: 42/42 tests passed;
- typecheck passed;
- changed-file ESLint and Prettier passed;
- dependency-scope guard passed;
- full commit hooks passed: 384 suites / 3,913 tests;
- adversarial review covered all four lookup consumers, ownership/null behavior, batch ordering and limits, optional Convex serialization, deploy skew, and structured-log privacy.

## Manual verification

1. In a non-production environment, generate download URLs through the single, service-batch, metadata-batch, and authenticated-batch paths; owned S3 files should return the same URL/result shapes, while missing or unowned files remain null/omitted.
2. Force a lookup return-validation failure; the caller should receive only `Failed to get file URL`, and the structured log should contain `reason=returns_validation` plus opaque IDs without a returned record, filename content, auxiliary description, object key, or signed URL.

Visual QA is not applicable to this backend-only boundary change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File lookup results now expose only necessary URL and metadata fields, excluding private content and internal sizing details.
  * Legacy files without URL metadata are handled safely.
  * File URL lookup failures now return a generic error while limiting diagnostic details in logs.
* **Security**
  * Prevented private and future fields from crossing action boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->