### PR TITLE
Fix regional MicroVM release variable resolution

### DIFF
--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -83,26 +83,19 @@ jobs:
       matrix:
         include:
           - region: us-east-1
-            artifact_bucket: ${{ vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_US_EAST_1 || vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET }}
-            build_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_US_EAST_1 || vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN }}
-            execution_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_US_EAST_1 || vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN }}
-            release_role_arn: ${{ vars.AWS_RELEASE_ROLE_ARN_US_EAST_1 || vars.AWS_RELEASE_ROLE_ARN }}
+            variable_suffix: US_EAST_1
           - region: us-west-2
-            artifact_bucket: ${{ vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_US_WEST_2 }}
-            build_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_US_WEST_2 }}
-            execution_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_US_WEST_2 }}
-            release_role_arn: ${{ vars.AWS_RELEASE_ROLE_ARN_US_WEST_2 }}
+            variable_suffix: US_WEST_2
           - region: eu-west-1
-            artifact_bucket: ${{ vars.AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_EU_WEST_1 }}
-            build_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_EU_WEST_1 }}
-            execution_role_arn: ${{ vars.AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_EU_WEST_1 }}
-            release_role_arn: ${{ vars.AWS_RELEASE_ROLE_ARN_EU_WEST_1 }}
+            variable_suffix: EU_WEST_1
     env:
       AWS_REGION: ${{ matrix.region }}
-      AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET: ${{ matrix.artifact_bucket }}
-      AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN: ${{ matrix.build_role_arn }}
-      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: ${{ matrix.execution_role_arn }}
-      AWS_RELEASE_ROLE_ARN: ${{ matrix.release_role_arn }}
+      # Environment-scoped vars are unavailable while GitHub expands a job matrix.
+      # Resolve them only after this job has entered the protected environment.
+      AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET: ${{ vars[format('AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET_{0}', matrix.variable_suffix)] }}
+      AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN: ${{ vars[format('AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN_{0}', matrix.variable_suffix)] }}
+      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN: ${{ vars[format('AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN_{0}', matrix.variable_suffix)] }}
+      AWS_RELEASE_ROLE_ARN: ${{ vars[format('AWS_RELEASE_ROLE_ARN_{0}', matrix.variable_suffix)] }}
     steps:
       - name: Validate regional release configuration
         shell: bash


### PR DESCRIPTION
## Summary
- resolve protected-environment AWS variables after each regional matrix job starts
- keep the matrix limited to stable region/suffix metadata
- prevent all regional publishing jobs from receiving empty AWS release configuration

## Validation
- Prettier workflow check
- `git diff --check`
- Existing release configuration confirmed in the `aws-lambda-microvm-production` GitHub environment

Follow-up to #1132 and failed release run #32398637092.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved regional release configuration for AWS Lambda microVM deployments.
  * Ensured artifact storage and permissions are resolved correctly for each deployment region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->