### PR TITLE
Fix stale local runner relay recovery

### DIFF
--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -57,6 +57,7 @@ import {
   PtySessionManager,
   MAX_CONCURRENT_PTYS_PER_CHAT,
 } from "../utils/pty-session-manager";
+import { LocalCommandRelayUnsubscribedError } from "../utils/local-sandbox-errors";
 
 // ── Mock hybrid-sandbox-manager so we can return a fake sandbox ──────
 jest.mock("../utils/e2b-pty-adapter", () => {
@@ -871,9 +872,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
   });
 
   test("retires an unsubscribed relay and retries once on its verified successor", async () => {
-    const relayError = new Error(
-      "Local sandbox connection conn-stale is not subscribed to the command relay. Reconnect the local runner or Desktop app, wait until it is ready, then try again.",
-    );
+    const relayError = new LocalCommandRelayUnsubscribedError("conn-stale");
     const staleSandbox = {
       sandboxKind: "centrifugo" as const,
       getConnectionId: () => "conn-stale",
@@ -939,9 +938,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
       isWindows: () => false,
       commands: {
         run: jest.fn(async () => {
-          throw new Error(
-            "Local sandbox connection conn-stale is not subscribed to the command relay.",
-          );
+          throw new LocalCommandRelayUnsubscribedError("conn-stale");
         }),
       },
     };

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -870,6 +870,125 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     ).toContain("echo hi");
   });
 
