### PR TITLE
HAC-71: route AWS MicroVMs by Trigger region

### DIFF
--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/sync-trigger-microvm-release-env.ts"
       - "scripts/lib/aws-microvm-release-manifest.ts"
       - "scripts/lib/trigger-microvm-release-env.ts"
+      - "lib/ai/tools/utils/aws-lambda-microvm-release.ts"
       - "package.json"
       - "pnpm-lock.yaml"
   workflow_dispatch:
@@ -29,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: aws-lambda-microvm-production
+    permissions:
+      contents: read
     env:
       CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
     steps:
@@ -144,6 +147,7 @@ jobs:
           AWS_LAMBDA_MICROVM_OUTPUT_FILE: ${{ runner.temp }}/${{ matrix.region }}.env
         shell: bash
         run: |
+          # shellcheck disable=SC2163 # Export the variable named by each verified release-output key.
           while IFS='=' read -r name value; do
             case "$name" in
               AWS_LAMBDA_MICROVM_IMAGE_ID|AWS_LAMBDA_MICROVM_IMAGE_VERSION)
@@ -168,9 +172,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: aws-lambda-microvm-production
+    permissions:
+      contents: read
     env:
       TRIGGER_PROJECT_ID: ${{ vars.TRIGGER_PROJECT_ID }}
       TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+      AWS_LAMBDA_MICROVM_ENABLED_REGIONS: ${{ vars.AWS_LAMBDA_MICROVM_ENABLED_REGIONS || 'us-east-1,us-west-2,eu-west-1' }}
     steps:
       - name: Validate promotion configuration
         shell: bash

--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -12,6 +12,8 @@ on:
       - "scripts/deploy-aws-microvm.mjs"
       - "scripts/package-aws-microvm.mjs"
       - "scripts/smoke-aws-microvm.mjs"
+      - "scripts/sync-trigger-microvm-release-env.ts"
+      - "scripts/lib/trigger-microvm-release-env.ts"
       - "package.json"
       - "pnpm-lock.yaml"
   workflow_dispatch:
@@ -117,18 +119,11 @@ jobs:
       - name: Launch and terminate exact image version
         run: pnpm aws:microvm:smoke
 
+      - name: Sync and verify Trigger.dev production environment
+        run: pnpm aws:microvm:sync-trigger-env
+
       - name: Deploy pinned Trigger.dev worker
-        shell: bash
-        run: |
-          trigger_env_file="$RUNNER_TEMP/trigger-microvm-release.env"
-          printf '%s\n' \
-            "TRIGGER_PROJECT_ID=$TRIGGER_PROJECT_ID" \
-            "CLOUD_SANDBOX_PROVIDER=aws-lambda-microvm" \
-            "AWS_LAMBDA_MICROVM_IMAGE_ID=$AWS_LAMBDA_MICROVM_IMAGE_ID" \
-            "AWS_LAMBDA_MICROVM_IMAGE_VERSION=$AWS_LAMBDA_MICROVM_IMAGE_VERSION" \
-            "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=$AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN" \
-            > "$trigger_env_file"
-          pnpm exec trigger deploy --env prod --env-file "$trigger_env_file"
+        run: pnpm exec trigger deploy --env prod --skip-update-check
 
       - name: Write release summary
         shell: bash

--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -2,17 +2,18 @@ name: Release AWS Lambda MicroVM image
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - ".github/workflows/aws-lambda-microvm-release.yml"
-      - "aws-lambda-microvm/naabu"
+      - "aws-lambda-microvm/**"
       - "docker/**"
       - "packages/local/**"
+      - "scripts/build-aws-microvm-release-manifest.ts"
       - "scripts/deploy-aws-microvm.mjs"
       - "scripts/package-aws-microvm.mjs"
       - "scripts/smoke-aws-microvm.mjs"
       - "scripts/sync-trigger-microvm-release-env.ts"
+      - "scripts/lib/aws-microvm-release-manifest.ts"
       - "scripts/lib/trigger-microvm-release-env.ts"
       - "package.json"
       - "pnpm-lock.yaml"
@@ -23,117 +24,207 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Publish, smoke-test, and promote
+  prepare:
+    name: Build release artifact
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 30
     environment: aws-lambda-microvm-production
-    permissions:
-      contents: read
-      id-token: write
     env:
-      AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET: ${{ vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET }}
-      AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN: ${{ vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN }}
-      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: ${{ vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN }}
-      AWS_RELEASE_ROLE_ARN: ${{ vars.AWS_RELEASE_ROLE_ARN }}
       CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-      TRIGGER_PROJECT_ID: ${{ vars.TRIGGER_PROJECT_ID }}
-      TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
-
     steps:
-      - name: Validate release configuration
+      - name: Validate shared release configuration
         shell: bash
         run: |
-          required=(
-            AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET
-            AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN
-            AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN
-            AWS_RELEASE_ROLE_ARN
-            CONVEX_DEPLOY_KEY
-            TRIGGER_PROJECT_ID
-            TRIGGER_ACCESS_TOKEN
-          )
-          missing=()
-          for name in "${required[@]}"; do
-            if [[ -z "${!name:-}" ]]; then
-              missing+=("$name")
-            fi
-          done
-          if (( ${#missing[@]} > 0 )); then
-            printf 'Missing GitHub environment variables or secrets:\n'
-            printf '  %s\n' "${missing[@]}"
+          if [[ -z "$CONVEX_DEPLOY_KEY" ]]; then
+            echo "Missing GitHub environment secret: CONVEX_DEPLOY_KEY"
             exit 1
           fi
-
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20.x
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Type check release sources
         run: pnpm typecheck
-
       - name: Deploy production Convex backend
         run: pnpm exec convex deploy --message "AWS Lambda MicroVM release ${GITHUB_SHA}"
-
-      - name: Authenticate to AWS with GitHub OIDC
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+      - name: Build image artifact once
+        run: pnpm aws:microvm:package
+      - name: Upload image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          aws-region: us-east-1
-          role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
-          role-session-name: hackerai-microvm-${{ github.run_id }}
+          name: aws-lambda-microvm-image
+          path: .artifacts/aws-lambda-microvm/hackerai-lambda-microvm.zip
+          if-no-files-found: error
+          retention-days: 1
 
-      - name: Publish exact image version
-        id: publish
-        env:
-          AWS_LAMBDA_MICROVM_OUTPUT_FILE: ${{ runner.temp }}/microvm-release.env
+  publish:
+    name: Publish and smoke-test ${{ matrix.region }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    environment: aws-lambda-microvm-production
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - region: us-east-1
+            artifact_bucket: ${{ vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_US_EAST_1 || vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET }}
+            build_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_US_EAST_1 || vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN }}
+            execution_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_US_EAST_1 || vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN }}
+            release_role_arn: ${{ vars.AWS_RELEASE_ROLE_ARN_US_EAST_1 || vars.AWS_RELEASE_ROLE_ARN }}
+          - region: us-west-2
+            artifact_bucket: ${{ vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_US_WEST_2 }}
+            build_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_US_WEST_2 }}
+            execution_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_US_WEST_2 }}
+            release_role_arn: ${{ vars.AWS_RELEASE_ROLE_ARN_US_WEST_2 }}
+          - region: eu-west-1
+            artifact_bucket: ${{ vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_EU_WEST_1 }}
+            build_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_EU_WEST_1 }}
+            execution_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_EU_WEST_1 }}
+            release_role_arn: ${{ vars.AWS_RELEASE_ROLE_ARN_EU_WEST_1 }}
+    env:
+      AWS_REGION: ${{ matrix.region }}
+      AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET: ${{ matrix.artifact_bucket }}
+      AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN: ${{ matrix.build_role_arn }}
+      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: ${{ matrix.execution_role_arn }}
+      AWS_RELEASE_ROLE_ARN: ${{ matrix.release_role_arn }}
+    steps:
+      - name: Validate regional release configuration
         shell: bash
         run: |
-          pnpm aws:microvm:deploy
+          required=(AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN AWS_RELEASE_ROLE_ARN)
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing GitHub environment variable for $AWS_REGION: $name"
+              exit 1
+            fi
+          done
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20.x
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: aws-lambda-microvm-image
+          path: .artifacts/aws-lambda-microvm
+      - name: Authenticate to regional AWS release role
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
+          role-session-name: hackerai-microvm-${{ github.run_id }}-${{ strategy.job-index }}
+      - name: Publish exact regional image version
+        env:
+          AWS_LAMBDA_MICROVM_OUTPUT_FILE: ${{ runner.temp }}/${{ matrix.region }}.env
+        run: node scripts/deploy-aws-microvm.mjs
+      - name: Launch and terminate exact regional image version
+        env:
+          AWS_LAMBDA_MICROVM_OUTPUT_FILE: ${{ runner.temp }}/${{ matrix.region }}.env
+        shell: bash
+        run: |
           while IFS='=' read -r name value; do
             case "$name" in
               AWS_LAMBDA_MICROVM_IMAGE_ID|AWS_LAMBDA_MICROVM_IMAGE_VERSION)
                 printf -v "$name" '%s' "$value"
+                export "$name"
                 printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
-                printf '%s=%s\n' "$name" "$value" >> "$GITHUB_OUTPUT"
                 ;;
             esac
           done < "$AWS_LAMBDA_MICROVM_OUTPUT_FILE"
-          if [[ -z "${AWS_LAMBDA_MICROVM_IMAGE_ID:-}" || -z "${AWS_LAMBDA_MICROVM_IMAGE_VERSION:-}" ]]; then
-            echo "Image publisher did not return an ID and exact active version"
+          pnpm aws:microvm:smoke
+      - name: Upload verified regional release
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: aws-lambda-microvm-release-${{ matrix.region }}
+          path: ${{ runner.temp }}/${{ matrix.region }}.env
+          if-no-files-found: error
+          retention-days: 7
+
+  promote:
+    name: Atomically promote regional release
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: aws-lambda-microvm-production
+    env:
+      TRIGGER_PROJECT_ID: ${{ vars.TRIGGER_PROJECT_ID }}
+      TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+    steps:
+      - name: Validate promotion configuration
+        shell: bash
+        run: |
+          if [[ -z "$TRIGGER_PROJECT_ID" || -z "$TRIGGER_ACCESS_TOKEN" ]]; then
+            echo "Missing TRIGGER_PROJECT_ID or TRIGGER_ACCESS_TOKEN"
             exit 1
           fi
-
-      - name: Launch and terminate exact image version
-        run: pnpm aws:microvm:smoke
-
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20.x
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Download every verified regional release
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: aws-lambda-microvm-release-*
+          path: ${{ runner.temp }}/regional-releases
+          merge-multiple: true
+      - name: Build atomic release manifest
+        env:
+          AWS_LAMBDA_MICROVM_RELEASE_INPUT_DIR: ${{ runner.temp }}/regional-releases
+          AWS_LAMBDA_MICROVM_OUTPUT_FILE: ${{ runner.temp }}/microvm-release.env
+        shell: bash
+        run: |
+          pnpm aws:microvm:build-release-manifest
+          while IFS='=' read -r name value; do
+            case "$name" in
+              AWS_LAMBDA_MICROVM_RELEASE_MANIFEST|AWS_LAMBDA_MICROVM_IMAGE_ID|AWS_LAMBDA_MICROVM_IMAGE_VERSION|AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN)
+                printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
+                ;;
+            esac
+          done < "$AWS_LAMBDA_MICROVM_OUTPUT_FILE"
       - name: Sync and verify Trigger.dev production environment
         run: pnpm aws:microvm:sync-trigger-env
-
       - name: Deploy pinned Trigger.dev worker
         run: pnpm exec trigger deploy --env prod --skip-update-check
