### PR TITLE
HAC-73: stage DeepSeek Pro defaults for Pro Plus and Ultra

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -670,6 +670,10 @@ describe("captureUsageSettlement", () => {
         usageDeductionFailureReason: "monthly_cap_exceeded",
       },
       forced: false,
+      experiment: {
+        key: "pro_plus_ultra_deepseek_pro_default_v1",
+        variant: "deepseek_pro",
+      },
     });
 
     expect(capture).toHaveBeenCalledWith({
@@ -705,6 +709,9 @@ describe("captureUsageSettlement", () => {
           isUsageSettlementSuccessSampled("settlement_123"),
         settlement_success_sample_rate: 0.005,
         settlement_event_version: 2,
+        experiment_key: "pro_plus_ultra_deepseek_pro_default_v1",
+        experiment_variant: "deepseek_pro",
+        "$feature/pro_plus_ultra_deepseek_pro_default_v1": "deepseek_pro",
       },
     });
   });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -158,6 +158,12 @@ import {
   getDeepSeekV4Pro0813ExperimentContext,
 } from "@/lib/experiments/deepseek-v4-pro-0813";
 import {
+  captureProPlusUltraDeepSeekProDefaultExposure,
+  evaluateProPlusUltraDeepSeekProDefault,
+  getActiveProPlusUltraDeepSeekProDefaultAssignment,
+  getProPlusUltraDeepSeekProDefaultContext,
+} from "@/lib/experiments/pro-plus-ultra-deepseek-pro-default";
+import {
   createAuxiliaryVisionExposureRecorder,
   evaluateAuxiliaryDeepSeekVisionFlag,
 } from "@/lib/experiments/auxiliary-deepseek-vision";
@@ -382,17 +388,28 @@ export const createChatHandler = () => {
         selectedModelOverride,
         subscription,
       );
-      const auxiliaryVisionAssignment =
-        isAgentMode(mode) ||
-        countFileAttachments(truncatedMessages).imageCount > 0
-          ? await evaluateAuxiliaryDeepSeekVisionFlag({
-              posthog: (posthog ??= PostHogClient()),
-              userId,
-              subscription,
-              selectedModelOverride,
-              requestId: req.headers.get("x-vercel-id") ?? undefined,
-            })
-          : undefined;
+      const attachmentCounts = countFileAttachments(truncatedMessages);
+      const routingPosthog = (posthog ??= PostHogClient());
+      const [auxiliaryVisionAssignment, deepSeekProDefaultAssignment] =
+        await Promise.all([
+          isAgentMode(mode) || attachmentCounts.imageCount > 0
+            ? evaluateAuxiliaryDeepSeekVisionFlag({
+                posthog: routingPosthog,
+                userId,
+                subscription,
+                selectedModelOverride,
+                requestId: req.headers.get("x-vercel-id") ?? undefined,
+              })
+            : Promise.resolve(undefined),
+          evaluateProPlusUltraDeepSeekProDefault({
+            posthog: routingPosthog,
+            userId,
+            subscription,
+            selectedModelOverride,
+            hasImageAttachment: attachmentCounts.imageCount > 0,
+            requestId: req.headers.get("x-vercel-id") ?? undefined,
+          }),
+        ]);
 
       await handleInitialChatAndUserMessage({
         chatId,
@@ -439,6 +456,8 @@ export const createChatHandler = () => {
         allowLocalDesktopFiles:
           isAgentMode(mode) && sandboxPreference === "desktop",
         auxiliaryVisionEnabled: !!auxiliaryVisionAssignment,
+        proPlusUltraDeepSeekProDefaultEnabled:
+          deepSeekProDefaultAssignment?.variant === "deepseek_pro",
         chatId,
         requestId: req.headers.get("x-vercel-id") ?? undefined,
       });
@@ -607,9 +626,18 @@ export const createChatHandler = () => {
           deepSeekV4Pro0813Experiment,
           selectedModel,
         );
-      let routingExperimentContext = getDeepSeekV4Pro0813ExperimentContext(
-        activeDeepSeekV4Pro0813Experiment,
-      );
+      let activeDeepSeekProDefaultAssignment =
+        getActiveProPlusUltraDeepSeekProDefaultAssignment(
+          deepSeekProDefaultAssignment,
+          selectedModel,
+        );
+      let routingExperimentContext =
+        getProPlusUltraDeepSeekProDefaultContext(
+          activeDeepSeekProDefaultAssignment,
+        ) ??
+        getDeepSeekV4Pro0813ExperimentContext(
+          activeDeepSeekV4Pro0813Experiment,
+        );
 
       const freeMonthlyBudgetSnapshot =
         subscription === "free"
@@ -924,7 +952,15 @@ export const createChatHandler = () => {
                     deepSeekV4Pro0813Experiment,
                     selectedModel,
                   );
+                activeDeepSeekProDefaultAssignment =
+                  getActiveProPlusUltraDeepSeekProDefaultAssignment(
+                    deepSeekProDefaultAssignment,
+                    selectedModel,
+                  );
                 routingExperimentContext =
+                  getProPlusUltraDeepSeekProDefaultContext(
+                    activeDeepSeekProDefaultAssignment,
+                  ) ??
                   getDeepSeekV4Pro0813ExperimentContext(
                     activeDeepSeekV4Pro0813Experiment,
                   );
@@ -1367,6 +1403,7 @@ export const createChatHandler = () => {
                   requestedDeltaPoints: additionalCostPoints,
                   deduction: deductionResult,
                   forced: force,
+                  experiment: routingExperimentContext,
                 });
 
                 usageRefundTracker.addDeductions(deductionResult);
