### PR TITLE
Bound sandbox placement recovery and group error spikes

### DIFF
--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -52,6 +52,10 @@ import {
   type AwsLambdaMicrovmRolloutAssignment,
 } from "@/lib/experiments/aws-lambda-microvm-rollout";
 import type { CloudSandboxAcquisitionContext } from "./utils/cloud-sandbox";
+import {
+  AlternateCloudSandboxUnavailableError,
+  getCloudSandboxRecoveryTelemetryProperties,
+} from "./utils/cloud-sandbox-recovery";
 import type { CloudSandboxProvider } from "./utils/cloud-sandbox-provider";
 
 export { isE2BSandbox };
@@ -157,6 +161,7 @@ export const createTools = (
         subscription_tier: subscription,
         agent_run_kind: cloudSandboxContext.runKind,
         ...getAwsLambdaMicrovmRolloutTelemetryProperties(rollout),
+        ...getCloudSandboxRecoveryTelemetryProperties(cloudSandboxContext),
         sandbox_boot_path: sandboxBootInfo?.path,
         sandbox_acquisition_duration_ms: sandboxBootInfo?.duration_ms,
         sandbox_create_attempts: sandboxBootInfo?.create_attempts,
@@ -305,9 +310,12 @@ export const createTools = (
     refresh?: boolean;
     reason?: string;
     excludeConnectionId?: string;
+    requireAlternateCloudProvider?: boolean;
   }) => {
     const recoveryRequested = Boolean(
-      options?.refresh || options?.excludeConnectionId,
+      options?.refresh ||
+      options?.excludeConnectionId ||
+      options?.requireAlternateCloudProvider,
     );
     if (!recoveryRequested && pendingSandbox) return pendingSandbox;
 
@@ -319,6 +327,13 @@ export const createTools = (
           options.excludeConnectionId,
           "command_unresponsive",
         );
+      }
+      if (options?.requireAlternateCloudProvider) {
+        const alternateProvider =
+          sandboxManager.selectAlternateCloudProviderForRecovery?.() ?? null;
+        if (!alternateProvider) {
+          throw new AlternateCloudSandboxUnavailableError();
+        }
       }
       if (options?.refresh) {
         await sandboxManager.resetSandbox?.(options.reason);

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-recovery.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-recovery.test.ts
@@ -1,0 +1,49 @@
+jest.mock("server-only", () => ({}), { virtual: true });
+
+import {
+  getCloudSandboxRecoveryTelemetryProperties,
+  selectAlternateCloudSandboxProviderForRecovery,
+} from "../cloud-sandbox-recovery";
+import type { CloudSandboxAcquisitionContext } from "../cloud-sandbox";
+
+describe("cloud sandbox placement recovery", () => {
+  const originalE2BApiKey = process.env.E2B_API_KEY;
+
+  afterEach(() => {
+    if (originalE2BApiKey === undefined) delete process.env.E2B_API_KEY;
+    else process.env.E2B_API_KEY = originalE2BApiKey;
+  });
+
+  it("switches an AWS-assigned run once to the established E2B backend", () => {
+    process.env.E2B_API_KEY = "configured";
+    const context: CloudSandboxAcquisitionContext = {
+      provider: "aws-lambda-microvm",
+    };
+
+    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBe("e2b");
+    expect(context.provider).toBe("e2b");
+    expect(getCloudSandboxRecoveryTelemetryProperties(context)).toEqual({
+      cloud_sandbox_recovery_from_provider: "aws-lambda-microvm",
+      cloud_sandbox_recovery_to_provider: "e2b",
+      cloud_sandbox_recovery_reason: "attachment_placement_failure",
+    });
+  });
+
+  it("does not bypass the AWS rollout for an E2B-assigned run", () => {
+    process.env.E2B_API_KEY = "configured";
+    const context: CloudSandboxAcquisitionContext = { provider: "e2b" };
+
+    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBeNull();
+    expect(context).toEqual({ provider: "e2b" });
+  });
+
+  it("fails closed when E2B is not configured", () => {
+    delete process.env.E2B_API_KEY;
+    const context: CloudSandboxAcquisitionContext = {
+      provider: "aws-lambda-microvm",
+    };
+
+    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBeNull();
+    expect(context.provider).toBe("aws-lambda-microvm");
+  });
+});

--- a/lib/ai/tools/utils/cloud-sandbox-recovery.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-recovery.ts
@@ -1,0 +1,40 @@
+import type { CloudSandboxAcquisitionContext } from "./cloud-sandbox";
+import type { CloudSandboxProvider } from "./cloud-sandbox-provider";
+
+export class AlternateCloudSandboxUnavailableError extends Error {
+  constructor() {
+    super(
+      "No rollout-authorized alternate cloud sandbox provider is available",
+    );
+    this.name = "AlternateCloudSandboxUnavailableError";
+  }
+}
+
+export function selectAlternateCloudSandboxProviderForRecovery(
+  context?: CloudSandboxAcquisitionContext,
+): CloudSandboxProvider | null {
+  // AWS-assigned runs may safely fall back to the established E2B backend.
+  // E2B-assigned runs must not bypass the AWS rollout gate during recovery.
+  if (context?.provider !== "aws-lambda-microvm" || !process.env.E2B_API_KEY) {
+    return null;
+  }
+
+  context.recovery = {
+    fromProvider: "aws-lambda-microvm",
+    toProvider: "e2b",
+    reason: "attachment_placement_failure",
+  };
+  context.provider = "e2b";
+  return "e2b";
+}
+
+export function getCloudSandboxRecoveryTelemetryProperties(
+  context?: CloudSandboxAcquisitionContext,
+): Record<string, unknown> {
+  if (!context?.recovery) return {};
+  return {
+    cloud_sandbox_recovery_from_provider: context.recovery.fromProvider,
+    cloud_sandbox_recovery_to_provider: context.recovery.toProvider,
+    cloud_sandbox_recovery_reason: context.recovery.reason,
+  };
+}

--- a/lib/ai/tools/utils/cloud-sandbox.ts
+++ b/lib/ai/tools/utils/cloud-sandbox.ts
@@ -11,6 +11,7 @@ import {
 import { ensureSandboxConnection } from "./sandbox";
 import { isAwsLambdaMicrovmSandbox, isE2BSandbox } from "./sandbox-types";
 import { phLogger } from "@/lib/posthog/server";
+import { getCloudSandboxRecoveryTelemetryProperties } from "./cloud-sandbox-recovery";
 
 export type CloudSandboxAcquisitionContext = {
   provider?: CloudSandboxProvider;
@@ -19,6 +20,11 @@ export type CloudSandboxAcquisitionContext = {
   triggerRunId?: string;
   rollout?: AwsLambdaMicrovmRolloutAssignment;
   runKind?: "parent" | "subagent";
+  recovery?: {
+    fromProvider: CloudSandboxProvider;
+    toProvider: CloudSandboxProvider;
+    reason: "attachment_placement_failure";
+  };
 };
 
 export type CloudSandboxSuspensionSummary = {
@@ -78,6 +84,7 @@ export async function ensureCloudSandboxConnection(options: {
       subscription: options.context?.subscription,
       subscription_tier: options.context?.subscription,
       agent_run_kind: options.context?.runKind ?? "parent",
+      ...getCloudSandboxRecoveryTelemetryProperties(options.context),
       ...getAwsLambdaMicrovmRolloutTelemetryProperties(rollout),
       failure_stage: "ensure_cloud_sandbox",
       duration_ms: Date.now() - startedAt,

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -34,6 +34,7 @@ import {
   ensureCloudSandboxConnection,
   type CloudSandboxAcquisitionContext,
 } from "./cloud-sandbox";
+import { selectAlternateCloudSandboxProviderForRecovery } from "./cloud-sandbox-recovery";
 import { getCloudSandboxProvider } from "./cloud-sandbox-provider";
 
 type SandboxInstance = AnySandbox;
@@ -449,6 +450,13 @@ export class HybridSandboxManager implements SandboxManager {
     }
     // Sandbox hasn't been initialized yet; return original preference
     return this.sandboxPreference;
+  }
+
+  selectAlternateCloudProviderForRecovery() {
+    if (this.sandboxPreference !== "e2b") return null;
+    return selectAlternateCloudSandboxProviderForRecovery(
+      this.cloudSandboxContext,
+    );
   }
 
   /**

--- a/lib/ai/tools/utils/sandbox-manager.ts
+++ b/lib/ai/tools/utils/sandbox-manager.ts
@@ -11,6 +11,7 @@ import {
   ensureCloudSandboxConnection,
   type CloudSandboxAcquisitionContext,
 } from "./cloud-sandbox";
+import { selectAlternateCloudSandboxProviderForRecovery } from "./cloud-sandbox-recovery";
 import { getCloudSandboxProvider } from "./cloud-sandbox-provider";
 import { isE2BSandbox } from "./sandbox-types";
 import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
@@ -61,6 +62,12 @@ export class DefaultSandboxManager implements SandboxManager {
 
   getEffectivePreference(): string {
     return "e2b";
+  }
+
+  selectAlternateCloudProviderForRecovery() {
+    return selectAlternateCloudSandboxProviderForRecovery(
+      this.cloudSandboxContext,
+    );
   }
 
   getSandboxType(toolName: string): SandboxType | undefined {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1953,4 +1953,19 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       "cloudSandboxRollout.provider",
     );
   });
+
+  test("agent-long disables whole-task retries for its shared UI stream", () => {
+    expect(taskSrc).toMatch(
+      /Streaming tasks must not retry:[\s\S]*retry:\s*\{\s*maxAttempts:\s*1\s*\}/,
+    );
+  });
+
+  test("agent-long groups provider transport alerts by failure category", () => {
+    expect(taskSrc).toMatch(
+      /GROUPED_PROVIDER_ALERT_CATEGORIES[\s\S]*provider_timeout[\s\S]*provider_stream_terminated/,
+    );
+    expect(taskSrc).toMatch(
+      /recordGroupedSpikeAlert\(\{[\s\S]*spikeKey:\s*`agent_long:\$\{summary\.category\}`[\s\S]*sourceEvent:\s*"agent_long_provider_transport_failed"/,
+    );
+  });
 });

--- a/lib/observability/__tests__/grouped-spike-alert.test.ts
+++ b/lib/observability/__tests__/grouped-spike-alert.test.ts
@@ -1,0 +1,93 @@
+jest.mock("server-only", () => ({}), { virtual: true });
+
+jest.mock("@/lib/rate-limit/redis", () => ({
+  createRedisClient: jest.fn(),
+}));
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: { error: jest.fn(), warn: jest.fn() },
+}));
+
+import { createRedisClient } from "@/lib/rate-limit/redis";
+import { phLogger } from "@/lib/posthog/server";
+import {
+  recordGroupedSpikeAlert,
+  resetGroupedSpikeAlertStateForTests,
+} from "../grouped-spike-alert";
+
+const mockRedis = {
+  incr: jest.fn(),
+  expire: jest.fn(),
+  set: jest.fn(),
+};
+const mockCreateRedisClient = createRedisClient as jest.MockedFunction<
+  typeof createRedisClient
+>;
+const mockPhLogger = phLogger as jest.Mocked<typeof phLogger>;
+
+describe("recordGroupedSpikeAlert", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetGroupedSpikeAlertStateForTests();
+    mockCreateRedisClient.mockReturnValue(mockRedis as never);
+    mockRedis.expire.mockResolvedValue(1);
+  });
+
+  it("emits one stable error only after the shared threshold is crossed", async () => {
+    mockRedis.incr
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(6);
+    mockRedis.set.mockResolvedValueOnce("OK").mockResolvedValueOnce(null);
+
+    for (let attempt = 0; attempt < 6; attempt++) {
+      await recordGroupedSpikeAlert({
+        spikeKey: "sandbox_attachment_acquisition:placement_failure",
+        sourceEvent: "sandbox_attachment_acquisition_retry_failed",
+      });
+    }
+
+    expect(mockPhLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockPhLogger.error).toHaveBeenCalledWith(
+      "Grouped operational error spike detected",
+      expect.objectContaining({
+        event: "grouped_operational_error_spike_detected",
+        occurrence_count: 5,
+        threshold: 5,
+        window_ms: 300_000,
+        cooldown_ms: 900_000,
+      }),
+    );
+    expect(mockRedis.set).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing when the shared counter is not configured", async () => {
+    mockCreateRedisClient.mockReturnValueOnce(null as never);
+
+    await recordGroupedSpikeAlert({
+      spikeKey: "sandbox_attachment_acquisition:placement_failure",
+      sourceEvent: "sandbox_attachment_acquisition_retry_failed",
+    });
+
+    expect(mockRedis.incr).not.toHaveBeenCalled();
+    expect(mockPhLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("reports a counter outage at most once per worker", async () => {
+    mockRedis.incr.mockRejectedValue(new Error("Redis unavailable"));
+
+    await recordGroupedSpikeAlert({
+      spikeKey: "sandbox_attachment_acquisition:placement_failure",
+      sourceEvent: "sandbox_attachment_acquisition_retry_failed",
+    });
+    await recordGroupedSpikeAlert({
+      spikeKey: "sandbox_attachment_acquisition:placement_failure",
+      sourceEvent: "sandbox_attachment_acquisition_retry_failed",
+    });
+
+    expect(mockPhLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockPhLogger.error).not.toHaveBeenCalled();
+  });
+});

--- a/lib/observability/__tests__/grouped-spike-alert.test.ts
+++ b/lib/observability/__tests__/grouped-spike-alert.test.ts
@@ -64,6 +64,9 @@ describe("recordGroupedSpikeAlert", () => {
   });
 
   it("does not let caller attributes override the grouped-event contract", async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValue(Date.parse("2026-08-20T14:38:41.000Z"));
     mockRedis.incr.mockResolvedValueOnce(1);
     mockRedis.set.mockResolvedValueOnce("OK");
 
@@ -85,6 +88,7 @@ describe("recordGroupedSpikeAlert", () => {
         request_id: "request-123",
       },
     });
+    dateNowSpy.mockRestore();
 
     expect(mockPhLogger.error).toHaveBeenCalledWith(
       "Grouped operational error spike detected",
@@ -96,6 +100,7 @@ describe("recordGroupedSpikeAlert", () => {
         threshold: 1,
         window_ms: 60_000,
         cooldown_ms: 120_000,
+        window_started_at: "2026-08-20T14:38:00.000Z",
         request_id: "request-123",
       }),
     );

--- a/lib/observability/__tests__/grouped-spike-alert.test.ts
+++ b/lib/observability/__tests__/grouped-spike-alert.test.ts
@@ -63,6 +63,44 @@ describe("recordGroupedSpikeAlert", () => {
     expect(mockRedis.set).toHaveBeenCalledTimes(2);
   });
 
+  it("does not let caller attributes override the grouped-event contract", async () => {
+    mockRedis.incr.mockResolvedValueOnce(1);
+    mockRedis.set.mockResolvedValueOnce("OK");
+
+    await recordGroupedSpikeAlert({
+      spikeKey: "provider timeout / openai",
+      sourceEvent: "provider_timeout",
+      threshold: 1,
+      windowMs: 60_000,
+      cooldownMs: 120_000,
+      attributes: {
+        event: "caller_event",
+        spike_key: "caller_spike_key",
+        source_event: "caller_source_event",
+        occurrence_count: 999,
+        threshold: 999,
+        window_ms: 999,
+        cooldown_ms: 999,
+        window_started_at: "caller_window",
+        request_id: "request-123",
+      },
+    });
+
+    expect(mockPhLogger.error).toHaveBeenCalledWith(
+      "Grouped operational error spike detected",
+      expect.objectContaining({
+        event: "grouped_operational_error_spike_detected",
+        spike_key: "provider_timeout___openai",
+        source_event: "provider_timeout",
+        occurrence_count: 1,
+        threshold: 1,
+        window_ms: 60_000,
+        cooldown_ms: 120_000,
+        request_id: "request-123",
+      }),
+    );
+  });
+
   it("does nothing when the shared counter is not configured", async () => {
     mockCreateRedisClient.mockReturnValueOnce(null as never);
 

--- a/lib/observability/__tests__/grouped-spike-alert.test.ts
+++ b/lib/observability/__tests__/grouped-spike-alert.test.ts
@@ -32,6 +32,10 @@ describe("recordGroupedSpikeAlert", () => {
     mockRedis.expire.mockResolvedValue(1);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("emits one stable error only after the shared threshold is crossed", async () => {
     mockRedis.incr
       .mockResolvedValueOnce(1)
@@ -64,7 +68,7 @@ describe("recordGroupedSpikeAlert", () => {
   });
 
   it("does not let caller attributes override the grouped-event contract", async () => {
-    const dateNowSpy = jest
+    jest
       .spyOn(Date, "now")
       .mockReturnValue(Date.parse("2026-08-20T14:38:41.000Z"));
     mockRedis.incr.mockResolvedValueOnce(1);
@@ -88,7 +92,6 @@ describe("recordGroupedSpikeAlert", () => {
         request_id: "request-123",
       },
     });
-    dateNowSpy.mockRestore();
 
     expect(mockPhLogger.error).toHaveBeenCalledWith(
       "Grouped operational error spike detected",

--- a/lib/observability/grouped-spike-alert.ts
+++ b/lib/observability/grouped-spike-alert.ts
@@ -57,6 +57,7 @@ export async function recordGroupedSpikeAlert({
     if (!claimed) return;
 
     phLogger.error("Grouped operational error spike detected", {
+      ...attributes,
       event: "grouped_operational_error_spike_detected",
       spike_key: normalizedSpikeKey,
       source_event: sourceEvent,
@@ -65,7 +66,6 @@ export async function recordGroupedSpikeAlert({
       window_ms: windowMs,
       cooldown_ms: cooldownMs,
       window_started_at: new Date(bucketStartedAt).toISOString(),
-      ...attributes,
     });
   } catch (error) {
     if (counterFailureLogged) return;

--- a/lib/observability/grouped-spike-alert.ts
+++ b/lib/observability/grouped-spike-alert.ts
@@ -1,0 +1,85 @@
+import { createRedisClient } from "@/lib/rate-limit/redis";
+import { phLogger } from "@/lib/posthog/server";
+
+type GroupedSpikeAlertOptions = {
+  spikeKey: string;
+  sourceEvent: string;
+  threshold?: number;
+  windowMs?: number;
+  cooldownMs?: number;
+  attributes?: Record<string, unknown>;
+};
+
+export const GROUPED_SPIKE_ALERT_WINDOW_MS = 5 * 60 * 1000;
+export const GROUPED_SPIKE_ALERT_THRESHOLD = 5;
+export const GROUPED_SPIKE_ALERT_COOLDOWN_MS = 15 * 60 * 1000;
+
+let counterFailureLogged = false;
+
+const normalizeKey = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9:_-]/g, "_").slice(0, 160);
+
+/**
+ * Best-effort distributed aggregation for noisy operational failures.
+ * Individual failures remain queryable as warning logs; one stable exception
+ * is emitted only after the shared threshold is crossed, then cooled down.
+ */
+export async function recordGroupedSpikeAlert({
+  spikeKey,
+  sourceEvent,
+  threshold = GROUPED_SPIKE_ALERT_THRESHOLD,
+  windowMs = GROUPED_SPIKE_ALERT_WINDOW_MS,
+  cooldownMs = GROUPED_SPIKE_ALERT_COOLDOWN_MS,
+  attributes = {},
+}: GroupedSpikeAlertOptions): Promise<void> {
+  const redis = createRedisClient();
+  if (!redis) return;
+
+  const now = Date.now();
+  const bucketStartedAt = Math.floor(now / windowMs) * windowMs;
+  const normalizedSpikeKey = normalizeKey(spikeKey);
+  const counterKey = `observability:spike:${normalizedSpikeKey}:${bucketStartedAt}`;
+  const cooldownKey = `observability:spike-alert:${normalizedSpikeKey}`;
+  const counterTtlSeconds = Math.max(1, Math.ceil((windowMs * 2) / 1000));
+  const cooldownSeconds = Math.max(1, Math.ceil(cooldownMs / 1000));
+
+  try {
+    const count = Number(await redis.incr(counterKey));
+    // Refresh TTL on every write so a transient expiry failure cannot leave a
+    // permanent operational counter behind.
+    await redis.expire(counterKey, counterTtlSeconds);
+    if (count < threshold) return;
+
+    const claimed = await redis.set(cooldownKey, String(bucketStartedAt), {
+      nx: true,
+      ex: cooldownSeconds,
+    });
+    if (!claimed) return;
+
+    phLogger.error("Grouped operational error spike detected", {
+      event: "grouped_operational_error_spike_detected",
+      spike_key: normalizedSpikeKey,
+      source_event: sourceEvent,
+      occurrence_count: count,
+      threshold,
+      window_ms: windowMs,
+      cooldown_ms: cooldownMs,
+      window_started_at: new Date(bucketStartedAt).toISOString(),
+      ...attributes,
+    });
+  } catch (error) {
+    if (counterFailureLogged) return;
+    counterFailureLogged = true;
+    phLogger.warn("Grouped spike counter unavailable", {
+      event: "grouped_spike_counter_unavailable",
+      request_id: attributes.request_id ?? null,
+      spike_key: normalizedSpikeKey,
+      source_event: sourceEvent,
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+  }
+}
+
+export function resetGroupedSpikeAlertStateForTests(): void {
+  counterFailureLogged = false;
+}

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -1,6 +1,7 @@
 jest.mock("server-only", () => ({}), { virtual: true });
 
 import type { UIMessage } from "ai";
+import { AlternateCloudSandboxUnavailableError } from "@/lib/ai/tools/utils/cloud-sandbox-recovery";
 import {
   getSandboxUploadFailureMetadata,
   getSandboxUploadUserMessage,
@@ -628,18 +629,21 @@ describe("desktop-local sandbox file helpers", () => {
     [
       "Sandbox operation timed out. The sandbox may be overloaded. Please try again.",
       "operation_timeout",
+      "fresh_sandbox",
     ],
     [
       "Failed creating persistent sandbox: The operation was aborted due to timeout",
       "operation_timeout",
+      "fresh_sandbox",
     ],
     [
       "Failed creating persistent sandbox: 500: Failed to place sandbox",
       "placement_failure",
+      "alternate_cloud_provider",
     ],
   ])(
     "refreshes once after retryable sandbox acquisition failure %s",
-    async (errorMessage, failureReason) => {
+    async (errorMessage, failureReason, recoveryStrategy) => {
       const consoleWarnSpy = jest
         .spyOn(console, "warn")
         .mockImplementation(() => {});
@@ -682,6 +686,8 @@ describe("desktop-local sandbox file helpers", () => {
         expect(ensureSandbox.mock.calls[1][0]).toEqual({
           refresh: true,
           reason: "attachment_staging_sandbox_acquisition_failure",
+          requireAlternateCloudProvider:
+            recoveryStrategy === "alternate_cloud_provider",
         });
         expect(downloadFromUrl).toHaveBeenCalledTimes(1);
 
@@ -703,6 +709,7 @@ describe("desktop-local sandbox file helpers", () => {
           chat_id: "chat-123",
           initial_failure_reason: failureReason,
           final_failure_reason: null,
+          recovery_strategy: recoveryStrategy,
         });
         expect(
           consoleInfoSpy.mock.calls.some(([value]) =>
@@ -811,7 +818,7 @@ describe("desktop-local sandbox file helpers", () => {
       });
       const retryFailedLog = JSON.parse(
         String(
-          consoleErrorSpy.mock.calls.find(([value]) =>
+          consoleWarnSpy.mock.calls.find(([value]) =>
             String(value).includes(
               "sandbox_attachment_acquisition_retry_failed",
             ),
@@ -819,12 +826,56 @@ describe("desktop-local sandbox file helpers", () => {
         ),
       );
       expect(retryFailedLog).toMatchObject({
+        level: "warn",
         initial_failure_reason: "operation_timeout",
         final_failure_reason: "placement_failure",
+        recovery_strategy: "fresh_sandbox",
       });
     } finally {
       consoleWarnSpy.mockRestore();
       consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("fails fast when placement recovery has no rollout-authorized alternate provider", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const ensureSandbox = jest
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "Failed creating persistent sandbox: 500: Failed to place sandbox",
+        ),
+      )
+      .mockRejectedValueOnce(new AlternateCloudSandboxUnavailableError());
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+        { retryWithFreshSandboxOnTransientFailure: true },
+      );
+
+      expect(ensureSandbox).toHaveBeenCalledTimes(2);
+      expect(ensureSandbox.mock.calls[1][0]).toEqual({
+        refresh: true,
+        reason: "attachment_staging_sandbox_acquisition_failure",
+        requireAlternateCloudProvider: true,
+      });
+      expect(result.retriedWithFreshSandbox).toBeUndefined();
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_reason: "sandbox_placement_failure",
+        upload_failure_sandbox_readiness_reason: "placement_failure",
+      });
+    } finally {
+      consoleWarnSpy.mockRestore();
     }
   });
 

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -5,6 +5,8 @@ import { UIMessage } from "ai";
 import type { SandboxPreference, SandboxReadinessFailureReason } from "@/types";
 import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
 import { classifySandboxReadinessFailureSignal } from "@/lib/ai/tools/utils/sandbox-readiness-failure";
+import { AlternateCloudSandboxUnavailableError } from "@/lib/ai/tools/utils/cloud-sandbox-recovery";
+import { recordGroupedSpikeAlert } from "@/lib/observability/grouped-spike-alert";
 
 export type SandboxFile = {
   localPath: string;
@@ -63,6 +65,7 @@ type SandboxRefreshOptions = {
   refresh?: boolean;
   reason?: string;
   excludeConnectionId?: string;
+  requireAlternateCloudProvider?: boolean;
 };
 
 type EnsureSandboxForUpload = (options?: SandboxRefreshOptions) => Promise<any>;
@@ -209,9 +212,10 @@ const logSandboxAcquisitionRecovery = (
     | "sandbox_attachment_acquisition_retry_scheduled"
     | "sandbox_attachment_acquisition_recovered"
     | "sandbox_attachment_acquisition_retry_failed",
-  level: "info" | "warn" | "error",
+  level: "info" | "warn",
   initialFailureReason: SandboxReadinessFailureReason,
   finalFailureReason?: SandboxReadinessFailureReason,
+  recoveryStrategy?: "fresh_sandbox" | "alternate_cloud_provider",
 ): void => {
   const payload = JSON.stringify({
     timestamp: new Date().toISOString(),
@@ -229,10 +233,10 @@ const logSandboxAcquisitionRecovery = (
     chat_id: options?.logContext?.chatId ?? null,
     initial_failure_reason: initialFailureReason,
     final_failure_reason: finalFailureReason ?? null,
+    recovery_strategy: recoveryStrategy ?? null,
   });
 
-  if (level === "error") console.error(payload);
-  else if (level === "warn") console.warn(payload);
+  if (level === "warn") console.warn(payload);
   else console.info(payload);
 };
 
@@ -1031,40 +1035,70 @@ export const uploadSandboxFiles = async (
     }
 
     retriedWithFreshSandbox = true;
+    const recoveryStrategy =
+      initialFailureReason === "placement_failure"
+        ? "alternate_cloud_provider"
+        : "fresh_sandbox";
     logSandboxAcquisitionRecovery(
       options,
       "sandbox_attachment_acquisition_retry_scheduled",
       "warn",
       initialFailureReason,
+      undefined,
+      recoveryStrategy,
     );
     try {
       sandbox = await ensureSandbox({
         refresh: true,
         reason: "attachment_staging_sandbox_acquisition_failure",
+        requireAlternateCloudProvider:
+          recoveryStrategy === "alternate_cloud_provider",
       });
       logSandboxAcquisitionRecovery(
         options,
         "sandbox_attachment_acquisition_recovered",
         "info",
         initialFailureReason,
+        undefined,
+        recoveryStrategy,
       );
     } catch (retryError) {
-      const finalFailureReason =
-        classifySandboxUploadReadinessFailure(retryError);
+      const alternateUnavailable =
+        retryError instanceof AlternateCloudSandboxUnavailableError;
+      const finalFailureReason = alternateUnavailable
+        ? initialFailureReason
+        : classifySandboxUploadReadinessFailure(retryError);
       logSandboxAcquisitionRecovery(
         options,
         "sandbox_attachment_acquisition_retry_failed",
-        "error",
+        "warn",
         initialFailureReason,
         finalFailureReason,
+        recoveryStrategy,
       );
+      await recordGroupedSpikeAlert({
+        spikeKey: `sandbox_attachment_acquisition:${finalFailureReason}`,
+        sourceEvent: "sandbox_attachment_acquisition_retry_failed",
+        attributes: {
+          component: options?.logContext?.service ?? "chat-handler",
+          request_id: options?.logContext?.requestId ?? null,
+          initial_failure_reason: initialFailureReason,
+          final_failure_reason: finalFailureReason,
+          recovery_strategy: recoveryStrategy,
+          alternate_provider_available: !alternateUnavailable,
+        },
+      });
       return {
         failedCount: sandboxFiles.length,
         pathRewrites: [],
         failureDetails: sandboxFiles.map((file) =>
-          summarizeSandboxUploadFailure(file, retryError, "acquisition"),
+          summarizeSandboxUploadFailure(
+            file,
+            alternateUnavailable ? error : retryError,
+            "acquisition",
+          ),
         ),
-        retriedWithFreshSandbox: true,
+        ...(alternateUnavailable ? {} : { retriedWithFreshSandbox: true }),
       };
     }
   }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -20,6 +20,7 @@ import type { Geo } from "@vercel/functions";
 import PostHogClient from "@/app/posthog";
 import { getCloudSandboxProvider } from "@/lib/ai/tools/utils/cloud-sandbox-provider";
 import { evaluateAwsLambdaMicrovmRollout } from "@/lib/experiments/aws-lambda-microvm-rollout";
+import { recordGroupedSpikeAlert } from "@/lib/observability/grouped-spike-alert";
 
 import { systemPrompt } from "@/lib/system-prompt";
 import { getResumeSection } from "@/lib/system-prompt/resume";
@@ -1673,6 +1674,11 @@ type RecordedAgentLongFailure = {
   userCorrectable: boolean;
 };
 
+const GROUPED_PROVIDER_ALERT_CATEGORIES = new Set([
+  "provider_timeout",
+  "provider_stream_terminated",
+]);
+
 const recordAgentLongFailureForDashboard = async (
   error: unknown,
   context: {
@@ -1830,6 +1836,21 @@ const recordAgentLongFailureForDashboard = async (
     );
   } else {
     triggerLogger.error("[agent-long] run failed", logFields);
+  }
+
+  if (GROUPED_PROVIDER_ALERT_CATEGORIES.has(summary.category)) {
+    await recordGroupedSpikeAlert({
+      spikeKey: `agent_long:${summary.category}`,
+      sourceEvent: "agent_long_provider_transport_failed",
+      attributes: {
+        component: "agent-long",
+        request_id: context.runId,
+        error_category: summary.category,
+        error_name: summary.name,
+        error_code: summary.code ?? null,
+        terminal_phase: context.phase,
+      },
+    });
   }
 
   await metadata.flush();

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -29,6 +29,8 @@ export interface SandboxManager {
   getSandbox(): Promise<{ sandbox: AnySandbox }>;
   setSandbox(sandbox: AnySandbox): void;
   resetSandbox?(reason?: string): Promise<void>;
+  /** Select a rollout-authorized alternate cloud provider for one recovery attempt. */
+  selectAlternateCloudProviderForRecovery?(): CloudSandboxProvider | null;
   /** Quarantine an unresponsive local connection and keep retry acquisition bound to that explicit selection. */
   quarantineLocalConnection?(
     connectionId: string,


### PR DESCRIPTION
## Summary

- keep agent-long whole-task retries disabled so the shared UI stream cannot duplicate output or tool side effects
- recover attachment placement failures through one rollout-authorized AWS MicroVM to E2B fallback; E2B-assigned and explicitly local runs fail fast instead of repeating the same placement request
- aggregate provider timeout, provider stream termination, and attachment acquisition failures into five-minute Redis windows; emit one stable PostHog error at five occurrences with a fifteen-minute cooldown while retaining per-run warning diagnostics
- add recovery-provider telemetry and regression coverage for rollout boundaries, fail-fast behavior, grouped alerts, and the no-task-retry contract

## Validation

- 409 Jest suites passed (4,108 tests)
- pnpm typecheck
- pnpm lint
- ESLint on trigger/agent-long.ts

## Manual verification

1. In a non-production environment with the AWS MicroVM rollout enabled, force an AWS placement failure and attach a file. The run should acquire E2B once, stage the file, and record recovery from aws-lambda-microvm to e2b.
2. With an E2B-assigned run, force a placement failure. The run should return the existing friendly Cloud sandbox error without making a second E2B placement request, and pre-stream usage should be refunded.
3. Produce five matching provider or attachment-acquisition failures inside five minutes. PostHog should receive one grouped_operational_error_spike_detected exception, then suppress another grouped exception for fifteen minutes while individual failures remain queryable as warnings.

Visual verification is not required because this changes backend recovery and observability only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery using an alternate cloud sandbox provider when placement fails.
  * Added grouped alerts for recurring provider timeouts and interrupted streams.
  * Added recovery details to operational telemetry.

* **Bug Fixes**
  * Preserved original failure reasons when alternate-provider recovery is unavailable.
  * Improved recovery behavior by distinguishing placement failures from timeout failures.

* **Tests**
  * Added coverage for provider switching, unavailable-provider handling, grouped alerts, and recovery strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->