### PR TITLE
Fix durable Agent deletion cleanup

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import { workos } from "../../workos";
 import { fenceAndGetActiveAgentResourcesForUser } from "@/lib/db/actions";
 import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
 import { cancelSubagentsForUserDeletion } from "@/lib/db/subagents";
+import { terminateCloudSandboxesForUser } from "@/lib/ai/tools/utils/cloud-sandbox";
 import { logger } from "@/lib/logger";
 
 const mockConvexMutation = jest.fn();
@@ -45,6 +46,10 @@ jest.mock("@/lib/db/subagents", () => ({
   cancelSubagentsForUserDeletion: jest.fn(),
 }));
 
+jest.mock("@/lib/ai/tools/utils/cloud-sandbox", () => ({
+  terminateCloudSandboxesForUser: jest.fn(),
+}));
+
 jest.mock("@/lib/logger", () => ({
   logger: {
     error: jest.fn(),
@@ -59,6 +64,8 @@ jest.mock("@/convex/_generated/api", () => ({
       markDeleted: "accountIdentities.markDeleted",
     },
     userDeletion: {
+      beginUserDataDeletionByService:
+        "userDeletion.beginUserDataDeletionByService",
       deleteAllUserDataByService: "userDeletion.deleteAllUserDataByService",
     },
   },
@@ -137,6 +144,10 @@ const mockCancelSubagentsForUserDeletion =
   cancelSubagentsForUserDeletion as jest.MockedFunction<
     typeof cancelSubagentsForUserDeletion
   >;
+const mockTerminateCloudSandboxesForUser =
+  terminateCloudSandboxesForUser as jest.MockedFunction<
+    typeof terminateCloudSandboxesForUser
+  >;
 const mockLoggerError = logger.error as jest.MockedFunction<
   typeof logger.error
 >;
@@ -170,6 +181,11 @@ describe("POST /api/delete-account", () => {
       triggerRunIds: [],
       hasMore: false,
     } as never);
+    mockTerminateCloudSandboxesForUser.mockResolvedValue({
+      total: 0,
+      killed: 0,
+      alreadyGone: 0,
+    });
     mockConvexMutation.mockImplementation(async (functionReference) =>
       functionReference === "userDeletion.deleteAllUserDataByService"
         ? { hasMore: false }
@@ -254,11 +270,16 @@ describe("POST /api/delete-account", () => {
     );
     expect(
       mockCloseAndCancelAgentResources.mock.invocationCallOrder[0],
-    ).toBeLessThan(mockConvexMutation.mock.invocationCallOrder[1]);
-    expect(mockConvexMutation.mock.invocationCallOrder[1]).toBeLessThan(
+    ).toBeLessThan(
+      mockTerminateCloudSandboxesForUser.mock.invocationCallOrder[0],
+    );
+    expect(
+      mockTerminateCloudSandboxesForUser.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockConvexMutation.mock.invocationCallOrder[2]);
+    expect(mockConvexMutation.mock.invocationCallOrder[2]).toBeLessThan(
       mockDeleteOrganizationMembership.mock.invocationCallOrder[0],
     );
-    expect(mockConvexMutation.mock.invocationCallOrder[1]).toBeLessThan(
+    expect(mockConvexMutation.mock.invocationCallOrder[2]).toBeLessThan(
       mockDeleteUser.mock.invocationCallOrder[0],
     );
   });
@@ -323,6 +344,14 @@ describe("POST /api/delete-account", () => {
     expect(response.status).toBe(200);
     expect(mockConvexMutation).toHaveBeenNthCalledWith(
       1,
+      "userDeletion.beginUserDataDeletionByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      2,
       "accountIdentities.markDeleted",
       {
         serviceKey: "service_key",
@@ -331,14 +360,14 @@ describe("POST /api/delete-account", () => {
       },
     );
     expect(mockConvexMutation).toHaveBeenNthCalledWith(
-      2,
+      3,
       "userDeletion.deleteAllUserDataByService",
       {
         serviceKey: "service_key",
         userId: "user_123",
       },
     );
-    expect(mockConvexMutation.mock.invocationCallOrder[1]).toBeLessThan(
+    expect(mockConvexMutation.mock.invocationCallOrder[2]).toBeLessThan(
       mockDeleteUser.mock.invocationCallOrder[0],
     );
   });
@@ -396,6 +425,7 @@ describe("POST /api/delete-account", () => {
     } as never);
     mockConvexMutation
       .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
       .mockRejectedValueOnce(new Error("Convex cleanup failed"));
 
     const response = await POST(request() as any);
@@ -436,8 +466,13 @@ describe("POST /api/delete-account", () => {
     );
     expect(
       mockCloseAndCancelAgentResources.mock.invocationCallOrder[0],
-    ).toBeLessThan(mockConvexMutation.mock.invocationCallOrder[1]);
-    expect(mockConvexMutation.mock.invocationCallOrder[1]).toBeLessThan(
+    ).toBeLessThan(
+      mockTerminateCloudSandboxesForUser.mock.invocationCallOrder[0],
+    );
+    expect(
+      mockTerminateCloudSandboxesForUser.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockConvexMutation.mock.invocationCallOrder[2]);
+    expect(mockConvexMutation.mock.invocationCallOrder[2]).toBeLessThan(
       mockDeleteUser.mock.invocationCallOrder[0],
     );
   });
@@ -459,7 +494,27 @@ describe("POST /api/delete-account", () => {
 
     expect(response.status).toBe(500);
     expect(body.error).toBe("Trigger cleanup failed");
-    expect(mockConvexMutation).toHaveBeenCalledTimes(1);
+    expect(mockConvexMutation).toHaveBeenCalledTimes(2);
+    expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockDeleteUserRateLimitKeys).not.toHaveBeenCalled();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+  });
+
+  it("keeps cloud session identifiers when provider termination fails", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    mockTerminateCloudSandboxesForUser.mockRejectedValueOnce(
+      new Error("AWS termination failed"),
+    );
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("AWS termination failed");
+    expect(mockCloseAndCancelAgentResources).toHaveBeenCalled();
+    expect(mockConvexMutation).toHaveBeenCalledTimes(2);
     expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
     expect(mockDeleteUserRateLimitKeys).not.toHaveBeenCalled();
     expect(mockDeleteUser).not.toHaveBeenCalled();
@@ -471,6 +526,7 @@ describe("POST /api/delete-account", () => {
     } as never);
     mockConvexMutation
       .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ hasMore: true })
       .mockResolvedValueOnce({ hasMore: false });
 
@@ -479,18 +535,18 @@ describe("POST /api/delete-account", () => {
     expect(response.status).toBe(200);
     expect(mockConvexMutation).toHaveBeenNthCalledWith(
       1,
-      "accountIdentities.markDeleted",
+      "userDeletion.beginUserDataDeletionByService",
       {
         serviceKey: "service_key",
-        identityHash: "free_quota:v1:identity_hash",
         userId: "user_123",
       },
     );
     expect(mockConvexMutation).toHaveBeenNthCalledWith(
       2,
-      "userDeletion.deleteAllUserDataByService",
+      "accountIdentities.markDeleted",
       {
         serviceKey: "service_key",
+        identityHash: "free_quota:v1:identity_hash",
         userId: "user_123",
       },
     );
@@ -502,7 +558,15 @@ describe("POST /api/delete-account", () => {
         userId: "user_123",
       },
     );
-    expect(mockConvexMutation.mock.invocationCallOrder[2]).toBeLessThan(
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      4,
+      "userDeletion.deleteAllUserDataByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
+    expect(mockConvexMutation.mock.invocationCallOrder[3]).toBeLessThan(
       mockDeleteUser.mock.invocationCallOrder[0],
     );
     expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
@@ -514,6 +578,7 @@ describe("POST /api/delete-account", () => {
       data: [],
     } as never);
     mockConvexMutation
+      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       // Older Convex deployments returned only the completion marker. Keep
       // that deploy-skew shape compatible while collecting newer progress.
@@ -530,7 +595,7 @@ describe("POST /api/delete-account", () => {
 
     expect(response.status).toBe(500);
     expect(body.error).toContain("taking longer than expected");
-    expect(mockConvexMutation).toHaveBeenCalledTimes(51);
+    expect(mockConvexMutation).toHaveBeenCalledTimes(52);
     expect(mockLoggerError).toHaveBeenCalledWith(
       "account_cleanup_batch_limit_exhausted",
       undefined,
@@ -561,7 +626,10 @@ describe("POST /api/delete-account", () => {
     mockListOrganizationMemberships.mockResolvedValueOnce({
       data: [],
     } as never);
-    mockConvexMutation.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockConvexMutation
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
 
     const response = await POST(request() as any);
     const body = await response.json();

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -10,6 +10,7 @@ import { logger } from "@/lib/logger";
 import { fenceAndGetActiveAgentResourcesForUser } from "@/lib/db/actions";
 import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
 import { cancelSubagentsForUserDeletion } from "@/lib/db/subagents";
+import { terminateCloudSandboxesForUser } from "@/lib/ai/tools/utils/cloud-sandbox";
 
 type OrganizationMembership = Awaited<
   ReturnType<typeof workos.userManagement.listOrganizationMemberships>
@@ -271,6 +272,14 @@ export const POST = async (req: NextRequest) => {
     }
 
     const serviceKey = getConvexServiceKey();
+    stage = "begin_user_data_deletion";
+    await getConvexClient().mutation(
+      api.userDeletion.beginUserDataDeletionByService,
+      {
+        serviceKey,
+        userId,
+      },
+    );
     stage = "mark_account_identity_deleted";
     await markAccountIdentityDeleted(userId, freeQuotaSubject, serviceKey);
 
@@ -304,6 +313,11 @@ export const POST = async (req: NextRequest) => {
       ],
       "account-deleted",
     );
+
+    // Provider cleanup must finish while the Convex session rows still retain
+    // the AWS MicroVM identifiers needed for termination and safe retries.
+    stage = "terminate_cloud_sandboxes";
+    await terminateCloudSandboxesForUser(userId);
 
     // Own app-data cleanup on the server so account deletion does not depend
     // on the browser successfully running a Convex mutation before this route.

--- a/convex/__tests__/chats.agentApprovalLifecycle.test.ts
+++ b/convex/__tests__/chats.agentApprovalLifecycle.test.ts
@@ -60,10 +60,23 @@ const {
   setActiveTriggerRun,
 } = require("../chats") as typeof import("../chats");
 
-const makeCtx = (chat: Record<string, unknown> | null) => {
+const makeCtx = (
+  chat: Record<string, unknown> | null,
+  deletionFenced = false,
+) => {
   const first = jest.fn<any>().mockResolvedValue(chat);
   const withIndex = jest.fn(() => ({ first }));
-  const query = jest.fn(() => ({ withIndex }));
+  const query = jest.fn((table: string) =>
+    table === "user_deletion_fences"
+      ? {
+          withIndex: jest.fn(() => ({
+            first: jest
+              .fn<any>()
+              .mockResolvedValue(deletionFenced ? { _id: "fence-1" } : null),
+          })),
+        }
+      : { withIndex },
+  );
   const patch = jest.fn<any>().mockResolvedValue(undefined);
   return { ctx: { db: { query, patch } } as any, patch };
 };
@@ -113,6 +126,26 @@ describe("Agent approval lifecycle guards", () => {
     expect(patch).not.toHaveBeenCalled();
   });
 
+  it("does not attach a new run after account deletion starts", async () => {
+    const { ctx, patch } = makeCtx(
+      {
+        _id: "chat-doc-1",
+        id: "chat-1",
+        user_id: "user-1",
+      },
+      true,
+    );
+
+    await expect(
+      setActiveTriggerRun.handler(ctx, {
+        serviceKey: "service-key",
+        chatId: "chat-1",
+        triggerRunId: "late-run",
+      }),
+    ).resolves.toBe("deleting");
+    expect(patch).not.toHaveBeenCalled();
+  });
+
   it("fences an inactive chat before a late run can be associated", async () => {
     const chat: Record<string, unknown> = {
       _id: "chat-doc-1",
@@ -132,7 +165,18 @@ describe("Agent approval lifecycle guards", () => {
       Object.assign(chat, update);
     });
     const ctx = {
-      db: { query: jest.fn(() => ({ withIndex })), patch },
+      db: {
+        query: jest.fn((table: string) =>
+          table === "user_deletion_fences"
+            ? {
+                withIndex: jest.fn(() => ({
+                  first: jest.fn<any>().mockResolvedValue(null),
+                })),
+              }
+            : { withIndex },
+        ),
+        patch,
+      },
     } as any;
 
     await expect(

--- a/convex/__tests__/chats.saveChat.test.ts
+++ b/convex/__tests__/chats.saveChat.test.ts
@@ -72,11 +72,13 @@ const makeCtx = ({
   insertResult = "chat-doc-1",
   project,
   authenticatedUserId = "user-1",
+  deletionFenced = false,
 }: {
   existingChat?: Record<string, unknown> | null;
   insertResult?: string;
   project?: Record<string, unknown> | null;
   authenticatedUserId?: string | null;
+  deletionFenced?: boolean;
 }) => {
   const unique = jest.fn<any>().mockResolvedValue(existingChat ?? null);
   const first = jest.fn<any>().mockResolvedValue(existingChat ?? null);
@@ -91,7 +93,17 @@ const makeCtx = ({
     build(q);
     return { first, unique };
   });
-  const query = jest.fn(() => ({ withIndex }));
+  const query = jest.fn((table: string) =>
+    table === "user_deletion_fences"
+      ? {
+          withIndex: jest.fn(() => ({
+            first: jest
+              .fn<any>()
+              .mockResolvedValue(deletionFenced ? { _id: "fence-1" } : null),
+          })),
+        }
+      : { withIndex },
+  );
   const insert = jest.fn<any>().mockResolvedValue(insertResult);
   const normalizeId = jest.fn<any>((_table: string, id: string) => id);
   const get = jest.fn<any>().mockResolvedValue(project ?? null);
@@ -127,6 +139,18 @@ const makeCtx = ({
 };
 
 describe("saveChat", () => {
+  it("rejects chat creation after account deletion starts", async () => {
+    const { saveChat } = await import("../chats");
+    const { ctx, insert } = makeCtx({ deletionFenced: true });
+
+    await expect(saveChat.handler(ctx, saveChatArgs)).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "ACCOUNT_DELETION_IN_PROGRESS",
+      }),
+    });
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it("uses unique chat id lookup before inserting", async () => {
     const { saveChat } = await import("../chats");
     const { ctx, first, indexEq, insert, unique, withIndex } = makeCtx({});

--- a/convex/__tests__/localSandbox.cloudCleanup.test.ts
+++ b/convex/__tests__/localSandbox.cloudCleanup.test.ts
@@ -45,6 +45,7 @@ describe("cloud sandbox session cleanup", () => {
         imageIdentifier: "image-1",
       }),
     ).rejects.toBeInstanceOf(Error);
+    expect(query).toHaveBeenCalledWith("user_deletion_fences");
     expect(insert).not.toHaveBeenCalled();
   });
 

--- a/convex/__tests__/localSandbox.cloudCleanup.test.ts
+++ b/convex/__tests__/localSandbox.cloudCleanup.test.ts
@@ -25,6 +25,29 @@ describe("cloud sandbox session cleanup", () => {
     jest.clearAllMocks();
   });
 
+  it("does not create a MicroVM session after account deletion starts", async () => {
+    const query = jest.fn((table: string) => {
+      expect(table).toBe("user_deletion_fences");
+      return {
+        withIndex: jest.fn(() => ({
+          first: jest.fn().mockResolvedValue({ _id: "fence-1" }),
+        })),
+      };
+    });
+    const insert = jest.fn();
+    const { beginCloudSession } = await import("../localSandbox");
+
+    await expect(
+      beginCloudSession.handler({ db: { query, insert } } as never, {
+        serviceKey: "service-key",
+        userId: "user-1",
+        region: "us-east-1",
+        imageIdentifier: "image-1",
+      }),
+    ).rejects.toBeInstanceOf(Error);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it("purges only terminal rows and disconnects their relay records", async () => {
     const statuses: string[] = [];
     const rowsByStatus = {

--- a/convex/__tests__/subagents.test.ts
+++ b/convex/__tests__/subagents.test.ts
@@ -37,6 +37,7 @@ const {
   attachTriggerRunForBackend,
   cancelForBackend,
   cancelForChatDeletionBackend,
+  cancelForUserDeletionBackend,
   claimNextTerminalForParentBackend,
   consumePendingMessagesForBackend,
   failUnattachedForBackend,
@@ -75,10 +76,12 @@ const makeCtx = ({
   exact = null,
   parentRuns = [],
   sameCandidate = [],
+  deletionFenced = false,
 }: {
   exact?: Record<string, any> | null;
   parentRuns?: Array<Record<string, any>>;
   sameCandidate?: Array<Record<string, any>>;
+  deletionFenced?: boolean;
 }) => {
   const insert = jest.fn<any>().mockResolvedValue("subagent-doc");
   const runAfter = jest.fn<any>().mockResolvedValue(undefined);
@@ -89,6 +92,13 @@ const makeCtx = ({
   const query = jest.fn((table: string) => ({
     withIndex: jest.fn((indexName: string, callback: (q: any) => unknown) => {
       callback(chain);
+      if (table === "user_deletion_fences") {
+        return {
+          first: jest
+            .fn<any>()
+            .mockResolvedValue(deletionFenced ? { _id: "fence-1" } : null),
+        };
+      }
       if (table === "chats") {
         return {
           first: jest.fn<any>().mockResolvedValue({
@@ -119,6 +129,15 @@ const makeCtx = ({
 
 describe("subagent reservation", () => {
   beforeEach(() => jest.clearAllMocks());
+
+  it("does not reserve a child after account deletion starts", async () => {
+    const { ctx, insert } = makeCtx({ deletionFenced: true });
+
+    await expect(reserveForBackend.handler(ctx, args)).resolves.toEqual({
+      outcome: "chat_missing",
+    });
+    expect(insert).not.toHaveBeenCalled();
+  });
 
   it("returns the exact prior child for a retried parent tool call", async () => {
     const { ctx, insert } = makeCtx({
@@ -1098,6 +1117,51 @@ describe("subagent deletion cancellation", () => {
         cancel_reason: "chat_deleted",
       }),
     );
+  });
+
+  it("retries a sandbox-deletion cancellation after Trigger cleanup fails", async () => {
+    const patch = jest.fn<any>().mockResolvedValue(undefined);
+    const retryRow = {
+      _id: "retry-child",
+      user_id: "user-1",
+      status: "canceled",
+      trigger_run_id: "child-run-retry",
+      cancel_reason: "terminal-sandbox-deleted",
+    };
+    const ctx = {
+      db: {
+        query: jest.fn(() => ({
+          withIndex: jest.fn((_name: string, callback: (q: any) => void) => {
+            let status = "";
+            const q = {
+              eq: jest.fn((field: string, value: string) => {
+                if (field === "status") status = value;
+                return q;
+              }),
+            };
+            callback(q);
+            return {
+              take: jest
+                .fn<any>()
+                .mockResolvedValue(status === "canceled" ? [retryRow] : []),
+            };
+          }),
+        })),
+        patch,
+      },
+    } as any;
+
+    await expect(
+      cancelForUserDeletionBackend.handler(ctx, {
+        serviceKey: "service-key",
+        userId: "user-1",
+        reason: "terminal-sandbox-deleted",
+      }),
+    ).resolves.toEqual({
+      triggerRunIds: ["child-run-retry"],
+      hasMore: false,
+    });
+    expect(patch).not.toHaveBeenCalled();
   });
 
   it("fails closed without patching when a status batch is truncated", async () => {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -115,6 +115,7 @@ function createMockCtx(tables: Tables, subject = "user_123") {
   const scheduler = {
     runAfter: jest.fn().mockResolvedValue(undefined),
   };
+  let insertedDocuments = 0;
 
   const db = {
     query: jest.fn((table: string) =>
@@ -150,6 +151,12 @@ function createMockCtx(tables: Tables, subject = "user_123") {
           }
         }
       }
+    }),
+    insert: jest.fn(async (table: string, value: Record<string, any>) => {
+      insertedDocuments += 1;
+      const id = `inserted-${table}-${insertedDocuments}`;
+      (tables[table] ??= []).push({ _id: id, ...value });
+      return id;
     }),
   };
 
@@ -535,6 +542,10 @@ function seedTables(userId = "user_123", otherUserId = "user_other"): Tables {
     ],
     processed_webhooks: [{ _id: "webhook", event_id: "evt_1" }],
     processed_checkout_sessions: [{ _id: "checkout", session_key: "cs_1" }],
+    user_deletion_fences: [
+      { _id: "fence-user", user_id: userId, started_at: 1 },
+      { _id: "fence-other", user_id: otherUserId, started_at: 1 },
+    ],
     research_runs: [
       {
         _id: "research-run",
@@ -598,12 +609,18 @@ describe("userDeletion", () => {
   });
 
   it("deletes product data, anonymizes ledgers, and retains aggregate tables", async () => {
-    const { deleteAllUserData, DELETED_USER_ID, USER_DELETION_TABLE_POLICY } =
-      await import("../userDeletion");
+    const {
+      deleteAllUserDataByService,
+      DELETED_USER_ID,
+      USER_DELETION_TABLE_POLICY,
+    } = await import("../userDeletion");
     const tables = seedTables();
     const { ctx, scheduler, deletedIds } = createMockCtx(tables);
 
-    await deleteAllUserData.handler(ctx as any, {});
+    await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
 
     for (const table of USER_DELETION_TABLE_POLICY.delete) {
       expect(
@@ -632,6 +649,7 @@ describe("userDeletion", () => {
     expect(row(tables, "research_reports", "research-report")).toBeTruthy();
     expect(row(tables, "temp_streams", "temp-stream-user")).toBeUndefined();
     expect(row(tables, "temp_streams", "temp-stream-other")).toBeTruthy();
+    expect(row(tables, "user_deletion_fences", "fence-user")).toBeTruthy();
 
     expect(row(tables, "cancellation_reasons", "cancel-user")).toMatchObject({
       user_id: DELETED_USER_ID,
@@ -715,7 +733,9 @@ describe("userDeletion", () => {
     });
 
     for (const table of USER_DELETION_TABLE_POLICY.retain) {
-      expect(tables[table]).toHaveLength(1);
+      expect(tables[table]).toHaveLength(
+        table === "user_deletion_fences" ? 2 : 1,
+      );
     }
 
     expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
@@ -747,6 +767,29 @@ describe("userDeletion", () => {
     });
 
     expect(row(tables, "chats", "chat-doc")).toBeUndefined();
+  });
+
+  it("creates an idempotent deletion fence before lifecycle cleanup", async () => {
+    const { beginUserDataDeletionByService } = await import("../userDeletion");
+    const tables = seedTables();
+    tables.user_deletion_fences = [];
+    const { ctx, db } = createMockCtx(tables);
+
+    await beginUserDataDeletionByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
+    await beginUserDataDeletionByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
+
+    expect(tables.user_deletion_fences).toHaveLength(1);
+    expect(tables.user_deletion_fences[0]).toMatchObject({
+      user_id: "user_123",
+      started_at: expect.any(Number),
+    });
+    expect(db.insert).toHaveBeenCalledTimes(1);
   });
 
   it("rejects service-key cleanup with an invalid key", async () => {
@@ -838,7 +881,7 @@ describe("userDeletion", () => {
   });
 
   it("keeps cleanup reads bounded and preserves chats until a later message batch", async () => {
-    const { deleteAllUserData } = await import("../userDeletion");
+    const { deleteAllUserDataByService } = await import("../userDeletion");
     const tables = seedTables();
     tables.feedback = Array.from({ length: 101 }, (_, index) => ({
       _id: `feedback-user-${index}`,
@@ -856,7 +899,10 @@ describe("userDeletion", () => {
     }));
     const { ctx, readCounter } = createMockCtx(tables);
 
-    const firstBatch = await deleteAllUserData.handler(ctx as any, {});
+    const firstBatch = await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
     const firstBatchReads = readCounter.value;
 
     expect(firstBatch.hasMore).toBe(true);
@@ -867,7 +913,10 @@ describe("userDeletion", () => {
     expect(firstBatchReads).toBeLessThanOrEqual(100);
     expect(row(tables, "chats", "chat-doc")).toBeTruthy();
 
-    const secondBatch = await deleteAllUserData.handler(ctx as any, {});
+    const secondBatch = await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
     const secondBatchReads = readCounter.value - firstBatchReads;
 
     expect(secondBatch.hasMore).toBe(true);
@@ -878,7 +927,10 @@ describe("userDeletion", () => {
     expect(secondBatchReads).toBeLessThanOrEqual(100);
     expect(row(tables, "chats", "chat-doc")).toBeTruthy();
 
-    const thirdBatch = await deleteAllUserData.handler(ctx as any, {});
+    const thirdBatch = await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
     const thirdBatchReads =
       readCounter.value - firstBatchReads - secondBatchReads;
 
@@ -892,20 +944,35 @@ describe("userDeletion", () => {
   });
 
   it("fails user deletion if S3 cleanup scheduling fails", async () => {
-    const { deleteAllUserData } = await import("../userDeletion");
+    const { deleteAllUserDataByService } = await import("../userDeletion");
     const tables = seedTables();
     const { ctx, scheduler } = createMockCtx(tables);
     scheduler.runAfter.mockRejectedValueOnce(new Error("Scheduler error"));
 
-    await expect(deleteAllUserData.handler(ctx as any, {})).rejects.toThrow(
-      "Scheduler error",
-    );
+    await expect(
+      deleteAllUserDataByService.handler(ctx as any, {
+        serviceKey: "service_key",
+        userId: "user_123",
+      }),
+    ).rejects.toThrow("Scheduler error");
 
     expect(scheduler.runAfter).toHaveBeenCalledWith(
       0,
       "deleteS3ObjectsBatchAction",
       { s3Keys: ["users/user_123/file.pdf"] },
     );
+  });
+
+  it("blocks authenticated clients from bypassing lifecycle-aware account deletion", async () => {
+    const { deleteAllUserData } = await import("../userDeletion");
+    const tables = seedTables();
+    const { ctx } = createMockCtx(tables);
+
+    await expect(deleteAllUserData.handler(ctx as any, {})).rejects.toThrow(
+      "use the secure account deletion endpoint",
+    );
+
+    expect(row(tables, "chats", "chat-doc")).toBeTruthy();
   });
 
   it("throws if the public mutation has no authenticated user", async () => {

--- a/convex/__tests__/userDeletionFence.test.ts
+++ b/convex/__tests__/userDeletionFence.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { isUserDeletionFenced } from "../lib/userDeletionFence";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("user deletion fence", () => {
+  it.each([
+    [null, false],
+    [{ _id: "fence-1", user_id: "user-1", started_at: 1 }, true],
+  ] as const)("maps a persisted fence to %s", async (row, expected) => {
+    const first = jest.fn(async () => row);
+    const withIndex = jest.fn(
+      (_index: string, callback: (q: { eq: jest.Mock }) => void) => {
+        const q = { eq: jest.fn(() => q) };
+        callback(q);
+        return { first };
+      },
+    );
+    const db = {
+      query: jest.fn(() => ({ withIndex })),
+    };
+
+    await expect(isUserDeletionFenced(db as never, "user-1")).resolves.toBe(
+      expected,
+    );
+    expect(withIndex).toHaveBeenCalledWith("by_user_id", expect.any(Function));
+  });
+
+  it("guards every resource-creation boundary used during account deletion", () => {
+    const accountRoute = read("app/api/delete-account/route.ts");
+    const chats = read("convex/chats.ts");
+    const subagents = read("convex/subagents.ts");
+    const localSandbox = read("convex/localSandbox.ts");
+
+    expect(
+      accountRoute.indexOf('stage = "begin_user_data_deletion"'),
+    ).toBeLessThan(
+      accountRoute.indexOf('stage = "fence_active_agent_resources"'),
+    );
+    expect(chats).toMatch(
+      /saveChat = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, args\.userId\)/,
+    );
+    expect(chats).toMatch(
+      /setActiveTriggerRun = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, chat\.user_id\)/,
+    );
+    expect(subagents).toMatch(
+      /reserveForBackend = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, args\.userId\)/,
+    );
+    expect(localSandbox).toMatch(
+      /beginCloudSession = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, args\.userId\)/,
+    );
+  });
+});

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -26,6 +26,7 @@ import {
   assertUserCanAccessChatHistory,
 } from "./lib/suspensionGuards";
 import { resolveBranchedFromTitle } from "./lib/branchedChatTitle";
+import { isUserDeletionFenced } from "./lib/userDeletionFence";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
@@ -646,6 +647,15 @@ export const saveChat = mutation({
     let failureStage = "start";
 
     try {
+      failureStage = "check_user_deletion_fence";
+      if (await isUserDeletionFenced(ctx.db, args.userId)) {
+        throw new ConvexError({
+          code: "ACCOUNT_DELETION_IN_PROGRESS",
+          message: "Account deletion is in progress",
+          operation: "chats.saveChat",
+        });
+      }
+
       failureStage = "find_existing_chat";
       const existingChat = await ctx.db
         .query("chats")
@@ -712,6 +722,7 @@ export const saveChat = mutation({
       const causeData = getConvexErrorData(error);
       if (
         getConvexErrorCode(causeData) === "CHAT_UNAUTHORIZED" ||
+        getConvexErrorCode(causeData) === "ACCOUNT_DELETION_IN_PROGRESS" ||
         getConvexErrorCode(causeData) === "PROJECT_NOT_FOUND" ||
         getConvexErrorCode(causeData) === "PROJECT_ACCESS_DENIED"
       ) {
@@ -1619,6 +1630,12 @@ export const setActiveTriggerRun = mutation({
       .withIndex("by_chat_id", (q) => q.eq("id", args.chatId))
       .first();
     if (!chat) return "not_found" as const;
+    if (
+      args.triggerRunId !== null &&
+      (await isUserDeletionFenced(ctx.db, chat.user_id))
+    ) {
+      return "deleting" as const;
+    }
     if (chat.deletion_started_at !== undefined && args.triggerRunId !== null) {
       return "deleting" as const;
     }

--- a/convex/lib/userDeletionFence.ts
+++ b/convex/lib/userDeletionFence.ts
@@ -1,0 +1,14 @@
+import type { GenericDatabaseReader } from "convex/server";
+
+import type { DataModel } from "../_generated/dataModel";
+
+export async function isUserDeletionFenced(
+  db: GenericDatabaseReader<DataModel>,
+  userId: string,
+): Promise<boolean> {
+  const fence = await db
+    .query("user_deletion_fences")
+    .withIndex("by_user_id", (q) => q.eq("user_id", userId))
+    .first();
+  return fence !== null;
+}

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -4,6 +4,7 @@ import { validateServiceKey } from "./lib/utils";
 import { DatabaseReader, DatabaseWriter } from "./_generated/server";
 import type { Doc } from "./_generated/dataModel";
 import { SignJWT } from "jose";
+import { isUserDeletionFenced } from "./lib/userDeletionFence";
 
 /**
  * Internal mutation: purge disconnected sandbox connections older than cutoff.
@@ -534,6 +535,12 @@ export const beginCloudSession = mutation({
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
+    if (await isUserDeletionFenced(ctx.db, args.userId)) {
+      throw new ConvexError({
+        code: "ACCOUNT_DELETION_IN_PROGRESS",
+        message: "Account deletion is in progress",
+      });
+    }
     const now = Date.now();
     const [starting, running] = await Promise.all([
       ctx.db

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -695,6 +695,14 @@ export default defineSchema({
     .index("by_identity_hash", ["identity_hash"])
     .index("by_latest_user_id", ["latest_user_id"]),
 
+  // Durable tombstone created before account deletion starts. It prevents
+  // concurrent requests from provisioning new execution resources after the
+  // deletion route has enumerated the user's existing resources.
+  user_deletion_fences: defineTable({
+    user_id: v.string(),
+    started_at: v.number(),
+  }).index("by_user_id", ["user_id"]),
+
   user_suspensions: defineTable({
     user_id: v.string(),
     status: v.union(v.literal("active"), v.literal("resolved")),

--- a/convex/subagents.ts
+++ b/convex/subagents.ts
@@ -12,6 +12,7 @@ import {
   SUBAGENT_WATCHDOG_GRACE_SECONDS,
 } from "../lib/ai/subagents/contracts";
 import { toSubagentHandle } from "../lib/ai/subagents/agent-handle";
+import { isUserDeletionFenced } from "./lib/userDeletionFence";
 
 const statusValidator = v.union(
   v.literal("queued"),
@@ -98,20 +99,15 @@ const subagentSummaryValidator = v.object({
 
 const ACTIVE_SUBAGENT_STATUSES = ["queued", "running", "finalizing"] as const;
 const SUBAGENT_DELETION_CANCELLATION_BATCH_SIZE = 100;
-const DELETION_CANCELLATION_REASONS = new Set([
-  "chat_deleted",
-  "all_chats_deleted",
-  "account_deleted",
-]);
 const isActiveStatus = (status: string): boolean =>
   ACTIVE_SUBAGENT_STATUSES.some((activeStatus) => activeStatus === status);
-const isPendingDeletionCancellation = (row: {
-  status: string;
-  cancel_reason?: string;
-}): boolean =>
-  row.status === "canceled" &&
-  typeof row.cancel_reason === "string" &&
-  DELETION_CANCELLATION_REASONS.has(row.cancel_reason);
+const isPendingDeletionCancellation = (
+  row: {
+    status: string;
+    cancel_reason?: string;
+  },
+  reason: string,
+): boolean => row.status === "canceled" && row.cancel_reason === reason;
 const deletionCancellationResultValidator = v.object({
   triggerRunIds: v.array(v.string()),
   hasMore: v.boolean(),
@@ -220,6 +216,10 @@ export const reserveForBackend = mutation({
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
+
+    if (await isUserDeletionFenced(ctx.db, args.userId)) {
+      return { outcome: "chat_missing" as const };
+    }
 
     const chat = await ctx.db
       .query("chats")
@@ -948,7 +948,9 @@ export const cancelForChatDeletionBackend = mutation({
       isActiveStatus(row.status),
     );
     const cancellationRows = candidateRows.filter(
-      (row) => isActiveStatus(row.status) || isPendingDeletionCancellation(row),
+      (row) =>
+        isActiveStatus(row.status) ||
+        isPendingDeletionCancellation(row, args.reason),
     );
     const now = Date.now();
     await Promise.all(
@@ -1009,7 +1011,9 @@ export const cancelForUserDeletionBackend = mutation({
       isActiveStatus(row.status),
     );
     const cancellationRows = candidateRows.filter(
-      (row) => isActiveStatus(row.status) || isPendingDeletionCancellation(row),
+      (row) =>
+        isActiveStatus(row.status) ||
+        isPendingDeletionCancellation(row, args.reason),
     );
     const now = Date.now();
     await Promise.all(

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -43,6 +43,9 @@ export const USER_DELETION_TABLE_POLICY = {
     "user_suspensions",
   ],
   retain: [
+    // Operational tombstone that prevents stale authenticated requests from
+    // recreating execution resources after account deletion begins.
+    "user_deletion_fences",
     "team_extra_usage",
     "paid_start_mix_daily",
     "processed_webhooks",
@@ -862,8 +865,9 @@ async function cleanupOrphanChatSummaries(
 }
 
 /**
- * Delete all data for the authenticated user in the same policy path used by
- * the server-side account deletion route.
+ * Preserve the legacy public function as a fail-closed compatibility shim.
+ * Account deletion must run through the server route so Trigger runs and
+ * provider resources are terminated before their durable identifiers vanish.
  */
 export const deleteAllUserData = mutation({
   args: {},
@@ -874,7 +878,31 @@ export const deleteAllUserData = mutation({
       throw new Error("Unauthorized: User not authenticated");
     }
 
-    return await cleanupUserDataForUser(ctx, user.subject, "execute");
+    throw new Error(
+      "Direct user data deletion is disabled; use the secure account deletion endpoint",
+    );
+  },
+});
+
+export const beginUserDataDeletionByService = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const existing = await ctx.db
+      .query("user_deletion_fences")
+      .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+      .unique();
+    if (!existing) {
+      await ctx.db.insert("user_deletion_fences", {
+        user_id: args.userId,
+        started_at: Date.now(),
+      });
+    }
+    return null;
   },
 });
 

--- a/lib/ai/subagents/__tests__/runtime-authorization.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-authorization.test.ts
@@ -1,0 +1,144 @@
+import {
+  assertSubagentRuntimeAuthorized,
+  guardSubagentToolExecutions,
+} from "@/lib/ai/subagents/runtime-authorization";
+
+const activeChild = {
+  status: "running" as const,
+  parent_trigger_run_id: "parent-run",
+  trigger_run_id: "child-run",
+};
+
+describe("subagent runtime authorization", () => {
+  it("accepts a bound active child while its parent is non-terminal", async () => {
+    await expect(
+      assertSubagentRuntimeAuthorized({
+        subagentId: "subagent-1",
+        childTriggerRunId: "child-run",
+        parentTriggerRunId: "parent-run",
+        loadChild: jest.fn(async () => activeChild),
+        retrieveParent: jest.fn(async () => ({ status: "EXECUTING" })),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(["completed", "failed", "canceled", "timed_out"] as const)(
+    "rejects a %s persisted child before more work",
+    async (status) => {
+      await expect(
+        assertSubagentRuntimeAuthorized({
+          subagentId: "subagent-1",
+          childTriggerRunId: "child-run",
+          parentTriggerRunId: "parent-run",
+          loadChild: jest.fn(async () => ({ ...activeChild, status })),
+          retrieveParent: jest.fn(async () => ({ status: "EXECUTING" })),
+        }),
+      ).rejects.toThrow("authorization was revoked");
+    },
+  );
+
+  it("rejects a child whose Trigger binding no longer matches", async () => {
+    await expect(
+      assertSubagentRuntimeAuthorized({
+        subagentId: "subagent-1",
+        childTriggerRunId: "child-run",
+        parentTriggerRunId: "parent-run",
+        loadChild: jest.fn(async () => ({
+          ...activeChild,
+          trigger_run_id: "replacement-run",
+        })),
+        retrieveParent: jest.fn(async () => ({ status: "EXECUTING" })),
+      }),
+    ).rejects.toThrow("authorization was revoked");
+  });
+
+  it.each([
+    "COMPLETED",
+    "CANCELED",
+    "FAILED",
+    "CRASHED",
+    "SYSTEM_FAILURE",
+    "EXPIRED",
+    "TIMED_OUT",
+  ])("rejects a terminal parent with status %s", async (status) => {
+    await expect(
+      assertSubagentRuntimeAuthorized({
+        subagentId: "subagent-1",
+        childTriggerRunId: "child-run",
+        parentTriggerRunId: "parent-run",
+        loadChild: jest.fn(async () => activeChild),
+        retrieveParent: jest.fn(async () => ({ status })),
+      }),
+    ).rejects.toThrow("no longer active");
+  });
+
+  it("fails closed when either control-plane lookup fails", async () => {
+    await expect(
+      assertSubagentRuntimeAuthorized({
+        subagentId: "subagent-1",
+        childTriggerRunId: "child-run",
+        parentTriggerRunId: "parent-run",
+        loadChild: jest.fn(async () => {
+          throw new Error("Convex unavailable");
+        }),
+        retrieveParent: jest.fn(async () => ({ status: "EXECUTING" })),
+      }),
+    ).rejects.toThrow("Convex unavailable");
+
+    await expect(
+      assertSubagentRuntimeAuthorized({
+        subagentId: "subagent-1",
+        childTriggerRunId: "child-run",
+        parentTriggerRunId: "parent-run",
+        loadChild: jest.fn(async () => activeChild),
+        retrieveParent: jest.fn(async () => {
+          throw new Error("Trigger unavailable");
+        }),
+      }),
+    ).rejects.toThrow("Trigger unavailable");
+  });
+
+  it("authorizes immediately before executing every privileged tool", async () => {
+    const authorize = jest.fn(async () => undefined);
+    const execute = jest.fn(async (input: unknown) => input);
+    const guarded = guardSubagentToolExecutions(
+      {
+        run_terminal_cmd: { execute } as never,
+      },
+      authorize,
+    );
+
+    await expect(
+      guarded.run_terminal_cmd.execute?.({ cmd: "pwd" }, {
+        toolCallId: "tool-1",
+        messages: [],
+        abortSignal: undefined,
+      } as never),
+    ).resolves.toEqual({ cmd: "pwd" });
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(authorize.mock.invocationCallOrder[0]).toBeLessThan(
+      execute.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not execute a tool when authorization is revoked", async () => {
+    const execute = jest.fn(async () => "unsafe");
+    const guarded = guardSubagentToolExecutions(
+      {
+        file: { execute } as never,
+      },
+      async () => {
+        throw new Error("revoked");
+      },
+    );
+
+    await expect(
+      guarded.file.execute?.({ operation: "write" }, {
+        toolCallId: "tool-1",
+        messages: [],
+        abortSignal: undefined,
+      } as never),
+    ).rejects.toThrow("revoked");
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/lib/ai/subagents/__tests__/runtime-authorization.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-authorization.test.ts
@@ -10,14 +10,21 @@ const activeChild = {
 };
 
 describe("subagent runtime authorization", () => {
-  it("accepts a bound active child while its parent is non-terminal", async () => {
+  it.each([
+    "DELAYED",
+    "DEQUEUED",
+    "EXECUTING",
+    "PENDING_VERSION",
+    "QUEUED",
+    "WAITING",
+  ])("accepts a bound active child while its parent is %s", async (status) => {
     await expect(
       assertSubagentRuntimeAuthorized({
         subagentId: "subagent-1",
         childTriggerRunId: "child-run",
         parentTriggerRunId: "parent-run",
         loadChild: jest.fn(async () => activeChild),
-        retrieveParent: jest.fn(async () => ({ status: "EXECUTING" })),
+        retrieveParent: jest.fn(async () => ({ status })),
       }),
     ).resolves.toBeUndefined();
   });
@@ -60,7 +67,9 @@ describe("subagent runtime authorization", () => {
     "SYSTEM_FAILURE",
     "EXPIRED",
     "TIMED_OUT",
-  ])("rejects a terminal parent with status %s", async (status) => {
+    "INTERRUPTED",
+    "FUTURE_STATUS",
+  ])("rejects a non-active parent with status %s", async (status) => {
     await expect(
       assertSubagentRuntimeAuthorized({
         subagentId: "subagent-1",
@@ -69,6 +78,25 @@ describe("subagent runtime authorization", () => {
         loadChild: jest.fn(async () => activeChild),
         retrieveParent: jest.fn(async () => ({ status })),
       }),
+    ).rejects.toThrow("no longer active");
+  });
+
+  it("rejects finalization after authorization is revoked between checks", async () => {
+    let parentStatus = "EXECUTING";
+    const authorization = {
+      subagentId: "subagent-1",
+      childTriggerRunId: "child-run",
+      parentTriggerRunId: "parent-run",
+      loadChild: jest.fn(async () => activeChild),
+      retrieveParent: jest.fn(async () => ({ status: parentStatus })),
+    };
+
+    await expect(
+      assertSubagentRuntimeAuthorized(authorization),
+    ).resolves.toBeUndefined();
+    parentStatus = "INTERRUPTED";
+    await expect(
+      assertSubagentRuntimeAuthorized(authorization),
     ).rejects.toThrow("no longer active");
   });
 

--- a/lib/ai/subagents/__tests__/runtime-contracts.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-contracts.test.ts
@@ -77,6 +77,15 @@ describe("security validation subagent runtime contracts", () => {
     expect(child).toContain("Output.object({");
     expect(child).toContain("await generation.consumeStream()");
     expect(child).toContain("await acceptValidationResult(recoveredResult)");
+    const acceptValidationResult = child.slice(
+      child.indexOf("const acceptValidationResult ="),
+      child.indexOf("const submitResult ="),
+    );
+    expectMarkerOrder(
+      acceptValidationResult,
+      "await assertRuntimeAuthorized()",
+      "await markSubagentFinalizing(",
+    );
     expect(child).not.toContain(
       "model: provider.languageModel(activeModelName)",
     );

--- a/lib/ai/subagents/runtime-authorization.ts
+++ b/lib/ai/subagents/runtime-authorization.ts
@@ -2,14 +2,13 @@ import type { ToolSet } from "ai";
 
 import { SUBAGENT_TERMINAL_STATUSES, type SubagentStatus } from "./contracts";
 
-const TERMINAL_PARENT_RUN_STATUSES = new Set([
-  "COMPLETED",
-  "CANCELED",
-  "FAILED",
-  "CRASHED",
-  "SYSTEM_FAILURE",
-  "EXPIRED",
-  "TIMED_OUT",
+const ACTIVE_PARENT_RUN_STATUSES = new Set([
+  "DELAYED",
+  "DEQUEUED",
+  "EXECUTING",
+  "PENDING_VERSION",
+  "QUEUED",
+  "WAITING",
 ]);
 
 type ChildRunAuthorizationSnapshot = {
@@ -55,7 +54,7 @@ export async function assertSubagentRuntimeAuthorized(args: {
   const parent = await args.retrieveParent(args.parentTriggerRunId);
   if (
     typeof parent.status !== "string" ||
-    TERMINAL_PARENT_RUN_STATUSES.has(parent.status)
+    !ACTIVE_PARENT_RUN_STATUSES.has(parent.status)
   ) {
     throw new SubagentRuntimeAuthorizationError(
       "Parent Agent run is no longer active",

--- a/lib/ai/subagents/runtime-authorization.ts
+++ b/lib/ai/subagents/runtime-authorization.ts
@@ -1,0 +1,87 @@
+import type { ToolSet } from "ai";
+
+import { SUBAGENT_TERMINAL_STATUSES, type SubagentStatus } from "./contracts";
+
+const TERMINAL_PARENT_RUN_STATUSES = new Set([
+  "COMPLETED",
+  "CANCELED",
+  "FAILED",
+  "CRASHED",
+  "SYSTEM_FAILURE",
+  "EXPIRED",
+  "TIMED_OUT",
+]);
+
+type ChildRunAuthorizationSnapshot = {
+  status: SubagentStatus;
+  parent_trigger_run_id: string;
+  trigger_run_id?: string;
+};
+
+type ParentRunAuthorizationSnapshot = {
+  status?: string;
+};
+
+export class SubagentRuntimeAuthorizationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SubagentRuntimeAuthorizationError";
+  }
+}
+
+export async function assertSubagentRuntimeAuthorized(args: {
+  subagentId: string;
+  childTriggerRunId: string;
+  parentTriggerRunId: string;
+  loadChild: (
+    subagentId: string,
+  ) => Promise<ChildRunAuthorizationSnapshot | null>;
+  retrieveParent: (
+    parentTriggerRunId: string,
+  ) => Promise<ParentRunAuthorizationSnapshot>;
+}): Promise<void> {
+  const child = await args.loadChild(args.subagentId);
+  if (
+    !child ||
+    child.trigger_run_id !== args.childTriggerRunId ||
+    child.parent_trigger_run_id !== args.parentTriggerRunId ||
+    SUBAGENT_TERMINAL_STATUSES.has(child.status)
+  ) {
+    throw new SubagentRuntimeAuthorizationError(
+      "Subagent execution authorization was revoked",
+    );
+  }
+
+  const parent = await args.retrieveParent(args.parentTriggerRunId);
+  if (
+    typeof parent.status !== "string" ||
+    TERMINAL_PARENT_RUN_STATUSES.has(parent.status)
+  ) {
+    throw new SubagentRuntimeAuthorizationError(
+      "Parent Agent run is no longer active",
+    );
+  }
+}
+
+export function guardSubagentToolExecutions(
+  tools: ToolSet,
+  authorize: () => Promise<void>,
+): ToolSet {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, definition]) => {
+      const execute = definition.execute;
+      if (!execute) return [name, definition];
+
+      return [
+        name,
+        {
+          ...definition,
+          execute: async (...args: Parameters<typeof execute>) => {
+            await authorize();
+            return await execute(...args);
+          },
+        },
+      ];
+    }),
+  ) as ToolSet;
+}

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -512,6 +512,7 @@ export const subagentTask = task({
                   error: "A validation result was already accepted.",
                 };
               }
+              await assertRuntimeAuthorized();
               const finalizing = await markSubagentFinalizing(
                 row.subagent_id,
                 ctx.run.id,

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -1,6 +1,7 @@
 import {
   logger as triggerLogger,
   metadata,
+  runs,
   tags,
   task,
 } from "@trigger.dev/sdk";
@@ -47,6 +48,10 @@ import {
   SUBAGENT_TEXT_MODEL,
 } from "@/lib/ai/subagents/model-routing";
 import { assertSubagentSandboxIdentity } from "@/lib/ai/subagents/sandbox-identity";
+import {
+  assertSubagentRuntimeAuthorized,
+  guardSubagentToolExecutions,
+} from "@/lib/ai/subagents/runtime-authorization";
 import {
   attachSubagentTriggerRun,
   consumePendingSubagentMessages,
@@ -341,6 +346,7 @@ export const subagentTask = task({
     const activeAbort = new AbortController();
     let activeTimedOut = false;
     let spendCapExceeded = false;
+    let runtimeAuthorizationRevoked = false;
     const abortFromParent = () => activeAbort.abort();
     triggerSignal.addEventListener("abort", abortFromParent, { once: true });
     const timeout = setTimeout(() => {
@@ -367,6 +373,23 @@ export const subagentTask = task({
     metadata
       .set("selectedModel", selectedModel)
       .set("activeModel", activeModelName);
+
+    const assertRuntimeAuthorized = async (): Promise<void> => {
+      try {
+        await assertSubagentRuntimeAuthorized({
+          subagentId: row.subagent_id,
+          childTriggerRunId: ctx.run.id,
+          parentTriggerRunId: row.parent_trigger_run_id,
+          loadChild: getSubagent,
+          retrieveParent: async (parentTriggerRunId) =>
+            await runs.retrieve(parentTriggerRunId),
+        });
+      } catch (error) {
+        runtimeAuthorizationRevoked = true;
+        activeAbort.abort();
+        throw error;
+      }
+    };
 
     const settleUsage = async (): Promise<{
       costDollars: number;
@@ -431,6 +454,7 @@ export const subagentTask = task({
     };
 
     try {
+      await assertRuntimeAuthorized();
       const customization = await getUserCustomization({ userId: row.user_id });
       extraUsageConfig = await buildExtraUsageConfig({
         userId: row.user_id,
@@ -521,7 +545,11 @@ export const subagentTask = task({
                 sandboxIdentity: row.sandbox_identity,
               });
 
-            const { tools, ensureSandbox, setCurrentModelName } = createTools(
+            const {
+              tools: unguardedTools,
+              ensureSandbox,
+              setCurrentModelName,
+            } = createTools(
               row.user_id,
               row.chat_id,
               writer,
@@ -559,6 +587,10 @@ export const subagentTask = task({
                 chargeSandboxRuntime: false,
                 cloudSandboxRollout,
               },
+            );
+            const tools = guardSubagentToolExecutions(
+              unguardedTools,
+              assertRuntimeAuthorized,
             );
             const sandbox = await ensureSandbox();
             assertSubagentSandboxIdentity(sandbox, row.sandbox_identity);
@@ -639,6 +671,7 @@ export const subagentTask = task({
                 maxOutputTokens: profile.maxOutputTokens,
                 abortSignal: activeAbort.signal,
                 prepareStep: async ({ messages, steps }) => {
+                  await assertRuntimeAuthorized();
                   const pendingUpdates = await consumePendingSubagentMessages({
                     subagentId: row.subagent_id,
                     triggerRunId: ctx.run.id,
@@ -918,7 +951,7 @@ export const subagentTask = task({
             summary:
               "Independent validation reached its 15-minute active limit.",
           }
-        : triggerSignal.aborted
+        : triggerSignal.aborted || runtimeAuthorizationRevoked
           ? {
               status: "canceled" as const,
               code: "parent_or_user_canceled",
@@ -1034,7 +1067,7 @@ export const subagentTask = task({
             summary:
               "Independent validation reached its 15-minute active limit.",
           }
-        : triggerSignal.aborted
+        : triggerSignal.aborted || runtimeAuthorizationRevoked
           ? {
               status: "canceled" as const,
               code: "parent_or_user_canceled",


### PR DESCRIPTION
## Summary

- add a durable per-user deletion fence before account cleanup starts and enforce it at chat creation, Agent run association, validation-subagent reservation, and AWS MicroVM session creation
- terminate AWS MicroVM and E2B resources before deleting their Convex lifecycle rows
- disable the legacy authenticated direct-deletion mutation so account cleanup cannot bypass provider and Trigger teardown
- retain canceled child Trigger run IDs for retries based on the exact deletion reason instead of a hard-coded reason allowlist
- fail closed before every validation-subagent model step and privileged tool execution unless both the child record and parent Trigger run remain active

## Root cause

Database deletion, Trigger cancellation, and cloud-provider termination were separate lifecycle operations. Some paths marked or deleted the database record before external termination was confirmed, while parent cleanup treated control-plane failures as warning-only and children relied solely on the best-effort Trigger abort signal.

## Security findings addressed

- Data deletion orphans active AWS MicroVMs (`csf_3e4a6e181ba1194f78e0c715`)
- Public data deletion detaches active subagents (`csf_0f5ec661c99dd8008d2dee60`)
- Sandbox deletion retry loses child cancellation (`csf_240a36c59d0da9a5fc09811e`)
- Parent teardown fails open for privileged children (`csf_6aa92004a1dc7563eb92b008`)

All four were revalidated against current `origin/main`; no compensating control defeated the reported paths.

## Validation

- `corepack pnpm test --runInBand` — 405 suites / 4,050 tests passed
- focused lifecycle/security regression run — 12 suites / 126 tests passed
- `corepack pnpm typecheck` — passed
- targeted ESLint on all changed TypeScript files — passed
- `corepack pnpm exec next build` — passed
- `git diff --check` — passed

`CONVEX_AGENT_MODE=anonymous corepack pnpm exec convex dev --once` was attempted, but this publication-only worktree has no configured Convex deployment. Repository guidance explicitly avoids creating a deployment solely for PR publication, so the deployment check is left to CI.

## Manual verification

In a Preview environment with Trigger and Convex connected:

1. Start an Agent run with an AWS MicroVM and an active validation child, then request account deletion. Both Trigger runs and the MicroVM should terminate before Convex user rows disappear.
2. Force the first child cancellation request to fail, retry sandbox deletion, and confirm the same child run ID is canceled on retry.
3. End a parent Agent while its validation child is active. The child should stop before its next model step or terminal/file/network tool call.
4. While deletion is in progress, attempt to create a chat or acquire a new MicroVM. Both operations should fail closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safeguards preventing new chats, triggers, subagent reservations, and cloud sessions after account deletion begins.
  - Added runtime authorization checks that stop subagent activity when runs are revoked, invalid, or inactive.
- **Bug Fixes**
  - Improved account deletion sequencing to clean up cloud sandboxes reliably.
  - Made deletion operations safer to retry and blocked unauthorized deletion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->