### PR TITLE
Prime snapshots and streamline Lambda MicroVM startup

### DIFF
--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -56,6 +56,13 @@ the exact returned image version to become `SUCCESSFUL` and `ACTIVE`, and then
 prints `AWS_LAMBDA_MICROVM_IMAGE_ID` and
 `AWS_LAMBDA_MICROVM_IMAGE_VERSION`.
 
+During AWS image preparation, both lifecycle image hooks run a bounded,
+credential-free working-set primer. It initializes the in-process relay and
+command protocol, a real shell PTY, local DNS lookup libraries, and the startup
+paths for `bash`, passwordless `sudo`, `nmap`, and `naabu`. Any required step
+failure rejects image validation rather than publishing an incompletely primed
+image; structured hook logs include per-step duration without bootstrap data.
+
 If the image build fails, inspect the CloudWatch log group shown by the Lambda
 MicroVM image. The HackerAI image currently uses Kali's public ARM64 container
 base, while the Lambda-managed MicroVM base is selected separately by the
@@ -171,6 +178,14 @@ The packaged Lambda image automatically routes `naabu` hostname lookups through
 the non-loopback resolver supplied by the MicroVM runtime. An explicit `-r`
 resolver still takes precedence. The wrapper also disables the per-VM update
 check because images are immutable; an explicit `-up` request still works.
+
+The lifecycle server hosts the outbound command relay in its already
+snapshotted Node process. Suspend, resume, termination, and unexpected relay
+restart are serialized in-process; `/run` does not fork a second Node worker.
+The launcher watches the Convex session reactively while AWS allocates the VM,
+then overlaps readiness with the durable MicroVM-ID attachment. It still waits
+for that attachment before returning so failure cleanup always has a persisted
+or locally held AWS identifier.
 
 For network correctness, start known open and closed TCP/UDP listeners on a
 separate controlled host. Verify `nc`, `nmap -sT`, `nmap -sS`, `naabu`, and a UDP

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -424,6 +424,62 @@ describe("AWS Lambda MicroVM development logging", () => {
     jest.useRealTimers();
   });
 