@@ -1479,6 +1516,18 @@ export const createChatHandler = () => {
 
             let result;
             try {
+              captureProPlusUltraDeepSeekProDefaultExposure({
+                posthog,
+                userId,
+                subscription,
+                mode,
+                endpoint,
+                selectedModelOverride,
+                selectedModel,
+                configuredModel: configuredModelId,
+                chatId,
+                assignment: activeDeepSeekProDefaultAssignment,
+              });
               captureDeepSeekV4Pro0813ExperimentExposure({
                 posthog,
                 userId,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1570,6 +1570,7 @@ export function captureUsageSettlement({
   requestedDeltaPoints,
   deduction,
   forced,
+  experiment,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1586,6 +1587,7 @@ export function captureUsageSettlement({
   requestedDeltaPoints: number;
   deduction: UsageDeductionResult;
   forced: boolean;
+  experiment?: ExperimentAnalyticsContext;
 }) {
   if (!posthog) return;
   const runSampled = isUsageSettlementSuccessSampled(usageSettlementId);
@@ -1624,6 +1626,7 @@ export function captureUsageSettlement({
       settlement_run_sampled: runSampled,
       settlement_success_sample_rate: USAGE_SETTLEMENT_SUCCESS_SAMPLE_RATE,
       settlement_event_version: 2,
+      ...getExperimentAnalyticsProperties(experiment),
     },
   });
 }

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -154,6 +154,57 @@ describe("limitImageParts", () => {
 // selectModel - Model selection logic
 // ==========================================================================
 describe("selectModel", () => {
+  it.each([
+    ["ask", "pro-plus"],
+    ["agent", "pro-plus"],
+    ["ask", "ultra"],
+    ["agent", "ultra"],
+  ] as const)(
+    "routes %s %s Auto text to DeepSeek V4 Pro in the treatment",
+    (mode, subscription) => {
+      expect(
+        selectModel(mode, subscription, "auto", false, false, {
+          proPlusUltraDeepSeekProDefaultEnabled: true,
+        }),
+      ).toBe("model-deepseek-v4-pro-0813");
+    },
+  );
+
+  it.each(["pro", "team"] as const)(
+    "does not change %s Auto routing in the treatment",
+    (subscription) => {
+      expect(
+        selectModel("agent", subscription, "auto", false, false, {
+          proPlusUltraDeepSeekProDefaultEnabled: true,
+        }),
+      ).toBe("model-deepseek-v4-flash-0731");
+    },
+  );
+
+  it("keeps explicit models and image routes unchanged in the treatment", () => {
+    const treatment = {
+      auxiliaryVisionEnabled: true,
+      proPlusUltraDeepSeekProDefaultEnabled: true,
+    };
+
+    expect(
+      selectModel(
+        "agent",
+        "pro-plus",
+        "hackerai-standard",
+        false,
+        false,
+        treatment,
+      ),
+    ).toBe("model-deepseek-v4-flash-0731");
+    expect(
+      selectModel("agent", "pro-plus", "hackerai-pro", false, false, treatment),
+    ).toBe("model-deepseek-v4-pro-0813");
+    expect(selectModel("agent", "ultra", "auto", true, false, treatment)).toBe(
+      "model-deepseek-v4-flash-0731",
+    );
+  });
+
   it("routes HackerAI Pro through DeepSeek V4 Pro 0813", () => {
     expect(selectModel("agent", "pro", "hackerai-pro")).toBe(
       "model-deepseek-v4-pro-0813",

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -37,11 +37,10 @@ export const getMaxStepsForUser = (mode: ChatMode): number => {
  * @param mode - Chat mode (ask or agent)
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
- *   Paid Auto/Standard routes use DeepSeek V4 Flash 0731 for text/PDF prompts,
- *   Pro uses DeepSeek V4 Pro 0813, and Max uses Grok 4.6. In the control route,
- *   images promote Auto and Standard to Grok 4.5 with medium reasoning while
- *   Pro uses high reasoning. The auxiliary route describes images as text and
- *   keeps DeepSeek active. PDFs stay on DeepSeek and are parsed by OpenRouter.
+ *   Paid Auto normally uses DeepSeek V4 Flash 0731 for text/PDF prompts. A
+ *   staged Pro Plus/Ultra treatment promotes Auto to DeepSeek V4 Pro 0813.
+ *   Explicit Standard stays on Flash, Pro uses Pro 0813, and Max uses Grok
+ *   4.6. Images retain their existing direct or auxiliary vision behavior.
  * @returns Model name to use
  */
 export function selectModel(
@@ -53,6 +52,7 @@ export function selectModel(
   options: {
     extraUsageAvailable?: boolean;
     auxiliaryVisionEnabled?: boolean;
+    proPlusUltraDeepSeekProDefaultEnabled?: boolean;
   } = {},
 ): ModelName {
   const isAgent = isAgentMode(mode);
@@ -69,16 +69,22 @@ export function selectModel(
     !isAgent && !!hasImageAttachment && !options.auxiliaryVisionEnabled;
   const hasProviderImage =
     !!hasImageAttachment && !options.auxiliaryVisionEnabled;
+  const paidAutoTextModel: ModelName =
+    options.proPlusUltraDeepSeekProDefaultEnabled &&
+    (subscription === "pro-plus" || subscription === "ultra") &&
+    !hasImageAttachment
+      ? "model-deepseek-v4-pro-0813"
+      : "model-deepseek-v4-flash-0731";
   const paidAskMediaModel: ModelName = hasAskImage
     ? "model-grok-4.5"
-    : "model-deepseek-v4-flash-0731";
+    : paidAutoTextModel;
 
   const autoModel: ModelName = isAgent
     ? subscription === "free"
       ? "agent-model-free"
       : hasProviderImage
         ? "model-grok-4.5"
-        : "model-deepseek-v4-flash-0731"
+        : paidAutoTextModel
     : isFreeAsk
       ? "ask-model-free"
       : paidAskMediaModel;
@@ -646,6 +652,7 @@ export async function processChatMessages({
   extraUsageAvailable = false,
   allowLocalDesktopFiles = false,
   auxiliaryVisionEnabled = false,
+  proPlusUltraDeepSeekProDefaultEnabled = false,
   chatId,
   triggerRunId,
   requestId,
@@ -659,6 +666,7 @@ export async function processChatMessages({
   extraUsageAvailable?: boolean;
   allowLocalDesktopFiles?: boolean;
   auxiliaryVisionEnabled?: boolean;
+  proPlusUltraDeepSeekProDefaultEnabled?: boolean;
   chatId?: string;
   triggerRunId?: string;
   requestId?: string;
@@ -739,7 +747,11 @@ export async function processChatMessages({
     modelOverride,
     mediaAttachmentRouting.hasImage,
     mediaAttachmentRouting.hasPdf,
-    { extraUsageAvailable, auxiliaryVisionEnabled },
+    {
+      extraUsageAvailable,
+      auxiliaryVisionEnabled,
+      proPlusUltraDeepSeekProDefaultEnabled,
+    },
   );
 
   // Strip providerMetadata for Anthropic models to prevent cross-model signature errors.

--- a/lib/experiments/__tests__/pro-plus-ultra-deepseek-pro-default.test.ts
+++ b/lib/experiments/__tests__/pro-plus-ultra-deepseek-pro-default.test.ts
@@ -1,0 +1,177 @@
+import {
+  captureProPlusUltraDeepSeekProDefaultExposure,
+  evaluateProPlusUltraDeepSeekProDefault,
+  getActiveProPlusUltraDeepSeekProDefaultAssignment,
+  getProPlusUltraDeepSeekProDefaultContext,
+  isEligibleForProPlusUltraDeepSeekProDefault,
+  PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+  PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPOSURE_EVENT,
+  PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_FEATURE_PROPERTY,
+} from "@/lib/experiments/pro-plus-ultra-deepseek-pro-default";
+
+describe("Pro Plus and Ultra DeepSeek Pro default experiment", () => {
+  it.each(["pro-plus", "ultra"] as const)(
+    "makes %s Auto text requests eligible",
+    (subscription) => {
+      expect(
+        isEligibleForProPlusUltraDeepSeekProDefault({
+          subscription,
+          selectedModelOverride: "auto",
+          hasImageAttachment: false,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    ["pro", "auto", false],
+    ["team", "auto", false],
+    ["pro-plus", "hackerai-standard", false],
+    ["pro-plus", "hackerai-pro", false],
+    ["ultra", "hackerai-max", false],
+    ["ultra", "auto", true],
+  ] as const)(
+    "rejects plan %s, override %s, image=%s",
+    (subscription, selectedModelOverride, hasImageAttachment) => {
+      expect(
+        isEligibleForProPlusUltraDeepSeekProDefault({
+          subscription,
+          selectedModelOverride,
+          hasImageAttachment,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it.each([
+    ["control", "model-deepseek-v4-flash-0731"],
+    ["deepseek_pro", "model-deepseek-v4-pro-0813"],
+  ] as const)("maps %s to %s", async (variant, modelKey) => {
+    const evaluateFlags = jest.fn(async () => ({ getFlag: () => variant }));
+
+    await expect(
+      evaluateProPlusUltraDeepSeekProDefault({
+        posthog: { evaluateFlags } as never,
+        userId: "user-1",
+        subscription: "pro-plus",
+        selectedModelOverride: "auto",
+        hasImageAttachment: false,
+      }),
+    ).resolves.toEqual({
+      key: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+      variant,
+      modelKey,
+    });
+  });
+
+  it("does not evaluate ineligible requests", async () => {
+    const evaluateFlags = jest.fn();
+
+    await expect(
+      evaluateProPlusUltraDeepSeekProDefault({
+        posthog: { evaluateFlags } as never,
+        userId: "user-1",
+        subscription: "pro",
+        selectedModelOverride: "auto",
+        hasImageAttachment: false,
+      }),
+    ).resolves.toBeUndefined();
+    expect(evaluateFlags).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for unknown variants and evaluation errors", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(
+      evaluateProPlusUltraDeepSeekProDefault({
+        posthog: {
+          evaluateFlags: jest.fn(async () => ({ getFlag: () => true })),
+        } as never,
+        userId: "user-1",
+        subscription: "ultra",
+        hasImageAttachment: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      evaluateProPlusUltraDeepSeekProDefault({
+        posthog: {
+          evaluateFlags: jest.fn(async () => {
+            throw new Error("PostHog unavailable");
+          }),
+        } as never,
+        userId: "user-1",
+        subscription: "ultra",
+        hasImageAttachment: false,
+        requestId: "request-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      '"event":"pro_plus_ultra_deepseek_pro_default_evaluation_failed"',
+    );
+    expect(warnSpy.mock.calls[0][0]).toContain('"request_id":"request-1"');
+    warnSpy.mockRestore();
+  });
+
+  it("captures a content-free exposure at the provider request boundary", () => {
+    const capture = jest.fn();
+    const assignment = {
+      key: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+      variant: "deepseek_pro" as const,
+      modelKey: "model-deepseek-v4-pro-0813" as const,
+    };
+
+    captureProPlusUltraDeepSeekProDefaultExposure({
+      posthog: { capture } as never,
+      userId: "user-1",
+      subscription: "ultra",
+      mode: "agent",
+      endpoint: "/api/agent-long",
+      selectedModelOverride: "auto",
+      selectedModel: assignment.modelKey,
+      configuredModel: "deepseek/deepseek-v4-pro-0813",
+      chatId: "chat-1",
+      triggerRunId: "run-1",
+      assignment,
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user-1",
+      event: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPOSURE_EVENT,
+      properties: {
+        experiment_key: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+        experiment_variant: "deepseek_pro",
+        [PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_FEATURE_PROPERTY]: "deepseek_pro",
+        subscription: "ultra",
+        subscription_tier: "ultra",
+        mode: "agent",
+        endpoint: "/api/agent-long",
+        selected_model: "model-deepseek-v4-pro-0813",
+        selected_model_override: "auto",
+        configured_model: "deepseek/deepseek-v4-pro-0813",
+        exposure_surface: "provider_request",
+        chat_id: "chat-1",
+        trigger_run_id: "run-1",
+        $process_person_profile: false,
+      },
+    });
+    expect(getProPlusUltraDeepSeekProDefaultContext(assignment)).toEqual({
+      key: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+      variant: "deepseek_pro",
+    });
+    expect(
+      getActiveProPlusUltraDeepSeekProDefaultAssignment(
+        assignment,
+        "model-deepseek-v4-pro-0813",
+      ),
+    ).toBe(assignment);
+    expect(
+      getActiveProPlusUltraDeepSeekProDefaultAssignment(
+        assignment,
+        "model-deepseek-v4-flash-0731",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/lib/experiments/pro-plus-ultra-deepseek-pro-default.ts
+++ b/lib/experiments/pro-plus-ultra-deepseek-pro-default.ts
@@ -1,0 +1,165 @@
+import type { PostHog } from "posthog-node";
+
+import type { ExperimentAnalyticsContext } from "@/lib/analytics/experiment-context";
+import type { ModelName } from "@/lib/ai/providers";
+import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
+import type { ChatMode, SelectedModel, SubscriptionTier } from "@/types";
+
+export const PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY =
+  "pro_plus_ultra_deepseek_pro_default_v1";
+export const PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPOSURE_EVENT =
+  "pro_plus_ultra_deepseek_pro_default_exposed";
+export const PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_FEATURE_PROPERTY = `$feature/${PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY}`;
+
+export type ProPlusUltraDeepSeekProDefaultVariant = "control" | "deepseek_pro";
+
+export type ProPlusUltraDeepSeekProDefaultAssignment = {
+  key: typeof PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY;
+  variant: ProPlusUltraDeepSeekProDefaultVariant;
+  modelKey: "model-deepseek-v4-flash-0731" | "model-deepseek-v4-pro-0813";
+};
+
+export function isEligibleForProPlusUltraDeepSeekProDefault({
+  subscription,
+  selectedModelOverride,
+  hasImageAttachment,
+}: {
+  subscription: SubscriptionTier;
+  selectedModelOverride?: SelectedModel;
+  hasImageAttachment: boolean;
+}): boolean {
+  return (
+    (subscription === "pro-plus" || subscription === "ultra") &&
+    (!selectedModelOverride || selectedModelOverride === "auto") &&
+    !hasImageAttachment
+  );
+}
+
+export async function evaluateProPlusUltraDeepSeekProDefault({
+  posthog,
+  userId,
+  subscription,
+  selectedModelOverride,
+  hasImageAttachment,
+  requestId,
+}: {
+  posthog: Pick<PostHog, "evaluateFlags"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  selectedModelOverride?: SelectedModel;
+  hasImageAttachment: boolean;
+  requestId?: string;
+}): Promise<ProPlusUltraDeepSeekProDefaultAssignment | undefined> {
+  if (
+    !posthog ||
+    !isEligibleForProPlusUltraDeepSeekProDefault({
+      subscription,
+      selectedModelOverride,
+      hasImageAttachment,
+    })
+  ) {
+    return undefined;
+  }
+
+  try {
+    const flags = await posthog.evaluateFlags(userId, {
+      flagKeys: [PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY],
+    });
+    const variant = flags.getFlag(
+      PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+    );
+
+    if (variant !== "control" && variant !== "deepseek_pro") {
+      return undefined;
+    }
+
+    return {
+      key: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+      variant,
+      modelKey:
+        variant === "deepseek_pro"
+          ? "model-deepseek-v4-pro-0813"
+          : "model-deepseek-v4-flash-0731",
+    };
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "warn",
+        event: "pro_plus_ultra_deepseek_pro_default_evaluation_failed",
+        service: "model-routing-experiment",
+        environment:
+          process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+        request_id: requestId ?? "unavailable",
+        user_id: userId,
+        flag_key: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPERIMENT_KEY,
+        error_name: error instanceof Error ? error.name : "UnknownError",
+      }),
+    );
+    return undefined;
+  }
+}
+
+export function getActiveProPlusUltraDeepSeekProDefaultAssignment(
+  assignment: ProPlusUltraDeepSeekProDefaultAssignment | undefined,
+  selectedModel: ModelName,
+): ProPlusUltraDeepSeekProDefaultAssignment | undefined {
+  return assignment?.modelKey === selectedModel ? assignment : undefined;
+}
+
+export function getProPlusUltraDeepSeekProDefaultContext(
+  assignment: ProPlusUltraDeepSeekProDefaultAssignment | undefined,
+): ExperimentAnalyticsContext | undefined {
+  if (!assignment) return undefined;
+  return { key: assignment.key, variant: assignment.variant };
+}
+
+export function captureProPlusUltraDeepSeekProDefaultExposure({
+  posthog,
+  userId,
+  subscription,
+  mode,
+  endpoint,
+  selectedModelOverride,
+  selectedModel,
+  configuredModel,
+  chatId,
+  triggerRunId,
+  assignment,
+}: {
+  posthog: Pick<PostHog, "capture"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  endpoint: ChatApiEndpoint;
+  selectedModelOverride?: SelectedModel;
+  selectedModel: ModelName;
+  configuredModel: string;
+  chatId: string;
+  triggerRunId?: string;
+  assignment?: ProPlusUltraDeepSeekProDefaultAssignment;
+}): void {
+  if (!posthog || !assignment) return;
+
+  posthog.capture({
+    distinctId: userId,
+    event: PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_EXPOSURE_EVENT,
+    properties: {
+      experiment_key: assignment.key,
+      experiment_variant: assignment.variant,
+      [PRO_PLUS_ULTRA_DEEPSEEK_PRO_DEFAULT_FEATURE_PROPERTY]:
+        assignment.variant,
+      subscription,
+      subscription_tier: subscription,
+      mode,
+      endpoint,
+      selected_model: selectedModel,
+      selected_model_override: selectedModelOverride ?? "auto",
+      configured_model: configuredModel,
+      exposure_surface: "provider_request",
+      chat_id: chatId,
+      ...(triggerRunId && { trigger_run_id: triggerRunId }),
+      $process_person_profile: false,
+    },
+  });
+}

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -44,6 +44,7 @@ import {
   sendRateLimitWarnings,
   SummarizationTracker,
   appendSystemReminderToLastUserMessage,
+  countFileAttachments,
   estimatePreflightInputTokens,
   buildExtraUsageConfig,
   computeContextUsage,
@@ -146,6 +147,12 @@ import {
   getActiveDeepSeekV4Pro0813ExperimentAssignment,
   getDeepSeekV4Pro0813ExperimentContext,
 } from "@/lib/experiments/deepseek-v4-pro-0813";
+import {
+  captureProPlusUltraDeepSeekProDefaultExposure,
+  evaluateProPlusUltraDeepSeekProDefault,
+  getActiveProPlusUltraDeepSeekProDefaultAssignment,
+  getProPlusUltraDeepSeekProDefaultContext,
+} from "@/lib/experiments/pro-plus-ultra-deepseek-pro-default";
 import {
   createAuxiliaryVisionExposureRecorder,
   evaluateAuxiliaryDeepSeekVisionFlag,
@@ -2434,6 +2441,14 @@ export const agentLongTask = task({
         sandboxPreference,
       });
       const truncatedMessages = fetched.truncatedMessages;
+      const messagesForProcessing =
+        localDesktopAttachmentsPrepared && messages.length > 0
+          ? messages
+          : truncatedMessages.length
+            ? truncatedMessages
+            : messages;
+      const messagesForAccounting = messagesForProcessing;
+      const attachmentCounts = countFileAttachments(messagesForProcessing);
       const baseExtraUsageConfig = await buildExtraUsageConfig({
         userId,
         subscription,
@@ -2451,23 +2466,34 @@ export const agentLongTask = task({
         subscription,
       );
       const posthog = PostHogClient();
-      const [cloudSandboxRollout, auxiliaryVisionAssignment] =
-        await Promise.all([
-          evaluateAwsLambdaMicrovmRollout({
-            posthog,
-            userId,
-            subscription,
-            configuredProvider: getCloudSandboxProvider(),
-            requestId: ctx.run.id,
-          }),
-          evaluateAuxiliaryDeepSeekVisionFlag({
-            posthog,
-            userId,
-            subscription,
-            selectedModelOverride,
-            requestId: ctx.run.id,
-          }),
-        ]);
+      const [
+        cloudSandboxRollout,
+        auxiliaryVisionAssignment,
+        deepSeekProDefaultAssignment,
+      ] = await Promise.all([
+        evaluateAwsLambdaMicrovmRollout({
+          posthog,
+          userId,
+          subscription,
+          configuredProvider: getCloudSandboxProvider(),
+          requestId: ctx.run.id,
+        }),
+        evaluateAuxiliaryDeepSeekVisionFlag({
+          posthog,
+          userId,
+          subscription,
+          selectedModelOverride,
+          requestId: ctx.run.id,
+        }),
+        evaluateProPlusUltraDeepSeekProDefault({
+          posthog,
+          userId,
+          subscription,
+          selectedModelOverride,
+          hasImageAttachment: attachmentCounts.imageCount > 0,
+          requestId: ctx.run.id,
+        }),
+      ]);
 
       const baseTodos: Todo[] = getBaseTodosForRequest(
         (chat?.todos as unknown as Todo[]) || [],
@@ -2475,13 +2501,6 @@ export const agentLongTask = task({
       );
 
       const uploadBasePath = getUploadBasePath(sandboxPreference);
-      const messagesForProcessing =
-        localDesktopAttachmentsPrepared && messages.length > 0
-          ? messages
-          : truncatedMessages.length
-            ? truncatedMessages
-            : messages;
-      const messagesForAccounting = messagesForProcessing;
 
       let {
         processedMessages,
@@ -2498,6 +2517,8 @@ export const agentLongTask = task({
         extraUsageAvailable,
         allowLocalDesktopFiles: sandboxPreference === "desktop",
         auxiliaryVisionEnabled: !!auxiliaryVisionAssignment,
+        proPlusUltraDeepSeekProDefaultEnabled:
+          deepSeekProDefaultAssignment?.variant === "deepseek_pro",
         chatId,
         triggerRunId: ctx.run.id,
         requestId: ctx.run.id,
@@ -2822,7 +2843,15 @@ export const agentLongTask = task({
                 deepSeekV4Pro0813Experiment,
                 selectedModel,
               );
+            let activeDeepSeekProDefaultAssignment =
+              getActiveProPlusUltraDeepSeekProDefaultAssignment(
+                deepSeekProDefaultAssignment,
+                selectedModel,
+              );
             let routingExperimentContext =
+              getProPlusUltraDeepSeekProDefaultContext(
+                activeDeepSeekProDefaultAssignment,
+              ) ??
               getDeepSeekV4Pro0813ExperimentContext(
                 activeDeepSeekV4Pro0813Experiment,
               );
@@ -3321,7 +3350,15 @@ export const agentLongTask = task({
                     deepSeekV4Pro0813Experiment,
                     selectedModel,
                   );
+                activeDeepSeekProDefaultAssignment =
+                  getActiveProPlusUltraDeepSeekProDefaultAssignment(
+                    deepSeekProDefaultAssignment,
+                    selectedModel,
+                  );
                 routingExperimentContext =
+                  getProPlusUltraDeepSeekProDefaultContext(
+                    activeDeepSeekProDefaultAssignment,
+                  ) ??
                   getDeepSeekV4Pro0813ExperimentContext(
                     activeDeepSeekV4Pro0813Experiment,
                   );
@@ -3744,6 +3781,7 @@ export const agentLongTask = task({
                   requestedDeltaPoints: additionalCostPoints,
                   deduction: deductionResult,
                   forced: force,
+                  experiment: routingExperimentContext,
                 });
 
                 usageRefundTracker.addDeductions(deductionResult);
@@ -3872,6 +3910,19 @@ export const agentLongTask = task({
 
             let result;
             try {
+              captureProPlusUltraDeepSeekProDefaultExposure({
+                posthog,
+                userId,
+                subscription,
+                mode,
+                endpoint,
+                selectedModelOverride,
+                selectedModel,
+                configuredModel: configuredModelId,
+                chatId,
+                triggerRunId: ctx.run.id,
+                assignment: activeDeepSeekProDefaultAssignment,
+              });
               captureDeepSeekV4Pro0813ExperimentExposure({
                 posthog,
                 userId,


### PR DESCRIPTION
## Summary
- route eligible Pro Plus and Ultra Auto/default text and PDF requests to DeepSeek V4 Pro 0813 behind a fail-closed PostHog flag
- preserve existing routing for images, explicit Standard/Pro/Max selections, and all other plans
- emit provider-boundary exposure and attach experiment attribution to agent run, usage cost, and usage settlement events

## Rollout
- Linear: [HAC-73](https://linear.app/hackerai/issue/HAC-73/experiment-default-pro-plus-and-ultra-auto-to-deepseek-v4-pro-0813)
- PostHog flag: [`pro_plus_ultra_deepseek_pro_default_v1`](https://us.posthog.com/project/144137/feature_flags/832684)
- flag is inactive and configured for an internal-only treatment preflight after production deployment
- external ramp remains gated on success, cost, extra-usage, and settlement guardrails documented in HAC-73

## Validation
- `TMPDIR=/home/hackerai/.cache/tmp-hac73 pnpm test` (404 suites, 4,043 tests)
- `pnpm typecheck`
- touched-file ESLint and Prettier via pre-commit hook

## Manual verification
1. In production, enable the internal-only flag and start Auto/default text and PDF requests from the targeted Pro Plus or Ultra account.
2. Confirm provider requests use `deepseek/deepseek-v4-pro-0813`; image and explicit model requests keep their previous routes.
3. Confirm the exposure event and downstream run, cost, and settlement events carry `experiment_variant=deepseek_pro`.
4. Disable the flag and confirm Auto/default immediately returns to DeepSeek V4 Flash 0731.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic model selection for eligible Pro Plus and Ultra text, PDF, and Agent requests.
  * Eligible requests may now use DeepSeek V4 Pro by default for enhanced responses.
  * Model selection remains compatible with explicit model choices and image-based routing.
* **Bug Fixes**
  * Improved model fallback handling when auxiliary vision processing or other model attempts fail.
* **Analytics**
  * Usage and model-routing events now include relevant assignment and variant details for improved reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->