### PR TITLE
Allow scoped PM gateway through auth proxy

### DIFF
--- a/.agents/skills/hackerai-user-research/SKILL.md
+++ b/.agents/skills/hackerai-user-research/SKILL.md
@@ -7,7 +7,7 @@ description: Run privacy-safe HackerAI customer research from a Linear question 
 
 Turn a research question and 3-20 internal user IDs into restricted per-user
 profiles and an aggregated cohort report. The deployed task samples messages,
-redacts sensitive data, and uses Grok 4.6 with reasoning disabled.
+redacts sensitive data, and uses Grok 4.6 with low reasoning.
 
 Read [references/privacy-policy.md](references/privacy-policy.md) and
 [references/pm-runbook.md](references/pm-runbook.md) before running the task.

--- a/.agents/skills/hackerai-user-research/SKILL.md
+++ b/.agents/skills/hackerai-user-research/SKILL.md
@@ -7,7 +7,7 @@ description: Run privacy-safe HackerAI customer research from a Linear question 
 
 Turn a research question and 3-20 internal user IDs into restricted per-user
 profiles and an aggregated cohort report. The deployed task samples messages,
-redacts sensitive data, and uses DeepSeek V4 Flash with reasoning disabled.
+redacts sensitive data, and uses Grok 4.6 with reasoning disabled.
 
 Read [references/privacy-policy.md](references/privacy-policy.md) and
 [references/pm-runbook.md](references/pm-runbook.md) before running the task.

--- a/.agents/skills/hackerai-user-research/references/pm-runbook.md
+++ b/.agents/skills/hackerai-user-research/references/pm-runbook.md
@@ -26,7 +26,7 @@ keys. The runner always calls the production gateway at
 gateway key is required. The gateway can start and read only
 `pm-user-research`, and it returns only the aggregate result. The task runs one
 parallel worker per user and a final cohort synthesis. Both calls use
-`x-ai/grok-4.6` with OpenRouter reasoning explicitly disabled
+`x-ai/grok-4.6` with OpenRouter reasoning set to low
 and zero-data-retention routing required.
 
 The request JSON is temporary restricted data because it contains internal user

--- a/.agents/skills/hackerai-user-research/references/pm-runbook.md
+++ b/.agents/skills/hackerai-user-research/references/pm-runbook.md
@@ -26,7 +26,7 @@ keys. The runner always calls the production gateway at
 gateway key is required. The gateway can start and read only
 `pm-user-research`, and it returns only the aggregate result. The task runs one
 parallel worker per user and a final cohort synthesis. Both calls use
-`deepseek/deepseek-v4-flash-0731` with OpenRouter reasoning explicitly disabled
+`x-ai/grok-4.6` with OpenRouter reasoning explicitly disabled
 and zero-data-retention routing required.
 
 The request JSON is temporary restricted data because it contains internal user

--- a/.agents/skills/hackerai-user-research/references/privacy-policy.md
+++ b/.agents/skills/hackerai-user-research/references/privacy-policy.md
@@ -30,7 +30,7 @@ The owning Linear issue must define the cohort and intended output.
 
 Raw message excerpts exist only in the analysis worker's memory and model
 request. Model calls require an OpenRouter zero-data-retention route and fail
-closed if no eligible DeepSeek V4 Flash endpoint is available. Convex stores the
+closed if no eligible Grok 4.6 endpoint is available. Convex stores the
 run audit, pseudonymized structured profiles, and the aggregate report. Account
 deletion removes that user's stored profile and run-membership linkage; runs and
 reports are retained only as cohort-level outputs from cohorts of at least

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -102,6 +102,49 @@ describe("proxy", () => {
     expect(mockNextResponseRedirect).not.toHaveBeenCalled();
   });
 
