### PR TITLE
Add scoped PM user research gateway

### DIFF
--- a/.agents/skills/hackerai-user-research/SKILL.md
+++ b/.agents/skills/hackerai-user-research/SKILL.md
@@ -7,7 +7,7 @@ description: Run privacy-safe HackerAI customer research from a Linear question 
 
 Turn a research question and 3-20 internal user IDs into restricted per-user
 profiles and an aggregated cohort report. The deployed task samples messages,
-redacts sensitive data, and uses Grok 4.6 with reasoning disabled.
+redacts sensitive data, and uses DeepSeek V4 Flash with reasoning disabled.
 
 Read [references/privacy-policy.md](references/privacy-policy.md) and
 [references/pm-runbook.md](references/pm-runbook.md) before running the task.
@@ -27,12 +27,16 @@ Read [references/privacy-policy.md](references/privacy-policy.md) and
    internal/test/fraud accounts and deduplicate payer or organization
    relationships before triggering analysis. Stop unless 3-20 unique internal
    user IDs remain after filtering.
-4. Discover the Trigger task `pm-user-research` and inspect its current schema.
-   Trigger it in the intended environment with the Linear issue ID, exact
-   question, descriptive cohort label, 3-20 unique user IDs, PM name/handle, and
-   optional chat limit. Never call the worker task directly.
-5. Wait for the run to complete. Keep the returned `analysisId`; it is the audit
-   and lookup key for the restricted Convex records.
+4. Create a mode-600 temporary JSON request outside the repository using the
+   gateway payload below. Run
+   `node .agents/skills/hackerai-user-research/scripts/run-research.mjs --payload <path>`.
+   The runner requires `HACKERAI_PM_USER_RESEARCH_KEY` in the PM's Codex
+   environment and always calls the production HackerAI gateway. Never print
+   the key, put it in the request, or use Trigger
+   dashboard access. Remove the temporary request after the command reads it.
+5. Wait for the runner to return a completed aggregate. Keep the returned
+   `analysisId`; it is the audit and lookup key for the restricted Convex
+   records. Do not substitute direct Trigger access if the gateway fails.
 6. Present only the aggregate answer, evidence coverage, supported user types,
    avatars, primary/secondary target, confidence, unknowns, and experiments.
    Detailed pseudonym-level profiles remain in restricted Convex records and are
@@ -41,7 +45,7 @@ Read [references/privacy-policy.md](references/privacy-policy.md) and
    unknowns, and experiments. Never copy cohort IDs, pseudonym-level profiles,
    raw evidence, direct identifiers, or per-user findings or targeting decisions.
 
-## Trigger payload
+## Gateway payload
 
 Use the current task schema as the authority. A typical HAC-65 run is:
 
@@ -51,7 +55,6 @@ Use the current task schema as the authority. A typical HAC-65 run is:
   "question": "What kinds of users are our highest-spending customers, what recurring work do they use HackerAI for, and why do they pay?",
   "cohortLabel": "Top 10 users by reconciled lifetime net paid spend",
   "userIds": ["internal-user-id-1", "internal-user-id-2", "internal-user-id-3"],
-  "requestedBy": "PM name or handle",
   "maxChatsPerUser": 12
 }
 ```
@@ -76,6 +79,7 @@ payload. `userIds` must be the internal Convex/WorkOS user IDs.
 
 ## Result boundary
 
-The Trigger result contains only aggregate internal research. Detailed profiles
-remain restricted and deletion-aware in Convex. The aggregate report is the only
-part that may be copied to Linear, under the owning issue's privacy rules.
+The gateway returns only aggregate internal research and cannot read other
+Trigger tasks or runs. Detailed profiles remain restricted and deletion-aware
+in Convex. The aggregate report is the only part that may be copied to Linear,
+under the owning issue's privacy rules.

--- a/.agents/skills/hackerai-user-research/references/pm-runbook.md
+++ b/.agents/skills/hackerai-user-research/references/pm-runbook.md
@@ -18,11 +18,20 @@ Ask Codex:
 > cohort, run the analysis, wait for it, and give me the aggregate findings with
 > coverage, confidence, unknowns, and recommended experiments.
 
-Codex should use Trigger's task discovery/schema tools, trigger
-`pm-user-research` in production, then wait for completion. The task runs one
+Codex should use the skill's `scripts/run-research.mjs` gateway runner and wait
+for completion. The PM's Codex environment must contain the scoped
+`HACKERAI_PM_USER_RESEARCH_KEY`; it must not contain Trigger or Convex service
+keys. The runner always calls the production gateway at
+`https://hackerai.co/api/internal/user-research`; no Preview URL or Preview PM
+gateway key is required. The gateway can start and read only
+`pm-user-research`, and it returns only the aggregate result. The task runs one
 parallel worker per user and a final cohort synthesis. Both calls use
-`x-ai/grok-4.6` with OpenRouter reasoning explicitly disabled and zero-data-
-retention routing required.
+`deepseek/deepseek-v4-flash-0731` with OpenRouter reasoning explicitly disabled
+and zero-data-retention routing required.
+
+The request JSON is temporary restricted data because it contains internal user
+IDs. Create it outside the repository with mode 600, pass its path to the
+runner, then remove it. Never commit it or copy it into Linear.
 
 ## 3. Interpret the result
 
@@ -33,6 +42,7 @@ hypotheses until a separate experiment validates them.
 
 ## 4. Share safely
 
-Keep the complete Trigger result and Convex records restricted. A Linear update
-may include only the aggregate answer, avatars, coverage, confidence, unknowns,
-and experiments. Do not include the cohort IDs or pseudonym-level profiles.
+Keep the gateway key, request payload, Trigger records, and Convex records
+restricted. A Linear update may include only the aggregate answer, avatars,
+coverage, confidence, unknowns, and experiments. Do not include the cohort IDs
+or pseudonym-level profiles.

--- a/.agents/skills/hackerai-user-research/references/privacy-policy.md
+++ b/.agents/skills/hackerai-user-research/references/privacy-policy.md
@@ -30,7 +30,8 @@ The owning Linear issue must define the cohort and intended output.
 
 Raw message excerpts exist only in the analysis worker's memory and model
 request. Model calls require an OpenRouter zero-data-retention route and fail
