### PR TITLE
Handle oversized Agent trigger payloads

### DIFF
--- a/lib/api/__tests__/agent-trigger-route.test.ts
+++ b/lib/api/__tests__/agent-trigger-route.test.ts
@@ -75,12 +75,17 @@ jest.mock("@/lib/utils/sandbox-file-utils", () => ({
 }));
 
 const {
+  AGENT_TRIGGER_PAYLOAD_MAX_BYTES,
   buildAgentApprovalSessionId,
   buildAgentPermissionRunSnapshot,
   buildAgentRunDedupeKeyParts,
+  createAgentTriggerPayloadTooLargeResponse,
   createAgentTriggerPost,
   finalizeStartedAgentRun,
+  getAgentTriggerPayloadSizeBytes,
   getAgentTriggerMachine,
+  isAgentTriggerPayloadSizeTooLarge,
+  isTriggerRequestBodyTooLargeError,
   shouldRequireAgentApprovalWorkerVersion,
 } =
   require("../agent-trigger-route") as typeof import("../agent-trigger-route");
@@ -93,6 +98,61 @@ describe("Agent trigger route lifecycle", () => {
       .mockResolvedValueOnce("session-token");
     mockCancelAgentTriggerRun.mockResolvedValue(true);
     mockCloseAgentApprovalSession.mockResolvedValue(true);
+  });
+
+  it("measures the aggregate serialized trigger payload in UTF-8 bytes", () => {
+    const payload = { messages: [{ text: "security évidence" }] };
+
+    expect(getAgentTriggerPayloadSizeBytes(payload)).toBe(
+      Buffer.byteLength(JSON.stringify(payload), "utf8"),
+    );
+    expect(AGENT_TRIGGER_PAYLOAD_MAX_BYTES).toBe(3 * 1024 * 1024);
+    expect(
+      isAgentTriggerPayloadSizeTooLarge(AGENT_TRIGGER_PAYLOAD_MAX_BYTES),
+    ).toBe(false);
+    expect(
+      isAgentTriggerPayloadSizeTooLarge(AGENT_TRIGGER_PAYLOAD_MAX_BYTES + 1),
+    ).toBe(true);
+  });
+
+  it("recognizes only Trigger's exact request-body 413", () => {
+    const bodyTooLarge = Object.assign(new Error("Request body too large"), {
+      name: "TriggerApiError",
+      status: 413,
+    });
+
+    expect(isTriggerRequestBodyTooLargeError(bodyTooLarge)).toBe(true);
+    expect(
+      isTriggerRequestBodyTooLargeError(
+        Object.assign(new Error("Request body too large"), {
+          name: "TriggerApiError",
+          status: 500,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTriggerRequestBodyTooLargeError(
+        Object.assign(new Error("Provider media is too large"), {
+          name: "TriggerApiError",
+          statusCode: 413,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTriggerRequestBodyTooLargeError(
+        Object.assign(new Error("Request body too large"), { status: 413 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns a user-correctable 413 for oversized Agent starts", async () => {
+    const response = createAgentTriggerPayloadTooLargeResponse();
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "bad_request:api",
+      cause: expect.stringContaining("too large to start"),
+    });
   });
 
   it.each([true, false])(

--- a/lib/api/__tests__/agent-trigger-route.test.ts
+++ b/lib/api/__tests__/agent-trigger-route.test.ts
@@ -85,6 +85,7 @@ const {
   getAgentTriggerPayloadSizeBytes,
   getAgentTriggerMachine,
   isAgentTriggerPayloadSizeTooLarge,
+  isAgentTriggerRequestSizeTooLarge,
   isTriggerRequestBodyTooLargeError,
   shouldRequireAgentApprovalWorkerVersion,
 } =
@@ -112,6 +113,19 @@ describe("Agent trigger route lifecycle", () => {
     ).toBe(false);
     expect(
       isAgentTriggerPayloadSizeTooLarge(AGENT_TRIGGER_PAYLOAD_MAX_BYTES + 1),
+    ).toBe(true);
+  });
+
+  it("rejects an oversized approval request when its base payload fits", () => {
+    const basePayloadBytes = AGENT_TRIGGER_PAYLOAD_MAX_BYTES;
+    const approvalRequestBodyBytes = AGENT_TRIGGER_PAYLOAD_MAX_BYTES + 1;
+
+    expect(isAgentTriggerPayloadSizeTooLarge(basePayloadBytes)).toBe(false);
+    expect(
+      isAgentTriggerRequestSizeTooLarge({
+        payloadBytes: basePayloadBytes,
+        requestBodyBytes: approvalRequestBodyBytes,
+      }),
     ).toBe(true);
   });
 

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -81,6 +81,46 @@ const AGENT_TRIGGER_PRIORITY_BY_SUBSCRIPTION: Record<SubscriptionTier, number> =
     team: 5,
   };
 
+// Trigger.dev rejects a single trigger payload above 3 MiB. tasks.trigger()
+// offloads large packets, but sessions.start() sends triggerConfig.basePayload
+// inline, so enforce the documented payload boundary before either path.
+export const AGENT_TRIGGER_PAYLOAD_MAX_BYTES = 3 * 1024 * 1024;
+
+export const getAgentTriggerPayloadSizeBytes = (payload: unknown): number =>
+  Buffer.byteLength(JSON.stringify(payload), "utf8");
+
+export const isAgentTriggerPayloadSizeTooLarge = (sizeBytes: number): boolean =>
+  sizeBytes > AGENT_TRIGGER_PAYLOAD_MAX_BYTES;
+
+export const isTriggerRequestBodyTooLargeError = (error: unknown): boolean => {
+  if (!(error instanceof Error) || error.name !== "TriggerApiError") {
+    return false;
+  }
+
+  const status = (error as Error & { status?: unknown; statusCode?: unknown })
+    .status;
+  const statusCode = (
+    error as Error & { status?: unknown; statusCode?: unknown }
+  ).statusCode;
+
+  return (
+    (status === 413 || statusCode === 413) &&
+    error.message === "Request body too large"
+  );
+};
+
+export const createAgentTriggerPayloadTooLargeResponse = () =>
+  Response.json(
+    {
+      code: "bad_request:api",
+      message:
+        "The request couldn't be processed. Please check your input and try again.",
+      cause:
+        "This Agent request is too large to start. Remove some attachments or start a new chat and try again.",
+    },
+    { status: 413 },
+  );
+
 const getAgentTriggerPriority = (subscription: SubscriptionTier) =>
   AGENT_TRIGGER_PRIORITY_BY_SUBSCRIPTION[subscription];
 
@@ -632,6 +672,10 @@ export const createAgentTriggerPost =
           triggerRequestedAt,
         },
       };
+      const triggerPayloadBytes = getAgentTriggerPayloadSizeBytes(agentPayload);
+      const triggerApiMethod = approvalSessionId
+        ? "sessions.start"
+        : "tasks.trigger";
       const triggerMetadata = {
         status: "queued",
         chatId,
@@ -662,34 +706,83 @@ export const createAgentTriggerPost =
         idempotencyKeyTTL: "6h",
         metadata: triggerMetadata,
       };
+      let triggerRequestBodyBytes: number | undefined;
+      const triggerPayloadTooLargeResponse = (
+        reason: "payload_limit_exceeded" | "trigger_api_413",
+      ) => {
+        console.warn(
+          JSON.stringify({
+            timestamp: new Date().toISOString(),
+            level: "warn",
+            event: "agent_trigger_payload_rejected",
+            service: "hackerai-web",
+            environment:
+              process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+            endpoint,
+            reason,
+            http_status: 413,
+            trigger_api_method: triggerApiMethod,
+            trigger_payload_bytes: triggerPayloadBytes,
+            trigger_request_body_bytes: triggerRequestBodyBytes,
+            trigger_payload_limit_bytes: AGENT_TRIGGER_PAYLOAD_MAX_BYTES,
+            trigger_payload_message_count: messagesForPayload.length,
+            base_todos_count: Array.isArray(todos) ? todos.length : 0,
+            local_desktop_attachments_prepared: localDesktopAttachmentsPrepared,
+            agent_permission_mode: permissionSnapshot.mode,
+            request_id:
+              req.headers.get("x-vercel-id")?.slice(0, 128) ?? "unknown",
+            user_id: userId.slice(0, 128),
+            chat_id: chatId.slice(0, 128),
+            organization_id: organizationId?.slice(0, 128),
+          }),
+        );
+
+        return createAgentTriggerPayloadTooLargeResponse();
+      };
 
       let runId: string;
-      if (approvalSessionId) {
-        const approvalTriggerConfig = {
-          basePayload: agentPayload,
-          machine: triggerMachine,
-          tags: triggerTags,
-          ...(triggerRegion ? { region: triggerRegion } : {}),
-          ...(approvalWorkerVersion
-            ? { lockToVersion: approvalWorkerVersion }
-            : {}),
-        };
-        const session = await sessions.start({
-          type: `agent-long-approval.v${AGENT_APPROVAL_PROTOCOL_VERSION}`,
-          externalId: approvalSessionId,
-          taskIdentifier: AGENT_TRIGGER_TASK_ID,
-          tags: triggerTags,
-          metadata: triggerMetadata,
-          triggerConfig: approvalTriggerConfig,
-        });
-        runId = session.runId;
-      } else {
-        const handle = await tasks.trigger<typeof agentLongTask>(
-          AGENT_TRIGGER_TASK_ID,
-          agentPayload,
-          triggerOptions,
-        );
-        runId = handle.id;
+      try {
+        if (approvalSessionId) {
+          const approvalTriggerConfig = {
+            basePayload: agentPayload,
+            machine: triggerMachine,
+            tags: triggerTags,
+            ...(triggerRegion ? { region: triggerRegion } : {}),
+            ...(approvalWorkerVersion
+              ? { lockToVersion: approvalWorkerVersion }
+              : {}),
+          };
+          const approvalSessionBody = {
+            type: `agent-long-approval.v${AGENT_APPROVAL_PROTOCOL_VERSION}`,
+            externalId: approvalSessionId,
+            taskIdentifier: AGENT_TRIGGER_TASK_ID,
+            tags: triggerTags,
+            metadata: triggerMetadata,
+            triggerConfig: approvalTriggerConfig,
+          };
+          triggerRequestBodyBytes =
+            getAgentTriggerPayloadSizeBytes(approvalSessionBody);
+          if (isAgentTriggerPayloadSizeTooLarge(triggerPayloadBytes)) {
+            return triggerPayloadTooLargeResponse("payload_limit_exceeded");
+          }
+          const session = await sessions.start(approvalSessionBody);
+          runId = session.runId;
+        } else {
+          if (isAgentTriggerPayloadSizeTooLarge(triggerPayloadBytes)) {
+            return triggerPayloadTooLargeResponse("payload_limit_exceeded");
+          }
+          const handle = await tasks.trigger<typeof agentLongTask>(
+            AGENT_TRIGGER_TASK_ID,
+            agentPayload,
+            triggerOptions,
+          );
+          runId = handle.id;
+        }
+      } catch (error) {
+        if (isTriggerRequestBodyTooLargeError(error)) {
+          return triggerPayloadTooLargeResponse("trigger_api_413");
+        }
+        throw error;
       }
 
       const triggerCompletedAt = Date.now();

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -92,6 +92,15 @@ export const getAgentTriggerPayloadSizeBytes = (payload: unknown): number =>
 export const isAgentTriggerPayloadSizeTooLarge = (sizeBytes: number): boolean =>
   sizeBytes > AGENT_TRIGGER_PAYLOAD_MAX_BYTES;
 
+export const isAgentTriggerRequestSizeTooLarge = ({
+  payloadBytes,
+  requestBodyBytes,
+}: {
+  payloadBytes: number;
+  requestBodyBytes?: number;
+}): boolean =>
+  isAgentTriggerPayloadSizeTooLarge(requestBodyBytes ?? payloadBytes);
+
 export const isTriggerRequestBodyTooLargeError = (error: unknown): boolean => {
   if (!(error instanceof Error) || error.name !== "TriggerApiError") {
     return false;
@@ -762,13 +771,22 @@ export const createAgentTriggerPost =
           };
           triggerRequestBodyBytes =
             getAgentTriggerPayloadSizeBytes(approvalSessionBody);
-          if (isAgentTriggerPayloadSizeTooLarge(triggerPayloadBytes)) {
+          if (
+            isAgentTriggerRequestSizeTooLarge({
+              payloadBytes: triggerPayloadBytes,
+              requestBodyBytes: triggerRequestBodyBytes,
+            })
+          ) {
             return triggerPayloadTooLargeResponse("payload_limit_exceeded");
           }
           const session = await sessions.start(approvalSessionBody);
           runId = session.runId;
         } else {
-          if (isAgentTriggerPayloadSizeTooLarge(triggerPayloadBytes)) {
+          if (
+            isAgentTriggerRequestSizeTooLarge({
+              payloadBytes: triggerPayloadBytes,
+            })
+          ) {
             return triggerPayloadTooLargeResponse("payload_limit_exceeded");
           }
           const handle = await tasks.trigger<typeof agentLongTask>(


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-08-17T20:01:57.754Z` through `2026-08-18T20:01:57.754Z`.

Two production `/api/agent` requests at `2026-08-18T18:50:22Z` and `18:51:27Z` failed with exact `TriggerApiError: Request body too large` / HTTP 413, but the route converted both to generic HTTP 500 responses. Trigger.dev created no corresponding runs. The failures were on Vercel production deployment `dpl_FT3mCLqitDbBmxGLe7rC5soCQmy6` / `f9d650c2`.

The pinned Trigger.dev SDK offloads large `tasks.trigger` packets, while approval-mode `sessions.start` sends `triggerConfig.basePayload` inline. Runtime logs did not expose the path or payload dimensions, so approval Sessions are a high-confidence inference rather than a direct runtime fact.

## Root cause

The Agent trigger route neither enforced Trigger.dev's documented 3 MiB aggregate trigger-payload limit nor preserved the exact Trigger 413 response. Its generic catch returned 500 and omitted the bounded payload/path context needed to diagnose the failure.

## Change

- measure the complete serialized Agent trigger payload in UTF-8 bytes before both ordinary and approval trigger paths;
- reject payloads above 3 MiB with a user-correctable HTTP 413;
- map only the exact Trigger `TriggerApiError` 413 fallback to the same response;
- emit bounded `agent_trigger_payload_rejected` telemetry with method, reason, byte counts, message/todo counts, permission mode, attachment-preparation state, and opaque correlation IDs;
- preserve ordinary Trigger offloading, approval worker pinning, regions, idempotency, persistence, and unrelated errors.

No prompts, message content, todo content, file paths, URLs, tokens, or provider payloads are logged.

## Validation

- `corepack pnpm jest lib/api/__tests__/agent-trigger-route.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 109 tests passed
- `corepack pnpm typecheck`
- changed-file ESLint and Prettier
- `corepack pnpm check:local-dependencies`
- commit hooks — 400 suites / 3,995 tests passed
- adversarial review covered canonical and legacy routes, ordinary and approval trigger paths, exact/over-limit boundaries, retry fallback, deploy skew, region/version contracts, and structured-log privacy

## Manual verification

After deployment:

1. Start an approval-mode Agent request with a synthetic payload over 3 MiB. It should return HTTP 413, create no Trigger run, and emit one bounded `agent_trigger_payload_rejected` warning.
2. Start an ordinary Agent request below the limit. It should still use the existing Trigger offload path and start normally.
3. Simulate an exact Trigger 413 under the preflight limit. It should return the same user-correctable 413; non-413 Trigger failures must remain generic 500s and visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a 3 MiB size limit for Agent trigger payloads.
  - Added accurate UTF-8 byte-size measurement for payloads and approval requests.
  - Oversized payloads and request bodies now receive a consistent 413 response.
  - Trigger API request-size errors are recognized and surfaced consistently.

- **Bug Fixes**
  - Improved handling of oversized approval-session requests.
  - Preserved existing startup behavior for valid payloads.
  - Added coverage for size boundaries and oversized-request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->