### PR TITLE
Add reliability correlation telemetry

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -1135,6 +1135,8 @@ describe("forwardChunk", () => {
             type: "command",
             commandId: "cmd-publish-failure",
             command: "test",
+            chatId: "chat-1",
+            triggerRunId: "run-1",
             targetConnectionId: "conn-123",
           },
         });
@@ -1154,6 +1156,8 @@ describe("forwardChunk", () => {
           {
             connectionId: "conn-123",
             commandId: "cmd-publish-failure",
+            chatId: "chat-1",
+            triggerRunId: "run-1",
             chunkType: "stdout",
             reason,
             attempt: 1,
@@ -1166,6 +1170,8 @@ describe("forwardChunk", () => {
           {
             connectionId: "conn-123",
             commandId: "cmd-publish-failure",
+            chatId: "chat-1",
+            triggerRunId: "run-1",
             chunkType: "stdout",
             reason,
             attempts: 3,
@@ -1193,6 +1199,8 @@ describe("forwardChunk", () => {
             request_id: "cmd-publish-failure",
             connection_id: "conn-123",
             command_id: "cmd-publish-failure",
+            chat_id: "chat-1",
+            trigger_run_id: "run-1",
             chunk_type: "stdout",
             reason,
             attempt: 1,

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -82,6 +82,11 @@ interface DesktopStreamPublishRecoveryState {
   terminalChunkPublished: boolean;
 }
 
+type DesktopStreamTelemetryContext = Pick<
+  CommandMessage,
+  "chatId" | "triggerRunId"
+>;
+
 function shouldForwardStreamChunk(chunk: StreamChunk): boolean {
   if (chunk.type === "stdout" || chunk.type === "stderr") {
     return Boolean(chunk.data);
@@ -709,6 +714,10 @@ export class DesktopSandboxBridge {
 
   private async handleCommand(command: CommandMessage): Promise<void> {
     const { commandId } = command;
+    const telemetryContext: DesktopStreamTelemetryContext = {
+      chatId: command.chatId,
+      triggerRunId: command.triggerRunId,
+    };
     this.activeCommands.add(commandId);
     const commandStartedAt = Date.now();
     const recoveryState: DesktopStreamPublishRecoveryState = {
@@ -749,6 +758,7 @@ export class DesktopSandboxBridge {
               sequence,
               recoveryState,
               recoveryDeadlineAt,
+              telemetryContext,
             );
           } catch (error) {
             // Tauri does not await Channel callbacks. Exhausted known
@@ -793,6 +803,7 @@ export class DesktopSandboxBridge {
         commandId,
         recoveryState,
         Date.now() - commandStartedAt,
+        telemetryContext,
       );
       this.activeCommands.delete(commandId);
     }
@@ -802,6 +813,7 @@ export class DesktopSandboxBridge {
     commandId: string,
     recoveryState: DesktopStreamPublishRecoveryState,
     durationMs: number,
+    telemetryContext: DesktopStreamTelemetryContext,
   ): void {
     if (!recoveryState.failureReported) return;
 
@@ -814,6 +826,10 @@ export class DesktopSandboxBridge {
     const properties = {
       connectionId: this.connectionId,
       commandId,
+      ...(telemetryContext.chatId && { chatId: telemetryContext.chatId }),
+      ...(telemetryContext.triggerRunId && {
+        triggerRunId: telemetryContext.triggerRunId,
+      }),
       outcome,
       observedChunks: recoveryState.observedChunks,
       publishedChunks: recoveryState.publishedChunks,
@@ -833,6 +849,8 @@ export class DesktopSandboxBridge {
       request_id: commandId,
       connection_id: this.connectionId,
       command_id: commandId,
+      chat_id: telemetryContext.chatId,
+      trigger_run_id: telemetryContext.triggerRunId,
       outcome,
       observed_chunks: recoveryState.observedChunks,
       published_chunks: recoveryState.publishedChunks,
@@ -1224,6 +1242,7 @@ export class DesktopSandboxBridge {
     sequence: number,
     recoveryState: DesktopStreamPublishRecoveryState,
     recoveryDeadlineAt: number,
+    telemetryContext: DesktopStreamTelemetryContext,
   ): Promise<void> {
     let firstFailureAt: number | null = null;
     let firstFailureReason: DesktopStreamPublishFailureReason | null = null;
@@ -1258,6 +1277,8 @@ export class DesktopSandboxBridge {
               request_id: commandId,
               connection_id: this.connectionId,
               command_id: commandId,
+              chat_id: telemetryContext.chatId,
+              trigger_run_id: telemetryContext.triggerRunId,
               chunk_type: chunk.type,
               reason: firstFailureReason,
               attempts: attempt,
@@ -1267,6 +1288,12 @@ export class DesktopSandboxBridge {
           captureAuthenticatedEvent("desktop_stream_publish_recovered", {
             connectionId: this.connectionId,
             commandId,
+            ...(telemetryContext.chatId && {
+              chatId: telemetryContext.chatId,
+            }),
+            ...(telemetryContext.triggerRunId && {
+              triggerRunId: telemetryContext.triggerRunId,
+            }),
             chunkType: chunk.type,
             reason: firstFailureReason,
             attempts: attempt,
@@ -1293,6 +1320,8 @@ export class DesktopSandboxBridge {
               request_id: commandId,
               connection_id: this.connectionId,
               command_id: commandId,
+              chat_id: telemetryContext.chatId,
+              trigger_run_id: telemetryContext.triggerRunId,
               chunk_type: chunk.type,
               reason,
               attempt,
@@ -1302,6 +1331,12 @@ export class DesktopSandboxBridge {
           captureAuthenticatedEvent("desktop_stream_publish_failed", {
             connectionId: this.connectionId,
             commandId,
+            ...(telemetryContext.chatId && {
+              chatId: telemetryContext.chatId,
+            }),
+            ...(telemetryContext.triggerRunId && {
+              triggerRunId: telemetryContext.triggerRunId,
+            }),
             chunkType: chunk.type,
             reason,
             attempt,
@@ -1334,6 +1369,8 @@ export class DesktopSandboxBridge {
               request_id: commandId,
               connection_id: this.connectionId,
               command_id: commandId,
+              chat_id: telemetryContext.chatId,
+              trigger_run_id: telemetryContext.triggerRunId,
               chunk_type: chunk.type,
               reason: firstFailureReason,
               attempts: attempt,
@@ -1346,6 +1383,12 @@ export class DesktopSandboxBridge {
             {
               connectionId: this.connectionId,
               commandId,
+              ...(telemetryContext.chatId && {
+                chatId: telemetryContext.chatId,
+              }),
+              ...(telemetryContext.triggerRunId && {
+                triggerRunId: telemetryContext.triggerRunId,
+              }),
               chunkType: chunk.type,
               reason: firstFailureReason,
               attempts: attempt,

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -113,6 +113,7 @@ export const createTools = (
           onSandboxBoot,
           workingDirectory,
           triggerRunId,
+          chatId,
         )
       : new DefaultSandboxManager(
           userID,

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -201,6 +201,42 @@ describe("CentrifugoSandbox", () => {
   });
 
   describe("commands.run happy path", () => {
+    it("propagates stable chat and run identifiers to the desktop command", async () => {
+      const sandbox = new CentrifugoSandbox(
+        "user-1",
+        defaultConnection,
+        defaultConfig,
+        undefined,
+        "run-1",
+        "chat-1",
+      );
+      const { promise } = startCommand(sandbox, "echo correlated", {
+        timeoutMs: 5000,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(sub.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "command",
+          chatId: "chat-1",
+          triggerRunId: "run-1",
+        }),
+      );
+
+      sub.emit("publication", {
+        data: { type: "exit", commandId: FIXED_UUID, exitCode: 0 },
+      });
+      await expect(promise).resolves.toEqual({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
     it("uses the project folder as the default cwd", async () => {
       const sandbox = createDesktopSandbox("C:\\work\\hackerai");
       const { promise } = startCommand(sandbox, "git status", {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -276,6 +276,8 @@ export class CentrifugoSandbox extends EventEmitter {
     private connectionInfo: ConnectionInfo,
     private config: CentrifugoConfig,
     private workingDirectory?: string,
+    private triggerRunId?: string,
+    private chatId?: string,
   ) {
     super();
   }
@@ -898,6 +900,8 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
               timeout,
               background: opts?.background,
               displayName: opts?.displayName,
+              chatId: this.chatId,
+              triggerRunId: this.triggerRunId,
               targetConnectionId: this.connectionInfo.connectionId,
             };
 

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -250,6 +250,7 @@ export class HybridSandboxManager implements SandboxManager {
     private onBoot?: (info: SandboxBootInfo) => void,
     private workingDirectory?: string,
     private requestId?: string,
+    private chatId?: string,
   ) {
     this.sandbox = initialSandbox || null;
   }
@@ -673,6 +674,8 @@ export class HybridSandboxManager implements SandboxManager {
       connection,
       centrifugoConfig,
       this.workingDirectory,
+      this.requestId,
+      this.chatId,
     );
     this.isLocal = true;
     this.currentConnectionId = connection.connectionId;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -438,6 +438,8 @@ export const createChatHandler = () => {
         allowLocalDesktopFiles:
           isAgentMode(mode) && sandboxPreference === "desktop",
         auxiliaryVisionEnabled: !!auxiliaryVisionAssignment,
+        chatId,
+        requestId: req.headers.get("x-vercel-id") ?? undefined,
       });
 
       // Empty after processing → providers reject the request before the route can stream.
@@ -652,6 +654,7 @@ export const createChatHandler = () => {
         createAuxiliaryVisionExposureRecorder({
           posthog,
           userId,
+          chatId,
           subscription,
           mode,
           selectedModelOverride,

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -7,6 +7,8 @@ export interface CommandMessage {
   timeout?: number;
   background?: boolean;
   displayName?: string;
+  chatId?: string;
+  triggerRunId?: string;
   targetConnectionId: string;
 }
 

--- a/lib/chat/__tests__/auxiliary-vision.test.ts
+++ b/lib/chat/__tests__/auxiliary-vision.test.ts
@@ -67,6 +67,7 @@ describe("auxiliary vision", () => {
       requestId: "request-1",
       userId: "user-1",
       chatId: "chat-1",
+      triggerRunId: "run-1",
     });
     const providerError = new Error("sensitive provider details");
 
@@ -88,6 +89,7 @@ describe("auxiliary vision", () => {
       request_id: "request-1",
       user_id: "user-1",
       chat_id: "chat-1",
+      trigger_run_id: "run-1",
       source: "attachment",
       fallback_route: "direct_vision",
       failure_reason: "provider_error",
@@ -375,6 +377,9 @@ describe("auxiliary vision", () => {
           },
         ],
         userId: "user-1",
+        chatId: "chat-1",
+        triggerRunId: "run-1",
+        requestId: "run-1",
         cacheDescription,
         onCost,
         modelRunner,
@@ -387,6 +392,18 @@ describe("auxiliary vision", () => {
       expect.objectContaining({ fileId: "file-good" }),
     );
     expect(onCost).not.toHaveBeenCalled();
+    const failedEvent = (console.warn as jest.Mock).mock.calls
+      .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+      .find(
+        (payload) => payload.event === "auxiliary_vision_description_failed",
+      );
+    expect(failedEvent).toMatchObject({
+      request_id: "run-1",
+      user_id: "user-1",
+      chat_id: "chat-1",
+      trigger_run_id: "run-1",
+      source: "attachment",
+    });
   });
 
   it("fails explicitly when the auxiliary model returns no description", async () => {

--- a/lib/chat/auxiliary-vision.ts
+++ b/lib/chat/auxiliary-vision.ts
@@ -46,6 +46,7 @@ export function createAuxiliaryVisionFailoverController({
   requestId,
   userId,
   chatId,
+  triggerRunId,
   isUserAborted,
 }: {
   enabled: boolean;
@@ -53,6 +54,7 @@ export function createAuxiliaryVisionFailoverController({
   requestId?: string;
   userId?: string;
   chatId?: string;
+  triggerRunId?: string;
   isUserAborted?: () => boolean;
 }): AuxiliaryVisionFailoverController {
   let active = enabled;
@@ -74,6 +76,7 @@ export function createAuxiliaryVisionFailoverController({
           request_id: requestId ?? "unavailable",
           user_id: userId,
           chat_id: chatId,
+          trigger_run_id: triggerRunId,
           source,
           fallback_route: "direct_vision",
           failure_reason: failure.reason,
@@ -175,6 +178,7 @@ export async function describeImageWithAuxiliaryVision({
   requestId,
   userId,
   chatId,
+  triggerRunId,
   abortSignal,
   onCost,
   onExposure,
@@ -187,6 +191,7 @@ export async function describeImageWithAuxiliaryVision({
   requestId?: string;
   userId?: string;
   chatId?: string;
+  triggerRunId?: string;
   abortSignal?: AbortSignal;
   onCost?: (costDollars: number) => void;
   onExposure?: (source: AuxiliaryVisionSource) => void;
@@ -236,6 +241,7 @@ export async function describeImageWithAuxiliaryVision({
         request_id: requestId ?? "unavailable",
         user_id: userId,
         chat_id: chatId,
+        trigger_run_id: triggerRunId,
         source,
         model: AUXILIARY_VISION_SLUG,
         media_type: mediaType,
@@ -268,6 +274,7 @@ export async function describeImageWithAuxiliaryVision({
         request_id: requestId ?? "unavailable",
         user_id: userId,
         chat_id: chatId,
+        trigger_run_id: triggerRunId,
         source,
         model: AUXILIARY_VISION_SLUG,
         media_type: mediaType,
@@ -295,6 +302,7 @@ export async function describeImageAttachmentsWithAuxiliaryVision({
   requestId,
   userId,
   chatId,
+  triggerRunId,
   abortSignal,
   onCost,
   onExposure,
@@ -305,6 +313,7 @@ export async function describeImageAttachmentsWithAuxiliaryVision({
   requestId?: string;
   userId?: string;
   chatId?: string;
+  triggerRunId?: string;
   abortSignal?: AbortSignal;
   onCost?: (costDollars: number) => void;
   onExposure?: (source: AuxiliaryVisionSource) => void;
@@ -405,6 +414,7 @@ export async function describeImageAttachmentsWithAuxiliaryVision({
               requestId,
               userId,
               chatId,
+              triggerRunId,
               abortSignal,
               onCost: (costDollars) => {
                 pendingCostDollars += costDollars;

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -646,6 +646,9 @@ export async function processChatMessages({
   extraUsageAvailable = false,
   allowLocalDesktopFiles = false,
   auxiliaryVisionEnabled = false,
+  chatId,
+  triggerRunId,
+  requestId,
 }: {
   messages: UIMessage[];
   mode: ChatMode;
@@ -656,6 +659,9 @@ export async function processChatMessages({
   extraUsageAvailable?: boolean;
   allowLocalDesktopFiles?: boolean;
   auxiliaryVisionEnabled?: boolean;
+  chatId?: string;
+  triggerRunId?: string;
+  requestId?: string;
 }) {
   const messagesWithoutOpenRouterReasoningMetadata =
     stripOpenRouterReasoningMetadataFromMessages(messages);
@@ -680,6 +686,7 @@ export async function processChatMessages({
       uploadBasePath,
       subscription,
       allowLocalDesktopFiles,
+      { chatId, triggerRunId, requestId },
     );
 
   // Fix incomplete tool invocations and reasoning (from interrupted streams) before filtering.

--- a/lib/experiments/__tests__/auxiliary-deepseek-vision.test.ts
+++ b/lib/experiments/__tests__/auxiliary-deepseek-vision.test.ts
@@ -55,6 +55,8 @@ describe("auxiliary DeepSeek vision flag", () => {
     const record = createAuxiliaryVisionExposureRecorder({
       posthog: { capture } as never,
       userId: "user-1",
+      chatId: "chat-1",
+      triggerRunId: "run-1",
       subscription: "pro",
       mode: "agent",
       selectedModelOverride: "hackerai-pro",
@@ -73,6 +75,8 @@ describe("auxiliary DeepSeek vision flag", () => {
       properties: expect.objectContaining({
         experiment_variant: "test",
         exposure_surface: "file_view",
+        chat_id: "chat-1",
+        trigger_run_id: "run-1",
         selected_model_override: "hackerai-pro",
         selected_model: "model-deepseek-v4-pro-0813",
         $process_person_profile: false,

--- a/lib/experiments/auxiliary-deepseek-vision.ts
+++ b/lib/experiments/auxiliary-deepseek-vision.ts
@@ -88,6 +88,8 @@ export async function evaluateAuxiliaryDeepSeekVisionFlag({
 export function createAuxiliaryVisionExposureRecorder({
   posthog,
   userId,
+  chatId,
+  triggerRunId,
   subscription,
   mode,
   selectedModelOverride,
@@ -96,6 +98,8 @@ export function createAuxiliaryVisionExposureRecorder({
 }: {
   posthog: Pick<PostHog, "capture"> | null;
   userId: string;
+  chatId: string;
+  triggerRunId?: string;
   subscription: SubscriptionTier;
   mode: ChatMode;
   selectedModelOverride?: SelectedModel;
@@ -120,6 +124,8 @@ export function createAuxiliaryVisionExposureRecorder({
         selected_model_override: selectedModelOverride ?? "auto",
         selected_model: getSelectedModel(),
         exposure_surface: source,
+        chat_id: chatId,
+        ...(triggerRunId && { trigger_run_id: triggerRunId }),
         $process_person_profile: false,
       },
     });

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -87,16 +87,19 @@ const fileUrlInfo = (
 describe("processMessageFiles image size guards", () => {
   const originalFetch = global.fetch;
   let consoleWarnSpy: jest.SpyInstance;
+  let consoleInfoSpy: jest.SpyInstance;
 
   beforeEach(() => {
     mockConvexAction.mockResolvedValue([]);
     mockConvexQuery.mockResolvedValue([]);
     consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    consoleInfoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     consoleWarnSpy.mockRestore();
+    consoleInfoSpy.mockRestore();
   });
 
   it("does not preserve client auxiliary metadata on URL-only images", async () => {
@@ -224,6 +227,12 @@ describe("processMessageFiles image size guards", () => {
       "user123",
       undefined,
       "pro",
+      false,
+      {
+        chatId: "chat-1",
+        triggerRunId: "run-1",
+        requestId: "run-1",
+      },
     );
 
     expect(result.messages[0].parts[1]).toMatchObject({
@@ -233,6 +242,22 @@ describe("processMessageFiles image size guards", () => {
       url: "https://storage.example/actually-small.png",
       auxiliaryVisionDescription: "Cached trusted description",
       auxiliaryVisionModel: "google/gemini-3.6-flash",
+    });
+    const successEvent = consoleInfoSpy.mock.calls
+      .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+      .find((payload) => payload.event === "persisted_image_reload_succeeded");
+    expect(successEvent).toMatchObject({
+      service: "agent-long",
+      request_id: "run-1",
+      user_id: "user123",
+      chat_id: "chat-1",
+      trigger_run_id: "run-1",
+      mode: "ask",
+      subscription_tier: "pro",
+      reload_stage: "owner_checked_storage_lookup",
+      image_count: 1,
+      metadata_lookup_image_count: 1,
+      legacy_fallback_image_count: 0,
     });
   });
 

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -50,6 +50,17 @@ type ResolvedFileUrlInfo = {
   auxiliaryVisionModel?: string;
 };
 
+type PersistedFileUrlFetchResult = {
+  value: ResolvedFileUrlInfo | string | null;
+  lookupPath: "metadata" | "legacy_fallback" | "failed";
+};
+
+type PersistedImageReloadTelemetryContext = {
+  chatId?: string;
+  triggerRunId?: string;
+  requestId?: string;
+};
+
 type SizeProbeResult = {
   bytes: number;
   source: "file_record" | "content_length" | "content_range" | "download_probe";
@@ -498,7 +509,7 @@ const collectFilesToProcess = (
 const fetchFileUrls = async (
   fileIds: string[],
   userId: string | undefined,
-): Promise<(ResolvedFileUrlInfo | string | null)[]> => {
+): Promise<PersistedFileUrlFetchResult[]> => {
   if (!fileIds.length) return [];
   if (!userId) {
     logger.warn("file_url_fetch_skipped_missing_user_id", {
@@ -517,12 +528,9 @@ const fetchFileUrls = async (
 
     const chunkResults = await Promise.all(
       chunks.map(
-        async (
-          chunk,
-          index,
-        ): Promise<(ResolvedFileUrlInfo | string | null)[]> => {
+        async (chunk, index): Promise<PersistedFileUrlFetchResult[]> => {
           try {
-            return await getConvexClient().action(
+            const values = await getConvexClient().action(
               api.s3Actions.getFileUrlInfosByFileIdsAction,
               {
                 serviceKey,
@@ -530,6 +538,10 @@ const fetchFileUrls = async (
                 fileIds: chunk as Id<"files">[],
               },
             );
+            return values.map((value) => ({
+              value,
+              lookupPath: "metadata" as const,
+            }));
           } catch (error) {
             logger.warn("file_url_fetch_chunk_failed", {
               event: "file_url_fetch_chunk_failed",
@@ -542,7 +554,7 @@ const fetchFileUrls = async (
             });
 
             try {
-              return await getConvexClient().action(
+              const values = await getConvexClient().action(
                 api.s3Actions.getFileUrlsByFileIdsAction,
                 {
                   serviceKey,
@@ -550,6 +562,10 @@ const fetchFileUrls = async (
                   fileIds: chunk as Id<"files">[],
                 },
               );
+              return values.map((value) => ({
+                value,
+                lookupPath: "legacy_fallback" as const,
+              }));
             } catch (fallbackError) {
               logger.warn("file_url_legacy_fetch_chunk_failed", {
                 event: "file_url_legacy_fetch_chunk_failed",
@@ -560,7 +576,10 @@ const fetchFileUrls = async (
                 chunk_index: index,
                 chunk_count: chunks.length,
               });
-              return chunk.map(() => null);
+              return chunk.map(() => ({
+                value: null,
+                lookupPath: "failed" as const,
+              }));
             }
           }
         },
@@ -584,6 +603,8 @@ const applyUrlsToFileParts = async (
   filesToProcess: Map<string, FileToProcess>,
   mode: ChatMode,
   userId: string,
+  subscription?: SubscriptionTier,
+  telemetryContext?: PersistedImageReloadTelemetryContext,
 ) => {
   const filesNeedingUrls = Array.from(filesToProcess.values()).filter(
     (file) => file.fileId && !file.url,
@@ -592,9 +613,13 @@ const applyUrlsToFileParts = async (
 
   const fetchedUrls = await fetchFileUrls(fileIdsNeedingUrls, userId);
 
+  let metadataLookupImageCount = 0;
+  let legacyFallbackImageCount = 0;
+
   filesNeedingUrls.forEach((file, index) => {
+    const fetchResult = fetchedUrls[index];
     const resolved = validateResolvedFileUrlInfo(
-      fetchedUrls[index],
+      fetchResult?.value,
       file.fileId!,
     );
     if (resolved) {
@@ -607,8 +632,49 @@ const applyUrlsToFileParts = async (
       }
       file.auxiliaryVisionDescription = resolved.auxiliaryVisionDescription;
       file.auxiliaryVisionModel = resolved.auxiliaryVisionModel;
+
+      const resolvedMediaType =
+        normalizeImageMediaType(file.mediaType) ?? file.mediaType ?? "";
+      if (isSupportedImageMediaType(resolvedMediaType)) {
+        if (fetchResult?.lookupPath === "metadata") {
+          metadataLookupImageCount += 1;
+        } else if (fetchResult?.lookupPath === "legacy_fallback") {
+          legacyFallbackImageCount += 1;
+        }
+      }
     }
   });
+
+  const persistedImageCount =
+    metadataLookupImageCount + legacyFallbackImageCount;
+  if (persistedImageCount > 0) {
+    console.info(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        event: "persisted_image_reload_succeeded",
+        service: telemetryContext?.triggerRunId ? "agent-long" : "chat-handler",
+        environment:
+          process.env.TRIGGER_ENV ??
+          process.env.VERCEL_ENV ??
+          process.env.NODE_ENV ??
+          "unknown",
+        request_id:
+          telemetryContext?.requestId ??
+          telemetryContext?.triggerRunId ??
+          "unavailable",
+        user_id: userId,
+        chat_id: telemetryContext?.chatId,
+        trigger_run_id: telemetryContext?.triggerRunId,
+        mode,
+        subscription_tier: subscription,
+        reload_stage: "owner_checked_storage_lookup",
+        image_count: persistedImageCount,
+        metadata_lookup_image_count: metadataLookupImageCount,
+        legacy_fallback_image_count: legacyFallbackImageCount,
+      }),
+    );
+  }
 
   for (const [fileKey, file] of filesToProcess) {
     if (!file.url) continue;
@@ -892,6 +958,7 @@ export const processMessageFiles = async (
   uploadBasePath?: string,
   subscription?: SubscriptionTier,
   allowLocalDesktopFiles: boolean = false,
+  telemetryContext?: PersistedImageReloadTelemetryContext,
 ): Promise<{
   messages: UIMessage[];
   hasMediaFiles: boolean;
@@ -918,7 +985,14 @@ export const processMessageFiles = async (
   const { hasMedia, files } = collectFilesToProcess(updatedMessages, mode);
 
   if (files.size > 0) {
-    await applyUrlsToFileParts(updatedMessages, files, mode, userId);
+    await applyUrlsToFileParts(
+      updatedMessages,
+      files,
+      mode,
+      userId,
+      subscription,
+      telemetryContext,
+    );
   }
 
   const maxFileTokens = subscription

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2322,6 +2322,9 @@ export const agentLongTask = task({
         extraUsageAvailable,
         allowLocalDesktopFiles: sandboxPreference === "desktop",
         auxiliaryVisionEnabled: !!auxiliaryVisionAssignment,
+        chatId,
+        triggerRunId: ctx.run.id,
+        requestId: ctx.run.id,
       });
 
       if (!processedMessages.length) {
@@ -2471,12 +2474,15 @@ export const agentLongTask = task({
         requestId: ctx.run.id,
         userId,
         chatId,
+        triggerRunId: ctx.run.id,
         isUserAborted: () => userStopSignal.signal.aborted,
       });
       const captureAuxiliaryVisionExposure =
         createAuxiliaryVisionExposureRecorder({
           posthog,
           userId,
+          chatId,
+          triggerRunId: ctx.run.id,
           subscription,
           mode,
           selectedModelOverride,
@@ -2511,6 +2517,7 @@ export const agentLongTask = task({
                         requestId: ctx.run.id,
                         userId,
                         chatId,
+                        triggerRunId: ctx.run.id,
                         abortSignal: userStopSignal.signal,
                         onExposure: captureAuxiliaryVisionExposure,
                         onCost: (costDollars) => {
@@ -3107,6 +3114,7 @@ export const agentLongTask = task({
                     requestId: ctx.run.id,
                     userId,
                     chatId,
+                    triggerRunId: ctx.run.id,
                     abortSignal: userStopSignal.signal,
                     onExposure: captureAuxiliaryVisionExposure,
                     onCost: (costDollars) => {


### PR DESCRIPTION
## Summary

- add privacy-safe chat and Trigger run identifiers to auxiliary-vision exposure, failure, failover, and completion telemetry
- propagate the same identifiers through desktop command envelopes into publish failure, recovery, exhaustion, and settlement events
- emit `persisted_image_reload_succeeded` after an owner-checked storage lookup, segmented by metadata lookup versus legacy fallback

## Why

The HAC-70 rollout investigation could confirm aggregate exposure and failure counts but could not safely join exposure, auxiliary failover, persisted-image reloads, and desktop publish failures at run/chat grain. These bounded opaque identifiers close that observability gap without logging prompts, files, commands, output, targets, findings, or other user content.

The production Convex save cluster was also verified as five `/api/agent` 503s across five chats and one explicit application user identifier. Each request exhausted the existing 250 ms and 1 s retries before a third `convex_server_error` failure. Vercel's grouped `users=2` dimension remains incompatible with the explicit application-user field and is not treated as confirmed user breadth.

## Impact

This is behavior-neutral instrumentation. Existing desktop clients remain compatible because the command-envelope correlation fields are optional. Direct-vision failover remains deployed but is not described as production-verified until an activation is observed or safely exercised.

## Validation

- full pre-commit suite: 384 suites / 3,914 tests
- TypeScript: `tsc --noEmit`
- focused ESLint and Prettier checks
- local dependency-link guard
- focused telemetry suites: 140 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved tracking of sandbox command delivery, retries, failures, and recovery.
  - Added more complete request context to assist with diagnosing streamed command issues.

- **Image Processing**
  - Improved monitoring for persisted image reloads, including successful storage lookups and fallback behavior.
  - Enhanced visibility into auxiliary vision failover and image-description outcomes.

- **Observability**
  - Added chat and run identifiers to relevant analytics and structured logs for clearer request-level tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->