-
       - name: Write release summary
         shell: bash
         run: |
           {
-            echo "### AWS Lambda MicroVM released"
+            echo "### AWS Lambda MicroVM regional release promoted"
             echo
-            echo "- Image: \`$AWS_LAMBDA_MICROVM_IMAGE_ID\`"
-            echo "- Version: \`$AWS_LAMBDA_MICROVM_IMAGE_VERSION\`"
-            echo "- Smoke-test MicroVM: terminated"
-            echo "- Trigger.dev production: deployed"
+            echo "- Release: \`$GITHUB_SHA\`"
+            echo "- Regions: \`us-east-1\`, \`us-west-2\`, \`eu-west-1\`"
+            echo "- All regional images: built, validated, smoke-tested, and terminated"
+            echo "- Trigger.dev production: stored manifest verified and worker deployed"
             echo "- Vercel: unchanged (Agent execution is Trigger.dev-only)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -15,8 +15,8 @@ configured VPC connector.
 
 ## 1. Provision AWS prerequisites
 
-Lambda MicroVM execution is currently fixed to `us-east-1`. Deploy the stack
-there:
+HackerAI's curated catalog uses `us-east-1`, `us-west-2`, and `eu-west-1`.
+Deploy the primary stack first; it owns the account-wide GitHub OIDC provider:
 
 ```bash
 aws cloudformation deploy \
@@ -35,30 +35,49 @@ aws cloudformation describe-stacks \
   --query 'Stacks[0].Outputs'
 ```
 
+Save its `GitHubOidcProviderArn`, then deploy the same regional prerequisites
+without trying to create duplicate account-wide OIDC providers:
+
+```bash
+OIDC_PROVIDER_ARN='<GitHubOidcProviderArn from us-east-1>'
+for region in us-west-2 eu-west-1; do
+  aws cloudformation deploy \
+    --region "$region" \
+    --stack-name hackerai-lambda-microvm \
+    --template-file aws-lambda-microvm/cloudformation.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides ExistingGitHubOidcProviderArn="$OIDC_PROVIDER_ARN"
+done
+```
+
 Attach `DeployerPolicyArn` to the CI/operator identity that publishes images.
-Attach `RuntimePolicyArn` to the AWS identity used by Trigger.dev. The Vercel
+Attach every regional `RuntimePolicyArn` to the AWS identity used by
+Trigger.dev. The Vercel
 Data Controls cleanup path also needs `GetMicrovm`, `ListMicrovms`, and
 `TerminateMicrovm`; a separate cleanup-only policy is preferable once workload
 identity is configured. Prefer role assumption in production; access keys can
 be used for an initial test. Set `ExecutionRoleArn` as
-`AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN`; Lambda assumes this narrowly scoped
-role to write guest runtime logs to CloudWatch.
+regional release manifest stores the matching `ExecutionRoleArn`; Lambda
+assumes that narrowly scoped role to write guest runtime logs to CloudWatch.
 
 ## 2. Build and publish the image
 
-Set the two CloudFormation outputs, then run:
+Set one region's CloudFormation outputs and region, then run:
 
 ```bash
 export AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET='<ArtifactBucketName>'
 export AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN='<BuildRoleArn>'
+export AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN='<ExecutionRoleArn>'
+export AWS_REGION=us-east-1
 pnpm aws:microvm:deploy
 ```
 
 The command builds `packages/local`, creates a Lambda-compatible zip under
 `.artifacts/`, uploads it to S3, creates or updates the MicroVM image, waits for
 the exact returned image version to become `SUCCESSFUL` and `ACTIVE`, and then
-prints `AWS_LAMBDA_MICROVM_IMAGE_ID` and
-`AWS_LAMBDA_MICROVM_IMAGE_VERSION`.
+prints the region, exact image ID/version, and execution role. Repeat with the
+matching outputs for `us-west-2` and `eu-west-1`; S3 artifacts cannot be reused
+across regions.
 
 During AWS image preparation, both lifecycle image hooks run a bounded,
 credential-free working-set primer. It initializes the in-process transport and
@@ -94,9 +113,7 @@ reuses a MicroVM:
 
 ```dotenv
 CLOUD_SANDBOX_PROVIDER=aws-lambda-microvm
-AWS_LAMBDA_MICROVM_IMAGE_ID=<image ARN printed by deploy>
-AWS_LAMBDA_MICROVM_IMAGE_VERSION=<version printed by deploy>
-AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=<ExecutionRoleArn>
+AWS_LAMBDA_MICROVM_RELEASE_MANIFEST=<atomic JSON manifest produced by the release workflow>
 AWS_ACCESS_KEY_ID=<runtime identity key for an initial test>
 AWS_SECRET_ACCESS_KEY=<runtime identity secret for an initial test>
 CONVEX_SERVICE_ROLE_KEY=<existing server role key>
@@ -107,14 +124,18 @@ Keep the existing `CENTRIFUGO_WS_URL` and `CENTRIFUGO_TOKEN_SECRET` in
 Trigger.dev only if local/desktop sandbox connections are enabled. They are not
 read while the selected provider is `aws-lambda-microvm`.
 
-The provider region is intentionally fixed in code to `us-east-1` until
-multi-region image publication and routing are implemented. Vercel,
-Trigger.dev, and local development do not need `AWS_REGION` or
-`AWS_LAMBDA_MICROVM_REGION` for this provider.
+The Vercel route always pins a Trigger execution region. New AWS sessions map
+`us-east-1` to `us-east-1`, `us-west-2` to `us-west-2`, and Trigger's
+`eu-central-1` worker region to AWS Ireland (`eu-west-1`). Unknown geography
+defaults explicitly to US East. A running or suspended sandbox remains pinned
+to its persisted region and image until it ends; a later request never silently
+migrates its memory, disk, or outbound source location. Neither Trigger.dev nor
+Vercel needs `AWS_REGION` or `AWS_LAMBDA_MICROVM_REGION` at runtime.
 
-Vercel does not need the image ID, image version, execution role, or WebSocket
-configuration. Its Data Controls route terminates persisted MicroVM IDs
-directly, so Vercel only needs the dedicated AWS runtime credentials and
+Vercel does not need the release manifest, image IDs, execution roles, or
+WebSocket configuration. Its Data Controls route terminates persisted MicroVM
+IDs in their recorded regions, so Vercel only needs the dedicated AWS runtime
+credentials (authorized by all three regional runtime policies) and
 `CONVEX_SERVICE_ROLE_KEY` for that cleanup operation.
 
 Optional controls:
@@ -129,7 +150,9 @@ Optional controls:
 - Ingress is fixed to AWS's `ALL_INGRESS` connector so Trigger.dev can use the
   AWS-authenticated WebSocket endpoint. Runtime auth tokens are minted for one
   MicroVM, expire after at most 60 minutes, and are restricted to guest port 9000. Port 8080 lifecycle hooks are never included in application tokens.
-- `AWS_LAMBDA_MICROVM_EGRESS_CONNECTOR_ARN` defaults to `INTERNET_EGRESS`.
+- Egress is fixed to each region's managed `INTERNET_EGRESS` connector. A
+  future VPC connector rollout must add an explicit per-region catalog entry;
+  one global connector ARN is intentionally not accepted.
 - Lambda endpoint-idle suspension is intentionally hard-coded to five minutes,
   followed by termination after 30 suspended minutes. While a Trigger worker is
   using the sandbox, its WebSocket heartbeat counts as endpoint activity.
@@ -149,12 +172,13 @@ WebSocket subprotocol during the AWS-authenticated upgrade.
 `.github/workflows/aws-lambda-microvm-release.yml` publishes a new image only
 when MicroVM image inputs change on `main`, or when it is run manually. It does
 not float production to AWS's implicit latest version. Instead it waits for the
-exact published version, launches a short-lived VM, executes a real command
-through its authenticated WebSocket, terminates it, uploads and verifies that
-exact version in Trigger.dev's stored production environment, pins it in a new
-production worker, and leaves Vercel unchanged. Older AWS image versions remain
-available for an explicit rollback. A failed Trigger.dev upload or read-back
-verification stops the release before the worker deploys.
+exact versions in all three regions, launches a short-lived VM in each region,
+executes a real command through every authenticated WebSocket, and confirms
+termination. Only after every matrix leg succeeds does it build one release
+manifest, upload and read back that exact manifest in Trigger.dev production,
+and deploy the pinned worker. A partial regional build can never become the
+active release. Vercel remains unchanged and older AWS image versions remain
+available for rollback.
 
 The CloudFormation stack creates a GitHub OIDC release role, so GitHub Actions
 does not need long-lived AWS access keys. Create a GitHub environment named
@@ -162,12 +186,26 @@ does not need long-lived AWS access keys. Create a GitHub environment named
 these environment variables from the stack and project outputs:
 
 ```text
-AWS_RELEASE_ROLE_ARN=<GitHubReleaseRoleArn>
-AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET=<ArtifactBucketName>
-AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN=<BuildRoleArn>
-AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=<ExecutionRoleArn>
+AWS_RELEASE_ROLE_ARN_US_EAST_1=<GitHubReleaseRoleArn from us-east-1>
+AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_US_EAST_1=<ArtifactBucketName>
+AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_US_EAST_1=<BuildRoleArn>
+AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_US_EAST_1=<ExecutionRoleArn>
+
+AWS_RELEASE_ROLE_ARN_US_WEST_2=<GitHubReleaseRoleArn from us-west-2>
+AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_US_WEST_2=<ArtifactBucketName>
+AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_US_WEST_2=<BuildRoleArn>
+AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_US_WEST_2=<ExecutionRoleArn>
+
+AWS_RELEASE_ROLE_ARN_EU_WEST_1=<GitHubReleaseRoleArn from eu-west-1>
+AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_EU_WEST_1=<ArtifactBucketName>
+AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_EU_WEST_1=<BuildRoleArn>
+AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_EU_WEST_1=<ExecutionRoleArn>
+
 TRIGGER_PROJECT_ID=<Trigger.dev project ref>
 ```
+
+The unsuffixed US East variable names remain accepted temporarily so an
+existing production environment can migrate without a flag-day rename.
 
 Add dedicated CI tokens as environment secrets:
 
@@ -196,8 +234,9 @@ control.
 
 Measure actual acquisition exposure with `cloud_sandbox_provider_selected`.
 It includes the provider, transport (`aws_websocket` or `e2b_sdk`), rollout
-variant, subscription tier, acquisition path, acquisition duration, create
-attempts, and evaluated feature-flag value. Failed
+variant, subscription tier, Trigger region, requested and effective AWS region,
+placement reason, release ID, pinned image version, acquisition path,
+acquisition duration, create attempts, and evaluated feature-flag value. Failed
 acquisitions emit `cloud_sandbox_acquisition_failed` with the intended provider,
 rollout variant, failure stage, duration, and privacy-safe error name. Compare
 the `hackerai-agent_run` outcome and Trigger duration/cost fields by

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -150,9 +150,11 @@ WebSocket subprotocol during the AWS-authenticated upgrade.
 when MicroVM image inputs change on `main`, or when it is run manually. It does
 not float production to AWS's implicit latest version. Instead it waits for the
 exact published version, launches a short-lived VM, executes a real command
-through its authenticated WebSocket, terminates it, pins that version in a new
-Trigger.dev production worker, and leaves Vercel unchanged. Older AWS image
-versions remain available for an explicit rollback.
+through its authenticated WebSocket, terminates it, uploads and verifies that
+exact version in Trigger.dev's stored production environment, pins it in a new
+production worker, and leaves Vercel unchanged. Older AWS image versions remain
+available for an explicit rollback. A failed Trigger.dev upload or read-back
+verification stops the release before the worker deploys.
 
 The CloudFormation stack creates a GitHub OIDC release role, so GitHub Actions
 does not need long-lived AWS access keys. Create a GitHub environment named
@@ -182,15 +184,15 @@ local/desktop sandbox support also keeps its existing Centrifugo values there.
 Vercel retains only the AWS credentials and Convex key required by Data
 Controls cleanup. They are not copied through GitHub Actions.
 
-## 5. Validate the Ultra-only gradual rollout
+## 5. Validate the paid-plan gradual rollout
 
 Production assignment is controlled by the PostHog feature flag
 [`aws_lambda_microvm_ultra_rollout_v1`](https://us.posthog.com/project/144137/feature_flags/828023).
-The application hard-gates eligibility to Ultra before evaluating the flag, so
-no PostHog targeting mistake can expose another plan. Start at 10% of Ultra
-users; the remaining eligible users stay on E2B as the concurrent control.
-Preview and Trigger.dev development runs use AWS for Ultra users so the
-candidate remains testable without widening production.
+The application hard-gates Free users to local-only behavior and evaluates the
+flag for every paid plan. PostHog is the final AWS/E2B provider gate in every
+environment, so use an explicit allowlist before widening percentage rollout;
+paid users outside the enabled population stay on E2B as the concurrent
+control.
 
 Measure actual acquisition exposure with `cloud_sandbox_provider_selected`.
 It includes the provider, transport (`aws_websocket` or `e2b_sdk`), rollout

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -56,9 +56,9 @@ Trigger.dev. The Vercel
 Data Controls cleanup path also needs `GetMicrovm`, `ListMicrovms`, and
 `TerminateMicrovm`; a separate cleanup-only policy is preferable once workload
 identity is configured. Prefer role assumption in production; access keys can
-be used for an initial test. Set `ExecutionRoleArn` as
-regional release manifest stores the matching `ExecutionRoleArn`; Lambda
-assumes that narrowly scoped role to write guest runtime logs to CloudWatch.
+be used for an initial test. Every regional release manifest entry must set
+`ExecutionRoleArn` to the matching regional role ARN; Lambda assumes that
+narrowly scoped role to write guest runtime logs to CloudWatch.
 
 ## 2. Build and publish the image
 
@@ -179,6 +179,12 @@ manifest, upload and read back that exact manifest in Trigger.dev production,
 and deploy the pinned worker. A partial regional build can never become the
 active release. Vercel remains unchanged and older AWS image versions remain
 available for rollback.
+
+`AWS_LAMBDA_MICROVM_ENABLED_REGIONS` in the protected GitHub production
+environment is the durable placement kill switch. Keep `us-east-1` present and
+use a comma-separated subset such as `us-east-1,eu-west-1` to stop new Oregon
+placements without re-enabling them during the next image release. Existing
+sessions remain pinned to their persisted region.
 
 The CloudFormation stack creates a GitHub OIDC release role, so GitHub Actions
 does not need long-lived AWS access keys. Create a GitHub environment named

--- a/aws-lambda-microvm/cloudformation.yaml
+++ b/aws-lambda-microvm/cloudformation.yaml
@@ -10,6 +10,12 @@ Parameters:
     Type: String
     Default: aws-lambda-microvm-production
     Description: Protected GitHub environment allowed to publish MicroVM images
+  ExistingGitHubOidcProviderArn:
+    Type: String
+    Default: ""
+    Description: Existing account-wide GitHub OIDC provider ARN; leave empty only in the primary stack
+Conditions:
+  CreateGitHubOidcProvider: !Equals [!Ref ExistingGitHubOidcProviderArn, ""]
 Resources:
   ArtifactBucket:
     Type: AWS::S3::Bucket
@@ -144,6 +150,7 @@ Resources:
 
   GitHubActionsOidcProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: CreateGitHubOidcProvider
     Properties:
       Url: https://token.actions.githubusercontent.com
       ClientIdList:
@@ -162,7 +169,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !Ref GitHubActionsOidcProvider
+              Federated: !If
+                - CreateGitHubOidcProvider
+                - !Ref GitHubActionsOidcProvider
+                - !Ref ExistingGitHubOidcProviderArn
             Action: sts:AssumeRoleWithWebIdentity
             Condition:
               StringEquals:
@@ -185,3 +195,8 @@ Outputs:
     Value: !Ref MicrovmDeployerPolicy
   GitHubReleaseRoleArn:
     Value: !GetAtt GitHubMicrovmReleaseRole.Arn
+  GitHubOidcProviderArn:
+    Value: !If
+      - CreateGitHubOidcProvider
+      - !Ref GitHubActionsOidcProvider
+      - !Ref ExistingGitHubOidcProviderArn

--- a/convex/__tests__/localSandbox.cloudCleanup.test.ts
+++ b/convex/__tests__/localSandbox.cloudCleanup.test.ts
@@ -49,6 +49,80 @@ describe("cloud sandbox session cleanup", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  it("keeps a healthy active session pinned across region and image changes", async () => {
+    const now = Date.now();
+    const active = {
+      _id: "session-row-1",
+      user_id: "user-1",
+      session_id: "session-1",
+      provider: "aws-lambda-microvm",
+      status: "running",
+      microvm_id: "microvm-1",
+      connection_id: "connection-1",
+      bootstrap_expires_at: now + 60_000,
+      region: "us-east-1",
+      image_identifier: "east-image",
+      image_version: "14.0",
+      created_at: now - 1_000,
+      updated_at: now - 500,
+    };
+    const query = jest.fn((table: string) => {
+      if (table === "user_deletion_fences") {
+        return {
+          withIndex: jest.fn(() => ({
+            first: jest.fn().mockResolvedValue(null),
+          })),
+        };
+      }
+      expect(table).toBe("cloud_sandbox_sessions");
+      return {
+        withIndex: jest.fn((_index, buildRange) => {
+          let status = "";
+          const range = {
+            eq: jest.fn((_field: string, value: string) => {
+              if (value === "starting" || value === "running") status = value;
+              return range;
+            }),
+          };
+          buildRange(range);
+          return {
+            order: jest.fn(() => ({
+              take: jest
+                .fn()
+                .mockResolvedValue(status === "running" ? [active] : []),
+            })),
+          };
+        }),
+      };
+    });
+    const insert = jest.fn();
+    const patch = jest.fn();
+    const { beginCloudSession } = await import("../localSandbox");
+
+    await expect(
+      beginCloudSession.handler({ db: { query, insert, patch } } as never, {
+        serviceKey: "service-key",
+        userId: "user-1",
+        region: "eu-west-1",
+        imageIdentifier: "eu-image",
+        imageVersion: "2.0",
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        created: false,
+        session: expect.objectContaining({
+          sessionId: "session-1",
+          region: "us-east-1",
+          imageIdentifier: "east-image",
+          imageVersion: "14.0",
+        }),
+        cleanupCandidates: [],
+      }),
+    );
+    expect(insert).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+  });
+
   it("purges only terminal rows and disconnects their relay records", async () => {
     const statuses: string[] = [];
     const rowsByStatus = {

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -565,10 +565,11 @@ export const beginCloudSession = mutation({
       !(
         session.status === "starting" &&
         now - session.updated_at > CLOUD_SESSION_STARTING_STALE_MS
-      ) &&
-      session.region === args.region &&
-      session.image_identifier === args.imageIdentifier &&
-      session.image_version === args.imageVersion;
+      );
+    // An active sandbox owns in-memory and disk state. Keep it pinned to its
+    // persisted region and image even when a later Agent run is routed to a
+    // different Trigger region or a new global image release is promoted.
+    // New placement inputs apply only after the active session naturally ends.
     // Prefer an already-connected VM over a newer session that is still
     // starting. This is both the lowest-latency and least-expensive choice.
     const reusable = running.find(isReusable) ?? starting.find(isReusable);

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -45,8 +45,8 @@ import { getSandboxWithFallbackGuard } from "./utils/sandbox-fallback";
 import { createE2BResourcePressureObserver } from "@/lib/analytics/sandbox-resource-pressure";
 import { E2B_COST_PER_MS } from "./utils/e2b-cost";
 import { AWS_LAMBDA_MICROVM_COST_PER_MS } from "./utils/aws-lambda-microvm-cost";
-import { AWS_LAMBDA_MICROVM_REGION } from "./utils/aws-lambda-microvm";
 import { phLogger } from "@/lib/posthog/server";
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 import {
   getAwsLambdaMicrovmRolloutTelemetryProperties,
   type AwsLambdaMicrovmRolloutAssignment,
@@ -66,6 +66,7 @@ export type CreateToolsRuntimePolicy = {
   ptyScopeId?: string;
   chargeSandboxRuntime?: boolean;
   cloudSandboxRollout?: AwsLambdaMicrovmRolloutAssignment;
+  triggerRegion?: TriggerRunRegion;
 };
 
 // Factory function to create tools with context
@@ -116,6 +117,7 @@ export const createTools = (
     chatId,
     triggerRunId,
     rollout: runtimePolicy.cloudSandboxRollout,
+    triggerRegion: runtimePolicy.triggerRegion,
     runKind:
       runtimePolicy.chargeSandboxRuntime === false ? "subagent" : "parent",
   };
@@ -167,13 +169,29 @@ export const createTools = (
         sandbox_create_attempts: sandboxBootInfo?.create_attempts,
         region:
           provider === "aws-lambda-microvm"
-            ? AWS_LAMBDA_MICROVM_REGION
+            ? sandboxBootInfo?.region
+            : undefined,
+        trigger_region:
+          provider === "aws-lambda-microvm"
+            ? sandboxBootInfo?.trigger_region
+            : undefined,
+        requested_region:
+          provider === "aws-lambda-microvm"
+            ? sandboxBootInfo?.requested_region
+            : undefined,
+        region_placement_reason:
+          provider === "aws-lambda-microvm"
+            ? sandboxBootInfo?.placement_reason
+            : undefined,
+        microvm_release_id:
+          provider === "aws-lambda-microvm"
+            ? sandboxBootInfo?.release_id
             : undefined,
         image_version:
           provider === "aws-lambda-microvm"
-            ? (process.env.AWS_LAMBDA_MICROVM_IMAGE_VERSION ?? "latest")
+            ? (sandboxBootInfo?.image_version ?? "latest")
             : (process.env.E2B_TEMPLATE ?? "terminal-agent-sandbox"),
-        cloud_sandbox_provider_event_version: 3,
+        cloud_sandbox_provider_event_version: 4,
       });
     }
   };

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -652,4 +652,31 @@ describe("AWS Lambda MicroVM development logging", () => {
 
     expect(getAwsLambdaMicrovmConfig().region).toBe("us-east-1");
   });
+
+  it("selects the release entry paired with the Trigger execution region", () => {
+    process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST = JSON.stringify({
+      schemaVersion: 1,
+      releaseId: "regional-release",
+      regions: Object.fromEntries(
+        ["us-east-1", "us-west-2", "eu-west-1"].map((region) => [
+          region,
+          {
+            imageIdentifier: `arn:aws:lambda:${region}:630609837323:microvm-image:hackerai-cloud-agent`,
+            imageVersion: `${region}-version`,
+            executionRoleArn: `arn:aws:iam::630609837323:role/${region}`,
+            enabledForNewPlacements: true,
+          },
+        ]),
+      ),
+    });
+
+    expect(getAwsLambdaMicrovmConfig("eu-central-1")).toMatchObject({
+      triggerRegion: "eu-central-1",
+      requestedRegion: "eu-west-1",
+      region: "eu-west-1",
+      imageVersion: "eu-west-1-version",
+      placementReason: "trigger_region_europe_pairing",
+      releaseId: "regional-release",
+    });
+  });
 });

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-release.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-release.test.ts
@@ -60,6 +60,18 @@ describe("AWS Lambda MicroVM release manifest", () => {
     });
   });
 
+  it("falls back safely when a serialized task contains an unknown region", () => {
+    const parsed = parseAwsLambdaMicrovmReleaseManifest(
+      JSON.stringify(manifest()),
+    );
+    expect(resolveAwsLambdaMicrovmPlacement("ap-southeast-1", parsed)).toEqual({
+      triggerRegion: "us-east-1",
+      requestedRegion: "us-east-1",
+      region: "us-east-1",
+      reason: "invalid_trigger_region",
+    });
+  });
+
   it("rejects cross-region image ARNs and a disabled fallback", () => {
     const wrongArn = manifest();
     wrongArn.regions["us-west-2"].imageIdentifier =

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-release.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-release.test.ts
@@ -1,0 +1,77 @@
+import {
+  parseAwsLambdaMicrovmReleaseManifest,
+  resolveAwsLambdaMicrovmPlacement,
+} from "../aws-lambda-microvm-release";
+
+const manifest = () => ({
+  schemaVersion: 1,
+  releaseId: "release-sha",
+  regions: {
+    "us-east-1": {
+      imageIdentifier:
+        "arn:aws:lambda:us-east-1:123456789012:microvm-image:hackerai",
+      imageVersion: "15.0",
+      executionRoleArn: "arn:aws:iam::123456789012:role/east",
+      enabledForNewPlacements: true,
+    },
+    "us-west-2": {
+      imageIdentifier:
+        "arn:aws:lambda:us-west-2:123456789012:microvm-image:hackerai",
+      imageVersion: "8.0",
+      executionRoleArn: "arn:aws:iam::123456789012:role/west",
+      enabledForNewPlacements: true,
+    },
+    "eu-west-1": {
+      imageIdentifier:
+        "arn:aws:lambda:eu-west-1:123456789012:microvm-image:hackerai",
+      imageVersion: "3.0",
+      executionRoleArn: "arn:aws:iam::123456789012:role/eu",
+      enabledForNewPlacements: true,
+    },
+  },
+});
+
+describe("AWS Lambda MicroVM release manifest", () => {
+  it.each([
+    ["us-east-1", "us-east-1", "trigger_region_exact"],
+    ["us-west-2", "us-west-2", "trigger_region_exact"],
+    ["eu-central-1", "eu-west-1", "trigger_region_europe_pairing"],
+  ] as const)("maps Trigger %s to AWS %s", (triggerRegion, region, reason) => {
+    const parsed = parseAwsLambdaMicrovmReleaseManifest(
+      JSON.stringify(manifest()),
+    );
+    expect(resolveAwsLambdaMicrovmPlacement(triggerRegion, parsed)).toEqual({
+      triggerRegion,
+      requestedRegion: region,
+      region,
+      reason,
+    });
+  });
+
+  it("falls new placements back to US East when a regional release is disabled", () => {
+    const input = manifest();
+    input.regions["eu-west-1"].enabledForNewPlacements = false;
+    const parsed = parseAwsLambdaMicrovmReleaseManifest(JSON.stringify(input));
+    expect(resolveAwsLambdaMicrovmPlacement("eu-central-1", parsed)).toEqual({
+      triggerRegion: "eu-central-1",
+      requestedRegion: "eu-west-1",
+      region: "us-east-1",
+      reason: "regional_placement_disabled",
+    });
+  });
+
+  it("rejects cross-region image ARNs and a disabled fallback", () => {
+    const wrongArn = manifest();
+    wrongArn.regions["us-west-2"].imageIdentifier =
+      "arn:aws:lambda:us-east-1:123456789012:microvm-image:hackerai";
+    expect(() =>
+      parseAwsLambdaMicrovmReleaseManifest(JSON.stringify(wrongArn)),
+    ).toThrow("must be an ARN in us-west-2");
+
+    const disabledFallback = manifest();
+    disabledFallback.regions["us-east-1"].enabledForNewPlacements = false;
+    expect(() =>
+      parseAwsLambdaMicrovmReleaseManifest(JSON.stringify(disabledFallback)),
+    ).toThrow("us-east-1 must remain enabled");
+  });
+});

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-provider.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-provider.test.ts
@@ -3,6 +3,7 @@ import { getCloudSandboxProvider } from "../cloud-sandbox-provider";
 describe("cloud sandbox provider selection", () => {
   const originalProvider = process.env.CLOUD_SANDBOX_PROVIDER;
   const originalImage = process.env.AWS_LAMBDA_MICROVM_IMAGE_ID;
+  const originalManifest = process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST;
 
   afterEach(() => {
     if (originalProvider === undefined) {
@@ -15,12 +16,25 @@ describe("cloud sandbox provider selection", () => {
     } else {
       process.env.AWS_LAMBDA_MICROVM_IMAGE_ID = originalImage;
     }
+    if (originalManifest === undefined) {
+      delete process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST;
+    } else {
+      process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST = originalManifest;
+    }
   });
 
   it("defaults to E2B when AWS is not configured", () => {
     delete process.env.CLOUD_SANDBOX_PROVIDER;
     delete process.env.AWS_LAMBDA_MICROVM_IMAGE_ID;
+    delete process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST;
     expect(getCloudSandboxProvider()).toBe("e2b");
+  });
+
+  it("selects AWS when an atomic regional release manifest is configured", () => {
+    delete process.env.CLOUD_SANDBOX_PROVIDER;
+    delete process.env.AWS_LAMBDA_MICROVM_IMAGE_ID;
+    process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST = "{}";
+    expect(getCloudSandboxProvider()).toBe("aws-lambda-microvm");
   });
 
   it("selects AWS when an image is explicitly configured", () => {

--- a/lib/ai/tools/utils/aws-lambda-microvm-release.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm-release.ts
@@ -1,0 +1,167 @@
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
+
+export const AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV =
+  "AWS_LAMBDA_MICROVM_RELEASE_MANIFEST" as const;
+export const AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION = 1 as const;
+export const AWS_LAMBDA_MICROVM_DEFAULT_REGION = "us-east-1" as const;
+export const AWS_LAMBDA_MICROVM_REGIONS = [
+  "us-east-1",
+  "us-west-2",
+  "eu-west-1",
+] as const;
+
+export type AwsLambdaMicrovmRegion =
+  (typeof AWS_LAMBDA_MICROVM_REGIONS)[number];
+
+export type AwsLambdaMicrovmReleaseRegion = {
+  imageIdentifier: string;
+  imageVersion: string;
+  executionRoleArn: string;
+  enabledForNewPlacements: boolean;
+};
+
+export type AwsLambdaMicrovmReleaseManifest = {
+  schemaVersion: typeof AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION;
+  releaseId: string;
+  regions: Record<AwsLambdaMicrovmRegion, AwsLambdaMicrovmReleaseRegion>;
+};
+
+export type AwsLambdaMicrovmPlacement = {
+  triggerRegion: TriggerRunRegion;
+  requestedRegion: AwsLambdaMicrovmRegion;
+  region: AwsLambdaMicrovmRegion;
+  reason:
+    | "trigger_region_exact"
+    | "trigger_region_europe_pairing"
+    | "regional_placement_disabled";
+};
+
+const TRIGGER_TO_AWS_REGION: Record<TriggerRunRegion, AwsLambdaMicrovmRegion> =
+  {
+    "us-east-1": "us-east-1",
+    "us-west-2": "us-west-2",
+    "eu-central-1": "eu-west-1",
+  };
+
+function nonEmptyString(value: unknown, path: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${path} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function parseReleaseRegion(
+  value: unknown,
+  region: AwsLambdaMicrovmRegion,
+): AwsLambdaMicrovmReleaseRegion {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`regions.${region} must be an object`);
+  }
+  const record = value as Record<string, unknown>;
+  const imageIdentifier = nonEmptyString(
+    record.imageIdentifier,
+    `regions.${region}.imageIdentifier`,
+  );
+  if (!imageIdentifier.startsWith(`arn:aws:lambda:${region}:`)) {
+    throw new Error(
+      `regions.${region}.imageIdentifier must be an ARN in ${region}`,
+    );
+  }
+  const executionRoleArn = nonEmptyString(
+    record.executionRoleArn,
+    `regions.${region}.executionRoleArn`,
+  );
+  if (!executionRoleArn.startsWith("arn:aws:iam::")) {
+    throw new Error(
+      `regions.${region}.executionRoleArn must be an IAM role ARN`,
+    );
+  }
+  if (typeof record.enabledForNewPlacements !== "boolean") {
+    throw new Error(
+      `regions.${region}.enabledForNewPlacements must be a boolean`,
+    );
+  }
+  return {
+    imageIdentifier,
+    imageVersion: nonEmptyString(
+      record.imageVersion,
+      `regions.${region}.imageVersion`,
+    ),
+    executionRoleArn,
+    enabledForNewPlacements: record.enabledForNewPlacements,
+  };
+}
+
+export function parseAwsLambdaMicrovmReleaseManifest(
+  raw: string,
+): AwsLambdaMicrovmReleaseManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`${AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV} must be JSON`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `${AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV} must be an object`,
+    );
+  }
+  const record = parsed as Record<string, unknown>;
+  if (record.schemaVersion !== AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION) {
+    throw new Error(
+      `${AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV}.schemaVersion must be ${AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION}`,
+    );
+  }
+  if (
+    !record.regions ||
+    typeof record.regions !== "object" ||
+    Array.isArray(record.regions)
+  ) {
+    throw new Error(
+      `${AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV}.regions must be an object`,
+    );
+  }
+  const regions = record.regions as Record<string, unknown>;
+  const manifest: AwsLambdaMicrovmReleaseManifest = {
+    schemaVersion: AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION,
+    releaseId: nonEmptyString(record.releaseId, "releaseId"),
+    regions: {
+      "us-east-1": parseReleaseRegion(regions["us-east-1"], "us-east-1"),
+      "us-west-2": parseReleaseRegion(regions["us-west-2"], "us-west-2"),
+      "eu-west-1": parseReleaseRegion(regions["eu-west-1"], "eu-west-1"),
+    },
+  };
+  if (
+    !manifest.regions[AWS_LAMBDA_MICROVM_DEFAULT_REGION].enabledForNewPlacements
+  ) {
+    throw new Error(
+      `${AWS_LAMBDA_MICROVM_DEFAULT_REGION} must remain enabled for automatic fallback`,
+    );
+  }
+  return manifest;
+}
+
+export function resolveAwsLambdaMicrovmPlacement(
+  triggerRegion: TriggerRunRegion,
+  manifest: AwsLambdaMicrovmReleaseManifest,
+): AwsLambdaMicrovmPlacement {
+  const requestedRegion = TRIGGER_TO_AWS_REGION[triggerRegion];
+  const requested = manifest.regions[requestedRegion];
+  if (!requested.enabledForNewPlacements) {
+    return {
+      triggerRegion,
+      requestedRegion,
+      region: AWS_LAMBDA_MICROVM_DEFAULT_REGION,
+      reason: "regional_placement_disabled",
+    };
+  }
+  return {
+    triggerRegion,
+    requestedRegion,
+    region: requestedRegion,
+    reason:
+      triggerRegion === "eu-central-1"
+        ? "trigger_region_europe_pairing"
+        : "trigger_region_exact",
+  };
+}

--- a/lib/ai/tools/utils/aws-lambda-microvm-release.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm-release.ts
@@ -33,7 +33,8 @@ export type AwsLambdaMicrovmPlacement = {
   reason:
     | "trigger_region_exact"
     | "trigger_region_europe_pairing"
-    | "regional_placement_disabled";
+    | "regional_placement_disabled"
+    | "invalid_trigger_region";
 };
 
 const TRIGGER_TO_AWS_REGION: Record<TriggerRunRegion, AwsLambdaMicrovmRegion> =
@@ -142,25 +143,34 @@ export function parseAwsLambdaMicrovmReleaseManifest(
 }
 
 export function resolveAwsLambdaMicrovmPlacement(
-  triggerRegion: TriggerRunRegion,
+  triggerRegion: TriggerRunRegion | string,
   manifest: AwsLambdaMicrovmReleaseManifest,
 ): AwsLambdaMicrovmPlacement {
-  const requestedRegion = TRIGGER_TO_AWS_REGION[triggerRegion];
+  if (!Object.hasOwn(TRIGGER_TO_AWS_REGION, triggerRegion)) {
+    return {
+      triggerRegion: "us-east-1",
+      requestedRegion: AWS_LAMBDA_MICROVM_DEFAULT_REGION,
+      region: AWS_LAMBDA_MICROVM_DEFAULT_REGION,
+      reason: "invalid_trigger_region",
+    };
+  }
+  const normalizedTriggerRegion = triggerRegion as TriggerRunRegion;
+  const requestedRegion = TRIGGER_TO_AWS_REGION[normalizedTriggerRegion];
   const requested = manifest.regions[requestedRegion];
   if (!requested.enabledForNewPlacements) {
     return {
-      triggerRegion,
+      triggerRegion: normalizedTriggerRegion,
       requestedRegion,
       region: AWS_LAMBDA_MICROVM_DEFAULT_REGION,
       reason: "regional_placement_disabled",
     };
   }
   return {
-    triggerRegion,
+    triggerRegion: normalizedTriggerRegion,
     requestedRegion,
     region: requestedRegion,
     reason:
-      triggerRegion === "eu-central-1"
+      normalizedTriggerRegion === "eu-central-1"
         ? "trigger_region_europe_pairing"
         : "trigger_region_exact",
   };

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -13,9 +13,19 @@ import { getConvexClient, getConvexUrl } from "@/lib/db/convex-client";
 import { createConvexRealtimeClient } from "@/lib/db/convex-realtime-client";
 import { CentrifugoSandbox } from "./centrifugo-sandbox";
 import { AwsLambdaMicrovmDirectSandbox } from "./aws-lambda-microvm-direct-sandbox";
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
+import {
+  AWS_LAMBDA_MICROVM_DEFAULT_REGION,
+  AWS_LAMBDA_MICROVM_REGIONS,
+  AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV,
+  type AwsLambdaMicrovmPlacement,
+  type AwsLambdaMicrovmRegion,
+  parseAwsLambdaMicrovmReleaseManifest,
+  resolveAwsLambdaMicrovmPlacement,
+} from "./aws-lambda-microvm-release";
 
 const PROVIDER = "aws-lambda-microvm" as const;
-export const AWS_LAMBDA_MICROVM_REGION = "us-east-1" as const;
+export const AWS_LAMBDA_MICROVM_REGION = AWS_LAMBDA_MICROVM_DEFAULT_REGION;
 const PLATFORM_MAX_DURATION_SECONDS = 8 * 60 * 60;
 const DEFAULT_MAX_DURATION_SECONDS = 4 * 60 * 60;
 const DEFAULT_MIN_REMAINING_SECONDS = 2 * 60 * 60 + 5 * 60;
@@ -56,7 +66,11 @@ export type AwsLambdaMicrovmSuspensionSummary = {
 };
 
 type AwsLambdaMicrovmConfig = {
-  region: string;
+  region: AwsLambdaMicrovmRegion;
+  requestedRegion: AwsLambdaMicrovmRegion;
+  triggerRegion: TriggerRunRegion;
+  placementReason: AwsLambdaMicrovmPlacement["reason"] | "legacy_us_east";
+  releaseId?: string;
   imageIdentifier: string;
   imageVersion?: string;
   executionRoleArn?: string;
@@ -68,8 +82,7 @@ type AwsLambdaMicrovmConfig = {
   serviceKey: string;
 };
 
-let client: LambdaMicrovmsClient | null = null;
-let clientRegion: string | null = null;
+const clients = new Map<string, LambdaMicrovmsClient>();
 
 type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -210,8 +223,24 @@ function positiveInt(name: string, fallback: number): number {
   return value;
 }
 
-export function getAwsLambdaMicrovmConfig(): AwsLambdaMicrovmConfig {
-  const region = AWS_LAMBDA_MICROVM_REGION;
+export function getAwsLambdaMicrovmConfig(
+  triggerRegion: TriggerRunRegion = "us-east-1",
+): AwsLambdaMicrovmConfig {
+  const rawManifest =
+    process.env[AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV]?.trim();
+  const manifest = rawManifest
+    ? parseAwsLambdaMicrovmReleaseManifest(rawManifest)
+    : undefined;
+  const placement = manifest
+    ? resolveAwsLambdaMicrovmPlacement(triggerRegion, manifest)
+    : {
+        triggerRegion,
+        requestedRegion: AWS_LAMBDA_MICROVM_DEFAULT_REGION,
+        region: AWS_LAMBDA_MICROVM_DEFAULT_REGION,
+        reason: "legacy_us_east" as const,
+      };
+  const region = placement.region;
+  const regionalRelease = manifest?.regions[region];
   const maxDurationSeconds = Math.min(
     PLATFORM_MAX_DURATION_SECONDS,
     positiveInt(
@@ -228,15 +257,23 @@ export function getAwsLambdaMicrovmConfig(): AwsLambdaMicrovmConfig {
   );
   return {
     region,
-    imageIdentifier: required("AWS_LAMBDA_MICROVM_IMAGE_ID"),
+    requestedRegion: placement.requestedRegion,
+    triggerRegion: placement.triggerRegion,
+    placementReason: placement.reason,
+    releaseId: manifest?.releaseId,
+    imageIdentifier:
+      regionalRelease?.imageIdentifier ??
+      required("AWS_LAMBDA_MICROVM_IMAGE_ID"),
     imageVersion:
-      process.env.AWS_LAMBDA_MICROVM_IMAGE_VERSION?.trim() || undefined,
+      regionalRelease?.imageVersion ??
+      process.env.AWS_LAMBDA_MICROVM_IMAGE_VERSION?.trim() ??
+      undefined,
     executionRoleArn:
-      process.env.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN?.trim() || undefined,
+      regionalRelease?.executionRoleArn ??
+      process.env.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN?.trim() ??
+      undefined,
     ingressConnectorArn: `arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:ALL_INGRESS`,
-    egressConnectorArn:
-      process.env.AWS_LAMBDA_MICROVM_EGRESS_CONNECTOR_ARN?.trim() ||
-      `arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:INTERNET_EGRESS`,
+    egressConnectorArn: `arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:INTERNET_EGRESS`,
     maxDurationSeconds,
     minRemainingSeconds,
     logGroup:
@@ -247,12 +284,42 @@ export function getAwsLambdaMicrovmConfig(): AwsLambdaMicrovmConfig {
 }
 
 function getClient(region: string): LambdaMicrovmsClient {
-  if (!client || clientRegion !== region) {
-    client?.destroy();
-    client = new LambdaMicrovmsClient({ region, maxAttempts: 4 });
-    clientRegion = region;
+  const existing = clients.get(region);
+  if (existing) return existing;
+  const created = new LambdaMicrovmsClient({ region, maxAttempts: 4 });
+  clients.set(region, created);
+  return created;
+}
+
+function getConfigForPersistedSession(
+  session: CloudSession,
+  desired: AwsLambdaMicrovmConfig,
+): AwsLambdaMicrovmConfig {
+  if (
+    !AWS_LAMBDA_MICROVM_REGIONS.includes(
+      session.region as AwsLambdaMicrovmRegion,
+    )
+  ) {
+    throw new Error(
+      `Persisted AWS Lambda MicroVM region ${session.region} is not supported`,
+    );
   }
-  return client;
+  const region = session.region as AwsLambdaMicrovmRegion;
+  const rawManifest =
+    process.env[AWS_LAMBDA_MICROVM_RELEASE_MANIFEST_ENV]?.trim();
+  const regionalRelease = rawManifest
+    ? parseAwsLambdaMicrovmReleaseManifest(rawManifest).regions[region]
+    : undefined;
+  return {
+    ...desired,
+    region,
+    imageIdentifier: session.imageIdentifier,
+    imageVersion: session.imageVersion,
+    executionRoleArn:
+      regionalRelease?.executionRoleArn ?? desired.executionRoleArn,
+    ingressConnectorArn: `arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:ALL_INGRESS`,
+    egressConnectorArn: `arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:INTERNET_EGRESS`,
+  };
 }
 
 function log(
@@ -775,15 +842,19 @@ async function ensureExistingMicrovm(
 export async function ensureAwsLambdaMicrovmConnection(
   userId: string,
   onBoot?: (info: SandboxBootInfo) => void,
+  triggerRegion: TriggerRunRegion = "us-east-1",
+  triggerRunId?: string,
   replacementAttempt = 0,
 ): Promise<CentrifugoSandbox> {
   const startedAt = performance.now();
+  const correlation = { trigger_run_id: triggerRunId ?? null };
   let config: AwsLambdaMicrovmConfig;
   try {
-    config = getAwsLambdaMicrovmConfig();
+    config = getAwsLambdaMicrovmConfig(triggerRegion);
   } catch (error) {
     log("error", "cloud_sandbox_configuration_failed", {
       user_id: userId,
+      ...correlation,
       replacement_attempt: replacementAttempt,
       failure_stage: "resolve_configuration",
       failure_code: failureCode(error),
@@ -796,7 +867,12 @@ export async function ensureAwsLambdaMicrovmConnection(
   const convexUrl = getConvexUrl();
   log("debug", "cloud_sandbox_configuration_resolved", {
     user_id: userId,
+    ...correlation,
+    trigger_region: config.triggerRegion,
+    requested_region: config.requestedRegion,
     region: config.region,
+    placement_reason: config.placementReason,
+    release_id: config.releaseId ?? null,
     image_identifier: config.imageIdentifier,
     image_version: config.imageVersion ?? "latest",
     execution_role_configured: Boolean(config.executionRoleArn),
@@ -835,6 +911,7 @@ export async function ensureAwsLambdaMicrovmConnection(
   } catch (error) {
     log("error", "cloud_sandbox_session_prepare_failed", {
       user_id: userId,
+      ...correlation,
       region: config.region,
       image_version: config.imageVersion ?? "latest",
       replacement_attempt: replacementAttempt,
@@ -848,6 +925,7 @@ export async function ensureAwsLambdaMicrovmConnection(
 
   log("debug", "cloud_sandbox_session_prepared", {
     user_id: userId,
+    ...correlation,
     session_id: begin.session.sessionId,
     microvm_id: begin.session.microvmId ?? null,
     region: config.region,
@@ -859,6 +937,29 @@ export async function ensureAwsLambdaMicrovmConnection(
     bootstrap_token_present: Boolean(begin.bootstrapToken),
     duration_ms: Math.round(performance.now() - startedAt),
   });
+
+  const desiredConfig = config;
+  config = getConfigForPersistedSession(begin.session, desiredConfig);
+  if (
+    !begin.created &&
+    (config.region !== desiredConfig.region ||
+      config.imageIdentifier !== desiredConfig.imageIdentifier ||
+      config.imageVersion !== desiredConfig.imageVersion)
+  ) {
+    log("info", "cloud_sandbox_sticky_session_retained", {
+      user_id: userId,
+      ...correlation,
+      session_id: begin.session.sessionId,
+      microvm_id: begin.session.microvmId ?? null,
+      trigger_region: desiredConfig.triggerRegion,
+      requested_region: desiredConfig.requestedRegion,
+      selected_region: desiredConfig.region,
+      persisted_region: config.region,
+      requested_image_version: desiredConfig.imageVersion ?? "latest",
+      persisted_image_version: config.imageVersion ?? "latest",
+      release_id: desiredConfig.releaseId ?? null,
+    });
+  }
 
   const cleanupFailureCount = await cleanupCloudSessionCandidates(
     userId,
@@ -907,26 +1008,46 @@ export async function ensureAwsLambdaMicrovmConnection(
       await markEnded(userId, begin.session.sessionId, config, "failed", code);
       log("warn", "cloud_sandbox_direct_replacement", {
         user_id: userId,
+        ...correlation,
         session_id: begin.session.sessionId,
         microvm_id: begin.session.microvmId ?? null,
         region: config.region,
         failure_code: code,
       });
-      return ensureAwsLambdaMicrovmConnection(userId, onBoot, 1);
+      return ensureAwsLambdaMicrovmConnection(
+        userId,
+        onBoot,
+        triggerRegion,
+        triggerRunId,
+        1,
+      );
     }
     if (!existing) {
       if (replacementAttempt >= 1) {
         throw new Error("Cloud sandbox could not be replaced");
       }
-      return ensureAwsLambdaMicrovmConnection(userId, onBoot, 1);
+      return ensureAwsLambdaMicrovmConnection(
+        userId,
+        onBoot,
+        triggerRegion,
+        triggerRunId,
+        1,
+      );
     }
     onBoot?.({
       path: "reuse_existing",
       duration_ms: Math.round(performance.now() - startedAt),
       create_attempts: 0,
+      region: config.region,
+      trigger_region: config.triggerRegion,
+      requested_region: config.requestedRegion,
+      placement_reason: config.placementReason,
+      release_id: config.releaseId,
+      image_version: existing.session.imageVersion ?? "latest",
     });
     log("info", "cloud_sandbox_reused", {
       user_id: userId,
+      ...correlation,
       session_id: existing.session.sessionId,
       microvm_id: existing.session.microvmId,
       region: config.region,
@@ -942,6 +1063,7 @@ export async function ensureAwsLambdaMicrovmConnection(
     const runStartedAt = performance.now();
     log("debug", "cloud_sandbox_run_requested", {
       user_id: userId,
+      ...correlation,
       session_id: begin.session.sessionId,
       region: config.region,
       image_identifier: config.imageIdentifier,
@@ -986,6 +1108,7 @@ export async function ensureAwsLambdaMicrovmConnection(
     if (!microvmId) throw new Error("AWS did not return a MicroVM ID");
     log("info", "cloud_sandbox_run_accepted", {
       user_id: userId,
+      ...correlation,
       session_id: begin.session.sessionId,
       microvm_id: microvmId,
       region: config.region,
@@ -998,6 +1121,7 @@ export async function ensureAwsLambdaMicrovmConnection(
     failureStage = "attach_cloud_microvm";
     log("debug", "cloud_sandbox_direct_endpoint_wait_started", {
       user_id: userId,
+      ...correlation,
       session_id: begin.session.sessionId,
       microvm_id: microvmId,
       region: config.region,
@@ -1032,9 +1156,16 @@ export async function ensureAwsLambdaMicrovmConnection(
       path: "create_fresh",
       duration_ms: Math.round(performance.now() - startedAt),
       create_attempts: 1,
+      region: config.region,
+      trigger_region: config.triggerRegion,
+      requested_region: config.requestedRegion,
+      placement_reason: config.placementReason,
+      release_id: config.releaseId,
+      image_version: connected.imageVersion ?? "latest",
     });
     log("info", "cloud_sandbox_created", {
       user_id: userId,
+      ...correlation,
       session_id: connected.sessionId,
       microvm_id: connected.microvmId,
       region: config.region,
@@ -1046,6 +1177,7 @@ export async function ensureAwsLambdaMicrovmConnection(
     const code = failureCode(error);
     log("error", "cloud_sandbox_creation_failed", {
       user_id: userId,
+      ...correlation,
       session_id: begin.session.sessionId,
       microvm_id: microvmId ?? null,
       region: config.region,
@@ -1063,6 +1195,7 @@ export async function ensureAwsLambdaMicrovmConnection(
     await directSandbox?.close().catch((closeError: unknown) => {
       log("warn", "cloud_sandbox_direct_cleanup_failed", {
         user_id: userId,
+        ...correlation,
         session_id: begin.session.sessionId,
         microvm_id: microvmId ?? null,
         region: config.region,

--- a/lib/ai/tools/utils/cloud-sandbox-provider.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-provider.ts
@@ -13,5 +13,8 @@ export function getCloudSandboxProvider(): CloudSandboxProvider {
 
   // Supplying an image is an explicit opt-in that makes AWS the cloud
   // provider without requiring a second environment variable.
-  return process.env.AWS_LAMBDA_MICROVM_IMAGE_ID ? "aws-lambda-microvm" : "e2b";
+  return process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST ||
+    process.env.AWS_LAMBDA_MICROVM_IMAGE_ID
+    ? "aws-lambda-microvm"
+    : "e2b";
 }

--- a/lib/ai/tools/utils/cloud-sandbox.ts
+++ b/lib/ai/tools/utils/cloud-sandbox.ts
@@ -12,6 +12,7 @@ import { ensureSandboxConnection } from "./sandbox";
 import { isAwsLambdaMicrovmSandbox, isE2BSandbox } from "./sandbox-types";
 import { phLogger } from "@/lib/posthog/server";
 import { getCloudSandboxRecoveryTelemetryProperties } from "./cloud-sandbox-recovery";
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 
 export type CloudSandboxAcquisitionContext = {
   provider?: CloudSandboxProvider;
@@ -25,6 +26,7 @@ export type CloudSandboxAcquisitionContext = {
     toProvider: CloudSandboxProvider;
     reason: "attachment_placement_failure";
   };
+  triggerRegion?: TriggerRunRegion;
 };
 
 export type CloudSandboxSuspensionSummary = {
@@ -54,6 +56,8 @@ export async function ensureCloudSandboxConnection(options: {
       const sandbox = await ensureAwsLambdaMicrovmConnection(
         options.userId,
         options.onBoot,
+        options.context?.triggerRegion,
+        options.context?.triggerRunId,
       );
       options.setSandbox(sandbox);
       return { sandbox };
@@ -85,6 +89,7 @@ export async function ensureCloudSandboxConnection(options: {
       subscription_tier: options.context?.subscription,
       agent_run_kind: options.context?.runKind ?? "parent",
       ...getCloudSandboxRecoveryTelemetryProperties(options.context),
+      trigger_region: options.context?.triggerRegion,
       ...getAwsLambdaMicrovmRolloutTelemetryProperties(rollout),
       failure_stage: "ensure_cloud_sandbox",
       duration_ms: Date.now() - startedAt,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1876,7 +1876,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/alreadyEmittedFromStream/);
   });
 
-  test("agent-long only passes explicit Trigger.dev region when mapped", () => {
+  test("agent-long always pins the mapped Trigger.dev region", () => {
     const userLocationIdx = routeSrc.indexOf(
       "const userLocation = geolocation(req)",
     );
@@ -1889,7 +1889,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       routingIdx,
     );
     const triggerOptionsRegionIdx = routeSrc.indexOf(
-      "...(triggerRegion ? { region: triggerRegion } : {})",
+      "region: triggerRegion",
       triggerOptionsIdx,
     );
     const approvalTriggerConfigIdx = routeSrc.indexOf(
@@ -1897,7 +1897,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       triggerOptionsRegionIdx,
     );
     const sessionRegionIdx = routeSrc.indexOf(
-      "...(triggerRegion ? { region: triggerRegion } : {})",
+      "region: triggerRegion",
       approvalTriggerConfigIdx,
     );
     const sessionStartIdx = routeSrc.indexOf(

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -448,7 +448,8 @@ export const createAgentTriggerPost =
         );
       await assertUserCanMakeCostIncurringRequest(userId);
       const userLocation = geolocation(req);
-      const triggerRegion = getTriggerRegionForVercelRequest(req, userLocation);
+      const triggerRegion =
+        getTriggerRegionForVercelRequest(req, userLocation) ?? "us-east-1";
       const securityValidationSubagentsEnabled =
         agentPermissionMode === "full_access" &&
         (await resolveSecurityValidationSubagentsEnabled(userId));
@@ -668,6 +669,7 @@ export const createAgentTriggerPost =
         selectedModel: selectedModelOverride,
         autoReviewAssignment,
         userLocation,
+        triggerRegion,
         isAutoContinue,
         regenerate,
         limitRescue,
@@ -710,7 +712,7 @@ export const createAgentTriggerPost =
         ...(triggerPriority > 0 ? { priority: triggerPriority } : {}),
         machine: triggerMachine,
         tags: triggerTags,
-        ...(triggerRegion ? { region: triggerRegion } : {}),
+        region: triggerRegion,
         idempotencyKey: triggerIdempotencyKey,
         idempotencyKeyTTL: "6h",
         metadata: triggerMetadata,
@@ -756,7 +758,7 @@ export const createAgentTriggerPost =
             basePayload: agentPayload,
             machine: triggerMachine,
             tags: triggerTags,
-            ...(triggerRegion ? { region: triggerRegion } : {}),
+            region: triggerRegion,
             ...(approvalWorkerVersion
               ? { lockToVersion: approvalWorkerVersion }
               : {}),

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "prettier": "3.9.6",
     "tailwindcss": "^4.3.3",
     "trigger.dev": "4.5.11",
+    "tsx": "^4.23.12",
     "ts-node": "^10.9.2",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "aws:microvm:package": "pnpm local-sandbox:build && node scripts/package-aws-microvm.mjs",
     "aws:microvm:deploy": "pnpm aws:microvm:package && node scripts/deploy-aws-microvm.mjs",
     "aws:microvm:smoke": "node scripts/smoke-aws-microvm.mjs",
+    "aws:microvm:sync-trigger-env": "tsx scripts/sync-trigger-microvm-release-env.ts",
     "local-sandbox": "npx tsx packages/local/src/index.ts",
     "local-sandbox:build": "cd packages/local && pnpm build",
     "desktop:dev": "cd packages/desktop && pnpm dev",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "e2b:build:prod": "npx tsx e2b/build.prod.ts",
     "aws:microvm:package": "pnpm local-sandbox:build && node scripts/package-aws-microvm.mjs",
     "aws:microvm:deploy": "pnpm aws:microvm:package && node scripts/deploy-aws-microvm.mjs",
+    "aws:microvm:build-release-manifest": "tsx scripts/build-aws-microvm-release-manifest.ts",
     "aws:microvm:smoke": "node scripts/smoke-aws-microvm.mjs",
     "aws:microvm:sync-trigger-env": "tsx scripts/sync-trigger-microvm-release-env.ts",
     "local-sandbox": "npx tsx packages/local/src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@25.9.3)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -1049,6 +1052,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -1057,6 +1066,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.0':
     resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1073,6 +1088,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -1081,6 +1102,12 @@ packages:
 
   '@esbuild/android-x64@0.27.0':
     resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1097,6 +1124,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
@@ -1105,6 +1138,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.0':
     resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1121,6 +1160,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
@@ -1129,6 +1174,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.0':
     resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1145,6 +1196,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
@@ -1153,6 +1210,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.0':
     resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1169,6 +1232,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
@@ -1177,6 +1246,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.0':
     resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1193,6 +1268,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
@@ -1201,6 +1282,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.0':
     resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1217,6 +1304,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1225,6 +1318,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.0':
     resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1241,6 +1340,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -1249,6 +1354,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.0':
     resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1265,6 +1376,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -1273,6 +1390,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.0':
     resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1289,6 +1412,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -1297,6 +1426,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.0':
     resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1313,6 +1448,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
@@ -1321,6 +1462,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.0':
     resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1337,6 +1484,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
@@ -1345,6 +1498,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.0':
     resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -5198,6 +5357,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -8167,6 +8331,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -9331,10 +9500,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.0':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -9343,10 +9518,16 @@ snapshots:
   '@esbuild/android-arm@0.27.0':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -9355,10 +9536,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -9367,10 +9554,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -9379,10 +9572,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -9391,10 +9590,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -9403,10 +9608,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -9415,10 +9626,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -9427,10 +9644,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.0':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
@@ -9439,10 +9662,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -9451,10 +9680,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
@@ -9463,10 +9698,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
@@ -9475,10 +9716,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -13343,6 +13590,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.0
       '@esbuild/win32-x64': 0.27.0
 
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -17176,6 +17452,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tw-animate-css@1.4.0: {}
 

--- a/scripts/__tests__/aws-microvm-release-manifest.test.ts
+++ b/scripts/__tests__/aws-microvm-release-manifest.test.ts
@@ -1,5 +1,6 @@
 import {
   buildAwsLambdaMicrovmReleaseManifest,
+  parseAwsLambdaMicrovmEnabledRegions,
   parseRegionalReleaseOutput,
   serializeAwsLambdaMicrovmReleaseEnvironment,
 } from "../lib/aws-microvm-release-manifest";
@@ -27,9 +28,37 @@ describe("AWS Lambda MicroVM regional release manifest", () => {
       "eu-west-1",
     ]);
     expect(manifest.regions["eu-west-1"].enabledForNewPlacements).toBe(true);
-    expect(serializeAwsLambdaMicrovmReleaseEnvironment(manifest)).toContain(
+    expect(
+      serializeAwsLambdaMicrovmReleaseEnvironment(manifest).split("\n"),
+    ).toEqual([
       `AWS_LAMBDA_MICROVM_RELEASE_MANIFEST=${JSON.stringify(manifest)}`,
-    );
+      `AWS_LAMBDA_MICROVM_IMAGE_ID=${manifest.regions["us-east-1"].imageIdentifier}`,
+      "AWS_LAMBDA_MICROVM_IMAGE_VERSION=15.0",
+      "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/us-east-1",
+    ]);
+  });
+
+  it("preserves disabled regional placement across later image releases", () => {
+    const manifest = buildAwsLambdaMicrovmReleaseManifest({
+      releaseId: "kill-switch",
+      outputs: [output("us-east-1"), output("us-west-2"), output("eu-west-1")],
+      enabledRegions: parseAwsLambdaMicrovmEnabledRegions(
+        "us-east-1,eu-west-1",
+      ),
+    });
+
+    expect(manifest.regions["us-east-1"].enabledForNewPlacements).toBe(true);
+    expect(manifest.regions["us-west-2"].enabledForNewPlacements).toBe(false);
+    expect(manifest.regions["eu-west-1"].enabledForNewPlacements).toBe(true);
+  });
+
+  it("rejects enabled-region inputs without the fallback region", () => {
+    expect(() =>
+      parseAwsLambdaMicrovmEnabledRegions("us-west-2,eu-west-1"),
+    ).toThrow("must include us-east-1");
+    expect(() =>
+      parseAwsLambdaMicrovmEnabledRegions("us-east-1,ap-southeast-1"),
+    ).toThrow("contains an unsupported region");
   });
 
   it("rejects partial and duplicate regional builds", () => {

--- a/scripts/__tests__/aws-microvm-release-manifest.test.ts
+++ b/scripts/__tests__/aws-microvm-release-manifest.test.ts
@@ -1,0 +1,53 @@
+import {
+  buildAwsLambdaMicrovmReleaseManifest,
+  parseRegionalReleaseOutput,
+  serializeAwsLambdaMicrovmReleaseEnvironment,
+} from "../lib/aws-microvm-release-manifest";
+
+const output = (region: "us-east-1" | "us-west-2" | "eu-west-1") =>
+  parseRegionalReleaseOutput(
+    [
+      `AWS_REGION=${region}`,
+      `AWS_LAMBDA_MICROVM_IMAGE_ID=arn:aws:lambda:${region}:123456789012:microvm-image:hackerai`,
+      "AWS_LAMBDA_MICROVM_IMAGE_VERSION=15.0",
+      `AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/${region}`,
+    ].join("\n"),
+  );
+
+describe("AWS Lambda MicroVM regional release manifest", () => {
+  it("promotes exactly one validated entry for every supported region", () => {
+    const manifest = buildAwsLambdaMicrovmReleaseManifest({
+      releaseId: "abcdef",
+      outputs: [output("eu-west-1"), output("us-east-1"), output("us-west-2")],
+    });
+    expect(manifest.releaseId).toBe("abcdef");
+    expect(Object.keys(manifest.regions)).toEqual([
+      "us-east-1",
+      "us-west-2",
+      "eu-west-1",
+    ]);
+    expect(manifest.regions["eu-west-1"].enabledForNewPlacements).toBe(true);
+    expect(serializeAwsLambdaMicrovmReleaseEnvironment(manifest)).toContain(
+      `AWS_LAMBDA_MICROVM_RELEASE_MANIFEST=${JSON.stringify(manifest)}`,
+    );
+  });
+
+  it("rejects partial and duplicate regional builds", () => {
+    expect(() =>
+      buildAwsLambdaMicrovmReleaseManifest({
+        releaseId: "partial",
+        outputs: [output("us-east-1"), output("us-west-2")],
+      }),
+    ).toThrow("Missing regional release output for eu-west-1");
+    expect(() =>
+      buildAwsLambdaMicrovmReleaseManifest({
+        releaseId: "duplicate",
+        outputs: [
+          output("us-east-1"),
+          output("us-east-1"),
+          output("eu-west-1"),
+        ],
+      }),
+    ).toThrow("duplicate AWS region");
+  });
+});

--- a/scripts/__tests__/trigger-microvm-release-env.test.ts
+++ b/scripts/__tests__/trigger-microvm-release-env.test.ts
@@ -4,13 +4,26 @@ import {
   TRIGGER_MICROVM_RELEASE_ENV_NAMES,
 } from "../lib/trigger-microvm-release-env";
 
+const releaseManifest = {
+  schemaVersion: 1,
+  releaseId: "sha-test",
+  regions: Object.fromEntries(
+    ["us-east-1", "us-west-2", "eu-west-1"].map((region) => [
+      region,
+      {
+        imageIdentifier: `arn:aws:lambda:${region}:123:microvm-image:test`,
+        imageVersion: "15.0",
+        executionRoleArn: `arn:aws:iam::123:role/test-${region}`,
+        enabledForNewPlacements: true,
+      },
+    ]),
+  ),
+};
+
 const releaseEnv = {
   TRIGGER_ACCESS_TOKEN: "tr_pat_test",
   TRIGGER_PROJECT_ID: "proj_test",
-  AWS_LAMBDA_MICROVM_IMAGE_ID:
-    "arn:aws:lambda:us-east-1:123:microvm-image:test",
-  AWS_LAMBDA_MICROVM_IMAGE_VERSION: "15.0",
-  AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: "arn:aws:iam::123:role/test",
+  AWS_LAMBDA_MICROVM_RELEASE_MANIFEST: JSON.stringify(releaseManifest),
 };
 
 describe("Trigger.dev MicroVM release environment sync", () => {
@@ -20,10 +33,12 @@ describe("Trigger.dev MicroVM release environment sync", () => {
       projectRef: "proj_test",
       variables: {
         CLOUD_SANDBOX_PROVIDER: "aws-lambda-microvm",
+        AWS_LAMBDA_MICROVM_RELEASE_MANIFEST: JSON.stringify(releaseManifest),
         AWS_LAMBDA_MICROVM_IMAGE_ID:
           "arn:aws:lambda:us-east-1:123:microvm-image:test",
         AWS_LAMBDA_MICROVM_IMAGE_VERSION: "15.0",
-        AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: "arn:aws:iam::123:role/test",
+        AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN:
+          "arn:aws:iam::123:role/test-us-east-1",
       },
     });
   });
@@ -32,9 +47,9 @@ describe("Trigger.dev MicroVM release environment sync", () => {
     expect(() =>
       getTriggerMicrovmReleaseConfig({
         ...releaseEnv,
-        AWS_LAMBDA_MICROVM_IMAGE_VERSION: " ",
+        AWS_LAMBDA_MICROVM_RELEASE_MANIFEST: " ",
       }),
-    ).toThrow("AWS_LAMBDA_MICROVM_IMAGE_VERSION is required");
+    ).toThrow("AWS_LAMBDA_MICROVM_RELEASE_MANIFEST is required");
   });
 
   it("overrides and verifies every stored production value", async () => {

--- a/scripts/__tests__/trigger-microvm-release-env.test.ts
+++ b/scripts/__tests__/trigger-microvm-release-env.test.ts
@@ -1,0 +1,87 @@
+import {
+  getTriggerMicrovmReleaseConfig,
+  syncAndVerifyTriggerMicrovmReleaseEnv,
+  TRIGGER_MICROVM_RELEASE_ENV_NAMES,
+} from "../lib/trigger-microvm-release-env";
+
+const releaseEnv = {
+  TRIGGER_ACCESS_TOKEN: "tr_pat_test",
+  TRIGGER_PROJECT_ID: "proj_test",
+  AWS_LAMBDA_MICROVM_IMAGE_ID:
+    "arn:aws:lambda:us-east-1:123:microvm-image:test",
+  AWS_LAMBDA_MICROVM_IMAGE_VERSION: "15.0",
+  AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: "arn:aws:iam::123:role/test",
+};
+
+describe("Trigger.dev MicroVM release environment sync", () => {
+  it("builds the exact production values without treating them as secrets", () => {
+    expect(getTriggerMicrovmReleaseConfig(releaseEnv)).toEqual({
+      accessToken: "tr_pat_test",
+      projectRef: "proj_test",
+      variables: {
+        CLOUD_SANDBOX_PROVIDER: "aws-lambda-microvm",
+        AWS_LAMBDA_MICROVM_IMAGE_ID:
+          "arn:aws:lambda:us-east-1:123:microvm-image:test",
+        AWS_LAMBDA_MICROVM_IMAGE_VERSION: "15.0",
+        AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: "arn:aws:iam::123:role/test",
+      },
+    });
+  });
+
+  it("requires every release input", () => {
+    expect(() =>
+      getTriggerMicrovmReleaseConfig({
+        ...releaseEnv,
+        AWS_LAMBDA_MICROVM_IMAGE_VERSION: " ",
+      }),
+    ).toThrow("AWS_LAMBDA_MICROVM_IMAGE_VERSION is required");
+  });
+
+  it("overrides and verifies every stored production value", async () => {
+    const config = getTriggerMicrovmReleaseConfig(releaseEnv);
+    const upload = jest.fn(async () => ({ success: true }));
+    const retrieve = jest.fn(async (_project, _environment, name) => ({
+      name,
+      value: config.variables[name as keyof typeof config.variables],
+      isSecret: false,
+    }));
+
+    await expect(
+      syncAndVerifyTriggerMicrovmReleaseEnv({
+        client: { upload, retrieve },
+        config,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(upload).toHaveBeenCalledWith("proj_test", "prod", {
+      variables: config.variables,
+      override: true,
+    });
+    expect(retrieve).toHaveBeenCalledTimes(
+      TRIGGER_MICROVM_RELEASE_ENV_NAMES.length,
+    );
+  });
+
+  it("fails the release when Trigger stores a different value", async () => {
+    const config = getTriggerMicrovmReleaseConfig(releaseEnv);
+
+    await expect(
+      syncAndVerifyTriggerMicrovmReleaseEnv({
+        client: {
+          upload: async () => ({ success: true }),
+          retrieve: async (_project, _environment, name) => ({
+            name,
+            value:
+              name === "AWS_LAMBDA_MICROVM_IMAGE_VERSION"
+                ? "14.0"
+                : config.variables[name],
+            isSecret: false,
+          }),
+        },
+        config,
+      }),
+    ).rejects.toThrow(
+      "Trigger.dev stored value verification failed for AWS_LAMBDA_MICROVM_IMAGE_VERSION",
+    );
+  });
+});

--- a/scripts/build-aws-microvm-release-manifest.ts
+++ b/scripts/build-aws-microvm-release-manifest.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env tsx
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  buildAwsLambdaMicrovmReleaseManifest,
+  parseRegionalReleaseOutput,
+  serializeAwsLambdaMicrovmReleaseEnvironment,
+} from "./lib/aws-microvm-release-manifest";
+
+async function main() {
+  const inputDirectory = process.env.AWS_LAMBDA_MICROVM_RELEASE_INPUT_DIR;
+  const outputFile = process.env.AWS_LAMBDA_MICROVM_OUTPUT_FILE;
+  const releaseId = process.env.GITHUB_SHA?.trim();
+  if (!inputDirectory || !outputFile || !releaseId) {
+    throw new Error(
+      "AWS_LAMBDA_MICROVM_RELEASE_INPUT_DIR, AWS_LAMBDA_MICROVM_OUTPUT_FILE, and GITHUB_SHA are required",
+    );
+  }
+  const directory = resolve(inputDirectory);
+  const files = (await readdir(directory)).filter((file) =>
+    file.endsWith(".env"),
+  );
+  const outputs = await Promise.all(
+    files.map(async (file) =>
+      parseRegionalReleaseOutput(
+        await readFile(resolve(directory, file), "utf8"),
+      ),
+    ),
+  );
+  const manifest = buildAwsLambdaMicrovmReleaseManifest({ releaseId, outputs });
+  await writeFile(
+    resolve(outputFile),
+    `${serializeAwsLambdaMicrovmReleaseEnvironment(manifest)}\n`,
+    { mode: 0o600 },
+  );
+  console.log(
+    `Built atomic AWS Lambda MicroVM release ${manifest.releaseId} for ${Object.keys(manifest.regions).join(", ")}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/build-aws-microvm-release-manifest.ts
+++ b/scripts/build-aws-microvm-release-manifest.ts
@@ -3,7 +3,9 @@
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
+  AWS_LAMBDA_MICROVM_ENABLED_REGIONS_ENV,
   buildAwsLambdaMicrovmReleaseManifest,
+  parseAwsLambdaMicrovmEnabledRegions,
   parseRegionalReleaseOutput,
   serializeAwsLambdaMicrovmReleaseEnvironment,
 } from "./lib/aws-microvm-release-manifest";