+  it("bypasses AuthKit for the independently authenticated user-research gateway", async () => {
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/api/internal/user-research",
+        method: "POST",
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "next" });
+    expect(mockAuthkit).not.toHaveBeenCalled();
+    expect(mockNextResponseNext).toHaveBeenCalledWith();
+    expect(mockNextResponseJson).not.toHaveBeenCalled();
+    expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+  });
+
+  it("does not bypass AuthKit for sibling internal API paths", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://auth.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    await proxy(
+      createRequest({
+        pathname: "/api/internal/user-research/status",
+        method: "POST",
+      }),
+    );
+
+    expect(mockAuthkit).toHaveBeenCalledTimes(1);
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      {
+        code: "unauthorized:auth",
+        message: "You need to sign in before continuing.",
+        cause: "Session expired or invalid",
+      },
+      expect.objectContaining({ status: 401 }),
+    );
+  });
+
   it.each(["/robots.txt", "/sitemap.xml"])(
     "bypasses AuthKit for the public SEO route %s",
     async (pathname) => {

--- a/docs/internal/user-research.md
+++ b/docs/internal/user-research.md
@@ -18,7 +18,7 @@ called through the repo-owned Codex skill `$hackerai-user-research`.
    evidence coverage, token usage, and provider cost in Convex.
 
 Both stages use `x-ai/grok-4.6` through the existing OpenRouter
-provider with reasoning explicitly disabled and zero-data-retention routing
+provider with reasoning set to low and zero-data-retention routing
 required. The task fails closed if no ZDR-capable endpoint is available.
 
 ## Retention and deletion

--- a/docs/internal/user-research.md
+++ b/docs/internal/user-research.md
@@ -17,7 +17,7 @@ called through the repo-owned Codex skill `$hackerai-user-research`.
 6. Stores the audit record, structured pseudonymized profiles, aggregate report,
    evidence coverage, token usage, and provider cost in Convex.
 
-Both stages use `deepseek/deepseek-v4-flash-0731` through the existing OpenRouter
+Both stages use `x-ai/grok-4.6` through the existing OpenRouter
 provider with reasoning explicitly disabled and zero-data-retention routing
 required. The task fails closed if no ZDR-capable endpoint is available.
 

--- a/lib/research/__tests__/user-research.test.ts
+++ b/lib/research/__tests__/user-research.test.ts
@@ -40,11 +40,11 @@ const baseProfile = {
 };
 
 describe("user research privacy controls", () => {
-  it("pins Grok 4.6 for text-only research and disables reasoning", () => {
+  it("pins Grok 4.6 for text-only research with low reasoning", () => {
     expect(USER_RESEARCH_MODEL_KEY).toBe("model-grok-4.6");
     expect(USER_RESEARCH_PROVIDER_OPTIONS).toEqual({
       openrouter: {
-        reasoning: { enabled: false },
+        reasoning: { enabled: true, effort: "low" },
         usage: { include: true },
         provider: { zdr: true },
       },

--- a/lib/research/__tests__/user-research.test.ts
+++ b/lib/research/__tests__/user-research.test.ts
@@ -40,8 +40,8 @@ const baseProfile = {
 };
 
 describe("user research privacy controls", () => {
-  it("pins DeepSeek V4 Flash for text-only research and disables reasoning", () => {
-    expect(USER_RESEARCH_MODEL_KEY).toBe("model-deepseek-v4-flash-0731");
+  it("pins Grok 4.6 for text-only research and disables reasoning", () => {
+    expect(USER_RESEARCH_MODEL_KEY).toBe("model-grok-4.6");
     expect(USER_RESEARCH_PROVIDER_OPTIONS).toEqual({
       openrouter: {
         reasoning: { enabled: false },

--- a/lib/research/user-research.ts
+++ b/lib/research/user-research.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 
-// Research evidence is intentionally text-only, so use the fast structured
-// synthesis model without reasoning. If this workflow ever accepts images,
-// route that separate vision path to Grok 4.6 Pro with reasoning enabled.
-export const USER_RESEARCH_MODEL_KEY = "model-deepseek-v4-flash-0731" as const;
+// Research evidence is intentionally text-only, so use Grok 4.6 for structured
+// profiling and synthesis with reasoning disabled. If this workflow ever
+// accepts images, route that separate vision path to Grok 4.6 Pro with
+// reasoning enabled.
+export const USER_RESEARCH_MODEL_KEY = "model-grok-4.6" as const;
 export const USER_RESEARCH_PROMPT_VERSION = "user-research-v1";
 export const USER_RESEARCH_MAX_CONTEXT_CHARS = 120_000;
 export const USER_RESEARCH_MAX_COHORT_CONTEXT_CHARS = 240_000;

--- a/lib/research/user-research.ts
+++ b/lib/research/user-research.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 // Research evidence is intentionally text-only, so use Grok 4.6 for structured
-// profiling and synthesis with reasoning disabled. If this workflow ever
+// profiling and synthesis with the endpoint's minimum reasoning level. If this workflow ever
 // accepts images, route that separate vision path to Grok 4.6 Pro with
 // reasoning enabled.
 export const USER_RESEARCH_MODEL_KEY = "model-grok-4.6" as const;
@@ -13,7 +13,7 @@ export const USER_RESEARCH_MAX_COHORT_SIZE = 20;
 export const USER_RESEARCH_DEFAULT_MAX_CHATS_PER_USER = 12;
 export const USER_RESEARCH_PROVIDER_OPTIONS = {
   openrouter: {
-    reasoning: { enabled: false },
+    reasoning: { enabled: true, effort: "low" },
     usage: { include: true },
     provider: { zdr: true },
   },

--- a/proxy.ts
+++ b/proxy.ts
@@ -19,6 +19,7 @@ const AUTHKIT_BYPASS_PATHS = new Set([
   "/api/health/connectivity",
   "/api/health/core",
   "/api/health/trigger-agent-mode",
+  "/api/internal/user-research",
   "/robots.txt",
   "/sitemap.xml",
 ]);

--- a/trigger/user-research.ts
+++ b/trigger/user-research.ts
@@ -3,7 +3,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { generateText, Output } from "ai";
 import { z } from "zod";
 import { api } from "@/convex/_generated/api";
-import { DEEPSEEK_V4_FLASH_SLUG, myProvider } from "@/lib/ai/providers";
+import { GROK_4_6_SLUG, myProvider } from "@/lib/ai/providers";
 import { getProviderUsageRawModelCost } from "@/lib/provider-usage-cost";
 import {
   assertResearchPromptIsSafe,
@@ -138,7 +138,7 @@ export const analyzeUserResearchProfile = schemaTask({
       pseudonym: payload.pseudonym,
       profile,
       coverage,
-      model: DEEPSEEK_V4_FLASH_SLUG,
+      model: GROK_4_6_SLUG,
       promptVersion: USER_RESEARCH_PROMPT_VERSION,
       ...usage,
     });
@@ -176,7 +176,7 @@ export const pmUserResearch = schemaTask({
       requestedBy: payload.requestedBy,
       members,
       maxChatsPerUser: payload.maxChatsPerUser,
-      model: DEEPSEEK_V4_FLASH_SLUG,
+      model: GROK_4_6_SLUG,
     });
     try {
       await client.mutation(api.userResearch.markRunRunning, {
@@ -254,7 +254,7 @@ export const pmUserResearch = schemaTask({
         serviceKey,
         analysisId,
         report,
-        model: DEEPSEEK_V4_FLASH_SLUG,
+        model: GROK_4_6_SLUG,
         promptVersion: USER_RESEARCH_PROMPT_VERSION,
         ...usageForStorage(result.usage),
       });


### PR DESCRIPTION
## Summary
- bypass WorkOS session auth only for the scoped PM research gateway path while preserving its bearer-key authentication
- keep sibling paths protected by the normal auth proxy
- migrate privacy-redacted PM research to x-ai/grok-4.6 with low reasoning and mandatory OpenRouter ZDR routing
- add regression coverage for proxy isolation and model/provider options

## Root cause
The auth proxy required a WorkOS browser session before the PM gateway could perform its own scoped bearer-key authentication. Production also pinned TRIGGER_VERSION to an older worker, so model changes did not affect gateway-triggered runs until the Vercel pin was updated.

## Validation
- dependency guard passed
- focused proxy tests: 33/33 passed
- focused research tests: 11/11 passed
- TypeScript typecheck passed
- full commit-hook suite: 407 suites / 4101 tests passed
- production authentication probe returned HTTP 400 invalid_payload
- production end-to-end run completed on Trigger 20260820.4 using the Grok configuration: 3/3 users analyzed, 9 chats and 106 messages reviewed, 0 failed profiles
- production deployment and Vercel TRIGGER_VERSION pin both updated to 20260820.4

## Manual verification
1. From a Codex environment containing the scoped plaintext key, POST an empty JSON object to https://hackerai.co/api/internal/user-research with Bearer auth, JSON content type, and a random idempotency key.
2. Confirm the endpoint returns HTTP 400 with invalid_payload.
3. Run an approved bounded cohort and confirm the Trigger run records version 20260820.4 and completes without profile failures.
4. Confirm an incorrect key returns HTTP 401 and no Trigger research run is created.