+  test("retires an unsubscribed relay and retries once on its verified successor", async () => {
+    const relayError = new Error(
+      "Local sandbox connection conn-stale is not subscribed to the command relay. Reconnect the local runner or Desktop app, wait until it is ready, then try again.",
+    );
+    const staleSandbox = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "conn-stale",
+      isWindows: () => false,
+      commands: { run: jest.fn(async () => Promise.reject(relayError)) },
+    };
+    const replacementSandbox = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "conn-replacement",
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(
+          async (_cmd: string, opts?: { onStdout?: (s: string) => void }) => {
+            opts?.onStdout?.("recovered\n");
+            return { stdout: "recovered\n", stderr: "", exitCode: 0 };
+          },
+        ),
+      },
+    };
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const { context, sandboxManager } = makeContext({
+      sandbox: staleSandbox,
+    });
+    const recoverLocalConnection = jest.fn(async () => {
+      sandboxManager.getSandbox.mockResolvedValue({
+        sandbox: replacementSandbox,
+      });
+      return { sandbox: replacementSandbox };
+    });
+    Object.assign(sandboxManager, { recoverLocalConnection });
+
+    try {
+      const result = (await runTool(createRunTerminalCmd(context), {
+        command: "echo recovered",
+        brief: "verify local recovery",
+        is_background: false,
+        timeout: 5,
+        interactive: false,
+      })) as {
+        result: { output: string; exitCode: number; processStarted?: boolean };
+      };
+
+      expect(result.result).toMatchObject({
+        output: expect.stringContaining("recovered"),
+        exitCode: 0,
+        processStarted: true,
+      });
+      expect(staleSandbox.commands.run).toHaveBeenCalledTimes(1);
+      expect(recoverLocalConnection).toHaveBeenCalledWith(
+        "conn-stale",
+        "command_relay_unsubscribed",
+      );
+      expect(replacementSandbox.commands.run).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("does not reuse an approval after stale-relay recovery changes the connection", async () => {
+    const staleSandbox = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "conn-stale",
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(async () => {
+          throw new Error(
+            "Local sandbox connection conn-stale is not subscribed to the command relay.",
+          );
+        }),
+      },
+    };
+    const replacementSandbox = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "conn-replacement",
+      isWindows: () => false,
+      commands: { run: jest.fn() },
+    };
+    const requestToolApproval = jest.fn(async () => ({
+      approved: true as const,
+      approvalId: "approval-1",
+      sandboxIdentity: "connection:conn-stale" as const,
+    }));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const { context, sandboxManager } = makeContext({
+      sandbox: staleSandbox,
+      requestToolApproval,
+    });
+    Object.assign(sandboxManager, {
+      recoverLocalConnection: jest.fn(async () => {
+        sandboxManager.getSandbox.mockResolvedValue({
+          sandbox: replacementSandbox,
+        });
+        return { sandbox: replacementSandbox };
+      }),
+    });
+
+    try {
+      const result = (await runTool(createRunTerminalCmd(context), {
+        command: "echo protected",
+        brief: "verify approval binding",
+        is_background: false,
+        timeout: 5,
+        interactive: false,
+      })) as { result: { error: string; exitCode: number } };
+
+      expect(result.result.error).toContain(
+        "selected sandbox changed after approval",
+      );
+      expect(result.result.exitCode).toBe(1);
+      expect(replacementSandbox.commands.run).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   test("returns a real opaque session when a foreground command outlives its wait window", async () => {
     let finishCommand!: (result: {
       stdout: string;

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -74,6 +74,12 @@ const NOISY_TIMEOUT_MIN_BUFFERED_CHARS = 256 * 1024;
 // return in ~half a second instead of blocking the user-supplied timeout
 // ceiling. The agent can follow up with action=wait/send.
 const INTERACTIVE_QUIET_WINDOW_MS = 500;
+const LOCAL_COMMAND_RELAY_UNSUBSCRIBED =
+  /local sandbox connection\s+\S+\s+is not subscribed to the command relay/i;
+
+export const isLocalCommandRelayUnsubscribedError = (error: unknown): boolean =>
+  error instanceof Error &&
+  LOCAL_COMMAND_RELAY_UNSUBSCRIBED.test(error.message);
 
 const getTerminalProcessStatus = (
   result: Record<string, unknown>,
@@ -500,6 +506,67 @@ export const createRunTerminalCmd = (context: ToolContext) => {
         // Get fresh sandbox and verify it's ready
         const { sandbox } = await getApprovedExecutionSandbox();
 
+        const executeWithLocalRelayRecovery = async (
+          sandboxInstance: typeof sandbox,
+        ) => {
+          try {
+            return await executeCommand(sandboxInstance);
+          } catch (error) {
+            if (
+              !isCentrifugoSandbox(sandboxInstance) ||
+              !isLocalCommandRelayUnsubscribedError(error) ||
+              !sandboxManager.recoverLocalConnection
+            ) {
+              throw error;
+            }
+
+            const staleConnectionId = sandboxInstance.getConnectionId();
+            console.warn(
+              JSON.stringify({
+                timestamp: new Date().toISOString(),
+                level: "warn",
+                event: "agent_terminal_local_relay_recovery_started",
+                ...buildTerminalLogContext(),
+                chat_id: context.chatId,
+                user_id: context.userID,
+                subscription: context.subscription ?? "unknown",
+                tool_call_id: toolCallId,
+                stale_connection_id: staleConnectionId,
+              }),
+            );
+
+            await measureSandboxRecovery(() =>
+              sandboxManager.recoverLocalConnection!(
+                staleConnectionId,
+                "command_relay_unsubscribed",
+              ),
+            );
+            const { sandbox: recoveredSandbox } =
+              await getApprovedExecutionSandbox();
+
+            console.warn(
+              JSON.stringify({
+                timestamp: new Date().toISOString(),
+                level: "warn",
+                event: "agent_terminal_local_relay_recovery_completed",
+                ...buildTerminalLogContext(),
+                chat_id: context.chatId,
+                user_id: context.userID,
+                subscription: context.subscription ?? "unknown",
+                tool_call_id: toolCallId,
+                stale_connection_id: staleConnectionId,
+                replacement_connection_id: isCentrifugoSandbox(recoveredSandbox)
+                  ? recoveredSandbox.getConnectionId()
+                  : null,
+              }),
+            );
+
+            // The relay presence check rejects before the command is published,
+            // so one retry on the verified same-machine successor is safe.
+            return executeCommand(recoveredSandbox);
+          }
+        };
+
         // Bail early if sandbox was already marked unavailable by any tool
         if (sandboxManager.isSandboxUnavailable()) {
           return {
@@ -641,17 +708,19 @@ export const createRunTerminalCmd = (context: ToolContext) => {
             });
 
             if (!recovery.ok) return recovery.response;
-            return isE2BSandbox(recovery.sandbox) && !is_background
+            return await (isE2BSandbox(recovery.sandbox) && !is_background
               ? withE2BSandboxLeaseHeartbeat(recovery.sandbox, () =>
-                  executeCommand(recovery.sandbox),
+                  executeWithLocalRelayRecovery(recovery.sandbox),
                 )
-              : executeCommand(recovery.sandbox);
+              : executeWithLocalRelayRecovery(recovery.sandbox));
           }
         }
 
-        return isE2BSandbox(sandbox) && !is_background
-          ? withE2BSandboxLeaseHeartbeat(sandbox, () => executeCommand(sandbox))
-          : executeCommand(sandbox);
+        return await (isE2BSandbox(sandbox) && !is_background
+          ? withE2BSandboxLeaseHeartbeat(sandbox, () =>
+              executeWithLocalRelayRecovery(sandbox),
+            )
+          : executeWithLocalRelayRecovery(sandbox));
 
         async function executeCommand(sandboxInstance: typeof sandbox) {
           captureAgentBrowserUsage({
@@ -1084,6 +1153,13 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 // a process is terminated externally (e.g., by our abort handler).
                 // We must not retry these as the termination was intentional.
                 if (error.message.includes("signal:")) {
+                  return true;
+                }
+
+                // Presence is checked before the command is published. Handle
+                // this once at the sandbox layer instead of backing off against
+                // the same stale relay connection six times.
+                if (isLocalCommandRelayUnsubscribedError(error)) {
                   return true;
                 }
 

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -64,6 +64,7 @@ import {
   getAgentAutoReviewInspectionKind,
   terminalInspectionMatches,
 } from "@/lib/chat/agent-auto-review-evidence";
+import { isLocalCommandRelayUnsubscribedError } from "./utils/local-sandbox-errors";
 
 const DEFAULT_STREAM_TIMEOUT_SECONDS =
   RUN_TERMINAL_DEFAULT_STREAM_TIMEOUT_SECONDS;
@@ -74,13 +75,6 @@ const NOISY_TIMEOUT_MIN_BUFFERED_CHARS = 256 * 1024;
 // return in ~half a second instead of blocking the user-supplied timeout
 // ceiling. The agent can follow up with action=wait/send.
 const INTERACTIVE_QUIET_WINDOW_MS = 500;
-const LOCAL_COMMAND_RELAY_UNSUBSCRIBED =
-  /local sandbox connection\s+\S+\s+is not subscribed to the command relay/i;
-
-export const isLocalCommandRelayUnsubscribedError = (error: unknown): boolean =>
-  error instanceof Error &&
-  LOCAL_COMMAND_RELAY_UNSUBSCRIBED.test(error.message);
-
 const getTerminalProcessStatus = (
   result: Record<string, unknown>,
 ): string | undefined => {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -13,6 +13,7 @@ import type { CentrifugoConfig } from "../centrifugo-sandbox";
 import {
   LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE,
   LocalCommandRelayUnsubscribedError,
+  isLocalCommandRelayUnsubscribedError,
 } from "../local-sandbox-errors";
 import { fragmentCentrifugoMessage } from "@/packages/local/src/centrifugo-transport";
 
@@ -201,6 +202,44 @@ describe("CentrifugoSandbox", () => {
       } finally {
         warnSpy.mockRestore();
       }
+    });
+  });
+
+  describe("connection identity", () => {
+    it("returns defensive copies of nested recovery metadata", () => {
+      const sandbox = createDesktopSandbox();
+      const first = sandbox.getConnectionInfo();
+
+      (first.osInfo as { hostname: string }).hostname = "mutated-host";
+      (first.capabilities as { commands: boolean }).commands = false;
+
+      const second = sandbox.getConnectionInfo();
+      expect(second).not.toBe(first);
+      expect(second.osInfo).not.toBe(first.osInfo);
+      expect(second.capabilities).not.toBe(first.capabilities);
+      expect(second.osInfo?.hostname).toBe("WIN-DEV");
+      expect(second.capabilities?.commands).toBe(true);
+    });
+  });
+
+  describe("relay error classification", () => {
+    it("requires both the stable code and a string connection ID", () => {
+      expect(
+        isLocalCommandRelayUnsubscribedError(
+          new LocalCommandRelayUnsubscribedError("conn-1"),
+        ),
+      ).toBe(true);
+      expect(
+        isLocalCommandRelayUnsubscribedError({
+          code: LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE,
+        }),
+      ).toBe(false);
+      expect(
+        isLocalCommandRelayUnsubscribedError({
+          code: LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE,
+          connectionId: 123,
+        }),
+      ).toBe(false);
     });
   });
 

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -10,6 +10,10 @@
 import { EventEmitter } from "events";
 import { CentrifugoSandbox, parseSandboxMessage } from "../centrifugo-sandbox";
 import type { CentrifugoConfig } from "../centrifugo-sandbox";
+import {
+  LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE,
+  LocalCommandRelayUnsubscribedError,
+} from "../local-sandbox-errors";
 import { fragmentCentrifugoMessage } from "@/packages/local/src/centrifugo-transport";
 
 // Track all created mock subscriptions and clients for assertions
@@ -507,14 +511,18 @@ describe("CentrifugoSandbox", () => {
         },
       });
 
-      const rejection = expect(promise).rejects.toThrow(
-        "is not subscribed to the command relay",
-      );
+      const rejection = promise.catch((error) => error);
 
       sub.emit("subscribed");
       await jest.advanceTimersByTimeAsync(0);
 
-      await rejection;
+      const error = await rejection;
+      expect(error).toBeInstanceOf(LocalCommandRelayUnsubscribedError);
+      expect(error).toMatchObject({
+        code: LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE,
+        connectionId: "conn-1",
+      });
+      expect(error.message).toContain("is not subscribed to the command relay");
       expect(sub.publish).not.toHaveBeenCalled();
       expect(sub.unsubscribe).toHaveBeenCalled();
       expect(mockClients[0].disconnect).toHaveBeenCalled();

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -24,6 +24,7 @@ jest.mock("@/lib/db/convex-client", () => ({
 import {
   filterConnectionsByPresence,
   HybridSandboxManager,
+  isSameLocalMachine,
   LOCAL_SANDBOX_PRESENCE_GRACE_MS,
 } from "../hybrid-sandbox-manager";
 import {
@@ -107,6 +108,52 @@ describe("filterConnectionsByPresence", () => {
 
     expect(result.availableConnections).toEqual([live]);
     expect(result.staleConnections).toEqual([stale]);
+  });
+});
+
+describe("isSameLocalMachine", () => {
+  const kaliConnection = makeConnection({
+    connectionId: "conn-old",
+    name: "4p3x",
+    isDesktop: false,
+    osInfo: {
+      platform: "linux",
+      arch: "x86_64",
+      release: "6.18.5-kali1-amd64",
+      hostname: "4p3x",
+    },
+  });
+
+  it("matches a restarted runner on the same host", () => {
+    expect(
+      isSameLocalMachine(
+        kaliConnection,
+        makeConnection({
+          ...kaliConnection,
+          connectionId: "conn-new",
+          lastSeen: Date.now(),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects another host and connections without host identity", () => {
+    expect(
+      isSameLocalMachine(
+        kaliConnection,
+        makeConnection({
+          ...kaliConnection,
+          connectionId: "conn-other",
+          osInfo: { ...kaliConnection.osInfo!, hostname: "other-host" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isSameLocalMachine(
+        kaliConnection,
+        makeConnection({ connectionId: "conn-unknown", osInfo: undefined }),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -722,6 +769,139 @@ describe("HybridSandboxManager reset cleanup", () => {
     } finally {
       warnSpy.mockRestore();
       errorSpy.mockRestore();
+    }
+  });
+
+  it("recovers an unsubscribed relay only onto the same machine", async () => {
+    const originalWsUrl = process.env.CENTRIFUGO_WS_URL;
+    const originalTokenSecret = process.env.CENTRIFUGO_TOKEN_SECRET;
+    process.env.CENTRIFUGO_WS_URL = "ws://centrifugo.test/connection/websocket";
+    process.env.CENTRIFUGO_TOKEN_SECRET = "test-secret";
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const stale = makeConnection({
+      connectionId: "conn-stale",
+      name: "4p3x",
+      isDesktop: false,
+      osInfo: {
+        platform: "linux",
+        arch: "x86_64",
+        release: "6.18.5-kali1-amd64",
+        hostname: "4p3x",
+      },
+    });
+    const replacement = makeConnection({
+      ...stale,
+      connectionId: "conn-replacement",
+      lastSeen: 2_000,
+    });
+    const otherHost = makeConnection({
+      ...stale,
+      connectionId: "conn-other",
+      name: "other-host",
+      osInfo: { ...stale.osInfo!, hostname: "other-host" },
+      lastSeen: 3_000,
+    });
+    const setSandbox = jest.fn();
+    const manager = new HybridSandboxManager(
+      "user-1",
+      setSandbox,
+      "conn-stale",
+      "service-key",
+      null,
+      "free",
+      undefined,
+      undefined,
+      "run-123",
+    );
+    const staleSandbox = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => stale.connectionId,
+      getConnectionName: () => stale.name,
+      getConnectionInfo: () => stale,
+      getCloudProvider: () => null,
+    };
+    manager.setSandbox(staleSandbox as any);
+    jest
+      .spyOn(manager, "listConnections")
+      .mockResolvedValue([otherHost, replacement]);
+    mockConvexMutation.mockResolvedValue({ success: true });
+
+    try {
+      const recovered = await manager.recoverLocalConnection(
+        stale.connectionId,
+        "command_relay_unsubscribed",
+      );
+
+      expect((recovered.sandbox as any).getConnectionId()).toBe(
+        "conn-replacement",
+      );
+      expect(manager.getEffectivePreference()).toBe("conn-replacement");
+      expect(mockConvexMutation).toHaveBeenCalledWith(expect.anything(), {
+        serviceKey: "service-key",
+        connectionId: "conn-stale",
+        reason: "command_unresponsive",
+      });
+      expect(setSandbox).toHaveBeenLastCalledWith(recovered.sandbox);
+    } finally {
+      warnSpy.mockRestore();
+      if (originalWsUrl === undefined) delete process.env.CENTRIFUGO_WS_URL;
+      else process.env.CENTRIFUGO_WS_URL = originalWsUrl;
+      if (originalTokenSecret === undefined)
+        delete process.env.CENTRIFUGO_TOKEN_SECRET;
+      else process.env.CENTRIFUGO_TOKEN_SECRET = originalTokenSecret;
+    }
+  });
+
+  it("fails closed when only a different machine is connected", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const stale = makeConnection({
+      connectionId: "conn-stale",
+      name: "4p3x",
+      isDesktop: false,
+      osInfo: {
+        platform: "linux",
+        arch: "x86_64",
+        release: "6.18.5-kali1-amd64",
+        hostname: "4p3x",
+      },
+    });
+    const manager = new HybridSandboxManager(
+      "user-1",
+      jest.fn(),
+      "conn-stale",
+      "service-key",
+      null,
+      "free",
+    );
+    manager.setSandbox({
+      sandboxKind: "centrifugo",
+      getConnectionId: () => stale.connectionId,
+      getConnectionName: () => stale.name,
+      getConnectionInfo: () => stale,
+      getCloudProvider: () => null,
+    } as any);
+    jest.spyOn(manager, "listConnections").mockResolvedValue([
+      makeConnection({
+        connectionId: "conn-other",
+        name: "other-host",
+        osInfo: { ...stale.osInfo!, hostname: "other-host" },
+      }),
+    ]);
+    mockConvexMutation.mockResolvedValue({ success: true });
+
+    try {
+      await expect(
+        manager.recoverLocalConnection(
+          stale.connectionId,
+          "command_relay_unsubscribed",
+        ),
+      ).rejects.toThrow("selected local sandbox stopped responding");
+      await expect(manager.getSandbox()).rejects.toThrow(
+        "selected local sandbox stopped responding",
+      );
+      expect(sandboxApi.list).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -871,7 +871,7 @@ describe("HybridSandboxManager reset cleanup", () => {
       "conn-stale",
       "service-key",
       null,
-      "free",
+      "pro",
     );
     manager.setSandbox({
       sandboxKind: "centrifugo",

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -21,6 +21,7 @@ import {
 import { getPlatformDisplayName, escapeShellValue } from "./platform-utils";
 import type { ConnectionInfo } from "./sandbox-types";
 import { validateDownloadUrl } from "./path-validation";
+import { LocalCommandRelayUnsubscribedError } from "./local-sandbox-errors";
 
 const VALID_MESSAGE_TYPES = new Set([
   "command",
@@ -290,6 +291,7 @@ export class CentrifugoSandbox extends EventEmitter {
     return this.connectionInfo.name;
   }
 
+  /** Returns the immutable identity metadata used to bind recovery to this host. */
   getConnectionInfo(): Readonly<ConnectionInfo> {
     return this.connectionInfo;
   }
@@ -881,8 +883,8 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
                 settled = true;
                 cleanup();
                 reject(
-                  new Error(
-                    `Local sandbox connection ${this.connectionInfo.connectionId} is not subscribed to the command relay. Reconnect the local runner or Desktop app, wait until it is ready, then try again.`,
+                  new LocalCommandRelayUnsubscribedError(
+                    this.connectionInfo.connectionId,
                   ),
                 );
                 return;

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -290,6 +290,10 @@ export class CentrifugoSandbox extends EventEmitter {
     return this.connectionInfo.name;
   }
 
+  getConnectionInfo(): Readonly<ConnectionInfo> {
+    return this.connectionInfo;
+  }
+
   getCloudProvider(): "aws-lambda-microvm" | null {
     return this.connectionInfo.cloudProvider ?? null;
   }

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -293,7 +293,15 @@ export class CentrifugoSandbox extends EventEmitter {
 
   /** Returns the immutable identity metadata used to bind recovery to this host. */
   getConnectionInfo(): Readonly<ConnectionInfo> {
-    return this.connectionInfo;
+    return {
+      ...this.connectionInfo,
+      ...(this.connectionInfo.osInfo
+        ? { osInfo: { ...this.connectionInfo.osInfo } }
+        : {}),
+      ...(this.connectionInfo.capabilities
+        ? { capabilities: { ...this.connectionInfo.capabilities } }
+        : {}),
+    };
   }
 
   getCloudProvider(): "aws-lambda-microvm" | null {

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -80,6 +80,7 @@ interface PresenceFilterResult {
   staleConnections: ConnectionInfo[];
 }
 
+/** Requires a full local host identity match before changing connection IDs. */
 export function isSameLocalMachine(
   current: ConnectionInfo,
   candidate: ConnectionInfo,
@@ -371,6 +372,7 @@ export class HybridSandboxManager implements SandboxManager {
     throw lastError;
   }
 
+  /** Recovers a pre-publish relay failure without switching physical hosts. */
   async recoverLocalConnection(
     connectionId: string,
     reason: "command_relay_unsubscribed",

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -80,6 +80,23 @@ interface PresenceFilterResult {
   staleConnections: ConnectionInfo[];
 }
 
+export function isSameLocalMachine(
+  current: ConnectionInfo,
+  candidate: ConnectionInfo,
+): boolean {
+  if (!current.osInfo || !candidate.osInfo) return false;
+
+  return (
+    current.name === candidate.name &&
+    current.isDesktop === candidate.isDesktop &&
+    current.cloudProvider === candidate.cloudProvider &&
+    current.osInfo.platform === candidate.osInfo.platform &&
+    current.osInfo.arch === candidate.osInfo.arch &&
+    current.osInfo.release === candidate.osInfo.release &&
+    current.osInfo.hostname === candidate.osInfo.hostname
+  );
+}
+
 const logStructured = (
   level: "warn" | "error",
   event: string,
@@ -352,6 +369,65 @@ export class HybridSandboxManager implements SandboxManager {
       error: lastError instanceof Error ? lastError.message : String(lastError),
     });
     throw lastError;
+  }
+
+  async recoverLocalConnection(
+    connectionId: string,
+    reason: "command_relay_unsubscribed",
+  ): Promise<{ sandbox: SandboxInstance }> {
+    if (
+      !this.sandbox ||
+      !isCentrifugoSandbox(this.sandbox) ||
+      this.sandbox.getConnectionId() !== connectionId
+    ) {
+      throw new Error(
+        "The selected local sandbox changed before it could be reconnected. Try the command again.",
+      );
+    }
+
+    const previousConnection = this.sandbox.getConnectionInfo();
+    await this.quarantineLocalConnection(connectionId, "command_unresponsive");
+    await this.resetSandbox(reason);
+
+    const replacement = (await this.listConnections())
+      .filter(
+        (connection) =>
+          connection.connectionId !== connectionId &&
+          connection.capabilities?.commands !== false &&
+          isSameLocalMachine(previousConnection, connection),
+      )
+      .sort((a, b) => (b.lastSeen ?? 0) - (a.lastSeen ?? 0))[0];
+
+    if (!replacement) {
+      logStructured("warn", "local_sandbox_same_machine_recovery_unavailable", {
+        service: this.requestId ? "agent-long" : "chat-handler",
+        request_id: this.requestId ?? process.env.VERCEL_REQUEST_ID ?? null,
+        user_id: this.userID,
+        connection_id: connectionId,
+        reason,
+      });
+      throw new Error(
+        "The selected local sandbox stopped responding. Reconnect it in Remote Control, then try again.",
+      );
+    }
+
+    await this.useCentrifugoConnection(replacement);
+    this.requiredConnectionIdAfterQuarantine = null;
+    if (this.sandboxPreference !== "desktop") {
+      this.sandboxPreference = replacement.connectionId;
+    }
+    this.resetHealthFailures();
+
+    logStructured("warn", "local_sandbox_same_machine_recovered", {
+      service: this.requestId ? "agent-long" : "chat-handler",
+      request_id: this.requestId ?? process.env.VERCEL_REQUEST_ID ?? null,
+      user_id: this.userID,
+      stale_connection_id: connectionId,
+      replacement_connection_id: replacement.connectionId,
+      reason,
+    });
+
+    return { sandbox: this.sandbox! };
   }
 
   /**

--- a/lib/ai/tools/utils/local-sandbox-errors.ts
+++ b/lib/ai/tools/utils/local-sandbox-errors.ts
@@ -20,4 +20,6 @@ export const isLocalCommandRelayUnsubscribedError = (
   typeof error === "object" &&
   error !== null &&
   "code" in error &&
-  error.code === LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE;
+  error.code === LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE &&
+  "connectionId" in error &&
+  typeof error.connectionId === "string";

--- a/lib/ai/tools/utils/local-sandbox-errors.ts
+++ b/lib/ai/tools/utils/local-sandbox-errors.ts
@@ -1,0 +1,23 @@
+export const LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE =
+  "LOCAL_COMMAND_RELAY_UNSUBSCRIBED" as const;
+
+/** Signals that relay presence rejected a command before it was published. */
+export class LocalCommandRelayUnsubscribedError extends Error {
+  readonly code = LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE;
+
+  constructor(readonly connectionId: string) {
+    super(
+      `Local sandbox connection ${connectionId} is not subscribed to the command relay. Reconnect the local runner or Desktop app, wait until it is ready, then try again.`,
+    );
+    this.name = "LocalCommandRelayUnsubscribedError";
+  }
+}
+
+/** Classifies the stable relay error across module or serialization boundaries. */
+export const isLocalCommandRelayUnsubscribedError = (
+  error: unknown,
+): error is LocalCommandRelayUnsubscribedError =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === LOCAL_COMMAND_RELAY_UNSUBSCRIBED_ERROR_CODE;

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -34,6 +34,11 @@ export interface SandboxManager {
     connectionId: string,
     reason: "command_unresponsive",
   ): Promise<void>;
+  /** Replace a stale relay connection with a live successor for the same machine. */
+  recoverLocalConnection?(
+    connectionId: string,
+    reason: "command_relay_unsubscribed",
+  ): Promise<{ sandbox: AnySandbox }>;
   getSandboxType(toolName: string): SandboxType | undefined;
   getSandboxInfo(): SandboxInfo | null;
   // Optional: only HybridSandboxManager implements this


### PR DESCRIPTION
## Summary

- classify the local command-relay “not subscribed” error as a pre-publish connection failure instead of backing off against the same stale connection
- quarantine the stale connection and retry the command once on the newest live successor only when it matches the selected machine’s connection type and full host/OS identity
- keep recovery fail-closed when only another machine or Cloud is available
- add structured recovery lifecycle logs without command contents
- preserve exact sandbox approval binding when the connection ID changes

## Root cause

Restarting `@hackerai/local` creates a new connection UUID. A task can remain pinned to the previous UUID while the selector still shows the same hostname. The relay presence check correctly rejects that stale UUID before publishing the command, but `run_terminal_cmd` previously retried the same dead relay and never retired it or selected the healthy successor.

## Safety

The retry is bounded to one attempt and only happens after the presence check proves the command was not published. A replacement must match name, Desktop/remote type, cloud-provider classification, platform, architecture, OS release, and hostname. Otherwise the request fails closed and never switches to a different computer or Cloud. Existing approvals remain bound to the exact connection ID and cannot be reused after recovery.

## Validation

- `corepack pnpm exec jest --runInBand` — 400 suites, 4,002 tests passed
- `corepack pnpm typecheck`
- scoped ESLint on all changed TypeScript files
- `git diff --check`

## Manual verification

1. Start a local runner, select it, then stop it without a clean disconnect.
2. Start the runner again on the same machine so it receives a new connection ID.
3. Submit a non-interactive terminal command. The stale row should be quarantined and the command should run once on the same-machine successor.
4. Repeat with only a different host connected. The command must fail closed and must not run on that host or Cloud.

No visual UI surface changed, so automated validation is sufficient for visual QA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when local command connections become unavailable.
  - Commands can retry once using a replacement sandbox on the same machine.
  - Prevented approved commands from running on an unexpected replacement host.
  - Added safeguards to stop repeated retries on the same failed connection.
  - Preserved connection state and host validation during recovery.

- **Tests**
  - Added coverage for connection recovery, host validation, retry behavior, error handling, and approval invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->