-closed if no such Grok 4.6 endpoint is available. Convex stores the run audit,
-pseudonymized structured profiles, and the aggregate report. Account deletion
-removes that user's stored profile and run-membership linkage; runs and reports
-are retained only as cohort-level outputs from cohorts of at least three.
+closed if no eligible DeepSeek V4 Flash endpoint is available. Convex stores the
+run audit, pseudonymized structured profiles, and the aggregate report. Account
+deletion removes that user's stored profile and run-membership linkage; runs and
+reports are retained only as cohort-level outputs from cohorts of at least
+three.

--- a/.agents/skills/hackerai-user-research/scripts/run-research.mjs
+++ b/.agents/skills/hackerai-user-research/scripts/run-research.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { readFile, stat } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+
+const ENDPOINT = "https://hackerai.co/api/internal/user-research";
+const POLL_INTERVAL_MS = 5_000;
+const MAX_WAIT_MS = 35 * 60 * 1_000;
+const REQUEST_TIMEOUT_MS = 20_000;
+const MAX_PAYLOAD_BYTES = 32 * 1024;
+
+function usage() {
+  console.log(`Usage: node run-research.mjs --payload /secure/path/request.json [--no-wait]
+
+Required environment:
+  HACKERAI_PM_USER_RESEARCH_KEY  Scoped PM research gateway key`);
+}
+
+function parseArgs(argv) {
+  const args = { wait: true, payloadPath: undefined };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--help" || value === "-h") return { help: true };
+    if (value === "--no-wait") {
+      args.wait = false;
+      continue;
+    }
+    if (value === "--payload") {
+      args.payloadPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${value}`);
+  }
+  if (!args.payloadPath) throw new Error("--payload is required");
+  return args;
+}
+
+async function gatewayRequest(url, key, init = {}) {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${key}`,
+      accept: "application/json",
+      ...init.headers,
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const code = typeof body.error === "string" ? body.error : "request_failed";
+    throw new Error(`Research gateway returned ${response.status}: ${code}`);
+  }
+  return body;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    usage();
+    return;
+  }
+
+  const key = process.env.HACKERAI_PM_USER_RESEARCH_KEY?.trim();
+  if (!key) throw new Error("HACKERAI_PM_USER_RESEARCH_KEY is required");
+
+  const payloadStats = await stat(args.payloadPath);
+  if (!payloadStats.isFile()) throw new Error("Research request must be a file");
+  if ((payloadStats.mode & 0o077) !== 0) {
+    throw new Error("Research request must not be readable by group or others");
+  }
+  const payloadBuffer = await readFile(args.payloadPath);
+  if (payloadBuffer.byteLength > MAX_PAYLOAD_BYTES) {
+    throw new Error("Research request is larger than 32 KiB");
+  }
+  const payload = JSON.parse(payloadBuffer.toString("utf8"));
+  const gatewayUrl = ENDPOINT;
+  const started = await gatewayRequest(gatewayUrl, key, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "idempotency-key": randomUUID(),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (typeof started.runId !== "string") {
+    throw new Error("Research gateway returned an invalid run handle");
+  }
+  if (!args.wait) {
+    console.log(JSON.stringify(started, null, 2));
+    return;
+  }
+
+  console.error(`Research run ${started.runId} queued; waiting for aggregate result.`);
+  const deadline = Date.now() + MAX_WAIT_MS;
+  let polls = 0;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const statusUrl = new URL(gatewayUrl);
+    statusUrl.searchParams.set("runId", started.runId);
+    const status = await gatewayRequest(statusUrl, key);
+    if (status.status === "completed") {
+      console.log(JSON.stringify(status.result, null, 2));
+      return;
+    }
+    if (status.status === "failed") {
+      throw new Error("Research run failed without a shareable aggregate report");
+    }
+    polls += 1;
+    if (polls % 3 === 0) {
+      console.error(`Research run ${started.runId} is still running.`);
+    }
+  }
+  throw new Error("Timed out waiting for the research aggregate after 35 minutes");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : "Research runner failed");
+  process.exitCode = 1;
+});

--- a/.env.local.example
+++ b/.env.local.example
@@ -169,3 +169,10 @@ CENTRIFUGO_WS_URL=ws://localhost:8000/connection/websocket
 # Task-side env vars live in the Trigger.dev dashboard, not here.
 TRIGGER_PROJECT_ID=proj_
 TRIGGER_SECRET_KEY=tr_dev_
+
+# Production-only narrow PM user-research gateway. Store only the SHA-256 digest
+# of the PM's scoped runner key on the server; the PM stores the plaintext key
+# in its Codex environment. Never reuse a Trigger or Convex credential here.
+# Generate a key: openssl rand -hex 32
+# Hash it: printf '%s' "$PM_RESEARCH_KEY" | shasum -a 256 | awk '{print $1}'
+# PM_USER_RESEARCH_RUNNER_KEY_SHA256=

--- a/.env.local.example
+++ b/.env.local.example
@@ -173,6 +173,8 @@ TRIGGER_SECRET_KEY=tr_dev_
 # Production-only narrow PM user-research gateway. Store only the SHA-256 digest
 # of the PM's scoped runner key on the server; the PM stores the plaintext key
 # in its Codex environment. Never reuse a Trigger or Convex credential here.
-# Generate a key: openssl rand -hex 32
-# Hash it: printf '%s' "$PM_RESEARCH_KEY" | shasum -a 256 | awk '{print $1}'
+# Generate one key: export HACKERAI_PM_USER_RESEARCH_KEY="$(openssl rand -hex 32)"
+# Hash that exact key for Vercel:
+# printf '%s' "$HACKERAI_PM_USER_RESEARCH_KEY" | shasum -a 256 | awk '{print $1}'
+# Store the unchanged plaintext only in the PM's Codex environment.
 # PM_USER_RESEARCH_RUNNER_KEY_SHA256=

