### PR TITLE
Retry explicit DeepSeek Pro reasoning-only failures

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1430,6 +1430,23 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(fallbackIdx).toBeGreaterThan(retryModelIdx);
   });
 
+  test("explicit DeepSeek Pro retries only terminal reasoning-only provider failures", () => {
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      expect(source).toMatch(
+        /shouldRetryProviderStreamAfterReasoningOnlyOutput\(\s*lastAssistantMessageParts,/,
+      );
+      expect(source).toMatch(
+        /shouldRetryReasoningOnlyProviderError\s*&&\s*isExplicitDeepSeekProSelectionForRetry\(\{/,
+      );
+      expect(source).toMatch(
+        /shouldRetryInterruptedToolInput\s*\|\|\s*shouldRetryExplicitDeepSeekProReasoning/,
+      );
+    }
+
+    expect(taskSrc).toMatch(/state\?\.providerError != null\s*\|\|/);
+    expect(chatHandlerSrc).toMatch(/state\.providerError != null/);
+  });
+
   test("/api/chat attributes fallback usage to the persisted retry message", () => {
     expect(chatHandlerSrc).toMatch(
       /const deductAccumulatedUsage = async \(\s*assistantMessageIdForUsage = assistantMessageId,\s*\)/,

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -11,6 +11,7 @@ import {
   getContentFilterRetryModel,
   getRetryFallbackModel,
   isAutoModelSelectionForRetry,
+  isExplicitDeepSeekProSelectionForRetry,
   resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 
@@ -650,6 +651,45 @@ describe("isAutoModelSelectionForRetry", () => {
       }),
     ).toBe(true);
   });
+});
+
+describe("isExplicitDeepSeekProSelectionForRetry", () => {
+  it.each(["model-deepseek-v4-pro", "model-deepseek-v4-pro-0813"])(
+    "recognizes explicit HackerAI Pro on %s",
+    (selectedModel) => {
+      expect(
+        isExplicitDeepSeekProSelectionForRetry({
+          selectedModel,
+          selectedModelOverride: "hackerai-pro",
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    {
+      selectedModel: "model-deepseek-v4-pro",
+      selectedModelOverride: "auto" as const,
+    },
+    {
+      selectedModel: "model-deepseek-v4-pro",
+      selectedModelOverride: "hackerai-standard" as const,
+    },
+    {
+      selectedModel: "model-grok-4.5-pro",
+      selectedModelOverride: "hackerai-pro" as const,
+    },
+  ])(
+    "rejects non-explicit-DeepSeek selection $selectedModelOverride / $selectedModel",
+    ({ selectedModel, selectedModelOverride }) => {
+      expect(
+        isExplicitDeepSeekProSelectionForRetry({
+          selectedModel,
+          selectedModelOverride,
+        }),
+      ).toBe(false);
+    },
+  );
 });
 
 describe("getRetryFallbackModel", () => {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -94,6 +94,7 @@ import {
   getContentFilterRetryModel,
   getRetryFallbackModel,
   isAutoModelSelectionForRetry,
+  isExplicitDeepSeekProSelectionForRetry,
   resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 import { geolocation } from "@vercel/functions";
@@ -211,6 +212,7 @@ import {
 } from "@/lib/chat/multimodal-tool-result-recovery";
 import {
   detectAssistantContentLoopFromParts,
+  shouldRetryProviderStreamAfterReasoningOnlyOutput,
   shouldRetryProviderStreamAfterInterruptedToolInput,
   shouldRetryProviderStreamWithFallback,
 } from "@/lib/chat/agent-long-provider-retry";
@@ -1640,7 +1642,19 @@ export const createChatHandler = () => {
                       );
                     const hasTerminalProviderStreamError =
                       state.streamFinishReason === "error" ||
-                      providerContentBlocked;
+                      providerContentBlocked ||
+                      state.providerError != null;
+                    const shouldRetryReasoningOnlyProviderError =
+                      shouldRetryProviderStreamAfterReasoningOnlyOutput(
+                        lastAssistantMessageParts,
+                        { hasTerminalProviderStreamError },
+                      );
+                    const shouldRetryExplicitDeepSeekProReasoning =
+                      shouldRetryReasoningOnlyProviderError &&
+                      isExplicitDeepSeekProSelectionForRetry({
+                        selectedModel,
+                        selectedModelOverride,
+                      });
                     const shouldRetryInterruptedToolInput =
                       shouldRetryProviderStreamAfterInterruptedToolInput(
                         lastAssistantMessageParts,
@@ -1683,7 +1697,9 @@ export const createChatHandler = () => {
                               ? "doom_loop"
                               : shouldRetryInterruptedToolInput
                                 ? "interrupted_tool_input"
-                                : "incomplete_stream";
+                                : shouldRetryReasoningOnlyProviderError
+                                  ? "reasoning_only_provider_error"
+                                  : "incomplete_stream";
                       const blockedProviderModel = providerContentBlocked
                         ? state.responseModel
                         : undefined;
@@ -1709,9 +1725,12 @@ export const createChatHandler = () => {
                                 ? "Agent doom loop detected - triggering fallback"
                                 : retryReason === "interrupted_tool_input"
                                   ? "Provider stream errored during tool input - triggering bounded fallback"
-                                  : hasTerminalProviderStreamError
-                                    ? "Provider stream errored before useful output - triggering fallback"
-                                    : "Stream finished incomplete - triggering fallback",
+                                  : retryReason ===
+                                      "reasoning_only_provider_error"
+                                    ? "Provider stream errored after reasoning-only output - triggering bounded fallback"
+                                    : hasTerminalProviderStreamError
+                                      ? "Provider stream errored before useful output - triggering fallback"
+                                      : "Stream finished incomplete - triggering fallback",
                         {
                           chatId,
                           endpoint,
@@ -1747,7 +1766,8 @@ export const createChatHandler = () => {
                           providerContentBlocked ||
                           shouldRetryWithoutImageToolResults ||
                           loopTriggeredRetry ||
-                          shouldRetryInterruptedToolInput)
+                          shouldRetryInterruptedToolInput ||
+                          shouldRetryExplicitDeepSeekProReasoning)
                       ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -594,6 +594,10 @@ const AUTO_MODEL_KEYS = new Set<string>([
   "agent-model-free",
 ]);
 const EXPLICIT_RETRY_MODEL_KEYS = new Set<string>(["model-grok-4.6-pro"]);
+const EXPLICIT_DEEPSEEK_PRO_RETRY_MODEL_KEYS = new Set<string>([
+  "model-deepseek-v4-pro",
+  "model-deepseek-v4-pro-0813",
+]);
 
 export function isAutoModelSelectionForRetry({
   selectedModel,
@@ -607,6 +611,19 @@ export function isAutoModelSelectionForRetry({
     selectedModelOverride === "auto" ||
     AUTO_MODEL_KEYS.has(selectedModel) ||
     EXPLICIT_RETRY_MODEL_KEYS.has(selectedModel)
+  );
+}
+
+export function isExplicitDeepSeekProSelectionForRetry({
+  selectedModel,
+  selectedModelOverride,
+}: {
+  selectedModel: string;
+  selectedModelOverride?: SelectedModel | null;
+}): boolean {
+  return (
+    selectedModelOverride === "hackerai-pro" &&
+    EXPLICIT_DEEPSEEK_PRO_RETRY_MODEL_KEYS.has(selectedModel)
   );
 }
 

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -2,6 +2,7 @@ import {
   createAssistantContentLoopMonitor,
   detectAssistantContentLoopFromText,
   shouldRetryAgentLongWithFallback,
+  shouldRetryProviderStreamAfterReasoningOnlyOutput,
   shouldRetryProviderStreamAfterInterruptedToolInput,
 } from "../agent-long-provider-retry";
 
@@ -277,6 +278,77 @@ describe("shouldRetryAgentLongWithFallback", () => {
           hasTerminalProviderStreamError: false,
           detectAssistantContentLoop: false,
         },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("shouldRetryProviderStreamAfterReasoningOnlyOutput", () => {
+  it("accepts terminal reasoning-only output with hidden metadata", () => {
+    expect(
+      shouldRetryProviderStreamAfterReasoningOnlyOutput(
+        [
+          { type: "data-agent-heartbeat", data: { at: 1 } },
+          { type: "step-start" },
+          { type: "reasoning", text: "thinking", state: "done" },
+          { type: "data-context-usage", data: { usedTokens: 100 } },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "a completed tool side effect",
+      parts: [
+        { type: "step-start" },
+        { type: "reasoning", text: "thinking", state: "done" },
+        {
+          type: "tool-run_terminal_cmd",
+          toolCallId: "call_1",
+          state: "output-available",
+          output: { result: { exitCode: 0 } },
+        },
+      ],
+    },
+    {
+      label: "visible text",
+      parts: [
+        { type: "step-start" },
+        { type: "reasoning", text: "thinking", state: "done" },
+        { type: "text", text: "partial answer" },
+      ],
+    },
+    {
+      label: "interrupted tool input",
+      parts: [
+        { type: "step-start" },
+        { type: "reasoning", text: "thinking", state: "done" },
+        {
+          type: "tool-file",
+          toolCallId: "call_1",
+          state: "input-streaming",
+          input: { path: "/repo/file.ts" },
+        },
+      ],
+    },
+  ])("rejects terminal output containing $label", ({ parts }) => {
+    expect(
+      shouldRetryProviderStreamAfterReasoningOnlyOutput(parts, {
+        hasTerminalProviderStreamError: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects reasoning-only output without a terminal provider error", () => {
+    expect(
+      shouldRetryProviderStreamAfterReasoningOnlyOutput(
+        [
+          { type: "step-start" },
+          { type: "reasoning", text: "thinking", state: "done" },
+        ],
+        { hasTerminalProviderStreamError: false },
       ),
     ).toBe(false);
   });

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -241,6 +241,13 @@ export const createAssistantContentLoopMonitor = () => {
   };
 };
 
+export const shouldRetryProviderStreamAfterReasoningOnlyOutput = (
+  parts: unknown[],
+  options: Pick<RetryDecisionOptions, "hasTerminalProviderStreamError">,
+): boolean =>
+  options.hasTerminalProviderStreamError &&
+  isReasoningOnlyProviderOutput(parts);
+
 export const shouldRetryProviderStreamWithFallback = (
   parts: unknown[],
   options: RetryDecisionOptions,
@@ -271,8 +278,8 @@ export const shouldRetryProviderStreamWithFallback = (
   // is no text, tool call, or tool output to preserve. Retrying on fallback is
   // safer than failing the whole run on a discarded provider socket.
   return (
-    options.hasTerminalProviderStreamError &&
-    (isReasoningOnlyProviderOutput(parts) ||
+    shouldRetryProviderStreamAfterReasoningOnlyOutput(parts, options) ||
+    (options.hasTerminalProviderStreamError &&
       isInterruptedToolInputOnlyProviderOutput(parts))
   );
 };

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -54,6 +54,7 @@ import {
   getContentFilterRetryModel,
   getRetryFallbackModel,
   isAutoModelSelectionForRetry,
+  isExplicitDeepSeekProSelectionForRetry,
   resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 import {
@@ -254,6 +255,7 @@ import {
 } from "@/lib/chat/stop-conditions";
 import {
   detectAssistantContentLoopFromParts,
+  shouldRetryProviderStreamAfterReasoningOnlyOutput,
   shouldRetryProviderStreamAfterInterruptedToolInput,
   shouldRetryAgentLongWithFallback,
 } from "@/lib/chat/agent-long-provider-retry";
@@ -1639,14 +1641,13 @@ const getTerminalProviderStreamError = (
     Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): unknown | undefined => {
   if (!state) return undefined;
+  if (state.providerError) return state.providerError;
   if (
     state.streamFinishReason !== "error" &&
     !isProviderContentFilterFinishReason(state.streamFinishReason)
   ) {
     return undefined;
   }
-  if (state.providerError) return state.providerError;
-
   if (isProviderContentFilterFinishReason(state.streamFinishReason)) {
     return createProviderContentBlockedFinishReasonError();
   }
@@ -1664,6 +1665,7 @@ const isTerminalProviderStreamError = (
   state:
     Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): boolean =>
+  state?.providerError != null ||
   state?.streamFinishReason === "error" ||
   isProviderContentFilterFinishReason(state?.streamFinishReason);
 
@@ -4042,6 +4044,17 @@ export const agentLongTask = task({
                         );
                       const hasTerminalProviderStreamError =
                         isTerminalProviderStreamError(state);
+                      const shouldRetryReasoningOnlyProviderError =
+                        shouldRetryProviderStreamAfterReasoningOnlyOutput(
+                          lastAssistantMessageParts,
+                          { hasTerminalProviderStreamError },
+                        );
+                      const shouldRetryExplicitDeepSeekProReasoning =
+                        shouldRetryReasoningOnlyProviderError &&
+                        isExplicitDeepSeekProSelectionForRetry({
+                          selectedModel,
+                          selectedModelOverride,
+                        });
                       const shouldRetryInterruptedToolInput =
                         shouldRetryProviderStreamAfterInterruptedToolInput(
                           lastAssistantMessageParts,
@@ -4078,7 +4091,8 @@ export const agentLongTask = task({
                           shouldRetryWithoutImageToolResults ||
                           stoppedDueToAssistantContentLoop ||
                           state.stoppedDueToDoomLoop ||
-                          shouldRetryInterruptedToolInput)
+                          shouldRetryInterruptedToolInput ||
+                          shouldRetryExplicitDeepSeekProReasoning)
                       ) {
                         const retryReason = shouldRetryWithoutImageToolResults
                           ? "image_tool_result_rejection"
@@ -4090,7 +4104,9 @@ export const agentLongTask = task({
                                 ? "doom_loop"
                                 : shouldRetryInterruptedToolInput
                                   ? "interrupted_tool_input"
-                                  : "incomplete_stream";
+                                  : shouldRetryReasoningOnlyProviderError
+                                    ? "reasoning_only_provider_error"
+                                    : "incomplete_stream";
                         const blockedProviderModel = providerContentBlocked
                           ? state.responseModel
                           : undefined;


### PR DESCRIPTION
## What

- recognize provider `onError` state as terminal even when the AI SDK reports finish reason `other`
- allow one app-side fallback retry for an explicit HackerAI Pro / DeepSeek Pro selection when the failed step contains reasoning and hidden metadata only
- keep visible text, interrupted tool input, and completed tool output outside this new retry permission
- apply the same behavior to the synchronous chat handler and Trigger.dev agent task

## Why

The reported Together HTTP/2 stream failure can arrive after reasoning tokens through `onError` while the stream finish reason remains `other`. The existing reasoning-only fallback logic therefore saw the run as non-terminal, and explicit DeepSeek Pro was also outside the Auto-only execution gate.

This made a retry-safe provider transport failure terminate the run after the user had already incurred reasoning usage.

## Safety and billing impact

- retry remains bounded by the existing `isRetryWithFallback` one-shot guard
- the retry uses the configured DeepSeek Pro fallback (Grok 4.6)
- the failed model leg is reset before retry, while non-model/tool costs remain preserved
- the new explicit-model path requires actual reasoning-only output; it will not replay completed tool side effects or discard visible answer text
- no feature flag: this is a narrow reliability/correctness fix

## Validation

- `pnpm typecheck`
- targeted ESLint on all changed files
- focused Jest: 3 suites, 222 tests
- full pre-commit suite: 407 suites, 4,099 tests

## Manual verification

1. Explicitly select HackerAI Pro and simulate a Together provider error after reasoning-only output. Expect exactly one Grok 4.6 fallback and a completed response.
2. Repeat after a completed tool output or visible answer text. Expect no new explicit DeepSeek retry.
3. Confirm telemetry records `reasoning_only_provider_error` and settlement excludes the failed model leg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when DeepSeek Pro produces terminal provider errors with reasoning-only output.
  * Preserved existing recovery for interrupted tool input and prevented retries when visible responses or tool effects are present.
  * Added safeguards to limit retries to explicit DeepSeek Pro selections and eligible terminal failures.

* **Tests**
  * Expanded coverage for reasoning-only output, provider errors, model selection, and retry conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->