@@ -28,7 +30,13 @@ async function main() {
       ),
     ),
   );
-  const manifest = buildAwsLambdaMicrovmReleaseManifest({ releaseId, outputs });
+  const manifest = buildAwsLambdaMicrovmReleaseManifest({
+    releaseId,
+    outputs,
+    enabledRegions: parseAwsLambdaMicrovmEnabledRegions(
+      process.env[AWS_LAMBDA_MICROVM_ENABLED_REGIONS_ENV],
+    ),
+  });
   await writeFile(
     resolve(outputFile),
     `${serializeAwsLambdaMicrovmReleaseEnvironment(manifest)}\n`,

--- a/scripts/deploy-aws-microvm.mjs
+++ b/scripts/deploy-aws-microvm.mjs
@@ -19,15 +19,17 @@ const region =
   process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1";
 const bucket = process.env.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET;
 const buildRoleArn = process.env.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN;
+const executionRoleArn =
+  process.env.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN?.trim();
 const name =
   process.env.AWS_LAMBDA_MICROVM_IMAGE_NAME || "hackerai-cloud-agent";
 const baseImageArn =
   process.env.AWS_LAMBDA_MICROVM_BASE_IMAGE_ARN ||
   `arn:aws:lambda:${region}:aws:microvm-image:al2023-1`;
 
-if (!bucket || !buildRoleArn) {
+if (!bucket || !buildRoleArn || !executionRoleArn) {
   throw new Error(
-    "AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET and AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN are required",
+    "AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET, AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN, and AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN are required",
   );
 }
 
@@ -137,7 +139,7 @@ const output = [
   `AWS_REGION=${region}`,
   `AWS_LAMBDA_MICROVM_IMAGE_ID=${version.imageArn || imageIdentifier}`,
   `AWS_LAMBDA_MICROVM_IMAGE_VERSION=${imageVersion}`,
-  `AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=${process.env.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN || ""}`,
+  `AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=${executionRoleArn}`,
 ].join("\n");
 
 if (process.env.AWS_LAMBDA_MICROVM_OUTPUT_FILE) {

--- a/scripts/deploy-aws-microvm.mjs
+++ b/scripts/deploy-aws-microvm.mjs
@@ -15,7 +15,8 @@ const artifactPath = resolve(
   root,
   ".artifacts/aws-lambda-microvm/hackerai-lambda-microvm.zip",
 );
-const region = "us-east-1";
+const region =
+  process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1";
 const bucket = process.env.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET;
 const buildRoleArn = process.env.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN;
 const name =
@@ -133,8 +134,10 @@ if (version?.state !== "SUCCESSFUL" || version.status !== "ACTIVE") {
 }
 
 const output = [
+  `AWS_REGION=${region}`,
   `AWS_LAMBDA_MICROVM_IMAGE_ID=${version.imageArn || imageIdentifier}`,
   `AWS_LAMBDA_MICROVM_IMAGE_VERSION=${imageVersion}`,
+  `AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=${process.env.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN || ""}`,
 ].join("\n");
 
 if (process.env.AWS_LAMBDA_MICROVM_OUTPUT_FILE) {

--- a/scripts/lib/aws-microvm-release-manifest.ts
+++ b/scripts/lib/aws-microvm-release-manifest.ts
@@ -1,4 +1,5 @@
 import {
+  AWS_LAMBDA_MICROVM_DEFAULT_REGION,
   AWS_LAMBDA_MICROVM_REGIONS,
   AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION,
   type AwsLambdaMicrovmRegion,
@@ -12,6 +13,32 @@ type RegionalReleaseOutput = {
   AWS_LAMBDA_MICROVM_IMAGE_VERSION: string;
   AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: string;
 };
+
+export const AWS_LAMBDA_MICROVM_ENABLED_REGIONS_ENV =
+  "AWS_LAMBDA_MICROVM_ENABLED_REGIONS" as const;
+
+export function parseAwsLambdaMicrovmEnabledRegions(
+  raw: string | undefined,
+): readonly AwsLambdaMicrovmRegion[] {
+  if (!raw?.trim()) return AWS_LAMBDA_MICROVM_REGIONS;
+  const enabled = [...new Set(raw.split(",").map((value) => value.trim()))];
+  if (
+    enabled.some(
+      (region) =>
+        !AWS_LAMBDA_MICROVM_REGIONS.includes(region as AwsLambdaMicrovmRegion),
+    )
+  ) {
+    throw new Error(
+      `${AWS_LAMBDA_MICROVM_ENABLED_REGIONS_ENV} contains an unsupported region`,
+    );
+  }
+  if (!enabled.includes(AWS_LAMBDA_MICROVM_DEFAULT_REGION)) {
+    throw new Error(
+      `${AWS_LAMBDA_MICROVM_ENABLED_REGIONS_ENV} must include ${AWS_LAMBDA_MICROVM_DEFAULT_REGION}`,
+    );
+  }
+  return enabled as AwsLambdaMicrovmRegion[];
+}
 
 function required(record: Record<string, string>, name: string): string {
   const value = record[name]?.trim();
@@ -51,9 +78,11 @@ export function parseRegionalReleaseOutput(raw: string): RegionalReleaseOutput {
 export function buildAwsLambdaMicrovmReleaseManifest({
   releaseId,
   outputs,
+  enabledRegions = AWS_LAMBDA_MICROVM_REGIONS,
 }: {
   releaseId: string;
   outputs: RegionalReleaseOutput[];
+  enabledRegions?: readonly AwsLambdaMicrovmRegion[];
 }): AwsLambdaMicrovmReleaseManifest {
   const byRegion = new Map(
     outputs.map((output) => [output.AWS_REGION, output]),
@@ -72,7 +101,7 @@ export function buildAwsLambdaMicrovmReleaseManifest({
           imageIdentifier: output.AWS_LAMBDA_MICROVM_IMAGE_ID,
           imageVersion: output.AWS_LAMBDA_MICROVM_IMAGE_VERSION,
           executionRoleArn: output.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN,
-          enabledForNewPlacements: true,
+          enabledForNewPlacements: enabledRegions.includes(region),
         },
       ];
     }),

--- a/scripts/lib/aws-microvm-release-manifest.ts
+++ b/scripts/lib/aws-microvm-release-manifest.ts
@@ -1,0 +1,99 @@
+import {
+  AWS_LAMBDA_MICROVM_REGIONS,
+  AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION,
+  type AwsLambdaMicrovmRegion,
+  type AwsLambdaMicrovmReleaseManifest,
+  parseAwsLambdaMicrovmReleaseManifest,
+} from "../../lib/ai/tools/utils/aws-lambda-microvm-release";
+
+type RegionalReleaseOutput = {
+  AWS_REGION: AwsLambdaMicrovmRegion;
+  AWS_LAMBDA_MICROVM_IMAGE_ID: string;
+  AWS_LAMBDA_MICROVM_IMAGE_VERSION: string;
+  AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: string;
+};
+
+function required(record: Record<string, string>, name: string): string {
+  const value = record[name]?.trim();
+  if (!value) throw new Error(`${name} is required in regional release output`);
+  return value;
+}
+
+export function parseRegionalReleaseOutput(raw: string): RegionalReleaseOutput {
+  const record: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) throw new Error("Invalid regional release output line");
+    record[line.slice(0, separator)] = line.slice(separator + 1);
+  }
+  const region = required(record, "AWS_REGION");
+  if (!AWS_LAMBDA_MICROVM_REGIONS.includes(region as AwsLambdaMicrovmRegion)) {
+    throw new Error(`Unsupported AWS Lambda MicroVM release region ${region}`);
+  }
+  return {
+    AWS_REGION: region as AwsLambdaMicrovmRegion,
+    AWS_LAMBDA_MICROVM_IMAGE_ID: required(
+      record,
+      "AWS_LAMBDA_MICROVM_IMAGE_ID",
+    ),
+    AWS_LAMBDA_MICROVM_IMAGE_VERSION: required(
+      record,
+      "AWS_LAMBDA_MICROVM_IMAGE_VERSION",
+    ),
+    AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: required(
+      record,
+      "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN",
+    ),
+  };
+}
+
+export function buildAwsLambdaMicrovmReleaseManifest({
+  releaseId,
+  outputs,
+}: {
+  releaseId: string;
+  outputs: RegionalReleaseOutput[];
+}): AwsLambdaMicrovmReleaseManifest {
+  const byRegion = new Map(
+    outputs.map((output) => [output.AWS_REGION, output]),
+  );
+  if (byRegion.size !== outputs.length) {
+    throw new Error("Regional release output contains a duplicate AWS region");
+  }
+  const regions = Object.fromEntries(
+    AWS_LAMBDA_MICROVM_REGIONS.map((region) => {
+      const output = byRegion.get(region);
+      if (!output)
+        throw new Error(`Missing regional release output for ${region}`);
+      return [
+        region,
+        {
+          imageIdentifier: output.AWS_LAMBDA_MICROVM_IMAGE_ID,
+          imageVersion: output.AWS_LAMBDA_MICROVM_IMAGE_VERSION,
+          executionRoleArn: output.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN,
+          enabledForNewPlacements: true,
+        },
+      ];
+    }),
+  ) as AwsLambdaMicrovmReleaseManifest["regions"];
+  return parseAwsLambdaMicrovmReleaseManifest(
+    JSON.stringify({
+      schemaVersion: AWS_LAMBDA_MICROVM_RELEASE_SCHEMA_VERSION,
+      releaseId,
+      regions,
+    }),
+  );
+}
+
+export function serializeAwsLambdaMicrovmReleaseEnvironment(
+  manifest: AwsLambdaMicrovmReleaseManifest,
+): string {
+  const east = manifest.regions["us-east-1"];
+  return [
+    `AWS_LAMBDA_MICROVM_RELEASE_MANIFEST=${JSON.stringify(manifest)}`,
+    `AWS_LAMBDA_MICROVM_IMAGE_ID=${east.imageIdentifier}`,
+    `AWS_LAMBDA_MICROVM_IMAGE_VERSION=${east.imageVersion}`,
+    `AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN=${east.executionRoleArn}`,
+  ].join("\n");
+}

--- a/scripts/lib/trigger-microvm-release-env.ts
+++ b/scripts/lib/trigger-microvm-release-env.ts
@@ -1,0 +1,95 @@
+export const TRIGGER_MICROVM_RELEASE_ENVIRONMENT = "prod" as const;
+
+export const TRIGGER_MICROVM_RELEASE_ENV_NAMES = [
+  "CLOUD_SANDBOX_PROVIDER",
+  "AWS_LAMBDA_MICROVM_IMAGE_ID",
+  "AWS_LAMBDA_MICROVM_IMAGE_VERSION",
+  "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN",
+] as const;
+
+type TriggerMicrovmReleaseEnvName =
+  (typeof TRIGGER_MICROVM_RELEASE_ENV_NAMES)[number];
+
+type TriggerEnvClient = {
+  upload: (
+    projectRef: string,
+    environment: typeof TRIGGER_MICROVM_RELEASE_ENVIRONMENT,
+    params: {
+      variables: Record<TriggerMicrovmReleaseEnvName, string>;
+      override: true;
+    },
+  ) => Promise<{ success: boolean }>;
+  retrieve: (
+    projectRef: string,
+    environment: typeof TRIGGER_MICROVM_RELEASE_ENVIRONMENT,
+    name: TriggerMicrovmReleaseEnvName,
+  ) => Promise<{ name: string; value: string; isSecret: boolean }>;
+};
+
+export type TriggerMicrovmReleaseConfig = {
+  accessToken: string;
+  projectRef: string;
+  variables: Record<TriggerMicrovmReleaseEnvName, string>;
+};
+
+const required = (env: NodeJS.ProcessEnv, name: string) => {
+  const value = env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+export function getTriggerMicrovmReleaseConfig(
+  env: NodeJS.ProcessEnv,
+): TriggerMicrovmReleaseConfig {
+  return {
+    accessToken: required(env, "TRIGGER_ACCESS_TOKEN"),
+    projectRef: required(env, "TRIGGER_PROJECT_ID"),
+    variables: {
+      CLOUD_SANDBOX_PROVIDER: "aws-lambda-microvm",
+      AWS_LAMBDA_MICROVM_IMAGE_ID: required(env, "AWS_LAMBDA_MICROVM_IMAGE_ID"),
+      AWS_LAMBDA_MICROVM_IMAGE_VERSION: required(
+        env,
+        "AWS_LAMBDA_MICROVM_IMAGE_VERSION",
+      ),
+      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: required(
+        env,
+        "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN",
+      ),
+    },
+  };
+}
+
+export async function syncAndVerifyTriggerMicrovmReleaseEnv({
+  client,
+  config,
+}: {
+  client: TriggerEnvClient;
+  config: TriggerMicrovmReleaseConfig;
+}): Promise<void> {
+  const upload = await client.upload(
+    config.projectRef,
+    TRIGGER_MICROVM_RELEASE_ENVIRONMENT,
+    {
+      variables: config.variables,
+      override: true,
+    },
+  );
+  if (!upload.success) {
+    throw new Error(
+      "Trigger.dev did not confirm the environment variable upload",
+    );
+  }
+
+  for (const name of TRIGGER_MICROVM_RELEASE_ENV_NAMES) {
+    const stored = await client.retrieve(
+      config.projectRef,
+      TRIGGER_MICROVM_RELEASE_ENVIRONMENT,
+      name,
+    );
+    if (stored.isSecret || stored.value !== config.variables[name]) {
+      throw new Error(
+        `Trigger.dev stored value verification failed for ${name}`,
+      );
+    }
+  }
+}

--- a/scripts/lib/trigger-microvm-release-env.ts
+++ b/scripts/lib/trigger-microvm-release-env.ts
@@ -1,7 +1,10 @@
+import { parseAwsLambdaMicrovmReleaseManifest } from "../../lib/ai/tools/utils/aws-lambda-microvm-release";
+
 export const TRIGGER_MICROVM_RELEASE_ENVIRONMENT = "prod" as const;
 
 export const TRIGGER_MICROVM_RELEASE_ENV_NAMES = [
   "CLOUD_SANDBOX_PROVIDER",
+  "AWS_LAMBDA_MICROVM_RELEASE_MANIFEST",
   "AWS_LAMBDA_MICROVM_IMAGE_ID",
   "AWS_LAMBDA_MICROVM_IMAGE_VERSION",
   "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN",
@@ -41,20 +44,18 @@ const required = (env: NodeJS.ProcessEnv, name: string) => {
 export function getTriggerMicrovmReleaseConfig(
   env: NodeJS.ProcessEnv,
 ): TriggerMicrovmReleaseConfig {
+  const rawManifest = required(env, "AWS_LAMBDA_MICROVM_RELEASE_MANIFEST");
+  const manifest = parseAwsLambdaMicrovmReleaseManifest(rawManifest);
+  const east = manifest.regions["us-east-1"];
   return {
     accessToken: required(env, "TRIGGER_ACCESS_TOKEN"),
     projectRef: required(env, "TRIGGER_PROJECT_ID"),
     variables: {
       CLOUD_SANDBOX_PROVIDER: "aws-lambda-microvm",
-      AWS_LAMBDA_MICROVM_IMAGE_ID: required(env, "AWS_LAMBDA_MICROVM_IMAGE_ID"),
-      AWS_LAMBDA_MICROVM_IMAGE_VERSION: required(
-        env,
-        "AWS_LAMBDA_MICROVM_IMAGE_VERSION",
-      ),
-      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: required(
-        env,
-        "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN",
-      ),
+      AWS_LAMBDA_MICROVM_RELEASE_MANIFEST: JSON.stringify(manifest),
+      AWS_LAMBDA_MICROVM_IMAGE_ID: east.imageIdentifier,
+      AWS_LAMBDA_MICROVM_IMAGE_VERSION: east.imageVersion,
+      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: east.executionRoleArn,
     },
   };
 }

--- a/scripts/lib/trigger-microvm-release-env.ts
+++ b/scripts/lib/trigger-microvm-release-env.ts
@@ -1,3 +1,4 @@
+import type { envvars } from "@trigger.dev/sdk";
 import { parseAwsLambdaMicrovmReleaseManifest } from "../../lib/ai/tools/utils/aws-lambda-microvm-release";
 
 export const TRIGGER_MICROVM_RELEASE_ENVIRONMENT = "prod" as const;
@@ -13,21 +14,7 @@ export const TRIGGER_MICROVM_RELEASE_ENV_NAMES = [
 type TriggerMicrovmReleaseEnvName =
   (typeof TRIGGER_MICROVM_RELEASE_ENV_NAMES)[number];
 
-type TriggerEnvClient = {
-  upload: (
-    projectRef: string,
-    environment: typeof TRIGGER_MICROVM_RELEASE_ENVIRONMENT,
-    params: {
-      variables: Record<TriggerMicrovmReleaseEnvName, string>;
-      override: true;
-    },
-  ) => Promise<{ success: boolean }>;
-  retrieve: (
-    projectRef: string,
-    environment: typeof TRIGGER_MICROVM_RELEASE_ENVIRONMENT,
-    name: TriggerMicrovmReleaseEnvName,
-  ) => Promise<{ name: string; value: string; isSecret: boolean }>;
-};
+type TriggerEnvClient = Pick<typeof envvars, "upload" | "retrieve">;
 
 export type TriggerMicrovmReleaseConfig = {
   accessToken: string;

--- a/scripts/smoke-aws-microvm.mjs
+++ b/scripts/smoke-aws-microvm.mjs
@@ -7,7 +7,8 @@ import {
 } from "@aws-sdk/client-lambda-microvms";
 import WebSocket from "ws";
 
-const region = "us-east-1";
+const region =
+  process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1";
 const imageIdentifier = process.env.AWS_LAMBDA_MICROVM_IMAGE_ID;
 const imageVersion = process.env.AWS_LAMBDA_MICROVM_IMAGE_VERSION;
 const executionRoleArn = process.env.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN;

--- a/scripts/sync-trigger-microvm-release-env.ts
+++ b/scripts/sync-trigger-microvm-release-env.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env tsx
+
+import { configure, envvars } from "@trigger.dev/sdk";
+import {
+  getTriggerMicrovmReleaseConfig,
+  syncAndVerifyTriggerMicrovmReleaseEnv,
+} from "./lib/trigger-microvm-release-env";
+
+async function main() {
+  const releaseConfig = getTriggerMicrovmReleaseConfig(process.env);
+  configure({ secretKey: releaseConfig.accessToken });
+  await syncAndVerifyTriggerMicrovmReleaseEnv({
+    client: envvars,
+    config: releaseConfig,
+  });
+  console.log(
+    `Trigger.dev production environment now points to MicroVM image version ${releaseConfig.variables.AWS_LAMBDA_MICROVM_IMAGE_VERSION}.`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/sync-trigger-microvm-release-env.ts
+++ b/scripts/sync-trigger-microvm-release-env.ts
@@ -14,7 +14,7 @@ async function main() {
     config: releaseConfig,
   });
   console.log(
-    `Trigger.dev production environment now points to MicroVM image version ${releaseConfig.variables.AWS_LAMBDA_MICROVM_IMAGE_VERSION}.`,
+    "Trigger.dev production environment now points to one verified three-region MicroVM release manifest.",
   );
 }
 

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -1,20 +1,10 @@
 import { config } from "dotenv";
 import { defineConfig } from "@trigger.dev/sdk";
-import {
-  additionalPackages,
-  syncEnvVars,
-} from "@trigger.dev/build/extensions/core";
+import { additionalPackages } from "@trigger.dev/build/extensions/core";
 
 if (process.env.NODE_ENV !== "production") {
   config({ path: ".env.local" });
 }
-
-const microvmReleaseEnvNames = [
-  "CLOUD_SANDBOX_PROVIDER",
-  "AWS_LAMBDA_MICROVM_IMAGE_ID",
-  "AWS_LAMBDA_MICROVM_IMAGE_VERSION",
-  "AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN",
-] as const;
 
 export default defineConfig({
   project: process.env.TRIGGER_PROJECT_ID!,
@@ -47,12 +37,6 @@ export default defineConfig({
       additionalPackages({
         packages: ["node-pty", "sharp"],
       }),
-      syncEnvVars(({ env }) =>
-        microvmReleaseEnvNames.flatMap((name) => {
-          const value = env[name]?.trim();
-          return value ? [{ name, value }] : [];
-        }),
-      ),
     ],
   },
 });

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
   },
   dirs: ["./trigger"],
   build: {
+    autoDetectExternal: true,
+    keepNames: true,
+    minify: false,
     // Native modules that must be installed at deploy time, not bundled.
     // @e2b/code-interpreter is pure JS and intentionally NOT listed here —
     // bundling it lets esbuild convert chalk's ESM to CJS inline, avoiding

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -17,6 +17,7 @@ import {
   UIMessage,
 } from "ai";
 import type { Geo } from "@vercel/functions";
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 import PostHogClient from "@/app/posthog";
 import { getCloudSandboxProvider } from "@/lib/ai/tools/utils/cloud-sandbox-provider";
 import { evaluateAwsLambdaMicrovmRollout } from "@/lib/experiments/aws-lambda-microvm-rollout";
@@ -2221,6 +2222,7 @@ export type AgentLongPayload = {
   selectedModel?: SelectedModel;
   autoReviewAssignment?: AgentAutoReviewAssignment;
   userLocation: Geo;
+  triggerRegion?: TriggerRunRegion;
   isAutoContinue?: boolean;
   regenerate?: boolean;
   isNewChat?: boolean;
@@ -2295,6 +2297,7 @@ export const agentLongTask = task({
       selectedModel: rawSelectedModelOverride,
       autoReviewAssignment,
       userLocation,
+      triggerRegion = "us-east-1",
       isAutoContinue,
       regenerate,
       isNewChat,
@@ -3210,6 +3213,7 @@ export const agentLongTask = task({
               auxiliaryVision,
               {
                 cloudSandboxRollout,
+                triggerRegion,
                 ...(securityValidationSubagentsEnabled
                   ? {
                       additionalTools: (toolContext) => ({

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -68,6 +68,12 @@ export interface SandboxBootInfo {
     | "create_after_broken";
   duration_ms: number;
   create_attempts: number;
+  region?: string;
+  trigger_region?: string;
+  requested_region?: string;
+  placement_reason?: string;
+  release_id?: string;
+  image_version?: string;
 }
 
 export interface SandboxResourceMetrics {


### PR DESCRIPTION
## Summary

- map Trigger.dev Virginia, Oregon, and Frankfurt runs to AWS Lambda MicroVM images in us-east-1, us-west-2, and eu-west-1
- keep active user sandboxes sticky to their persisted region and image until they end
- publish, smoke-test, and atomically promote one verified three-region release manifest
- add placement/release telemetry and multi-region operational guidance
- allow secondary regional CloudFormation stacks to reuse the existing GitHub OIDC provider

## Placement

| Trigger.dev run | AWS MicroVM |
| --- | --- |
| us-east-1 | us-east-1 |
| us-west-2 | us-west-2 |
| eu-central-1 | eu-west-1 |

If a non-default region is disabled in the manifest, new sessions fall back to us-east-1. Existing sessions retain their region, disk, memory, and image version.

## Release safety

The release workflow packages once, publishes and launches the exact image in all three regions in parallel, verifies termination, and only then writes one atomic manifest to Trigger.dev production. Partial regional releases are rejected and never promoted.

## Validation

- 412 Jest suites / 4,123 tests passed
- TypeScript typecheck passed
- ESLint passed with 7 pre-existing warnings and no errors
- frozen MicroVM artifact packaging passed
- GitHub Actions workflow YAML parsed successfully
- CloudFormation template validated with AWS
- regional infrastructure deployed in all three approved regions
- runtime users have all three regional managed policies attached
- exact regional images passed authenticated direct-command smoke tests: us-east-1 16.0, us-west-2 1.0, eu-west-1 1.0
- every smoke-test MicroVM was confirmed terminated
- the atomic manifest was built successfully from those exact three outputs

## Rollout

The existing PostHog provider flag and its staged eligible population remain unchanged. This PR changes placement only after a user is already assigned AWS Lambda MicroVM.

Linear: https://linear.app/hackerai/issue/HAC-71/add-multi-region-placement-for-aws-lambda-microvm-sandboxes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-region AWS Lambda MicroVM deployments across the United States and Europe.
  * Added regional release manifests with image validation, placement resolution, fallback handling, and release metadata.
  * Added automatic synchronization and verification of production runtime configuration.
  * Agent runs now consistently select and report their execution region.
  * Existing active cloud sessions are reused while preserving their original placement and image settings.
* **Documentation**
  * Expanded deployment and rollout guidance for multi-region MicroVM releases.
* **Tests**
  * Added coverage for regional placement, manifests, configuration synchronization, logging, and session reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->