--- a/app/api/internal/user-research/__tests__/route.test.ts
+++ b/app/api/internal/user-research/__tests__/route.test.ts
@@ -100,16 +100,25 @@ function request({
   token = runnerKey,
   body = validPayload,
   idempotencyKey = "research-request-123",
+  contentLength,
   runId,
 }: {
   token?: string | null;
   body?: unknown;
   idempotencyKey?: string | null;
+  contentLength?: string | null;
   runId?: string;
 } = {}): NextRequest {
   const headers = new Headers({ "x-request-id": "request-123" });
   if (token) headers.set("authorization", `Bearer ${token}`);
   if (idempotencyKey) headers.set("idempotency-key", idempotencyKey);
+  if (contentLength !== null) {
+    headers.set(
+      "content-length",
+      contentLength ??
+        String(new TextEncoder().encode(JSON.stringify(body)).length),
+    );
+  }
   const nextUrl = new URL("https://hackerai.co/api/internal/user-research");
   if (runId) nextUrl.searchParams.set("runId", runId);
   return {
@@ -192,6 +201,26 @@ describe("PM user research gateway", () => {
       request({ body: { ...validPayload, userIds: ["user-1", "user-2"] } }),
     );
     expect(invalidCohort.status).toBe(400);
+    expect(triggerTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing, malformed, and oversized content lengths", async () => {
+    const { POST } = await import("../route");
+
+    const missing = await POST(request({ contentLength: null }));
+    expect(missing.status).toBe(411);
+    await expect(missing.json()).resolves.toEqual({
+      error: "content_length_required",
+    });
+
+    const malformed = await POST(request({ contentLength: "not-a-number" }));
+    expect(malformed.status).toBe(411);
+
+    const oversized = await POST(request({ contentLength: String(33 * 1024) }));
+    expect(oversized.status).toBe(413);
+    await expect(oversized.json()).resolves.toEqual({
+      error: "payload_too_large",
+    });
     expect(triggerTask).not.toHaveBeenCalled();
   });
 

--- a/app/api/internal/user-research/__tests__/route.test.ts
+++ b/app/api/internal/user-research/__tests__/route.test.ts
@@ -1,0 +1,259 @@
+import { createHash } from "node:crypto";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+jest.mock("next/server", () => ({
+  NextResponse: class MockNextResponse {
+    status: number;
+    headers: Headers;
+    private body: unknown;
+
+    constructor(body?: unknown, init?: ResponseInit) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+      this.headers = new Headers(init?.headers);
+    }
+
+    static json(body: unknown, init?: ResponseInit) {
+      return new MockNextResponse(body, init);
+    }
+
+    async json() {
+      return this.body;
+    }
+  },
+}));
+
+const triggerTask = jest.fn<any>();
+const retrieveRun = jest.fn<any>();
+jest.mock("@trigger.dev/sdk", () => ({
+  tasks: { trigger: (...args: unknown[]) => triggerTask(...args) },
+  runs: { retrieve: (...args: unknown[]) => retrieveRun(...args) },
+}));
+
+const runnerKey = "pm-runner-test-secret";
+const originalHash = process.env.PM_USER_RESEARCH_RUNNER_KEY_SHA256;
+
+const validPayload = {
+  linearIssueId: "HAC-65",
+  question: "What recurring work creates the most customer value?",
+  cohortLabel: "Approved production research cohort",
+  userIds: ["user-1", "user-2", "user-3"],
+  maxChatsPerUser: 12,
+};
+
+const validResult = {
+  analysisId: "c6e714d8-1da5-4ef4-be1c-39363a0c83fc",
+  status: "completed",
+  failedProfiles: 0,
+  usersAnalyzed: 3,
+  report: {
+    answerToQuestion: "Autonomous workflows create recurring value.",
+    executiveSummary: "The cohort values autonomy and execution.",
+    avatars: [
+      {
+        name: "Independent security practitioner",
+        definition: "A solo practitioner using assisted security workflows.",
+        mainJob: "Complete bounded security investigations.",
+        supportingUserTypes: ["solo_pentester"],
+        pains: ["Manual multi-step work"],
+        desiredOutcomes: ["Faster validated results"],
+        reasonsToPay: ["Execution and continuity"],
+        productFeatures: ["Agent mode"],
+        objectionsAndTrustNeeds: ["Clear sandbox boundaries"],
+        acquisitionHypotheses: ["Test practitioner-focused education"],
+        messageHypotheses: ["Test faster workflow completion"],
+        evidenceUserCount: 3,
+        confidence: "high",
+      },
+    ],
+    primaryAvatar: "Independent security practitioner",
+    secondaryAvatars: [],
+    crossCohortPatterns: ["Multi-step Agent usage"],
+    unknowns: ["Profession and authorization remain unknown"],
+    followUpExperiments: [
+      {
+        hypothesis: "Verified practitioners value faster activation.",
+        test: "Run an approved verified-practitioner cohort.",
+        successMetric: "Activation and repeat Agent usage",
+      },
+    ],
+    privacyNote: "Aggregate findings only.",
+    coverage: {
+      usersRequested: 3,
+      usersAnalyzed: 3,
+      profilesFailed: 0,
+      chatsReviewed: 36,
+      messagesReviewed: 622,
+    },
+  },
+};
+
+function request({
+  token = runnerKey,
+  body = validPayload,
+  idempotencyKey = "research-request-123",
+  runId,
+}: {
+  token?: string | null;
+  body?: unknown;
+  idempotencyKey?: string | null;
+  runId?: string;
+} = {}): NextRequest {
+  const headers = new Headers({ "x-request-id": "request-123" });
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  if (idempotencyKey) headers.set("idempotency-key", idempotencyKey);
+  const nextUrl = new URL("https://hackerai.co/api/internal/user-research");
+  if (runId) nextUrl.searchParams.set("runId", runId);
+  return {
+    headers,
+    nextUrl,
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+describe("PM user research gateway", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PM_USER_RESEARCH_RUNNER_KEY_SHA256 = createHash("sha256")
+      .update(runnerKey)
+      .digest("hex");
+    triggerTask.mockResolvedValue({ id: "run_gateway123" });
+  });
+
+  afterAll(() => {
+    if (originalHash === undefined) {
+      delete process.env.PM_USER_RESEARCH_RUNNER_KEY_SHA256;
+    } else {
+      process.env.PM_USER_RESEARCH_RUNNER_KEY_SHA256 = originalHash;
+    }
+  });
+
+  it("starts only the PM research task with server-owned requester identity", async () => {
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(body).toEqual({
+      runId: "run_gateway123",
+      status: "queued",
+      statusPath: "/api/internal/user-research?runId=run_gateway123",
+    });
+    expect(triggerTask).toHaveBeenCalledWith(
+      "pm-user-research",
+      { ...validPayload, requestedBy: "pm-gateway" },
+      {
+        idempotencyKey: "pm-research:research-request-123",
+        idempotencyKeyTTL: "24h",
+        tags: ["pm-user-research-gateway"],
+      },
+    );
+    expect(JSON.stringify(body)).not.toContain("user-1");
+    expect(infoSpy).toHaveBeenCalledWith(expect.not.stringContaining("user-1"));
+    infoSpy.mockRestore();
+  });
+
+  it("rejects an invalid credential before parsing or triggering", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const invalid = request({ token: "wrong-secret" });
+    invalid.json = jest.fn() as never;
+    const { POST } = await import("../route");
+
+    const response = await POST(invalid);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+    expect(invalid.json).not.toHaveBeenCalled();
+    expect(triggerTask).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.not.stringContaining("wrong-secret"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("rejects invalid cohorts and missing idempotency keys", async () => {
+    const { POST } = await import("../route");
+
+    const missingKey = await POST(request({ idempotencyKey: null }));
+    expect(missingKey.status).toBe(400);
+
+    const invalidCohort = await POST(
+      request({ body: { ...validPayload, userIds: ["user-1", "user-2"] } }),
+    );
+    expect(invalidCohort.status).toBe(400);
+    expect(triggerTask).not.toHaveBeenCalled();
+  });
+
+  it("returns only the validated aggregate result for a gateway run", async () => {
+    retrieveRun.mockResolvedValue({
+      taskIdentifier: "pm-user-research",
+      tags: ["pm-user-research-gateway"],
+      isSuccess: true,
+      isFailed: false,
+      isCancelled: false,
+      output: validResult,
+    });
+    const { GET } = await import("../route");
+
+    const response = await GET(request({ runId: "run_gateway123" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      runId: "run_gateway123",
+      status: "completed",
+      result: validResult,
+    });
+  });
+
+  it("does not expose unrelated Trigger runs", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    retrieveRun.mockResolvedValue({
+      taskIdentifier: "agent-long",
+      tags: [],
+      isSuccess: true,
+      output: { private: "agent output" },
+    });
+    const { GET } = await import("../route");
+
+    const response = await GET(request({ runId: "run_agent123" }));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "run_not_found" });
+    expect(JSON.stringify(await response.json())).not.toContain("agent output");
+    warnSpy.mockRestore();
+  });
+
+  it("returns a generic failure without provider diagnostics", async () => {
+    retrieveRun.mockResolvedValue({
+      taskIdentifier: "pm-user-research",
+      tags: ["pm-user-research-gateway"],
+      isSuccess: false,
+      isFailed: true,
+      isCancelled: false,
+      error: { message: "provider secret diagnostic" },
+    });
+    const { GET } = await import("../route");
+
+    const response = await GET(request({ runId: "run_gateway123" }));
+    const body = await response.json();
+
+    expect(body).toEqual({
+      runId: "run_gateway123",
+      status: "failed",
+      error: "research_run_failed",
+    });
+    expect(JSON.stringify(body)).not.toContain("provider secret diagnostic");
+  });
+});