+  it("does not spend the guest readiness budget on AWS allocation", async () => {
+    jest.useFakeTimers();
+    const session = {
+      sessionId: "session-slow-allocation",
+      status: "starting" as const,
+      region: "us-east-1",
+      imageIdentifier: process.env.AWS_LAMBDA_MICROVM_IMAGE_ID,
+      imageVersion: "6.0",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      bootstrapExpiresAt: Date.now() + 180_000,
+    };
+    let deliverSession!: (value: unknown) => void;
+    let acceptRun!: (value: unknown) => void;
+    mockRealtimeOnUpdate.mockImplementationOnce((_query, _args, callback) => {
+      deliverSession = callback;
+      return mockRealtimeUnsubscribe;
+    });
+    mockMutation
+      .mockResolvedValueOnce({
+        created: true,
+        session,
+        bootstrapToken: "bootstrap-slow-allocation",
+        cleanupCandidates: [],
+      })
+      .mockResolvedValueOnce(true);
+    mockSend.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          acceptRun = resolve;
+        }),
+    );
+    const infoSpy = jest.spyOn(console, "info").mockImplementation();
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation();
+
+    const pending = ensureAwsLambdaMicrovmConnection("user-slow-allocation");
+    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(90_000);
+    acceptRun({
+      microvmId: "microvm-slow-allocation",
+      $metadata: { requestId: "run-slow-allocation", httpStatusCode: 200 },
+    });
+    deliverSession({
+      ...session,
+      status: "running",
+      microvmId: "microvm-slow-allocation",
+      connectionId: "connection-slow-allocation",
+      relayReadyAt: Date.now(),
+    });
+
+    await expect(pending).resolves.toBeDefined();
+    infoSpy.mockRestore();
+    debugSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
   it.each(["terminal_status", "query_error"] as const)(
     "closes readiness subscriptions on %s",
     async (mode) => {

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -3,6 +3,19 @@ const mockDestroy = jest.fn();
 const mockMutation = jest.fn();
 const mockQuery = jest.fn();
 const mockRelayRun = jest.fn();
+const mockRealtimeClose = jest.fn().mockResolvedValue(undefined);
+const mockRealtimeUnsubscribe = jest.fn();
+const mockRealtimeOnUpdate = jest.fn(
+  (
+    query: unknown,
+    args: unknown,
+    callback: (value: unknown) => void,
+    onError: (error: Error) => void,
+  ) => {
+    Promise.resolve(mockQuery(query, args)).then(callback, onError);
+    return mockRealtimeUnsubscribe;
+  },
+);
 
 jest.mock("@aws-sdk/client-lambda-microvms", () => {
   class Command {
@@ -26,6 +39,13 @@ jest.mock("@/lib/db/convex-client", () => ({
   getConvexUrl: () => "http://127.0.0.1:3210",
 }));
 
+jest.mock("@/lib/db/convex-realtime-client", () => ({
+  createConvexRealtimeClient: () => ({
+    onUpdate: mockRealtimeOnUpdate,
+    close: mockRealtimeClose,
+  }),
+}));
+
 jest.mock("../centrifugo-sandbox", () => ({
   CentrifugoSandbox: jest.fn().mockImplementation(() => ({
     commands: { run: mockRelayRun },
@@ -43,6 +63,13 @@ describe("AWS Lambda MicroVM development logging", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRealtimeClose.mockResolvedValue(undefined);
+    mockRealtimeOnUpdate.mockImplementation(
+      (query, args, callback, onError) => {
+        Promise.resolve(mockQuery(query, args)).then(callback, onError);
+        return mockRealtimeUnsubscribe;
+      },
+    );
     mockRelayRun.mockResolvedValue({
       stdout: "ready\n",
       stderr: "",
@@ -110,6 +137,8 @@ describe("AWS Lambda MicroVM development logging", () => {
     ).resolves.toBeDefined();
 
     expect(mockRelayRun).not.toHaveBeenCalled();
+    expect(mockRealtimeUnsubscribe).toHaveBeenCalled();
+    expect(mockRealtimeClose).toHaveBeenCalledTimes(1);
     infoSpy.mockRestore();
     debugSpy.mockRestore();
   });
@@ -219,6 +248,7 @@ describe("AWS Lambda MicroVM development logging", () => {
     });
     expect(errorPayload.error_message).toContain("[REDACTED]");
     expect(errorPayload.error_message).not.toContain(bootstrapToken);
+    expect(mockRealtimeClose).toHaveBeenCalledTimes(1);
 
     const runInput = (
       mockSend.mock.calls[0][0] as {
@@ -250,6 +280,202 @@ describe("AWS Lambda MicroVM development logging", () => {
     errorSpy.mockRestore();
     debugSpy.mockRestore();
   });
+
+  it("cleans up a readiness watch whose initial value is delivered synchronously", async () => {
+    const session = {
+      sessionId: "session-sync",
+      status: "starting" as const,
+      region: "us-east-1",
+      imageIdentifier: process.env.AWS_LAMBDA_MICROVM_IMAGE_ID,
+      imageVersion: "6.0",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      bootstrapExpiresAt: Date.now() + 60_000,
+    };
+    mockRealtimeOnUpdate.mockImplementationOnce((_query, _args, callback) => {
+      callback({
+        ...session,
+        status: "running",
+        microvmId: "microvm-sync",
+        connectionId: "connection-sync",
+        relayReadyAt: Date.now(),
+      });
+      return mockRealtimeUnsubscribe;
+    });
+    mockMutation
+      .mockResolvedValueOnce({
+        created: true,
+        session,
+        bootstrapToken: "bootstrap-sync",
+        cleanupCandidates: [],
+      })
+      .mockResolvedValueOnce(true);
+    mockSend.mockResolvedValueOnce({
+      microvmId: "microvm-sync",
+      $metadata: { requestId: "run-sync", httpStatusCode: 200 },
+    });
+    const infoSpy = jest.spyOn(console, "info").mockImplementation();
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation();
+
+    await expect(
+      ensureAwsLambdaMicrovmConnection("user-sync"),
+    ).resolves.toBeDefined();
+
+    expect(mockRealtimeUnsubscribe).toHaveBeenCalled();
+    expect(mockRealtimeClose).toHaveBeenCalledTimes(1);
+    infoSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it("does not mask a successful launch when readiness teardown fails", async () => {
+    const session = {
+      sessionId: "session-close-failure",
+      status: "starting" as const,
+      region: "us-east-1",
+      imageIdentifier: process.env.AWS_LAMBDA_MICROVM_IMAGE_ID,
+      imageVersion: "6.0",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      bootstrapExpiresAt: Date.now() + 60_000,
+    };
+    mockMutation
+      .mockResolvedValueOnce({
+        created: true,
+        session,
+        bootstrapToken: "bootstrap-close-failure",
+        cleanupCandidates: [],
+      })
+      .mockResolvedValueOnce(true);
+    mockSend.mockResolvedValueOnce({
+      microvmId: "microvm-close-failure",
+      $metadata: { requestId: "run-close-failure", httpStatusCode: 200 },
+    });
+    mockQuery.mockResolvedValueOnce({
+      ...session,
+      status: "running",
+      microvmId: "microvm-close-failure",
+      connectionId: "connection-close-failure",
+      relayReadyAt: Date.now(),
+    });
+    mockRealtimeClose.mockRejectedValueOnce(new Error("socket close failed"));
+    const infoSpy = jest.spyOn(console, "info").mockImplementation();
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation();
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    await expect(
+      ensureAwsLambdaMicrovmConnection("user-close-failure"),
+    ).resolves.toBeDefined();
+
+    expect(
+      warnSpy.mock.calls.some(([value]) =>
+        String(value).includes(
+          "cloud_sandbox_readiness_subscription_close_failed",
+        ),
+      ),
+    ).toBe(true);
+    infoSpy.mockRestore();
+    debugSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("times out a silent readiness subscription and closes it", async () => {
+    jest.useFakeTimers();
+    const session = {
+      sessionId: "session-timeout",
+      status: "starting" as const,
+      region: "us-east-1",
+      imageIdentifier: process.env.AWS_LAMBDA_MICROVM_IMAGE_ID,
+      imageVersion: "6.0",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      bootstrapExpiresAt: Date.now() + 60_000,
+    };
+    mockRealtimeOnUpdate.mockImplementation(() => mockRealtimeUnsubscribe);
+    mockMutation
+      .mockResolvedValueOnce({
+        created: true,
+        session,
+        bootstrapToken: "bootstrap-timeout",
+        cleanupCandidates: [],
+      })
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    mockSend
+      .mockResolvedValueOnce({
+        microvmId: "microvm-timeout",
+        $metadata: { requestId: "run-timeout", httpStatusCode: 200 },
+      })
+      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation();
+    const infoSpy = jest.spyOn(console, "info").mockImplementation();
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation();
+
+    const pending = expect(
+      ensureAwsLambdaMicrovmConnection("user-timeout"),
+    ).rejects.toThrow("Failed creating AWS Lambda MicroVM sandbox");
+    await jest.advanceTimersByTimeAsync(90_000);
+    await pending;
+
+    expect(mockRealtimeUnsubscribe).toHaveBeenCalled();
+    expect(mockRealtimeClose).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+    infoSpy.mockRestore();
+    debugSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it.each(["terminal_status", "query_error"] as const)(
+    "closes readiness subscriptions on %s",
+    async (mode) => {
+      const session = {
+        sessionId: `session-${mode}`,
+        status: "starting" as const,
+        region: "us-east-1",
+        imageIdentifier: process.env.AWS_LAMBDA_MICROVM_IMAGE_ID,
+        imageVersion: "6.0",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        bootstrapExpiresAt: Date.now() + 60_000,
+      };
+      mockRealtimeOnUpdate.mockImplementation(
+        (_query, _args, callback, onError) => {
+          queueMicrotask(() => {
+            if (mode === "query_error") onError(new Error("query failed"));
+            else callback({ ...session, status: "terminated" });
+          });
+          return mockRealtimeUnsubscribe;
+        },
+      );
+      mockMutation
+        .mockResolvedValueOnce({
+          created: true,
+          session,
+          bootstrapToken: `bootstrap-${mode}`,
+          cleanupCandidates: [],
+        })
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+      mockSend
+        .mockResolvedValueOnce({
+          microvmId: `microvm-${mode}`,
+          $metadata: { requestId: `run-${mode}`, httpStatusCode: 200 },
+        })
+        .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
+      const errorSpy = jest.spyOn(console, "error").mockImplementation();
+      const infoSpy = jest.spyOn(console, "info").mockImplementation();
+      const debugSpy = jest.spyOn(console, "debug").mockImplementation();
+
+      await expect(
+        ensureAwsLambdaMicrovmConnection(`user-${mode}`),
+      ).rejects.toThrow("Failed creating AWS Lambda MicroVM sandbox");
+
+      expect(mockRealtimeUnsubscribe).toHaveBeenCalled();
+      expect(mockRealtimeClose).toHaveBeenCalledTimes(1);
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+      debugSpy.mockRestore();
+    },
+  );
 
   it("keeps a session retryable when cleanup cannot terminate its MicroVM", async () => {
     mockMutation
@@ -296,6 +522,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       sessionId: "session-cleanup",
       failureCode: "termination_retry_required",
     });
+    expect(mockRealtimeClose).toHaveBeenCalledTimes(1);
 
     errorSpy.mockRestore();
     warnSpy.mockRestore();

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -8,6 +8,7 @@ import {
 import { api } from "@/convex/_generated/api";
 import type { SandboxBootInfo } from "@/types";
 import { getConvexClient, getConvexUrl } from "@/lib/db/convex-client";
+import { createConvexRealtimeClient } from "@/lib/db/convex-realtime-client";
 import { CentrifugoSandbox } from "./centrifugo-sandbox";
 
 const PROVIDER = "aws-lambda-microvm" as const;
@@ -422,37 +423,121 @@ async function cleanupCloudSessionCandidates(
   return failures;
 }
 
+type SessionConnectionWaiter = {
+  promise: Promise<CloudSession>;
+  dispose: () => Promise<void>;
+};
+
+function createSessionConnectionWaiter(
+  userId: string,
+  sessionId: string,
+  config: AwsLambdaMicrovmConfig,
+): SessionConnectionWaiter {
+  const realtime = createConvexRealtimeClient();
+  let unsubscribe: (() => void) | undefined;
+  let subscriptionStopped = false;
+  let timeout: NodeJS.Timeout | undefined;
+  let settled = false;
+  let resolvePromise!: (session: CloudSession) => void;
+  let rejectPromise!: (error: Error) => void;
+
+  const promise = new Promise<CloudSession>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  // Readiness can fail while AWS Run/attachment is still in flight. Mark the
+  // deferred as observed immediately; callers still await the original promise
+  // and receive its rejection once the durable attachment stage completes.
+  void promise.catch(() => undefined);
+
+  const finish = (result: CloudSession | Error): void => {
+    if (settled) return;
+    settled = true;
+    if (timeout) clearTimeout(timeout);
+    if (unsubscribe && !subscriptionStopped) {
+      subscriptionStopped = true;
+      unsubscribe();
+    }
+    if (result instanceof Error) rejectPromise(result);
+    else resolvePromise(result);
+  };
+
+  timeout = setTimeout(
+    () =>
+      finish(new Error("Timed out waiting for the cloud sandbox guest relay")),
+    SESSION_READY_TIMEOUT_MS,
+  );
+
+  const registeredUnsubscribe = realtime.onUpdate(
+    api.localSandbox.getCloudSessionForBackend,
+    {
+      serviceKey: config.serviceKey,
+      userId,
+      sessionId,
+    },
+    (session) => {
+      const current = session as CloudSession | null;
+      if (!current) {
+        finish(new Error("Cloud sandbox session disappeared"));
+        return;
+      }
+      if (current.status === "failed" || current.status === "terminated") {
+        finish(new Error(`Cloud sandbox session ended: ${current.status}`));
+        return;
+      }
+      if (
+        current.status === "running" &&
+        current.microvmId &&
+        current.connectionId
+      ) {
+        finish(current);
+      }
+    },
+    (error) => finish(error),
+  );
+  unsubscribe = registeredUnsubscribe;
+  if (settled && !subscriptionStopped) {
+    subscriptionStopped = true;
+    registeredUnsubscribe();
+  }
+
+  return {
+    promise,
+    dispose: async () => {
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (unsubscribe && !subscriptionStopped) {
+        subscriptionStopped = true;
+        unsubscribe();
+      }
+      try {
+        await realtime.close();
+      } catch (error) {
+        // Subscription teardown must not turn an otherwise successful launch
+        // into a failure or mask the original AWS/Convex failure.
+        log("warn", "cloud_sandbox_readiness_subscription_close_failed", {
+          user_id: userId,
+          session_id: sessionId,
+          provider: PROVIDER,
+          region: config.region,
+          ...errorLogFields(error),
+        });
+      }
+    },
+  };
+}
+
 async function waitForSessionConnection(
   userId: string,
   sessionId: string,
   config: AwsLambdaMicrovmConfig,
 ): Promise<CloudSession> {
-  const deadline = Date.now() + SESSION_READY_TIMEOUT_MS;
-  let pollDelayMs = 200;
-  while (Date.now() < deadline) {
-    const session = (await getConvexClient().query(
-      api.localSandbox.getCloudSessionForBackend,
-      {
-        serviceKey: config.serviceKey,
-        userId,
-        sessionId,
-      },
-    )) as CloudSession | null;
-    if (!session) throw new Error("Cloud sandbox session disappeared");
-    if (session.status === "failed" || session.status === "terminated") {
-      throw new Error(`Cloud sandbox session ended: ${session.status}`);
-    }
-    if (
-      session.status === "running" &&
-      session.microvmId &&
-      session.connectionId
-    ) {
-      return session;
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollDelayMs));
-    pollDelayMs = Math.min(1_000, Math.round(pollDelayMs * 1.5));
+  const waiter = createSessionConnectionWaiter(userId, sessionId, config);
+  try {
+    return await waiter.promise;
+  } finally {
+    await waiter.dispose();
   }
-  throw new Error("Timed out waiting for the cloud sandbox guest relay");
 }
 
 function createRelaySandbox(
@@ -787,6 +872,14 @@ export async function ensureAwsLambdaMicrovmConnection(
     throw new Error("Cloud session bootstrap token was not returned");
   }
 
+  // Start the reactive query before asking AWS to run the VM. Its WebSocket
+  // handshake overlaps the control-plane allocation, so the guest's ready
+  // mutation is delivered without the old 200ms-to-1s polling gaps.
+  const sessionWaiter = createSessionConnectionWaiter(
+    userId,
+    begin.session.sessionId,
+    config,
+  );
   let microvmId: string | undefined;
   let failureStage = "run_microvm";
   try {
@@ -841,20 +934,6 @@ export async function ensureAwsLambdaMicrovmConnection(
     });
 
     failureStage = "attach_cloud_microvm";
-    const attached = await getConvexClient().mutation(
-      api.localSandbox.attachCloudMicrovm,
-      {
-        serviceKey: config.serviceKey,
-        userId,
-        sessionId: begin.session.sessionId,
-        microvmId,
-      },
-    );
-    if (!attached) {
-      throw new Error("Cloud session ended before the MicroVM was attached");
-    }
-
-    failureStage = "wait_for_guest_connection";
     log("debug", "cloud_sandbox_guest_connection_wait_started", {
       user_id: userId,
       session_id: begin.session.sessionId,
@@ -862,11 +941,25 @@ export async function ensureAwsLambdaMicrovmConnection(
       region: config.region,
       timeout_ms: SESSION_READY_TIMEOUT_MS,
     });
-    const connected = await waitForSessionConnection(
-      userId,
-      begin.session.sessionId,
-      config,
-    );
+    const attachPromise = getConvexClient()
+      .mutation(api.localSandbox.attachCloudMicrovm, {
+        serviceKey: config.serviceKey,
+        userId,
+        sessionId: begin.session.sessionId,
+        microvmId,
+      })
+      .then((attached) => {
+        if (!attached) {
+          throw new Error(
+            "Cloud session ended before the MicroVM was attached",
+          );
+        }
+      });
+    await attachPromise;
+    // Do not return until attachCloudMicrovm has durably persisted the AWS ID.
+    // The reactive readiness subscription has remained active in parallel.
+    failureStage = "wait_for_guest_connection";
+    const connected = await sessionWaiter.promise;
     const sandbox = createRelaySandbox(userId, connected, config);
     if (!connected.relayReadyAt) {
       failureStage = "wait_for_relay_ready";
@@ -939,6 +1032,8 @@ export async function ensureAwsLambdaMicrovmConnection(
     throw new Error(`Failed creating AWS Lambda MicroVM sandbox (${code})`, {
       cause: error,
     });
+  } finally {
+    await sessionWaiter.dispose();
   }
 }
 

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -425,6 +425,7 @@ async function cleanupCloudSessionCandidates(
 
 type SessionConnectionWaiter = {
   promise: Promise<CloudSession>;
+  armTimeout: () => void;
   dispose: () => Promise<void>;
 };
 
@@ -432,11 +433,13 @@ function createSessionConnectionWaiter(
   userId: string,
   sessionId: string,
   config: AwsLambdaMicrovmConfig,
+  armImmediately = true,
 ): SessionConnectionWaiter {
   const realtime = createConvexRealtimeClient();
   let unsubscribe: (() => void) | undefined;
   let subscriptionStopped = false;
   let timeout: NodeJS.Timeout | undefined;
+  let timeoutArmed = false;
   let settled = false;
   let resolvePromise!: (session: CloudSession) => void;
   let rejectPromise!: (error: Error) => void;
@@ -462,11 +465,18 @@ function createSessionConnectionWaiter(
     else resolvePromise(result);
   };
 
-  timeout = setTimeout(
-    () =>
-      finish(new Error("Timed out waiting for the cloud sandbox guest relay")),
-    SESSION_READY_TIMEOUT_MS,
-  );
+  const armTimeout = (): void => {
+    if (settled || timeoutArmed) return;
+    timeoutArmed = true;
+    timeout = setTimeout(
+      () =>
+        finish(
+          new Error("Timed out waiting for the cloud sandbox guest relay"),
+        ),
+      SESSION_READY_TIMEOUT_MS,
+    );
+  };
+  if (armImmediately) armTimeout();
 
   const registeredUnsubscribe = realtime.onUpdate(
     api.localSandbox.getCloudSessionForBackend,
@@ -503,6 +513,7 @@ function createSessionConnectionWaiter(
 
   return {
     promise,
+    armTimeout,
     dispose: async () => {
       settled = true;
       if (timeout) clearTimeout(timeout);
@@ -879,6 +890,7 @@ export async function ensureAwsLambdaMicrovmConnection(
     userId,
     begin.session.sessionId,
     config,
+    false,
   );
   let microvmId: string | undefined;
   let failureStage = "run_microvm";
@@ -959,6 +971,7 @@ export async function ensureAwsLambdaMicrovmConnection(
     // Do not return until attachCloudMicrovm has durably persisted the AWS ID.
     // The reactive readiness subscription has remained active in parallel.
     failureStage = "wait_for_guest_connection";
+    sessionWaiter.armTimeout();
     const connected = await sessionWaiter.promise;
     const sandbox = createRelaySandbox(userId, connected, config);
     if (!connected.relayReadyAt) {

--- a/lib/db/convex-realtime-client.ts
+++ b/lib/db/convex-realtime-client.ts
@@ -1,0 +1,14 @@
+import { ConvexClient } from "convex/browser";
+import { getConvexUrl } from "./convex-client";
+
+/**
+ * Create a short-lived reactive client for Node server waits. Keeping this in
+ * a separate module avoids pulling Convex's WebSocket runtime into functions
+ * analyzed for the Convex V8 backend.
+ */
+export function createConvexRealtimeClient(): ConvexClient {
+  return new ConvexClient(getConvexUrl(), {
+    logger: false,
+    unsavedChangesWarning: false,
+  });
+}

--- a/packages/local/src/__tests__/cloud-image-prime.test.ts
+++ b/packages/local/src/__tests__/cloud-image-prime.test.ts
@@ -1,0 +1,58 @@
+import {
+  CloudImagePrimeError,
+  primeCloudImageWorkingSet,
+} from "../cloud-image-prime";
+
+describe("Lambda MicroVM image priming", () => {
+  it("primes the bounded relay, DNS, PTY, shell, sudo, nmap, and naabu paths", async () => {
+    const calls: string[] = [];
+    const result = await primeCloudImageWorkingSet({
+      primeRelay: async () => calls.push("relay"),
+      lookupDns: async () => calls.push("dns"),
+      primePty: async () => calls.push("pty"),
+      runCommand: async (executable, args) =>
+        calls.push(`${executable} ${args.join(" ")}`),
+    });
+
+    expect(calls).toEqual([
+      "relay",
+      "dns",
+      "pty",
+      "/bin/bash --noprofile --norc -c :",
+      "/usr/bin/sudo -n true",
+      "/usr/bin/nmap --version",
+      "/usr/local/bin/naabu -version",
+    ]);
+    expect(result.steps.map((step) => step.name)).toEqual([
+      "relay_protocol",
+      "dns_lookup",
+      "pty",
+      "bash",
+      "sudo",
+      "nmap",
+      "naabu",
+    ]);
+  });
+
+  it("fails validation at the first required priming failure", async () => {
+    const runCommand = jest.fn(async (executable: string) => {
+      if (executable === "/usr/bin/nmap") throw new Error("missing nmap");
+    });
+
+    await expect(
+      primeCloudImageWorkingSet({
+        primeRelay: async () => undefined,
+        lookupDns: async () => undefined,
+        primePty: async () => undefined,
+        runCommand,
+      }),
+    ).rejects.toMatchObject<Partial<CloudImagePrimeError>>({
+      name: "CloudImagePrimeError",
+      step: "nmap",
+    });
+    expect(runCommand).not.toHaveBeenCalledWith(
+      "/usr/local/bin/naabu",
+      expect.anything(),
+    );
+  });
+});

--- a/packages/local/src/__tests__/cloud-relay-lifecycle.test.ts
+++ b/packages/local/src/__tests__/cloud-relay-lifecycle.test.ts
@@ -1,0 +1,77 @@
+import {
+  InProcessRelayClient,
+  InProcessRelayLifecycle,
+} from "../cloud-relay-lifecycle";
+
+describe("in-process cloud relay lifecycle", () => {
+  it("starts, suspends, resumes, and terminates clients exactly once", async () => {
+    const clients: Array<
+      InProcessRelayClient & { start: jest.Mock; cleanup: jest.Mock }
+    > = [];
+    const lifecycle = new InProcessRelayLifecycle(() => {
+      const client = {
+        start: jest.fn().mockResolvedValue(undefined),
+        cleanup: jest.fn().mockResolvedValue(undefined),
+      };
+      clients.push(client);
+      return client;
+    }, jest.fn());
+
+    await lifecycle.run({ sessionId: "one" });
+    expect(lifecycle.running).toBe(true);
+    await lifecycle.suspend();
+    expect(clients[0].cleanup).toHaveBeenCalledTimes(1);
+    await lifecycle.resume();
+    expect(clients).toHaveLength(2);
+    await lifecycle.terminate();
+    expect(clients[1].cleanup).toHaveBeenCalledTimes(1);
+    expect(clients[1].cleanup).toHaveBeenCalledWith({ terminated: true });
+    expect(lifecycle.running).toBe(false);
+  });
+
+  it("restarts after an unexpected in-process fatal callback", async () => {
+    const fatalCallbacks: Array<(error: Error) => void> = [];
+    const clients: Array<{ start: jest.Mock; cleanup: jest.Mock }> = [];
+    const onUnexpectedExit = jest.fn();
+    const lifecycle = new InProcessRelayLifecycle((_config, onFatal) => {
+      fatalCallbacks.push(onFatal);
+      const client = {
+        start: jest.fn().mockResolvedValue(undefined),
+        cleanup: jest.fn().mockResolvedValue(undefined),
+      };
+      clients.push(client);
+      return client;
+    }, onUnexpectedExit);
+
+    await lifecycle.run({ sessionId: "one" });
+    fatalCallbacks[0](new Error("relay disconnected"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onUnexpectedExit).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "relay disconnected" }),
+    );
+    expect(clients).toHaveLength(2);
+    expect(clients[1].start).toHaveBeenCalledTimes(1);
+    await lifecycle.terminate();
+  });
+
+  it("does not restart a client after suspension wins the transition", async () => {
+    let fatal: ((error: Error) => void) | undefined;
+    const factory = jest.fn((_config, onFatal) => {
+      fatal = onFatal;
+      return {
+        start: jest.fn().mockResolvedValue(undefined),
+        cleanup: jest.fn().mockResolvedValue(undefined),
+      };
+    });
+    const lifecycle = new InProcessRelayLifecycle(factory, jest.fn());
+
+    await lifecycle.run({ sessionId: "one" });
+    await lifecycle.suspend();
+    fatal?.(new Error("late fatal"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(lifecycle.running).toBe(false);
+  });
+});

--- a/packages/local/src/__tests__/cloud-relay-lifecycle.test.ts
+++ b/packages/local/src/__tests__/cloud-relay-lifecycle.test.ts
@@ -74,4 +74,23 @@ describe("in-process cloud relay lifecycle", () => {
     expect(factory).toHaveBeenCalledTimes(1);
     expect(lifecycle.running).toBe(false);
   });
+
+  it("retains a client when cleanup fails so a lifecycle retry can finish", async () => {
+    const cleanup = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("PTY still running"))
+      .mockResolvedValueOnce(undefined);
+    const lifecycle = new InProcessRelayLifecycle(
+      () => ({ start: jest.fn().mockResolvedValue(undefined), cleanup }),
+      jest.fn(),
+    );
+
+    await lifecycle.run({ sessionId: "one" });
+    await expect(lifecycle.suspend()).rejects.toThrow("PTY still running");
+    expect(lifecycle.running).toBe(true);
+
+    await expect(lifecycle.suspend()).resolves.toBeUndefined();
+    expect(cleanup).toHaveBeenCalledTimes(2);
+    expect(lifecycle.running).toBe(false);
+  });
 });

--- a/packages/local/src/__tests__/local-sandbox-client-lifecycle.test.ts
+++ b/packages/local/src/__tests__/local-sandbox-client-lifecycle.test.ts
@@ -1,0 +1,131 @@
+const mockShutdown = jest.fn().mockResolvedValue(undefined);
+const mockDispose = jest.fn();
+const mockConfirmProcessTermination = jest.fn().mockResolvedValue(true);
+
+jest.mock("../process-runner", () => ({
+  ProcessRunner: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    shutdown: mockShutdown,
+    dispose: mockDispose,
+  })),
+  isPtyAvailable: () => true,
+}));
+
+jest.mock("../command-cancellation", () => ({
+  confirmProcessTermination: (...args: unknown[]) =>
+    mockConfirmProcessTermination(...args),
+  isProcessTreeTerminationConfirmed: () => true,
+}));
+
+import { LocalSandboxClient } from "../index";
+
+const config = {
+  convexUrl: "http://127.0.0.1:3210",
+  token: "test-token",
+  name: "test",
+  authMode: "cloud" as const,
+  cloudSessionId: "test-session",
+  microvmId: "test-microvm",
+};
+
+describe("LocalSandboxClient in-process cleanup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockShutdown.mockResolvedValue(undefined);
+    mockConfirmProcessTermination.mockResolvedValue(true);
+  });
+
+  it("disposes process resources exactly once across repeated cleanup", async () => {
+    const client = new LocalSandboxClient(config);
+
+    await Promise.all([client.cleanup(), client.cleanup()]);
+
+    expect(mockShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a later lifecycle hook to retry failed process cleanup", async () => {
+    mockShutdown
+      .mockRejectedValueOnce(new Error("PTY still running"))
+      .mockResolvedValueOnce(undefined);
+    const client = new LocalSandboxClient(config);
+
+    await expect(client.cleanup()).rejects.toThrow("PTY still running");
+    await expect(client.cleanup()).resolves.toBeUndefined();
+
+    expect(mockShutdown).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for streamed-command termination confirmation", async () => {
+    let confirmTermination!: (confirmed: boolean) => void;
+    mockConfirmProcessTermination.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          confirmTermination = resolve;
+        }),
+    );
+    const client = new LocalSandboxClient(config);
+    const proc = {
+      pid: 1234,
+      exitCode: null,
+      signalCode: null,
+      kill: jest.fn(),
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    (
+      client as unknown as {
+        activeStreamCommands: Map<string, typeof proc>;
+      }
+    ).activeStreamCommands.set("command-1", proc);
+
+    let settled = false;
+    const cleanup = client.cleanup().then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    confirmTermination(true);
+    await cleanup;
+    expect(mockConfirmProcessTermination).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a lifecycle fatal without exiting the lifecycle process", async () => {
+    const onExitRequested = jest.fn();
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    const client = new LocalSandboxClient(config, { onExitRequested });
+
+    (
+      client as unknown as {
+        requestExit: (code: number, error: Error) => void;
+      }
+    ).requestExit(1, new Error("relay failed"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onExitRequested).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ message: "relay failed" }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("preserves the standalone CLI default exit behavior", async () => {
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    const client = new LocalSandboxClient(config);
+
+    (
+      client as unknown as {
+        requestExit: (code: number, error: Error) => void;
+      }
+    ).requestExit(1, new Error("relay failed"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/local/src/__tests__/process-runner.test.ts
+++ b/packages/local/src/__tests__/process-runner.test.ts
@@ -59,20 +59,23 @@ describe("ProcessRunner cleanup", () => {
     runner.dispose();
   });
 
-  it("drops local tracking after SIGKILL escalation", () => {
+  it("retains tracking until PTY exit is confirmed after SIGKILL", async () => {
     const proc = makePtyProcess();
     mockSpawn.mockReturnValue(proc);
 
     const runner = new ProcessRunner();
     runner.run("session-1", "sleep 10");
 
-    expect(runner.stop("session-1")).toBe(true);
-    jest.advanceTimersByTime(5_000);
+    const shutdown = runner.shutdown();
+    await jest.advanceTimersByTimeAsync(5_000);
 
     expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
     expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    expect(runner.isRunning("session-1")).toBe(true);
+    proc.__exit();
+    await jest.advanceTimersByTimeAsync(25);
+    await shutdown;
     expect(runner.isRunning("session-1")).toBe(false);
-    runner.dispose();
   });
 
   it("catches unexpected SIGKILL errors during escalation", () => {
@@ -93,6 +96,43 @@ describe("ProcessRunner cleanup", () => {
     expect(() => jest.advanceTimersByTime(5_000)).not.toThrow();
 
     expect(errorListener).toHaveBeenCalledWith("session-1", expect.any(Error));
+    proc.__exit();
+    runner.dispose();
+  });
+
+  it("rejects shutdown when a SIGKILL-resistant PTY never exits", async () => {
+    const proc = makePtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    const runner = new ProcessRunner();
+    runner.run("session-1", "trap '' TERM; sleep 10");
+
+    const shutdown = expect(runner.shutdown()).rejects.toThrow(
+      "Timed out terminating 1 PTY process",
+    );
+    await jest.advanceTimersByTimeAsync(7_000);
+
+    await shutdown;
+    expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    proc.__exit();
+    runner.dispose();
+  });
+
+  it("preserves the first SIGKILL deadline when shutdown is retried", async () => {
+    const proc = makePtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    const runner = new ProcessRunner();
+    runner.run("session-1", "sleep 10");
+
+    expect(runner.stop("session-1")).toBe(true);
+    await jest.advanceTimersByTimeAsync(4_000);
+    expect(runner.stop("session-1")).toBe(true);
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGTERM");
+    expect(proc.kill).toHaveBeenNthCalledWith(3, "SIGKILL");
+    proc.__exit();
     runner.dispose();
   });
 });

--- a/packages/local/src/cloud-image-prime.ts
+++ b/packages/local/src/cloud-image-prime.ts
@@ -96,8 +96,8 @@ async function primePty(): Promise<void> {
     try {
       await runner.shutdown();
     } catch (error) {
-      if (hasPrimeError) runner.dispose();
-      else {
+      runner.dispose();
+      if (!hasPrimeError) {
         shutdownError = error;
         hasShutdownError = true;
       }

--- a/packages/local/src/cloud-image-prime.ts
+++ b/packages/local/src/cloud-image-prime.ts
@@ -62,6 +62,9 @@ async function runBoundedCommand(
 async function primePty(): Promise<void> {
   const runner = new ProcessRunner();
   let primeError: unknown;
+  let hasPrimeError = false;
+  let shutdownError: unknown;
+  let hasShutdownError = false;
   try {
     await new Promise<void>((resolve, reject) => {
       const sessionId = "image-validation";
@@ -88,15 +91,20 @@ async function primePty(): Promise<void> {
     });
   } catch (error) {
     primeError = error;
-    throw error;
+    hasPrimeError = true;
   } finally {
     try {
       await runner.shutdown();
-    } catch (shutdownError) {
-      if (primeError === undefined) throw shutdownError;
-      runner.dispose();
+    } catch (error) {
+      if (hasPrimeError) runner.dispose();
+      else {
+        shutdownError = error;
+        hasShutdownError = true;
+      }
     }
   }
+  if (hasPrimeError) throw primeError;
+  if (hasShutdownError) throw shutdownError;
 }
 
 export async function primeCloudImageWorkingSet(

--- a/packages/local/src/cloud-image-prime.ts
+++ b/packages/local/src/cloud-image-prime.ts
@@ -1,0 +1,134 @@
+import { spawn } from "node:child_process";
+import { promises as dns } from "node:dns";
+import { tmpdir } from "node:os";
+import { ProcessRunner } from "./process-runner";
+
+const STEP_TIMEOUT_MS = 5_000;
+
+export type CloudImagePrimeStep = {
+  name: string;
+  duration_ms: number;
+};
+
+export type CloudImagePrimeResult = {
+  duration_ms: number;
+  steps: CloudImagePrimeStep[];
+};
+
+export class CloudImagePrimeError extends Error {
+  constructor(
+    readonly step: string,
+    readonly completedSteps: CloudImagePrimeStep[],
+    cause: unknown,
+  ) {
+    super(`Cloud image priming failed at ${step}`, { cause });
+    this.name = "CloudImagePrimeError";
+  }
+}
+
+type PrimeDependencies = {
+  primeRelay: () => Promise<void>;
+  lookupDns?: () => Promise<void>;
+  primePty?: () => Promise<void>;
+  runCommand?: (executable: string, args: string[]) => Promise<void>;
+};
+
+async function runBoundedCommand(
+  executable: string,
+  args: string[],
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(executable, args, {
+      cwd: tmpdir(),
+      env: process.env,
+      stdio: "ignore",
+    });
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`${executable} priming timed out`));
+    }, STEP_TIMEOUT_MS);
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      if (code === 0) resolve();
+      else reject(new Error(`${executable} priming exited ${code}`));
+    });
+  });
+}
+
+async function primePty(): Promise<void> {
+  const runner = new ProcessRunner();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const sessionId = "image-validation";
+      const timeout = setTimeout(() => {
+        runner.stop(sessionId);
+        reject(new Error("PTY priming timed out"));
+      }, STEP_TIMEOUT_MS);
+      runner.on("exit", (exitedSessionId, exitCode) => {
+        if (exitedSessionId !== sessionId) return;
+        clearTimeout(timeout);
+        if (exitCode === 0) resolve();
+        else reject(new Error(`PTY priming exited ${exitCode}`));
+      });
+      runner.on("error", (errorSessionId, error) => {
+        if (errorSessionId !== sessionId) return;
+        clearTimeout(timeout);
+        reject(error);
+      });
+      runner.run(sessionId, "printf hackerai-image-prime", {
+        cwd: tmpdir(),
+        cols: 80,
+        rows: 24,
+      });
+    });
+  } finally {
+    await runner.shutdown();
+  }
+}
+
+export async function primeCloudImageWorkingSet(
+  dependencies: PrimeDependencies,
+): Promise<CloudImagePrimeResult> {
+  const startedAt = performance.now();
+  const completedSteps: CloudImagePrimeStep[] = [];
+  const runStep = async (name: string, operation: () => Promise<void>) => {
+    const stepStartedAt = performance.now();
+    try {
+      await operation();
+      completedSteps.push({
+        name,
+        duration_ms: Math.round(performance.now() - stepStartedAt),
+      });
+    } catch (error) {
+      throw new CloudImagePrimeError(name, completedSteps, error);
+    }
+  };
+
+  await runStep("relay_protocol", dependencies.primeRelay);
+  await runStep(
+    "dns_lookup",
+    dependencies.lookupDns ??
+      (async () => {
+        await dns.lookup("localhost");
+      }),
+  );
+  await runStep("pty", dependencies.primePty ?? primePty);
+  const runCommand = dependencies.runCommand ?? runBoundedCommand;
+  await runStep("bash", () =>
+    runCommand("/bin/bash", ["--noprofile", "--norc", "-c", ":"]),
+  );
+  await runStep("sudo", () => runCommand("/usr/bin/sudo", ["-n", "true"]));
+  await runStep("nmap", () => runCommand("/usr/bin/nmap", ["--version"]));
+  await runStep("naabu", () =>
+    runCommand("/usr/local/bin/naabu", ["-version"]),
+  );
+
+  return {
+    duration_ms: Math.round(performance.now() - startedAt),
+    steps: completedSteps,
+  };
+}

--- a/packages/local/src/cloud-image-prime.ts
+++ b/packages/local/src/cloud-image-prime.ts
@@ -61,6 +61,7 @@ async function runBoundedCommand(
 
 async function primePty(): Promise<void> {
   const runner = new ProcessRunner();
+  let primeError: unknown;
   try {
     await new Promise<void>((resolve, reject) => {
       const sessionId = "image-validation";
@@ -85,8 +86,16 @@ async function primePty(): Promise<void> {
         rows: 24,
       });
     });
+  } catch (error) {
+    primeError = error;
+    throw error;
   } finally {
-    await runner.shutdown();
+    try {
+      await runner.shutdown();
+    } catch (shutdownError) {
+      if (primeError === undefined) throw shutdownError;
+      runner.dispose();
+    }
   }
 }
 

--- a/packages/local/src/cloud-relay-lifecycle.ts
+++ b/packages/local/src/cloud-relay-lifecycle.ts
@@ -1,0 +1,99 @@
+export interface InProcessRelayClient {
+  start(): Promise<void>;
+  cleanup(options?: { terminated?: boolean }): Promise<void>;
+}
+
+export type InProcessRelayFactory<Config> = (
+  config: Config,
+  onFatal: (error: Error) => void,
+) => InProcessRelayClient;
+
+/** Serializes AWS lifecycle transitions around one in-process relay client. */
+export class InProcessRelayLifecycle<Config> {
+  private config: Config | null = null;
+  private client: InProcessRelayClient | null = null;
+  private enabled = false;
+  private transition: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly createClient: InProcessRelayFactory<Config>,
+    private readonly onUnexpectedExit: (error: Error) => void,
+    private readonly onRestartFailed: (error: Error) => void = onUnexpectedExit,
+  ) {}
+
+  get running(): boolean {
+    return this.client !== null;
+  }
+
+  run(config: Config): Promise<void> {
+    this.config = config;
+    this.enabled = true;
+    return this.enqueue(async () => {
+      await this.stopCurrent(false);
+      await this.startCurrent();
+    });
+  }
+
+  suspend(): Promise<void> {
+    this.enabled = false;
+    return this.enqueue(() => this.stopCurrent(false));
+  }
+
+  resume(): Promise<void> {
+    this.enabled = true;
+    return this.enqueue(async () => {
+      await this.stopCurrent(false);
+      await this.startCurrent();
+    });
+  }
+
+  terminate(): Promise<void> {
+    this.enabled = false;
+    this.config = null;
+    return this.enqueue(() => this.stopCurrent(true));
+  }
+
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const result = this.transition.then(operation, operation);
+    this.transition = result.catch(() => undefined);
+    return result;
+  }
+
+  private async startCurrent(): Promise<void> {
+    if (!this.enabled || !this.config) {
+      throw new Error("Cloud sandbox is not bootstrapped");
+    }
+    let client!: InProcessRelayClient;
+    client = this.createClient(this.config, (error) => {
+      void this.handleFatal(client, error);
+    });
+    this.client = client;
+    try {
+      await client.start();
+    } catch (error) {
+      if (this.client === client) this.client = null;
+      await client.cleanup();
+      throw error;
+    }
+  }
+
+  private async stopCurrent(terminated: boolean): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    if (client) await client.cleanup({ terminated });
+  }
+
+  private handleFatal(client: InProcessRelayClient, error: Error): void {
+    if (this.client !== client) return;
+    this.client = null;
+    this.onUnexpectedExit(error);
+    if (!this.enabled || !this.config) return;
+    void this.enqueue(() => this.startCurrent()).catch((restartError) => {
+      this.onRestartFailed(
+        restartError instanceof Error
+          ? restartError
+          : new Error(String(restartError)),
+      );
+    });
+  }
+}

--- a/packages/local/src/cloud-relay-lifecycle.ts
+++ b/packages/local/src/cloud-relay-lifecycle.ts
@@ -80,7 +80,15 @@ export class InProcessRelayLifecycle<Config> {
   private async stopCurrent(terminated: boolean): Promise<void> {
     const client = this.client;
     this.client = null;
-    if (client) await client.cleanup({ terminated });
+    if (!client) return;
+    try {
+      await client.cleanup({ terminated });
+    } catch (error) {
+      // Retain the cleanup handle so an AWS lifecycle-hook retry cannot report
+      // success while the original process trees are still running.
+      if (this.client === null) this.client = client;
+      throw error;
+    }
   }
 
   private handleFatal(client: InProcessRelayClient, error: Error): void {

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -15,7 +15,7 @@
 import { ConvexHttpClient } from "convex/browser";
 import { Centrifuge, Subscription, PublicationContext } from "centrifuge";
 import WebSocket from "ws";
-import { fork, spawn, ChildProcess } from "child_process";
+import { spawn, ChildProcess } from "child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import os from "os";
 import {
@@ -35,6 +35,11 @@ import {
   isProcessTreeTerminationConfirmed,
 } from "./command-cancellation";
 import { CentrifugoPublishQueue } from "./centrifugo-transport";
+import {
+  CloudImagePrimeError,
+  primeCloudImageWorkingSet,
+} from "./cloud-image-prime";
+import { InProcessRelayLifecycle } from "./cloud-relay-lifecycle";
 
 const DEFAULT_SHELL = getDefaultShell(os.platform());
 
@@ -72,7 +77,7 @@ const chalk = {
   bold: (s: string) => `\x1b[1m${s}\x1b[0m`,
 };
 
-interface Config {
+export interface Config {
   convexUrl: string;
   token: string;
   name: string;
@@ -285,7 +290,11 @@ function isInvalidTokenError(error: unknown): boolean {
   return (data as { code?: string }).code === "UNAUTHORIZED";
 }
 
-class LocalSandboxClient {
+type LocalSandboxClientOptions = {
+  onExitRequested?: (code: number, error: Error) => void;
+};
+
+export class LocalSandboxClient {
   private convexHttp: ConvexHttpClient;
   private centrifuge?: Centrifuge;
   private subscription?: Subscription;
@@ -297,12 +306,70 @@ class LocalSandboxClient {
   private processRunner: ProcessRunner;
   private activeStreamCommands: Map<string, ChildProcess> = new Map();
   private publishQueue?: CentrifugoPublishQueue;
+  private cleanupPromise?: Promise<void>;
+  private exitRequested = false;
 
-  constructor(private config: Config) {
+  constructor(
+    private config: Config,
+    private readonly options: LocalSandboxClientOptions = {},
+  ) {
     this.convexHttp = new ConvexHttpClient(config.convexUrl);
     this.lastActivityTime = Date.now();
     this.processRunner = new ProcessRunner();
     this.setupProcessRunnerListeners();
+  }
+
+  async primeStartupWorkingSet(): Promise<void> {
+    const command = {
+      type: "command",
+      commandId: "image-validation",
+      command: "printf hackerai-image-prime",
+      targetConnectionId: "image-validation",
+    };
+    const parsed = JSON.parse(JSON.stringify(command)) as unknown;
+    if (!isTargetedIncomingMessage(parsed)) {
+      throw new Error("Command protocol priming failed");
+    }
+    const queue = new CentrifugoPublishQueue(async (fragment) => {
+      JSON.parse(JSON.stringify(fragment));
+    });
+    await queue.publish({
+      type: "exit",
+      commandId: "image-validation",
+      exitCode: 0,
+    });
+    this.getOsInfo();
+    this.getCapabilities();
+  }
+
+  disposePrimedResources(): void {
+    this.isShuttingDown = true;
+    this.processRunner.dispose();
+  }
+
+  private requestExit(code: number, error: Error): void {
+    if (this.exitRequested || this.isShuttingDown) return;
+    this.exitRequested = true;
+    void this.cleanup().then(
+      () => {
+        if (this.options.onExitRequested) {
+          this.options.onExitRequested(code, error);
+        } else {
+          process.exit(code);
+        }
+      },
+      (cleanupError) => {
+        const fatal =
+          cleanupError instanceof Error
+            ? cleanupError
+            : new Error(String(cleanupError));
+        if (this.options.onExitRequested) {
+          this.options.onExitRequested(code, fatal);
+        } else {
+          process.exit(code);
+        }
+      },
+    );
   }
 
   private setupProcessRunnerListeners(): void {
@@ -474,9 +541,6 @@ class LocalSandboxClient {
         console.error(chalk.yellow("Please regenerate your token in Settings"));
       }
       await this.cleanup();
-      if (this.config.authMode === "local") {
-        process.exit(1);
-      }
       throw error;
     }
   }
@@ -520,7 +584,7 @@ class LocalSandboxClient {
             // cleanup() synchronously calls centrifuge.disconnect() before any
             // awaits, so by the time we re-throw below Centrifuge is in a
             // terminal state and won't invoke getToken again.
-            this.cleanup().then(() => process.exit(1));
+            this.requestExit(1, new Error("Centrifugo token was rejected"));
           } else {
             console.error(
               chalk.red("Failed to refresh Centrifugo token:"),
@@ -563,7 +627,10 @@ class LocalSandboxClient {
         // calls centrifuge.disconnect() before any awaits, so by the time we
         // throw below Centrifuge is in a terminal state and won't invoke
         // getToken again.
-        this.cleanup().then(() => process.exit(1));
+        this.requestExit(
+          1,
+          new Error(`Centrifugo refresh aborted: ${result.reason}`),
+        );
         throw new Error(`Centrifugo refresh aborted: ${result.reason}`);
       },
     });
@@ -657,7 +724,7 @@ class LocalSandboxClient {
           console.error(
             chalk.yellow("Please try again later or contact support."),
           );
-          this.cleanup().then(() => process.exit(1));
+          this.requestExit(1, new Error("Centrifugo connection limit reached"));
         } else {
           console.log(
             chalk.yellow(`⚠️  Disconnected from Centrifugo: ${ctx.reason}`),
@@ -852,14 +919,29 @@ class LocalSandboxClient {
     }, 1000).unref();
   }
 
-  private terminateActiveStreamCommands(): void {
-    for (const [commandId, proc] of this.activeStreamCommands) {
-      console.log(
-        chalk.yellow(`[CMD] Terminating active command ${commandId}`),
+  private async terminateActiveStreamCommands(): Promise<void> {
+    const commands = [...this.activeStreamCommands.entries()];
+    const results = await Promise.all(
+      commands.map(async ([commandId, proc]) => {
+        console.log(
+          chalk.yellow(`[CMD] Terminating active command ${commandId}`),
+        );
+        const confirmed = await confirmProcessTermination(
+          proc,
+          () => this.terminateProcessTree(proc),
+          undefined,
+          () => isProcessTreeTerminationConfirmed(proc),
+        );
+        if (confirmed) this.activeStreamCommands.delete(commandId);
+        return confirmed;
+      }),
+    );
+    const unconfirmed = results.filter((confirmed) => !confirmed).length;
+    if (unconfirmed > 0) {
+      throw new Error(
+        `Could not confirm termination of ${unconfirmed} command process tree(s)`,
       );
-      this.terminateProcessTree(proc);
     }
-    this.activeStreamCommands.clear();
   }
 
   private async streamCommand(
@@ -1113,7 +1195,7 @@ class LocalSandboxClient {
           ),
         );
         console.log(chalk.yellow("Auto-terminating to save resources..."));
-        this.cleanup().then(() => process.exit(0));
+        this.requestExit(0, new Error("Local sandbox idle timeout"));
       }
     }, IDLE_CHECK_INTERVAL_MS);
   }
@@ -1126,16 +1208,28 @@ class LocalSandboxClient {
   }
 
   async cleanup(options: { terminated?: boolean } = {}): Promise<void> {
+    if (this.cleanupPromise) return this.cleanupPromise;
+    this.cleanupPromise = this.performCleanup(options).catch((error) => {
+      this.cleanupPromise = undefined;
+      throw error;
+    });
+    return this.cleanupPromise;
+  }
+
+  private async performCleanup(options: {
+    terminated?: boolean;
+  }): Promise<void> {
     console.log(chalk.blue("\n🧹 Cleaning up..."));
 
     this.isShuttingDown = true;
     this.stopIdleCheck();
 
-    // Stop all PTY sessions
-    this.processRunner.stopAll();
-
-    // Stop all active streamed commands before dropping the realtime connection.
-    this.terminateActiveStreamCommands();
+    // Confirm both PTY and streamed-command process trees are gone before AWS
+    // snapshots a suspended VM or completes termination.
+    const processShutdown = Promise.all([
+      this.processRunner.shutdown(),
+      this.terminateActiveStreamCommands(),
+    ]);
 
     // Disconnect Centrifugo
     if (this.subscription) {
@@ -1148,16 +1242,13 @@ class LocalSandboxClient {
       this.centrifuge = undefined;
     }
 
-    // Set up force-exit timeout (5 seconds)
-    const forceExitTimeout = setTimeout(() => {
-      console.log(chalk.yellow("⚠️  Force exiting after 5 second timeout..."));
-      process.exit(1);
-    }, 5000);
+    await processShutdown;
 
-    try {
-      if (this.connectionId) {
-        try {
-          await this.convexHttp.mutation(
+    if (this.connectionId) {
+      let disconnectTimeout: NodeJS.Timeout | undefined;
+      try {
+        await Promise.race([
+          this.convexHttp.mutation(
             (this.config.authMode === "cloud"
               ? api.localSandbox.disconnectCloud
               : api.localSandbox.disconnect) as never,
@@ -1172,16 +1263,22 @@ class LocalSandboxClient {
                   token: this.config.token,
                   connectionId: this.connectionId,
                 }) as never,
-          );
-          console.log(chalk.green("✓ Disconnected"));
-        } catch (error: unknown) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          console.warn(chalk.yellow(`⚠️  Failed to disconnect: ${message}`));
-        }
+          ),
+          new Promise<never>(
+            (_, reject) =>
+              (disconnectTimeout = setTimeout(
+                () => reject(new Error("Disconnect timed out after 5 seconds")),
+                5_000,
+              )),
+          ),
+        ]);
+        console.log(chalk.green("✓ Disconnected"));
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(chalk.yellow(`⚠️  Failed to disconnect: ${message}`));
+      } finally {
+        if (disconnectTimeout) clearTimeout(disconnectTimeout);
       }
-    } finally {
-      clearTimeout(forceExitTimeout);
     }
   }
 }
@@ -1267,116 +1364,71 @@ function parseCloudLifecyclePayload(value: unknown): {
 
 async function startCloudLifecycleServer(): Promise<void> {
   let lifecycleConfig: Config | null = null;
-  let agentProcess: ChildProcess | null = null;
-
-  const stopAgent = async (terminated = false): Promise<void> => {
-    const child = agentProcess;
-    agentProcess = null;
-    if (!child || child.exitCode !== null || child.killed) return;
-
-    await new Promise<void>((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(forceKillTimeout);
-        clearTimeout(hardStopTimeout);
-        child.off("exit", finish);
-        resolve();
-      };
-      const forceKillTimeout = setTimeout(() => {
-        child.kill("SIGKILL");
-      }, 5_000);
-      // Never let a wedged child consume the entire AWS lifecycle-hook
-      // timeout. AWS will complete suspend/termination after this handler
-      // returns even if the local process table has not emitted `exit`.
-      const hardStopTimeout = setTimeout(() => {
-        child.kill("SIGKILL");
-        finish();
-      }, 10_000);
-      child.once("exit", finish);
-      try {
-        child.send?.({ type: "shutdown", terminated });
-      } catch {
-        child.kill("SIGKILL");
-        finish();
-      }
-    });
-  };
-
-  const startAgent = async (): Promise<void> => {
-    if (!lifecycleConfig) throw new Error("Cloud sandbox is not bootstrapped");
-    const child = fork(process.argv[1], ["--cloud-agent"], {
-      env: {
-        ...process.env,
-        HACKERAI_CLOUD_BOOTSTRAP: JSON.stringify(lifecycleConfig),
-      },
-      stdio: ["ignore", "inherit", "inherit", "ipc"],
-    });
-    agentProcess = child;
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        child.kill("SIGKILL");
-        reject(new Error("Timed out starting the cloud relay worker"));
-      }, 25_000);
-      const cleanup = () => {
-        clearTimeout(timeout);
-        child.off("error", onError);
-        child.off("exit", onExit);
-        child.off("message", onMessage);
-      };
-      const onError = (error: Error) => {
-        cleanup();
-        reject(error);
-      };
-      const onExit = (code: number | null) => {
-        cleanup();
-        reject(new Error(`Cloud relay worker exited before ready (${code})`));
-      };
-      const onMessage = (message: unknown) => {
-        if (
-          message &&
-          typeof message === "object" &&
-          (message as { type?: unknown }).type === "ready"
-        ) {
-          cleanup();
-          resolve();
-        }
-      };
-      child.once("error", onError);
-      child.once("exit", onExit);
-      child.on("message", onMessage);
-    });
-    child.once("exit", (code) => {
-      // stopAgent clears agentProcess before intentionally terminating the
-      // worker, so only unexpected exits reach the restart path.
-      if (agentProcess !== child) return;
-      agentProcess = null;
+  const relay = new InProcessRelayLifecycle<Config>(
+    (config, onFatal) =>
+      new LocalSandboxClient(config, {
+        onExitRequested: (_code, error) => onFatal(error),
+      }),
+    (error) => {
       console.error(
         JSON.stringify({
           timestamp: new Date().toISOString(),
           level: "error",
-          event: "cloud_sandbox_relay_worker_exited",
+          event: "cloud_sandbox_relay_failed",
           service: "hackerai-cloud-sandbox-agent",
           environment: "aws-lambda-microvm",
           request_id: lifecycleConfig?.cloudSessionId ?? null,
-          exit_code: code,
+          error: error.message,
         }),
       );
-      void startAgent().catch((error) => {
-        console.error(
-          JSON.stringify({
-            timestamp: new Date().toISOString(),
-            level: "error",
-            event: "cloud_sandbox_relay_worker_restart_failed",
-            service: "hackerai-cloud-sandbox-agent",
-            environment: "aws-lambda-microvm",
-            request_id: lifecycleConfig?.cloudSessionId ?? null,
-            error: error instanceof Error ? error.message : String(error),
-          }),
-        );
-      });
+    },
+    (error) => {
+      console.error(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: "error",
+          event: "cloud_sandbox_relay_restart_failed",
+          service: "hackerai-cloud-sandbox-agent",
+          environment: "aws-lambda-microvm",
+          request_id: lifecycleConfig?.cloudSessionId ?? null,
+          error: error.message,
+        }),
+      );
+    },
+  );
+
+  const primeImage = async (hook: string): Promise<void> => {
+    const result = await primeCloudImageWorkingSet({
+      primeRelay: async () => {
+        const client = new LocalSandboxClient({
+          convexUrl: "http://127.0.0.1",
+          token: "image-validation",
+          name: "image-validation",
+          authMode: "cloud",
+          cloudSessionId: "image-validation",
+          microvmId: "image-validation",
+        });
+        try {
+          await client.primeStartupWorkingSet();
+        } finally {
+          client.disposePrimedResources();
+        }
+      },
     });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        event: "cloud_sandbox_image_primed",
+        service: "hackerai-cloud-sandbox-agent",
+        environment: "aws-lambda-microvm",
+        request_id: "image-build",
+        hook,
+        duration_ms: result.duration_ms,
+        step_count: result.steps.length,
+        steps: result.steps,
+      }),
+    );
   };
 
   const server = createServer(async (request, response) => {
@@ -1386,10 +1438,7 @@ async function startCloudLifecycleServer(): Promise<void> {
       if (request.method === "GET" && path === "/health") {
         writeLifecycleResponse(response, 200, {
           ok: true,
-          connected:
-            agentProcess !== null &&
-            agentProcess.exitCode === null &&
-            !agentProcess.killed,
+          connected: relay.running,
         });
         return;
       }
@@ -1399,7 +1448,8 @@ async function startCloudLifecycleServer(): Promise<void> {
         (path === "/aws/lambda-microvms/runtime/v1/ready" ||
           path === "/aws/lambda-microvms/runtime/v1/validate")
       ) {
-        writeLifecycleResponse(response, 200, { ok: true });
+        await primeImage(path.endsWith("/ready") ? "ready" : "validate");
+        writeLifecycleResponse(response, 200, { ok: true, primed: true });
         return;
       }
 
@@ -1412,7 +1462,7 @@ async function startCloudLifecycleServer(): Promise<void> {
         );
         if (smokeTest) {
           lifecycleConfig = null;
-          await stopAgent();
+          await relay.terminate();
           writeLifecycleResponse(response, 200, { ok: true, smokeTest: true });
           return;
         }
@@ -1425,8 +1475,7 @@ async function startCloudLifecycleServer(): Promise<void> {
           cloudSessionId: config.sessionId,
           microvmId,
         };
-        await stopAgent();
-        await startAgent();
+        await relay.run(lifecycleConfig);
         writeLifecycleResponse(response, 200, { ok: true });
         return;
       }
@@ -1435,7 +1484,7 @@ async function startCloudLifecycleServer(): Promise<void> {
         request.method === "POST" &&
         path === "/aws/lambda-microvms/runtime/v1/suspend"
       ) {
-        await stopAgent();
+        await relay.suspend();
         writeLifecycleResponse(response, 200, { ok: true });
         return;
       }
@@ -1444,8 +1493,7 @@ async function startCloudLifecycleServer(): Promise<void> {
         request.method === "POST" &&
         path === "/aws/lambda-microvms/runtime/v1/resume"
       ) {
-        await stopAgent();
-        await startAgent();
+        await relay.resume();
         writeLifecycleResponse(response, 200, { ok: true });
         return;
       }
@@ -1454,13 +1502,16 @@ async function startCloudLifecycleServer(): Promise<void> {
         request.method === "POST" &&
         path === "/aws/lambda-microvms/runtime/v1/terminate"
       ) {
-        await stopAgent(true);
+        await relay.terminate();
+        lifecycleConfig = null;
         writeLifecycleResponse(response, 200, { ok: true });
         return;
       }
 
       writeLifecycleResponse(response, 404, { error: "not_found" });
     } catch (error) {
+      const primeError =
+        error instanceof CloudImagePrimeError ? error : undefined;
       console.error(
         JSON.stringify({
           timestamp: new Date().toISOString(),
@@ -1470,6 +1521,12 @@ async function startCloudLifecycleServer(): Promise<void> {
           environment: "aws-lambda-microvm",
           request_id: requestId,
           hook: path,
+          failure_step: primeError?.step ?? null,
+          completed_steps: primeError?.completedSteps ?? null,
+          cause_error:
+            primeError?.cause instanceof Error
+              ? primeError.cause.message.slice(0, 500)
+              : null,
           error: error instanceof Error ? error.message : String(error),
         }),
       );
@@ -1478,7 +1535,7 @@ async function startCloudLifecycleServer(): Promise<void> {
   });
 
   const shutdown = async (): Promise<void> => {
-    await stopAgent(true);
+    await relay.terminate();
     server.close(() => process.exit(0));
   };
   process.on("SIGINT", () => void shutdown());
@@ -1499,9 +1556,10 @@ async function startCloudLifecycleServer(): Promise<void> {
   });
 }
 
-// Show help
-if (hasFlag("--help") || hasFlag("-h")) {
-  console.log(`
+export function main(): void {
+  // Show help
+  if (hasFlag("--help") || hasFlag("-h")) {
+    console.log(`
 ${chalk.bold("HackerAI Local Sandbox Client")}
 
 ${chalk.yellow("Usage:")}
@@ -1525,103 +1583,64 @@ ${chalk.cyan("Auto-termination:")}
   The client automatically terminates after 1 hour of inactivity (no commands
   executed) to save system resources.
 `);
-  process.exit(0);
-}
-
-if (hasFlag("--cloud-lifecycle")) {
-  void startCloudLifecycleServer().catch((error: unknown) => {
-    console.error(
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        level: "error",
-        event: "cloud_sandbox_lifecycle_server_failed",
-        service: "hackerai-cloud-sandbox-agent",
-        environment: "aws-lambda-microvm",
-        request_id: "startup",
-        error: error instanceof Error ? error.message : String(error),
-      }),
-    );
-    process.exit(1);
-  });
-} else if (hasFlag("--cloud-agent")) {
-  const rawConfig = process.env.HACKERAI_CLOUD_BOOTSTRAP;
-  delete process.env.HACKERAI_CLOUD_BOOTSTRAP;
-  if (!rawConfig) {
-    console.error("Cloud relay worker is missing bootstrap configuration");
-    process.exit(1);
-  }
-  const config = JSON.parse(rawConfig) as Config;
-  const client = new LocalSandboxClient(config);
-  let shuttingDown = false;
-  const shutdown = async (terminated = false): Promise<void> => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    await client.cleanup({ terminated });
     process.exit(0);
-  };
-  process.on("message", (message: unknown) => {
-    if (
-      message &&
-      typeof message === "object" &&
-      (message as { type?: unknown }).type === "shutdown"
-    ) {
-      void shutdown((message as { terminated?: unknown }).terminated === true);
-    }
-  });
-  process.on("SIGINT", () => void shutdown());
-  process.on("SIGTERM", () => void shutdown());
-  client
-    .start()
-    .then(() => process.send?.({ type: "ready" }))
-    .catch((error: unknown) => {
+  }
+
+  if (hasFlag("--cloud-lifecycle")) {
+    void startCloudLifecycleServer().catch((error: unknown) => {
       console.error(
         JSON.stringify({
           timestamp: new Date().toISOString(),
           level: "error",
-          event: "cloud_sandbox_relay_worker_failed",
+          event: "cloud_sandbox_lifecycle_server_failed",
           service: "hackerai-cloud-sandbox-agent",
           environment: "aws-lambda-microvm",
-          request_id: config.cloudSessionId ?? "startup",
+          request_id: "startup",
           error: error instanceof Error ? error.message : String(error),
         }),
       );
       process.exit(1);
     });
-} else {
-  const config: Config = {
-    convexUrl: getArg("--convex-url") || PRODUCTION_CONVEX_URL,
-    token: getArg("--token") || "",
-    name: getArg("--name") || os.hostname(),
-    authMode: "local",
-  };
+  } else {
+    const config: Config = {
+      convexUrl: getArg("--convex-url") || PRODUCTION_CONVEX_URL,
+      token: getArg("--token") || "",
+      name: getArg("--name") || os.hostname(),
+      authMode: "local",
+    };
 
-  if (!config.token) {
-    console.error(chalk.red("❌ No authentication token provided"));
-    console.error(
-      chalk.yellow("Usage: npx @hackerai/local --token YOUR_TOKEN"),
-    );
-    console.error(
-      chalk.yellow("Get your token from HackerAI Settings > Agents"),
-    );
-    process.exit(1);
+    if (!config.token) {
+      console.error(chalk.red("❌ No authentication token provided"));
+      console.error(
+        chalk.yellow("Usage: npx @hackerai/local --token YOUR_TOKEN"),
+      );
+      console.error(
+        chalk.yellow("Get your token from HackerAI Settings > Agents"),
+      );
+      process.exit(1);
+    }
+
+    const client = new LocalSandboxClient(config);
+
+    process.on("SIGINT", async () => {
+      console.log(chalk.yellow("\n🛑 Shutting down..."));
+      await client.cleanup();
+      process.exit(0);
+    });
+
+    process.on("SIGTERM", async () => {
+      await client.cleanup();
+      process.exit(0);
+    });
+
+    client.start().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(chalk.red("Fatal error:"), message);
+      process.exit(1);
+    });
   }
+}
 
-  const client = new LocalSandboxClient(config);
-
-  process.on("SIGINT", async () => {
-    console.log(chalk.yellow("\n🛑 Shutting down..."));
-    await client.cleanup();
-    process.exit(0);
-  });
-
-  process.on("SIGTERM", async () => {
-    await client.cleanup();
-    process.exit(0);
-  });
-
-  client.start().catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(chalk.red("Fatal error:"), message);
-    process.exit(1);
-  });
+if (require.main === module) {
+  main();
 }

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -540,7 +540,13 @@ export class LocalSandboxClient {
       ) {
         console.error(chalk.yellow("Please regenerate your token in Settings"));
       }
-      await this.cleanup();
+      await this.cleanup().catch((cleanupError: unknown) => {
+        const detail =
+          cleanupError instanceof Error
+            ? cleanupError.message
+            : String(cleanupError);
+        console.warn(chalk.yellow(`⚠️  Cleanup incomplete: ${detail}`));
+      });
       throw error;
     }
   }
@@ -1624,13 +1630,31 @@ ${chalk.cyan("Auto-termination:")}
 
     process.on("SIGINT", async () => {
       console.log(chalk.yellow("\n🛑 Shutting down..."));
-      await client.cleanup();
-      process.exit(0);
+      try {
+        await client.cleanup();
+        process.exit(0);
+      } catch (error) {
+        console.error(
+          chalk.red(
+            `Cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        );
+        process.exit(1);
+      }
     });
 
     process.on("SIGTERM", async () => {
-      await client.cleanup();
-      process.exit(0);
+      try {
+        await client.cleanup();
+        process.exit(0);
+      } catch (error) {
+        console.error(
+          chalk.red(
+            `Cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        );
+        process.exit(1);
+      }
     });
 
     client.start().catch((error: unknown) => {

--- a/packages/local/src/process-runner.ts
+++ b/packages/local/src/process-runner.ts
@@ -213,10 +213,9 @@ export class ProcessRunner {
       }
 
       try {
-        if (this.killProcess(sessionId, proc, "SIGKILL")) {
-          // Keep tracking until node-pty confirms exit. Signal delivery is not
-          // proof that the PTY process tree is gone.
-        }
+        // Keep tracking until node-pty confirms exit. Signal delivery is not
+        // proof that the PTY process tree is gone.
+        this.killProcess(sessionId, proc, "SIGKILL");
       } catch {
         // killProcess already emitted the error event.
       } finally {
@@ -250,7 +249,6 @@ export class ProcessRunner {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
     if (this.activeProcesses.size > 0) {
-      this.disposeTimers(false);
       throw new Error(
         `Timed out terminating ${this.activeProcesses.size} PTY process(es)`,
       );

--- a/packages/local/src/process-runner.ts
+++ b/packages/local/src/process-runner.ts
@@ -51,6 +51,7 @@ interface PtyModule {
 const FLUSH_INTERVAL_MS = 16;
 const FLUSH_THRESHOLD_BYTES = 32 * 1024; // 32 KB
 const SIGTERM_GRACE_MS = 5_000;
+const SHUTDOWN_TIMEOUT_MS = SIGTERM_GRACE_MS + 2_000;
 export const NODE_PTY_UNAVAILABLE_MESSAGE =
   "Interactive terminal sessions are unavailable because node-pty could not be loaded. Non-interactive commands still work.";
 
@@ -198,6 +199,13 @@ export class ProcessRunner {
       return false;
     }
 
+    // A failed lifecycle cleanup can be retried while the original SIGKILL
+    // escalation is still pending. Preserve the earlier (sooner) timer rather
+    // than orphaning it by overwriting the map entry with a later timer.
+    if (this.killTimers.has(sessionId)) {
+      return true;
+    }
+
     const timer = setTimeout(() => {
       if (!this.activeProcesses.has(sessionId)) {
         this.clearKillTimer(sessionId);
@@ -206,8 +214,8 @@ export class ProcessRunner {
 
       try {
         if (this.killProcess(sessionId, proc, "SIGKILL")) {
-          this.activeProcesses.delete(sessionId);
-          this.outputBuffers.delete(sessionId);
+          // Keep tracking until node-pty confirms exit. Signal delivery is not
+          // proof that the PTY process tree is gone.
         }
       } catch {
         // killProcess already emitted the error event.
@@ -232,14 +240,35 @@ export class ProcessRunner {
 
   dispose(): void {
     this.stopAll();
+    this.disposeTimers(false);
+  }
+
+  async shutdown(timeoutMs = SHUTDOWN_TIMEOUT_MS): Promise<void> {
+    this.stopAll();
+    const deadline = Date.now() + timeoutMs;
+    while (this.activeProcesses.size > 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    if (this.activeProcesses.size > 0) {
+      this.disposeTimers(false);
+      throw new Error(
+        `Timed out terminating ${this.activeProcesses.size} PTY process(es)`,
+      );
+    }
+    this.disposeTimers(true);
+  }
+
+  private disposeTimers(clearKillTimers: boolean): void {
     if (this.flushTimer) {
       clearInterval(this.flushTimer);
       this.flushTimer = undefined;
     }
-    for (const timer of this.killTimers.values()) {
-      clearTimeout(timer);
+    if (clearKillTimers) {
+      for (const timer of this.killTimers.values()) {
+        clearTimeout(timer);
+      }
+      this.killTimers.clear();
     }
-    this.killTimers.clear();
   }
 
   // -----------------------------------------------------------------------
@@ -251,8 +280,7 @@ export class ProcessRunner {
     ...args: Parameters<ProcessRunnerEvents[K]>
   ): void {
     const listener = this.listeners.get(event) as
-      | ProcessRunnerEvents[K]
-      | undefined;
+      ProcessRunnerEvents[K] | undefined;
     if (listener) {
       (listener as (...a: Parameters<ProcessRunnerEvents[K]>) => void)(...args);
     }


### PR DESCRIPTION
## Summary

- prime the AWS MicroVM snapshot working set during both image hooks with the relay protocol, local DNS, a real PTY, bash, sudo, nmap, and naabu
- replace Convex readiness polling with a transient reactive subscription started before RunMicrovm, while preserving durable MicroVM attachment before return
- host the outbound relay inside the snapshotted lifecycle process instead of forking a second Node worker
- make PTY and streamed-command shutdown confirmation explicit and retryable across suspend, terminate, and fatal relay recovery
- add structured per-step build-hook diagnostics and lifecycle coverage

## Why

AWS can optimize snapshot retrieval when representative code paths are exercised during validation. The old launcher also introduced polling gaps and paid a second Node process startup/module-load cost on every run.

This PR is stacked on PR #1074 and should merge after it.

## Validation

- 390 test suites / 3,945 tests passed
- TypeScript and Convex function analysis passed
- lint passed with seven pre-existing warnings and no errors
- Lambda MicroVM package build passed; packaged runtime contains no cloud-agent fork path
- CodeRabbit completed with all findings fixed, confirmed, and resolved
- Vercel and Trigger.dev preview checks passed
- AWS image 12.0 is SUCCESSFUL and ACTIVE at 4 GiB ARM64 from exact head 64de5f08
- image 12.0 ready primer: 8.85 s; validate primers: 5.75 s and 6.02 s, all seven steps successful
- exact-head 12.0 smoke reached a usable relay in 5.51 s; command completed in 1.95 s
- four earlier 10.0 fresh starts were 2.35-4.80 s to usable relay, median about 3.21 s
- real naabu scan found hackerai.co ports 80 and 443
- suspend/resume preserved filesystem state and reconnected in 1.58 s
- cancellation returned exit 130 and a follow-up command succeeded
- process inspection showed one lifecycle Node process and no forked cloud-agent worker
- every test MicroVM reached TERMINATED

## Deployment state

Image version 12.0 was published for validation, and the worktree and main-checkout local env files now select it. Vercel, Trigger.dev, Convex production, and production application traffic were not changed.