--- a/app/api/internal/user-research/route.ts
+++ b/app/api/internal/user-research/route.ts
@@ -94,8 +94,12 @@ export async function POST(request: NextRequest) {
   const authResponse = authenticate(request);
   if (authResponse) return authResponse;
 
-  const contentLength = Number(request.headers.get("content-length") ?? "0");
-  if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+  const contentLengthHeader = request.headers.get("content-length");
+  if (!contentLengthHeader || !/^\d+$/.test(contentLengthHeader)) {
+    return json({ error: "content_length_required" }, { status: 411 });
+  }
+  const contentLength = Number(contentLengthHeader);
+  if (contentLength > MAX_REQUEST_BYTES) {
     return json({ error: "payload_too_large" }, { status: 413 });
   }
 

--- a/app/api/internal/user-research/route.ts
+++ b/app/api/internal/user-research/route.ts
@@ -1,0 +1,209 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { runs, tasks } from "@trigger.dev/sdk";
+import { NextResponse, type NextRequest } from "next/server";
+import type { pmUserResearch } from "@/trigger/user-research";
+import {
+  pmUserResearchGatewayRequestSchema,
+  pmUserResearchResultSchema,
+} from "@/lib/research/user-research";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const maxDuration = 15;
+export const runtime = "nodejs";
+
+const GATEWAY_TAG = "pm-user-research-gateway";
+const GATEWAY_REQUESTER = "pm-gateway";
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._:-]{8,128}$/;
+const RUN_ID_PATTERN = /^run_[A-Za-z0-9]+$/;
+const MAX_REQUEST_BYTES = 32 * 1024;
+const NO_STORE_HEADERS = { "Cache-Control": "private, no-store" } as const;
+
+function json(body: Record<string, unknown>, init?: ResponseInit) {
+  return NextResponse.json(body, {
+    ...init,
+    headers: { ...NO_STORE_HEADERS, ...init?.headers },
+  });
+}
+
+function requestId(request: NextRequest): string {
+  return (
+    request.headers.get("x-request-id") ??
+    request.headers.get("x-vercel-id") ??
+    crypto.randomUUID()
+  ).slice(0, 128);
+}
+
+function audit(
+  request: NextRequest,
+  level: "info" | "warn" | "error",
+  event: string,
+  fields: Record<string, unknown> = {},
+) {
+  const entry = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    request_id: requestId(request),
+    service: "hackerai-web",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+    ...fields,
+  });
+  if (level === "error") console.error(entry);
+  else if (level === "warn") console.warn(entry);
+  else console.info(entry);
+}
+
+function getBearerToken(request: NextRequest): string | null {
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) return null;
+  const token = authorization.slice("Bearer ".length).trim();
+  return token || null;
+}
+
+function isAuthorized(
+  request: NextRequest,
+): "authorized" | "unauthorized" | "misconfigured" {
+  const expectedHash = process.env.PM_USER_RESEARCH_RUNNER_KEY_SHA256?.trim();
+  if (!expectedHash || !/^[a-f0-9]{64}$/i.test(expectedHash)) {
+    return "misconfigured";
+  }
+
+  const token = getBearerToken(request);
+  if (!token) return "unauthorized";
+
+  const actual = createHash("sha256").update(token).digest();
+  const expected = Buffer.from(expectedHash, "hex");
+  return timingSafeEqual(actual, expected) ? "authorized" : "unauthorized";
+}
+
+function authenticate(request: NextRequest): NextResponse | null {
+  const result = isAuthorized(request);
+  if (result === "authorized") return null;
+
+  if (result === "misconfigured") {
+    audit(request, "error", "pm_user_research_gateway_misconfigured");
+    return json({ error: "research_gateway_unavailable" }, { status: 503 });
+  }
+
+  audit(request, "warn", "pm_user_research_gateway_auth_rejected");
+  return json({ error: "unauthorized" }, { status: 401 });
+}
+
+export async function POST(request: NextRequest) {
+  const authResponse = authenticate(request);
+  if (authResponse) return authResponse;
+
+  const contentLength = Number(request.headers.get("content-length") ?? "0");
+  if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+    return json({ error: "payload_too_large" }, { status: 413 });
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key")?.trim();
+  if (!idempotencyKey || !IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey)) {
+    return json({ error: "invalid_idempotency_key" }, { status: 400 });
+  }
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = await request.json();
+  } catch {
+    return json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const parsed = pmUserResearchGatewayRequestSchema.safeParse(rawPayload);
+  if (!parsed.success) {
+    return json(
+      {
+        error: "invalid_payload",
+        issues: parsed.error.issues.map(({ code, message, path }) => ({
+          code,
+          message,
+          path,
+        })),
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const handle = await tasks.trigger<typeof pmUserResearch>(
+      "pm-user-research",
+      { ...parsed.data, requestedBy: GATEWAY_REQUESTER },
+      {
+        idempotencyKey: `pm-research:${idempotencyKey}`,
+        idempotencyKeyTTL: "24h",
+        tags: [GATEWAY_TAG],
+      },
+    );
+
+    audit(request, "info", "pm_user_research_run_started", {
+      run_id: handle.id,
+      linear_issue_id: parsed.data.linearIssueId,
+      cohort_size: parsed.data.userIds.length,
+      requested_by: GATEWAY_REQUESTER,
+    });
+
+    return json(
+      {
+        runId: handle.id,
+        status: "queued",
+        statusPath: `/api/internal/user-research?runId=${encodeURIComponent(handle.id)}`,
+      },
+      { status: 202 },
+    );
+  } catch (error) {
+    audit(request, "error", "pm_user_research_run_start_failed", {
+      linear_issue_id: parsed.data.linearIssueId,
+      cohort_size: parsed.data.userIds.length,
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return json({ error: "research_run_start_failed" }, { status: 502 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const authResponse = authenticate(request);
+  if (authResponse) return authResponse;
+
+  const runId = request.nextUrl.searchParams.get("runId")?.trim();
+  if (!runId || !RUN_ID_PATTERN.test(runId)) {
+    return json({ error: "invalid_run_id" }, { status: 400 });
+  }
+
+  try {
+    const run = await runs.retrieve<typeof pmUserResearch>(runId);
+    if (
+      run.taskIdentifier !== "pm-user-research" ||
+      !run.tags.includes(GATEWAY_TAG)
+    ) {
+      audit(request, "warn", "pm_user_research_run_access_rejected", {
+        run_id: runId,
+      });
+      return json({ error: "run_not_found" }, { status: 404 });
+    }
+
+    if (run.isSuccess) {
+      const output = pmUserResearchResultSchema.safeParse(run.output);
+      if (!output.success) {
+        audit(request, "error", "pm_user_research_run_output_invalid", {
+          run_id: runId,
+        });
+        return json({ error: "research_run_output_invalid" }, { status: 502 });
+      }
+      return json({ runId, status: "completed", result: output.data });
+    }
+
+    if (run.isFailed || run.isCancelled) {
+      return json({ runId, status: "failed", error: "research_run_failed" });
+    }
+
+    return json({ runId, status: "running" });
+  } catch (error) {
+    audit(request, "error", "pm_user_research_run_status_failed", {
+      run_id: runId,
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return json({ error: "research_run_status_failed" }, { status: 502 });
+  }
+}

--- a/docs/internal/user-research.md
+++ b/docs/internal/user-research.md
@@ -17,9 +17,9 @@ called through the repo-owned Codex skill `$hackerai-user-research`.
 6. Stores the audit record, structured pseudonymized profiles, aggregate report,
    evidence coverage, token usage, and provider cost in Convex.
 
-Both stages use `x-ai/grok-4.6` through the existing OpenRouter provider with
-reasoning explicitly disabled and zero-data-retention routing required. The task
-fails closed if no ZDR-capable endpoint is available.
+Both stages use `deepseek/deepseek-v4-flash-0731` through the existing OpenRouter
+provider with reasoning explicitly disabled and zero-data-retention routing
+required. The task fails closed if no ZDR-capable endpoint is available.
 
 ## Retention and deletion
 
@@ -53,9 +53,19 @@ matching Convex deployment, but use independent values for Preview and
 Production. Deploy the Trigger project after the application/Convex schema
 reaches the target environment.
 
+The Vercel Production environment also exposes a narrow PM gateway at
+`/api/internal/user-research`. Configure only its Production
+`PM_USER_RESEARCH_RUNNER_KEY_SHA256` with the SHA-256 digest of the scoped key
+held by the PM. The gateway records `pm-gateway` as the requester, uses Vercel's
+existing `TRIGGER_SECRET_KEY` server-side, can start only `pm-user-research`, and
+returns status/output only for runs carrying its gateway tag. It never returns
+task payloads, other runs, worker profiles, or provider diagnostics. The PM
+runner uses the fixed production URL, so Preview needs no PM gateway URL or key.
+
 ## PM invocation
 
 Invoke `$hackerai-user-research` in Codex with the Linear issue. The skill uses
-PostHog for cohort selection and Trigger MCP to discover, trigger, and wait for
+PostHog for cohort selection and the scoped gateway runner to start and wait for
 `pm-user-research`. PostHog's Stripe sync can be the normal spend source; direct
-Stripe access is only necessary for reconciliation gaps.
+Stripe access is only necessary for reconciliation gaps. Do not add PMs to the
+Trigger organization or give them Trigger/Convex credentials.

--- a/lib/research/__tests__/user-research.test.ts
+++ b/lib/research/__tests__/user-research.test.ts
@@ -1,6 +1,8 @@
 import {
+  assertResearchPromptIsSafe,
   buildCohortPrompt,
   buildUserProfilePrompt,
+  containsUnredactedResearchSecret,
   normalizeCohortSynthesis,
   normalizeResearchUserProfile,
   sanitizeResearchText,
@@ -71,6 +73,74 @@ nmap -sV target.example.com`);
     expect(sanitizeResearchText("Open customer-report.pdf")).toBe(
       "Open [file omitted]",
     );
+  });
+
+  it("redacts standalone provider credentials and private keys", () => {
+    const openAiKey = `sk-proj-${"a".repeat(48)}`;
+    const githubToken = `ghp_${"b".repeat(36)}`;
+    const awsAccessKey = `AKIA${"C".repeat(16)}`;
+    const privateKey = `-----BEGIN PRIVATE KEY-----
+${"QUJD".repeat(16)}
+-----END PRIVATE KEY-----`;
+    const sanitized = sanitizeResearchText(
+      `Tokens: ${openAiKey} ${githubToken} ${awsAccessKey}\n${privateKey}`,
+    );
+
+    expect(sanitized).not.toContain(openAiKey);
+    expect(sanitized).not.toContain(githubToken);
+    expect(sanitized).not.toContain(awsAccessKey);
+    expect(sanitized).not.toContain("BEGIN PRIVATE KEY");
+    expect(sanitized.match(/\[secret omitted\]/g)).toHaveLength(4);
+
+    const assigned = sanitizeResearchText(
+      "OPENAI_API_KEY=unredacted-value\nAuthorization: Bearer bearer-value",
+    );
+    expect(assigned).not.toContain("unredacted-value");
+    expect(assigned).not.toContain("bearer-value");
+    expect(containsUnredactedResearchSecret(assigned)).toBe(false);
+  });
+
+  it("fails closed when recognizable secret material reaches a model prompt", () => {
+    const leakedSecrets = [
+      `sk-proj-${"a".repeat(48)}`,
+      `github_pat_${"d".repeat(40)}`,
+      `AKIA${"C".repeat(16)}`,
+      "-----BEGIN RSA PRIVATE KEY-----",
+      "OPENAI_API_KEY=unredacted-value",
+      "Authorization: Bearer unredacted-value",
+      "eyJheader.payload.signature",
+    ];
+
+    for (const leakedSecret of leakedSecrets) {
+      expect(containsUnredactedResearchSecret(leakedSecret)).toBe(true);
+      expect(() =>
+        assertResearchPromptIsSafe(`Evidence: ${leakedSecret}`),
+      ).toThrow("Research prompt contains unredacted secret material");
+    }
+    expect(() =>
+      assertResearchPromptIsSafe("Evidence: recurring Agent workflows"),
+    ).not.toThrow();
+  });
+
+  it("removes standalone secrets before constructing the model prompt", () => {
+    const leakedToken = `sk-svcacct-${"e".repeat(48)}`;
+    const prompt = buildUserProfilePrompt({
+      question: "What recurring workflows appear?",
+      pseudonym: "U01",
+      chats: [
+        {
+          chatId: "never-included",
+          updatedAt: Date.UTC(2026, 7, 1),
+          mode: "agent",
+          truncated: false,
+          messages: [{ role: "user", text: `Use ${leakedToken}` }],
+        },
+      ],
+    });
+
+    expect(prompt).not.toContain(leakedToken);
+    expect(prompt).toContain("[secret omitted]");
+    expect(() => assertResearchPromptIsSafe(prompt)).not.toThrow();
   });
 
   it("redacts evidence before constructing the model prompt", () => {

--- a/lib/research/user-research.ts
+++ b/lib/research/user-research.ts
@@ -192,9 +192,17 @@ export type ResearchChatEvidence = {
 
 const fencedCodePattern = /```[\s\S]*?```/g;
 const secretAssignmentPattern =
-  /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|authorization)\b\s*[:=]\s*(?:"[^"]+"|'[^']+'|[^\s,;]+)/gi;
+  /\b((?:[a-z0-9]+[_-])*(?:api[_-]?key|access[_-]?token|refresh[_-]?token|secret[_-]?access[_-]?key|secret|password|authorization|private[_-]?key))\b\s*[:=]\s*(?:"[^"]+"|'[^']+'|[^\s,;]+)/gi;
 const bearerPattern = /\bbearer\s+[a-z0-9._~+/=-]+/gi;
 const jwtPattern = /\beyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\b/g;
+const privateKeyBlockPattern =
+  /-----BEGIN(?: [A-Z0-9]+)* PRIVATE KEY-----[\s\S]*?-----END(?: [A-Z0-9]+)* PRIVATE KEY-----/gi;
+const privateKeyMarkerPattern = /-----BEGIN(?: [A-Z0-9]+)* PRIVATE KEY-----/i;
+const standaloneSecretPatterns = [
+  /\bsk-(?:proj-|svcacct-)?[a-zA-Z0-9_-]{20,}\b/gi,
+  /\b(?:gh[pousr]_[a-zA-Z0-9]{20,255}|github_pat_[a-zA-Z0-9_]{20,255})\b/gi,
+  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g,
+] as const;
 const emailPattern = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const urlPattern = /\b(?:https?|ftp):\/\/[^\s<>{}\[\]"']+/gi;
 const ipv4Pattern =
@@ -211,16 +219,45 @@ const posixPathPattern =
 const securityCommandPattern =
   /^(\s*)(?:\$\s*)?(nmap|curl|wget|sqlmap|ffuf|gobuster|nikto|nuclei|masscan|hydra|john|hashcat|burp|metasploit|msfconsole)(?:\s+.+)$/gim;
 
+const redactStandaloneSecrets = (value: string): string =>
+  standaloneSecretPatterns.reduce(
+    (sanitized, pattern) => sanitized.replace(pattern, "[secret omitted]"),
+    value,
+  );
+
+const patternMatches = (pattern: RegExp, value: string): boolean => {
+  pattern.lastIndex = 0;
+  const matches = pattern.test(value);
+  pattern.lastIndex = 0;
+  return matches;
+};
+
+export const containsUnredactedResearchSecret = (value: string): boolean =>
+  patternMatches(secretAssignmentPattern, value) ||
+  patternMatches(bearerPattern, value) ||
+  patternMatches(jwtPattern, value) ||
+  patternMatches(privateKeyMarkerPattern, value) ||
+  standaloneSecretPatterns.some((pattern) => patternMatches(pattern, value));
+
+export const assertResearchPromptIsSafe = (prompt: string): void => {
+  if (containsUnredactedResearchSecret(prompt)) {
+    throw new Error("Research prompt contains unredacted secret material");
+  }
+};
+
 /**
  * Remove direct identifiers, secrets, targets, and bulky payloads while
  * preserving product/workflow language and security tool names.
  */
 export const sanitizeResearchText = (value: string): string =>
-  value
-    .replace(fencedCodePattern, "[code omitted]")
-    .replace(secretAssignmentPattern, "$1=[secret omitted]")
-    .replace(bearerPattern, "Bearer [secret omitted]")
-    .replace(jwtPattern, "[token omitted]")
+  redactStandaloneSecrets(
+    value
+      .replace(fencedCodePattern, "[code omitted]")
+      .replace(privateKeyBlockPattern, "[secret omitted]")
+      .replace(bearerPattern, "Bearer [secret omitted]")
+      .replace(secretAssignmentPattern, "[secret omitted]")
+      .replace(jwtPattern, "[token omitted]"),
+  )
     .replace(emailPattern, "[email omitted]")
     .replace(urlPattern, "[url omitted]")
     .replace(ipv4Pattern, "[ip omitted]")

--- a/lib/research/user-research.ts
+++ b/lib/research/user-research.ts
@@ -7,6 +7,9 @@ export const USER_RESEARCH_MODEL_KEY = "model-deepseek-v4-flash-0731" as const;
 export const USER_RESEARCH_PROMPT_VERSION = "user-research-v1";
 export const USER_RESEARCH_MAX_CONTEXT_CHARS = 120_000;
 export const USER_RESEARCH_MAX_COHORT_CONTEXT_CHARS = 240_000;
+export const USER_RESEARCH_MIN_COHORT_SIZE = 3;
+export const USER_RESEARCH_MAX_COHORT_SIZE = 20;
+export const USER_RESEARCH_DEFAULT_MAX_CHATS_PER_USER = 12;
 export const USER_RESEARCH_PROVIDER_OPTIONS = {
   openrouter: {
     reasoning: { enabled: false },
@@ -16,6 +19,48 @@ export const USER_RESEARCH_PROVIDER_OPTIONS = {
 } as const;
 
 const confidenceSchema = z.enum(["low", "medium", "high"]);
+
+const pmUserResearchPayloadBaseSchema = z.object({
+  linearIssueId: z
+    .string()
+    .trim()
+    .regex(/^[A-Z]+-\d+$/),
+  question: z.string().trim().min(10).max(1_000),
+  cohortLabel: z.string().trim().min(3).max(200),
+  userIds: z
+    .array(z.string().trim().min(1).max(200))
+    .min(USER_RESEARCH_MIN_COHORT_SIZE)
+    .max(USER_RESEARCH_MAX_COHORT_SIZE),
+  requestedBy: z.string().trim().min(2).max(100),
+  maxChatsPerUser: z
+    .number()
+    .int()
+    .min(3)
+    .max(20)
+    .default(USER_RESEARCH_DEFAULT_MAX_CHATS_PER_USER),
+});
+
+const requireUniqueResearchUsers = (
+  payload: { userIds: string[] },
+  ctx: z.core.$RefinementCtx,
+) => {
+  if (new Set(payload.userIds).size !== payload.userIds.length) {
+    ctx.addIssue({
+      code: "custom",
+      message: "userIds must be unique",
+      path: ["userIds"],
+      input: payload.userIds,
+    });
+  }
+};
+
+export const pmUserResearchPayloadSchema =
+  pmUserResearchPayloadBaseSchema.superRefine(requireUniqueResearchUsers);
+
+export const pmUserResearchGatewayRequestSchema =
+  pmUserResearchPayloadBaseSchema
+    .omit({ requestedBy: true })
+    .superRefine(requireUniqueResearchUsers);
 
 export const researchUserTypeSchema = z.enum([
   "bug_bounty_hunter",
@@ -112,18 +157,28 @@ const cohortSynthesisSchema = z.object({
   privacyNote: z.string().trim().min(1).max(500),
 });
 
+export const researchCohortReportSchema = cohortSynthesisSchema.extend({
+  coverage: z.object({
+    usersRequested: z.number().int().min(USER_RESEARCH_MIN_COHORT_SIZE).max(20),
+    usersAnalyzed: z.number().int().min(USER_RESEARCH_MIN_COHORT_SIZE).max(20),
+    profilesFailed: z.number().int().min(0).max(20),
+    chatsReviewed: z.number().int().min(0),
+    messagesReviewed: z.number().int().min(0),
+  }),
+});
+
+export const pmUserResearchResultSchema = z.object({
+  analysisId: z.uuid(),
+  status: z.literal("completed"),
+  failedProfiles: z.number().int().min(0).max(20),
+  usersAnalyzed: z.number().int().min(USER_RESEARCH_MIN_COHORT_SIZE).max(20),
+  report: researchCohortReportSchema,
+});
+
 export type ResearchUserProfile = z.infer<typeof researchUserProfileSchema>;
 export type ResearchCoverage = z.infer<typeof researchCoverageSchema>;
 export type ResearchCohortSynthesis = z.infer<typeof cohortSynthesisSchema>;
-export type ResearchCohortReport = ResearchCohortSynthesis & {
-  coverage: {
-    usersRequested: number;
-    usersAnalyzed: number;
-    profilesFailed: number;
-    chatsReviewed: number;
-    messagesReviewed: number;
-  };
-};
+export type ResearchCohortReport = z.infer<typeof researchCohortReportSchema>;
 
 export type ResearchChatEvidence = {
   chatId: string;

--- a/trigger/user-research.ts
+++ b/trigger/user-research.ts
@@ -11,17 +11,16 @@ import {
   cohortSynthesisSchema,
   normalizeCohortSynthesis,
   normalizeResearchUserProfile,
+  pmUserResearchPayloadSchema,
   researchUserProfileSchema,
   USER_RESEARCH_MODEL_KEY,
+  USER_RESEARCH_MIN_COHORT_SIZE,
   USER_RESEARCH_PROMPT_VERSION,
   USER_RESEARCH_PROVIDER_OPTIONS,
   type ResearchCohortReport,
   type ResearchCoverage,
 } from "@/lib/research/user-research";
 
-const MIN_COHORT_SIZE = 3;
-const MAX_COHORT_SIZE = 20;
-const DEFAULT_MAX_CHATS_PER_USER = 12;
 const MAX_MESSAGES_PER_CHAT = 80;
 
 const workerPayloadSchema = z.object({
@@ -32,35 +31,7 @@ const workerPayloadSchema = z.object({
   maxChatsPerUser: z.number().int().min(3).max(20),
 });
 
-export const pmUserResearchPayloadSchema = z
-  .object({
-    linearIssueId: z
-      .string()
-      .trim()
-      .regex(/^[A-Z]+-\d+$/),
-    question: z.string().trim().min(10).max(1_000),
-    cohortLabel: z.string().trim().min(3).max(200),
-    userIds: z
-      .array(z.string().trim().min(1).max(200))
-      .min(MIN_COHORT_SIZE)
-      .max(MAX_COHORT_SIZE),
-    requestedBy: z.string().trim().min(2).max(100),
-    maxChatsPerUser: z
-      .number()
-      .int()
-      .min(3)
-      .max(20)
-      .default(DEFAULT_MAX_CHATS_PER_USER),
-  })
-  .superRefine((payload, ctx) => {
-    if (new Set(payload.userIds).size !== payload.userIds.length) {
-      ctx.addIssue({
-        code: "custom",
-        message: "userIds must be unique",
-        path: ["userIds"],
-      });
-    }
-  });
+export { pmUserResearchPayloadSchema } from "@/lib/research/user-research";
 
 const getResearchClient = () => {
   const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL?.trim();
@@ -234,7 +205,7 @@ export const pmUserResearch = schemaTask({
         serviceKey,
         analysisId,
       });
-      if (profiles.length < MIN_COHORT_SIZE) {
+      if (profiles.length < USER_RESEARCH_MIN_COHORT_SIZE) {
         throw new Error(
           "Fewer than three users had enough evidence for privacy-safe synthesis",
         );

--- a/trigger/user-research.ts
+++ b/trigger/user-research.ts
@@ -6,6 +6,7 @@ import { api } from "@/convex/_generated/api";
 import { DEEPSEEK_V4_FLASH_SLUG, myProvider } from "@/lib/ai/providers";
 import { getProviderUsageRawModelCost } from "@/lib/provider-usage-cost";
 import {
+  assertResearchPromptIsSafe,
   buildCohortPrompt,
   buildUserProfilePrompt,
   cohortSynthesisSchema,
@@ -109,6 +110,12 @@ export const analyzeUserResearchProfile = schemaTask({
       truncatedChats: evidence.filter((chat) => chat.truncated).length,
     };
 
+    const prompt = buildUserProfilePrompt({
+      question: payload.question,
+      pseudonym: payload.pseudonym,
+      chats: evidence,
+    });
+    assertResearchPromptIsSafe(prompt);
     const result = await generateText({
       model: myProvider.languageModel(USER_RESEARCH_MODEL_KEY),
       output: Output.object({ schema: researchUserProfileSchema }),
@@ -116,11 +123,7 @@ export const analyzeUserResearchProfile = schemaTask({
       temperature: 0,
       maxOutputTokens: 6_000,
       maxRetries: 1,
-      prompt: buildUserProfilePrompt({
-        question: payload.question,
-        pseudonym: payload.pseudonym,
-        chats: evidence,
-      }),
+      prompt,
     });
     const profile = normalizeResearchUserProfile(
       result.output,
@@ -211,6 +214,12 @@ export const pmUserResearch = schemaTask({
         );
       }
 
+      const prompt = buildCohortPrompt({
+        question: payload.question,
+        cohortLabel: payload.cohortLabel,
+        profiles,
+      });
+      assertResearchPromptIsSafe(prompt);
       const result = await generateText({
         model: myProvider.languageModel(USER_RESEARCH_MODEL_KEY),
         output: Output.object({ schema: cohortSynthesisSchema }),
@@ -218,11 +227,7 @@ export const pmUserResearch = schemaTask({
         temperature: 0,
         maxOutputTokens: 8_000,
         maxRetries: 1,
-        prompt: buildCohortPrompt({
-          question: payload.question,
-          cohortLabel: payload.cohortLabel,
-          profiles,
-        }),
+        prompt,
       });
       const synthesis = normalizeCohortSynthesis(
         result.output,


### PR DESCRIPTION
## What changed

- add a production-only authenticated Vercel gateway that can start and read only `pm-user-research` Trigger runs
- authenticate the PM runner with a plaintext Codex key whose SHA-256 digest is stored in Vercel Production
- keep Trigger and Convex credentials server-side and return only schema-validated aggregate research
- add a fixed-production Codex runner and update the user-research skill, privacy policy, runbook, and internal documentation
- centralize the Trigger payload/result schemas and add gateway authorization and isolation tests

## Why

PMs need to run approved privacy-safe user research without broad Trigger.dev access or access to Convex service credentials. Preview configuration is intentionally omitted because the PM workflow is production-only.

## Impact

The PM stores only `HACKERAI_PM_USER_RESEARCH_KEY` in their Codex environment. Vercel Production stores only `PM_USER_RESEARCH_RUNNER_KEY_SHA256`; it uses its existing Production `TRIGGER_SECRET_KEY` to start the restricted task.

## Validation

- `pnpm typecheck`
- focused gateway/research tests: 14 passed
- full Jest suite from the commit hook: 404 suites / 4,029 tests passed
- focused ESLint passed
- Prettier passed for all supported changed files
- `git diff --check` passed
- runner help confirms only the production key is configurable

## Manual verification after deployment

1. In Vercel Production, verify `PM_USER_RESEARCH_RUNNER_KEY_SHA256` is set to the digest of the PM key and the Production `TRIGGER_SECRET_KEY` remains available.
2. From the PM Codex environment, invoke `$hackerai-user-research` with an approved Linear issue and a 3-user cohort.
3. Confirm the gateway queues `pm-user-research`, polling completes, and only the aggregate report is returned.
4. Confirm an invalid PM key receives HTTP 401 and an unrelated Trigger run ID is not exposed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secure gateway for submitting and monitoring user research.
  * Added validation for research requests, cohort sizes, chat limits, and completed results.
  * Added clear status reporting for queued, running, completed, and failed research.

* **Privacy & Security**
  * Restricted access to authorized research requests and aggregate results.
  * Added safeguards for sensitive payloads, credentials, retention, and error handling.
  * Added protections to detect and remove exposed secrets from research data.

* **Updates**
  * Research analysis now uses DeepSeek V4 Flash with required privacy controls.
  * Updated internal runbooks and documentation for the new workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->