### PR TITLE
Fix large AWS MicroVM transcript writes

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -821,6 +821,11 @@ describe("native desktop file relay", () => {
       ok: true,
       json: async () => ({ ok: true }),
     } as Response);
+    const publicationPublished = new Promise<void>((resolve) => {
+      mockSubscription.publish.mockImplementationOnce(async () => {
+        resolve();
+      });
+    });
 
     handler({
       data: {
@@ -831,7 +836,7 @@ describe("native desktop file relay", () => {
         targetConnectionId: "conn-123",
       },
     });
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await publicationPublished;
 
     expect(global.fetch).toHaveBeenCalledWith(
       "http://127.0.0.1:49152/files/write",

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -803,6 +803,52 @@ describe("native desktop file relay", () => {
     });
   });
 
+  it("falls back when native file IPC is blocked by an older Tauri ACL", async () => {
+    const bridge = new DesktopSandboxBridge(buildConfig());
+    await bridge.start();
+    const handler = getPublicationHandler();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "desktop_file_request") {
+        throw new Error("Command desktop_file_request not allowed by ACL");
+      }
+      if (cmd === "get_cmd_server_info") {
+        return { port: 49152, token: "file-token" };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    handler({
+      data: {
+        type: "file_write",
+        requestId: "file-acl-fallback-1",
+        path: "C:\\repo\\transcript.json",
+        content: "compatible",
+        targetConnectionId: "conn-123",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:49152/files/write",
+      expect.objectContaining({
+        body: JSON.stringify({
+          path: "C:\\repo\\transcript.json",
+          content: "compatible",
+          is_base64: false,
+        }),
+      }),
+    );
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "file_ok",
+      requestId: "file-acl-fallback-1",
+    });
+  });
+
   it("does not fall back when native IPC reports a real file error", async () => {
     const bridge = new DesktopSandboxBridge(buildConfig());
     await bridge.start();

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -885,13 +885,14 @@ export class DesktopSandboxBridge {
     });
   }
 
-  private isMissingNativeFileCommandError(error: unknown): boolean {
+  private isUnavailableNativeFileCommandError(error: unknown): boolean {
     const message = this.getErrorMessage(error).toLowerCase();
     return (
       message.includes("desktop_file_request") &&
       (message.includes("not found") ||
         message.includes("unknown command") ||
-        message.includes("not registered"))
+        message.includes("not registered") ||
+        message.includes("not allowed by acl"))
     );
   }
 
@@ -946,7 +947,7 @@ export class DesktopSandboxBridge {
         this.nativeFileIpcAvailable = true;
         return payload;
       } catch (error) {
-        if (!this.isMissingNativeFileCommandError(error)) {
+        if (!this.isUnavailableNativeFileCommandError(error)) {
           throw error;
         }
         this.nativeFileIpcAvailable = false;

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-direct-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-direct-sandbox.test.ts
@@ -53,6 +53,19 @@ class FakeWebSocket extends EventEmitter {
         );
       });
     }
+    if (message.type === "file_write" || message.type === "file_append") {
+      queueMicrotask(() => {
+        this.emit(
+          "message",
+          Buffer.from(
+            JSON.stringify({
+              type: "file_ok",
+              requestId: message.requestId,
+            }),
+          ),
+        );
+      });
+    }
     if (message.type === "pty_create") {
       queueMicrotask(() => {
         this.emit(
@@ -112,7 +125,12 @@ describe("AwsLambdaMicrovmDirectSandbox", () => {
         queueMicrotask(() => {
           socket.emit(
             "message",
-            Buffer.from(JSON.stringify({ type: "transport_ready" })),
+            Buffer.from(
+              JSON.stringify({
+                type: "transport_ready",
+                capabilities: { fileMutations: true },
+              }),
+            ),
           );
         });
         return socket as unknown as WebSocket;
@@ -211,6 +229,106 @@ describe("AwsLambdaMicrovmDirectSandbox", () => {
     await expect(pty.exited).resolves.toEqual({ exitCode: 0 });
     expect(chunks).toEqual(["id\n"]);
 
+    await sandbox.close();
+  });
+
+  it("writes large transcripts as bounded native file chunks", async () => {
+    const socket = new FakeWebSocket();
+    const sandbox = new AwsLambdaMicrovmDirectSandbox({
+      userId: "user-direct",
+      sessionId: "session-direct",
+      microvmId: "microvm-direct",
+      endpoint: "https://microvm-direct.example.test",
+      issueAuthToken: jest.fn().mockResolvedValue("short-lived-jwe"),
+      log: jest.fn(),
+      createWebSocket: () => {
+        queueMicrotask(() => {
+          socket.emit(
+            "message",
+            Buffer.from(
+              JSON.stringify({
+                type: "transport_ready",
+                capabilities: { fileMutations: true },
+              }),
+            ),
+          );
+        });
+        return socket as unknown as WebSocket;
+      },
+    });
+    const transcript = Buffer.from(
+      JSON.stringify({ messages: [{ content: "x".repeat(256 * 1024) }] }),
+    );
+    const transcriptArrayBuffer = new ArrayBuffer(transcript.byteLength);
+    new Uint8Array(transcriptArrayBuffer).set(transcript);
+
+    await sandbox.ready();
+    await sandbox.files.write("transcripts/large.json", transcriptArrayBuffer);
+
+    const mutations = socket.sent.filter(
+      (message) =>
+        message.type === "file_write" || message.type === "file_append",
+    );
+    expect(mutations.length).toBeGreaterThan(1);
+    expect(mutations[0]).toMatchObject({
+      type: "file_write",
+      path: "/home/user/transcripts/large.json",
+      allowedRoot: "/home/user",
+      targetConnectionId: "microvm-direct",
+    });
+    expect(mutations.slice(1)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "file_append" }),
+      ]),
+    );
+    expect(
+      mutations.every(
+        (message) =>
+          typeof message.content === "string" &&
+          message.content.length <= 48 * 1024,
+      ),
+    ).toBe(true);
+    const reconstructed = Buffer.from(
+      mutations.map((message) => message.content).join(""),
+      "base64",
+    );
+    expect(reconstructed.equals(transcript)).toBe(true);
+    expect(socket.sent).not.toContainEqual(
+      expect.objectContaining({ type: "command" }),
+    );
+
+    await sandbox.close();
+  });
+
+  it("keeps shell writes for older guests without file capabilities", async () => {
+    const socket = new FakeWebSocket();
+    const sandbox = new AwsLambdaMicrovmDirectSandbox({
+      userId: "user-direct",
+      sessionId: "session-direct",
+      microvmId: "microvm-direct",
+      endpoint: "https://microvm-direct.example.test",
+      issueAuthToken: jest.fn().mockResolvedValue("short-lived-jwe"),
+      log: jest.fn(),
+      createWebSocket: () => {
+        queueMicrotask(() => {
+          socket.emit(
+            "message",
+            Buffer.from(JSON.stringify({ type: "transport_ready" })),
+          );
+        });
+        return socket as unknown as WebSocket;
+      },
+    });
+
+    await sandbox.ready();
+    await sandbox.files.write("transcripts/compatible.json", Buffer.from("{}"));
+
+    expect(socket.sent).toContainEqual(
+      expect.objectContaining({ type: "command" }),
+    );
+    expect(socket.sent).not.toContainEqual(
+      expect.objectContaining({ type: "file_write" }),
+    );
     await sandbox.close();
   });
 });

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -654,6 +654,32 @@ describe("HybridSandboxManager reset cleanup", () => {
     }
   });
 
+  it("keeps a cloud fallback pinned when the preferred desktop reconnects", async () => {
+    const manager = new HybridSandboxManager(
+      "user-1",
+      jest.fn(),
+      "desktop",
+      "service-key",
+      null,
+      "pro",
+    );
+    const sandbox = Object.assign(new Sandbox(), {
+      sandboxId: "sandbox-1",
+      setTimeout: jest.fn(async () => {}),
+    });
+    manager.setSandbox(sandbox as any);
+    mockConvexQuery.mockResolvedValue([
+      makeConnection({
+        connectionId: "desktop-conn",
+        name: "Desktop",
+        isDesktop: true,
+      }),
+    ]);
+
+    await expect(manager.getSandbox()).resolves.toEqual({ sandbox });
+    expect(mockConvexQuery).not.toHaveBeenCalled();
+  });
+
   it("classifies an AWS relay sandbox as cloud rather than local", () => {
     const originalProvider = process.env.CLOUD_SANDBOX_PROVIDER;
     process.env.CLOUD_SANDBOX_PROVIDER = "aws-lambda-microvm";

--- a/lib/ai/tools/utils/aws-lambda-microvm-direct-sandbox.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm-direct-sandbox.ts
@@ -3,6 +3,8 @@ import WebSocket from "ws";
 import type {
   CommandCancelResultMessage,
   CommandResponseMessage,
+  FileRequestMessage,
+  FileResponseMessage,
   PtyCreateMessage,
   PtyDataMessage,
   PtyErrorMessage,
@@ -12,7 +14,7 @@ import type {
   PtyReadyMessage,
   PtyResizeMessage,
 } from "@/lib/centrifugo/types";
-import { CentrifugoSandbox } from "./centrifugo-sandbox";
+import { CentrifugoSandbox, type FileRequestInput } from "./centrifugo-sandbox";
 import type { CreatePtyOptions, PtyHandle } from "./e2b-pty-adapter";
 import { createResolvableExited } from "./pty-exited-promise";
 
@@ -90,6 +92,7 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
   private directSocket: WebSocket | null = null;
   private connectPromise: Promise<void> | null = null;
   private closed = false;
+  private nativeFileMutations = false;
   private heartbeat: NodeJS.Timeout | null = null;
   private lastPongAt = 0;
   private readonly commandHandlers = new Map<
@@ -106,6 +109,10 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
         | PtyErrorMessage
         | Error,
     ) => void
+  >();
+  private readonly fileHandlers = new Map<
+    string,
+    (message: FileResponseMessage | Error) => void
   >();
 
   constructor(private readonly direct: AwsLambdaMicrovmDirectSandboxOptions) {
@@ -130,6 +137,70 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
 
   async ready(): Promise<void> {
     await this.ensureConnected();
+  }
+
+  protected override supportsNativeFileMutations(): boolean {
+    return this.nativeFileMutations;
+  }
+
+  protected override async runFileRequest<T extends FileResponseMessage>(
+    input: FileRequestInput,
+    expectedTypes: Set<string>,
+    timeoutMs = 30_000,
+  ): Promise<T> {
+    if (input.type !== "file_write" && input.type !== "file_append") {
+      throw new Error("Direct MicroVM file request is not supported");
+    }
+
+    const requestId = crypto.randomUUID();
+    const workingDirectory = this.getWorkingDirectory();
+    const request = {
+      ...input,
+      path: this.resolveWorkingPath(input.path),
+      requestId,
+      ...(workingDirectory ? { allowedRoot: workingDirectory } : {}),
+      targetConnectionId: this.direct.microvmId,
+    } satisfies FileRequestMessage;
+
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+      const cleanup = () => {
+        clearTimeout(timeout);
+        this.fileHandlers.delete(requestId);
+      };
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const timeout = setTimeout(() => {
+        fail(
+          new Error(
+            `Direct MicroVM file request timed out after ${timeoutMs}ms`,
+          ),
+        );
+      }, timeoutMs + 5_000);
+
+      this.fileHandlers.set(requestId, (message) => {
+        if (message instanceof Error) {
+          fail(message);
+          return;
+        }
+        if (message.type === "file_error") {
+          fail(new Error(message.message));
+          return;
+        }
+        if (!expectedTypes.has(message.type) || settled) return;
+        settled = true;
+        cleanup();
+        resolve(message as T);
+      });
+
+      void this.send(request).catch((error) =>
+        fail(error instanceof Error ? error : new Error(String(error))),
+      );
+    });
   }
 
   commands = {
@@ -509,6 +580,11 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
         if (!message) return;
         if (message.type === "transport_ready" && !opened) {
           opened = true;
+          const capabilities = message.capabilities;
+          this.nativeFileMutations =
+            typeof capabilities === "object" &&
+            capabilities !== null &&
+            (capabilities as Record<string, unknown>).fileMutations === true;
           clearTimeout(timeout);
           socket.off("error", fail);
           this.installSocket(socket);
@@ -529,6 +605,13 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
       if (!message || message.type === "transport_ready") return;
       if (message.type === "transport_pong") {
         this.lastPongAt = Date.now();
+        return;
+      }
+      const requestId = message.requestId;
+      if (typeof requestId === "string") {
+        this.fileHandlers.get(requestId)?.(
+          message as unknown as FileResponseMessage,
+        );
         return;
       }
       const commandId = message.commandId;
@@ -577,6 +660,7 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
     this.heartbeat = null;
     const pendingCommands = this.commandHandlers.size;
     const pendingPtys = this.ptyHandlers.size;
+    const pendingFiles = this.fileHandlers.size;
     const error = new Error(`AWS MicroVM WebSocket closed (code ${code})`);
     this.failPending(error);
     if (!this.closed) {
@@ -588,6 +672,7 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
         close_code: code,
         pending_command_count: pendingCommands,
         pending_pty_count: pendingPtys,
+        pending_file_request_count: pendingFiles,
       });
     }
   }
@@ -595,7 +680,9 @@ export class AwsLambdaMicrovmDirectSandbox extends CentrifugoSandbox {
   private failPending(error: Error): void {
     for (const handler of this.commandHandlers.values()) handler(error);
     for (const handler of this.ptyHandlers.values()) handler(error);
+    for (const handler of this.fileHandlers.values()) handler(error);
     this.commandHandlers.clear();
     this.ptyHandlers.clear();
+    this.fileHandlers.clear();
   }
 }

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -254,7 +254,7 @@ interface CommandResult {
 type DistributiveOmit<T, K extends keyof any> = T extends unknown
   ? Omit<T, K>
   : never;
-type FileRequestInput = DistributiveOmit<
+export type FileRequestInput = DistributiveOmit<
   FileRequestMessage,
   "requestId" | "targetConnectionId"
 >;
@@ -323,6 +323,11 @@ export class CentrifugoSandbox extends EventEmitter {
     );
   }
 
+  /** Native write/append support may be available without the full file API. */
+  protected supportsNativeFileMutations(): boolean {
+    return this.supportsNativeFileRelay();
+  }
+
   getUserId(): string {
     return this.userId;
   }
@@ -383,7 +388,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     return this.getSandboxContext();
   }
 
-  private async runFileRequest<T extends FileResponseMessage>(
+  protected async runFileRequest<T extends FileResponseMessage>(
     input: FileRequestInput,
     expectedTypes: Set<string>,
     timeoutMs = 30000,
@@ -1008,7 +1013,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     return `'${path.replace(/'/g, "'\\''")}'`;
   }
 
-  private resolveWorkingPath(path: string): string {
+  protected resolveWorkingPath(path: string): string {
     if (!this.workingDirectory) return path;
     const isAbsolute =
       path.startsWith("/") ||
@@ -1404,15 +1409,42 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     rawPath: string,
     content: string,
   ): Promise<void> {
-    await this.runFileRequest<FileOkMessage>(
-      {
-        type: "file_append",
-        path: rawPath,
-        content,
-      },
-      new Set(["file_ok"]),
-      120000,
-    );
+    if (
+      Buffer.byteLength(content, "utf8") <=
+      CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS
+    ) {
+      await this.runFileRequest<FileOkMessage>(
+        {
+          type: "file_append",
+          path: rawPath,
+          content,
+        },
+        new Set(["file_ok"]),
+        120000,
+      );
+      return;
+    }
+
+    const encodedContent = Buffer.from(content, "utf8").toString("base64");
+    for (
+      let offset = 0;
+      offset < encodedContent.length;
+      offset += CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS
+    ) {
+      await this.runFileRequest<FileOkMessage>(
+        {
+          type: "file_append",
+          path: rawPath,
+          content: encodedContent.slice(
+            offset,
+            offset + CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS,
+          ),
+          isBase64: true,
+        },
+        new Set(["file_ok"]),
+        120000,
+      );
+    }
   }
 
   private async removeNativeFile(rawPath: string): Promise<void> {
@@ -1451,7 +1483,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     },
 
     append: async (rawPath: string, content: string): Promise<void> => {
-      if (this.supportsNativeFileRelay()) {
+      if (this.supportsNativeFileMutations()) {
         await this.appendNativeTextFile(rawPath, content);
         return;
       }
@@ -1464,7 +1496,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       rawPath: string,
       content: string | Buffer | ArrayBuffer,
     ): Promise<void> => {
-      if (this.supportsNativeFileRelay()) {
+      if (this.supportsNativeFileMutations()) {
         await this.writeNativeFile(rawPath, content);
         return;
       }

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1383,20 +1383,27 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       return;
     }
 
+    await this.sendNativeBase64Chunks(rawPath, encodedContent, "file_write");
+  }
+
+  private async sendNativeBase64Chunks(
+    rawPath: string,
+    encodedContent: string,
+    firstChunkType: "file_write" | "file_append",
+  ): Promise<void> {
     for (
       let offset = 0;
       offset < encodedContent.length;
       offset += CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS
     ) {
-      const chunk = encodedContent.slice(
-        offset,
-        offset + CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS,
-      );
       await this.runFileRequest<FileOkMessage>(
         {
-          type: offset === 0 ? "file_write" : "file_append",
+          type: offset === 0 ? firstChunkType : "file_append",
           path: rawPath,
-          content: chunk,
+          content: encodedContent.slice(
+            offset,
+            offset + CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS,
+          ),
           isBase64: true,
         },
         new Set(["file_ok"]),
@@ -1425,26 +1432,11 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       return;
     }
 
-    const encodedContent = Buffer.from(content, "utf8").toString("base64");
-    for (
-      let offset = 0;
-      offset < encodedContent.length;
-      offset += CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS
-    ) {
-      await this.runFileRequest<FileOkMessage>(
-        {
-          type: "file_append",
-          path: rawPath,
-          content: encodedContent.slice(
-            offset,
-            offset + CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS,
-          ),
-          isBase64: true,
-        },
-        new Set(["file_ok"]),
-        120000,
-      );
-    }
+    await this.sendNativeBase64Chunks(
+      rawPath,
+      Buffer.from(content, "utf8").toString("base64"),
+      "file_append",
+    );
   }
 
   private async removeNativeFile(rawPath: string): Promise<void> {

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -674,6 +674,14 @@ export class HybridSandboxManager implements SandboxManager {
       );
     }
 
+    // Once this Agent run has fallen back to Cloud, keep using that same
+    // filesystem for the rest of the run. A local connection may reappear
+    // while the model is streaming; switching at that point would split
+    // commands and transcript files across two unrelated sandboxes.
+    if (!this.isLocal && this.sandbox) {
+      return this.getCloudSandbox();
+    }
+
     // If preference is E2B, always use E2B (but block for free users)
     if (this.sandboxPreference === "e2b") {
       if (this.subscription === "free") {

--- a/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
+++ b/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
@@ -10,6 +10,7 @@ commands.allow = [
   "read_generated_text_attachment",
   "remove_generated_text_attachment",
   "read_local_file",
+  "desktop_file_request",
   "execute_command",
   "execute_stream_command",
   "cancel_stream_command",

--- a/packages/local/src/__tests__/cloud-direct-files.test.ts
+++ b/packages/local/src/__tests__/cloud-direct-files.test.ts
@@ -1,0 +1,127 @@
+import { EventEmitter } from "events";
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import type WebSocket from "ws";
+
+import { CloudDirectTransport } from "../cloud-direct-transport";
+import { LocalSandboxClient } from "../index";
+
+jest.mock("../process-runner", () => ({
+  ProcessRunner: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+    dispose: jest.fn(),
+  })),
+  isPtyAvailable: () => true,
+}));
+
+class FakeSocket extends EventEmitter {
+  readonly OPEN = 1;
+  readonly CLOSED = 3;
+  readyState = this.OPEN;
+  readonly sent: Array<Record<string, unknown>> = [];
+
+  send(data: string, callback?: (error?: Error) => void): void {
+    const message = JSON.parse(data) as Record<string, unknown>;
+    this.sent.push(message);
+    this.emit("sent", message);
+    callback?.();
+  }
+
+  close(code = 1000): void {
+    this.readyState = this.CLOSED;
+    queueMicrotask(() => this.emit("close", code));
+  }
+
+  terminate(): void {
+    this.close(1006);
+  }
+
+  receive(message: Record<string, unknown>): void {
+    this.emit("message", Buffer.from(JSON.stringify(message)), false);
+  }
+}
+
+function waitForResponse(
+  socket: FakeSocket,
+  requestId: string,
+): Promise<Record<string, unknown>> {
+  const existing = socket.sent.find(
+    (message) => message.requestId === requestId,
+  );
+  if (existing) return Promise.resolve(existing);
+  return new Promise((resolve) => {
+    const onSent = (message: Record<string, unknown>) => {
+      if (message.requestId !== requestId) return;
+      socket.off("sent", onSent);
+      resolve(message);
+    };
+    socket.on("sent", onSent);
+  });
+}
+
+describe("direct cloud file mutations", () => {
+  it("writes and appends a transcript larger than the process argument limit", async () => {
+    const allowedRoot = await mkdtemp(join(tmpdir(), "hackerai-direct-files-"));
+    const transport = new CloudDirectTransport();
+    const client = new LocalSandboxClient(
+      {
+        convexUrl: "http://127.0.0.1",
+        token: "direct-cloud",
+        name: "AWS Lambda MicroVM",
+        authMode: "direct-cloud",
+        cloudSessionId: "session-files",
+        microvmId: "microvm-files",
+      },
+      { directTransport: transport },
+    );
+    const socket = new FakeSocket();
+    const targetPath = join(allowedRoot, "transcripts", "large.json");
+    const transcript = Buffer.from(
+      JSON.stringify({ messages: [{ content: "x".repeat(256 * 1024) }] }),
+    );
+    const first = transcript.subarray(0, 128 * 1024);
+    const second = transcript.subarray(128 * 1024);
+
+    try {
+      await client.start();
+      transport.accept(socket as unknown as WebSocket);
+
+      const firstResponse = waitForResponse(socket, "write-1");
+      socket.receive({
+        type: "file_write",
+        requestId: "write-1",
+        path: targetPath,
+        content: first.toString("base64"),
+        isBase64: true,
+        allowedRoot,
+        targetConnectionId: "microvm-files",
+      });
+      await expect(firstResponse).resolves.toMatchObject({
+        type: "file_ok",
+        requestId: "write-1",
+      });
+
+      const secondResponse = waitForResponse(socket, "append-1");
+      socket.receive({
+        type: "file_append",
+        requestId: "append-1",
+        path: targetPath,
+        content: second.toString("base64"),
+        isBase64: true,
+        allowedRoot,
+        targetConnectionId: "microvm-files",
+      });
+      await expect(secondResponse).resolves.toMatchObject({
+        type: "file_ok",
+        requestId: "append-1",
+      });
+
+      await expect(readFile(targetPath)).resolves.toEqual(transcript);
+    } finally {
+      await client.cleanup();
+      await rm(allowedRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/local/src/__tests__/cloud-direct-files.test.ts
+++ b/packages/local/src/__tests__/cloud-direct-files.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { mkdtemp, readFile, rm } from "fs/promises";
+import { mkdtemp, readFile, rm, stat, symlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import type WebSocket from "ws";
@@ -61,22 +61,42 @@ function waitForResponse(
   });
 }
 
+async function createDirectFileHarness(): Promise<{
+  allowedRoot: string;
+  client: LocalSandboxClient;
+  socket: FakeSocket;
+}> {
+  const allowedRoot = await mkdtemp(join(tmpdir(), "hackerai-direct-files-"));
+  const transport = new CloudDirectTransport();
+  const client = new LocalSandboxClient(
+    {
+      convexUrl: "http://127.0.0.1",
+      token: "direct-cloud",
+      name: "AWS Lambda MicroVM",
+      authMode: "direct-cloud",
+      cloudSessionId: "session-files",
+      microvmId: "microvm-files",
+    },
+    { directTransport: transport },
+  );
+  const socket = new FakeSocket();
+  await client.start();
+  transport.accept(socket as unknown as WebSocket);
+  return { allowedRoot, client, socket };
+}
+
+async function sendFileMutation(
+  socket: FakeSocket,
+  message: Record<string, unknown> & { requestId: string },
+): Promise<Record<string, unknown>> {
+  const response = waitForResponse(socket, message.requestId);
+  socket.receive({ ...message, targetConnectionId: "microvm-files" });
+  return response;
+}
+
 describe("direct cloud file mutations", () => {
   it("writes and appends a transcript larger than the process argument limit", async () => {
-    const allowedRoot = await mkdtemp(join(tmpdir(), "hackerai-direct-files-"));
-    const transport = new CloudDirectTransport();
-    const client = new LocalSandboxClient(
-      {
-        convexUrl: "http://127.0.0.1",
-        token: "direct-cloud",
-        name: "AWS Lambda MicroVM",
-        authMode: "direct-cloud",
-        cloudSessionId: "session-files",
-        microvmId: "microvm-files",
-      },
-      { directTransport: transport },
-    );
-    const socket = new FakeSocket();
+    const { allowedRoot, client, socket } = await createDirectFileHarness();
     const targetPath = join(allowedRoot, "transcripts", "large.json");
     const transcript = Buffer.from(
       JSON.stringify({ messages: [{ content: "x".repeat(256 * 1024) }] }),
@@ -85,33 +105,26 @@ describe("direct cloud file mutations", () => {
     const second = transcript.subarray(128 * 1024);
 
     try {
-      await client.start();
-      transport.accept(socket as unknown as WebSocket);
-
-      const firstResponse = waitForResponse(socket, "write-1");
-      socket.receive({
+      const firstResponse = sendFileMutation(socket, {
         type: "file_write",
         requestId: "write-1",
         path: targetPath,
         content: first.toString("base64"),
         isBase64: true,
         allowedRoot,
-        targetConnectionId: "microvm-files",
       });
       await expect(firstResponse).resolves.toMatchObject({
         type: "file_ok",
         requestId: "write-1",
       });
 
-      const secondResponse = waitForResponse(socket, "append-1");
-      socket.receive({
+      const secondResponse = sendFileMutation(socket, {
         type: "file_append",
         requestId: "append-1",
         path: targetPath,
         content: second.toString("base64"),
         isBase64: true,
         allowedRoot,
-        targetConnectionId: "microvm-files",
       });
       await expect(secondResponse).resolves.toMatchObject({
         type: "file_ok",
@@ -122,6 +135,82 @@ describe("direct cloud file mutations", () => {
     } finally {
       await client.cleanup();
       await rm(allowedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unsafe paths and malformed file content", async () => {
+    const { allowedRoot, client, socket } = await createDirectFileHarness();
+    const outsideRoot = await mkdtemp(
+      join(tmpdir(), "hackerai-direct-files-outside-"),
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const targetSymlink = join(allowedRoot, "target-link.json");
+    const parentSymlink = join(allowedRoot, "parent-link");
+    await symlink(join(outsideRoot, "target.json"), targetSymlink);
+    await symlink(outsideRoot, parentSymlink, "dir");
+
+    const rejectedRequests = [
+      {
+        type: "file_write",
+        requestId: "outside-root",
+        path: join(outsideRoot, "outside.json"),
+        content: "e30=",
+        isBase64: true,
+        allowedRoot,
+      },
+      {
+        type: "file_write",
+        requestId: "target-symlink",
+        path: targetSymlink,
+        content: "e30=",
+        isBase64: true,
+        allowedRoot,
+      },
+      {
+        type: "file_write",
+        requestId: "missing-root",
+        path: join(allowedRoot, "missing-root.json"),
+        content: "e30=",
+        isBase64: true,
+      },
+      {
+        type: "file_write",
+        requestId: "invalid-base64",
+        path: join(allowedRoot, "invalid-base64.json"),
+        content: "not-canonical-base64",
+        isBase64: true,
+        allowedRoot,
+      },
+      {
+        type: "file_write",
+        requestId: "parent-symlink",
+        path: join(parentSymlink, "created", "outside.json"),
+        content: "e30=",
+        isBase64: true,
+        allowedRoot,
+      },
+    ];
+
+    try {
+      for (const request of rejectedRequests) {
+        await expect(sendFileMutation(socket, request)).resolves.toMatchObject({
+          type: "file_error",
+          requestId: request.requestId,
+        });
+      }
+      await expect(
+        stat(join(outsideRoot, "outside.json")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(stat(join(outsideRoot, "created"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      errorSpy.mockRestore();
+      await client.cleanup();
+      await Promise.all([
+        rm(allowedRoot, { recursive: true, force: true }),
+        rm(outsideRoot, { recursive: true, force: true }),
+      ]);
     }
   });
 });

--- a/packages/local/src/__tests__/cloud-direct-files.test.ts
+++ b/packages/local/src/__tests__/cloud-direct-files.test.ts
@@ -1,5 +1,13 @@
 import { EventEmitter } from "events";
-import { mkdtemp, readFile, rm, stat, symlink } from "fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  symlink,
+} from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import type WebSocket from "ws";
@@ -61,7 +69,9 @@ function waitForResponse(
   });
 }
 
-async function createDirectFileHarness(): Promise<{
+async function createDirectFileHarness(
+  beforeDirectFileDescriptorOpen?: (allowedRoot: string) => Promise<void>,
+): Promise<{
   allowedRoot: string;
   client: LocalSandboxClient;
   socket: FakeSocket;
@@ -77,7 +87,12 @@ async function createDirectFileHarness(): Promise<{
       cloudSessionId: "session-files",
       microvmId: "microvm-files",
     },
-    { directTransport: transport },
+    {
+      directTransport: transport,
+      beforeDirectFileDescriptorOpen: beforeDirectFileDescriptorOpen
+        ? () => beforeDirectFileDescriptorOpen(allowedRoot)
+        : undefined,
+    },
   );
   const socket = new FakeSocket();
   await client.start();
@@ -198,6 +213,22 @@ describe("direct cloud file mutations", () => {
           requestId: request.requestId,
         });
       }
+      socket.receive({
+        type: "file_write",
+        requestId: "invalid-base64-flag",
+        path: join(allowedRoot, "invalid-base64-flag.json"),
+        content: "plain text",
+        isBase64: "true",
+        allowedRoot,
+        targetConnectionId: "microvm-files",
+      });
+      await Promise.resolve();
+      expect(socket.sent).not.toContainEqual(
+        expect.objectContaining({ requestId: "invalid-base64-flag" }),
+      );
+      await expect(
+        stat(join(allowedRoot, "invalid-base64-flag.json")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
       await expect(
         stat(join(outsideRoot, "outside.json")),
       ).rejects.toMatchObject({ code: "ENOENT" });
@@ -205,6 +236,52 @@ describe("direct cloud file mutations", () => {
         code: "ENOENT",
       });
     } finally {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      errorSpy.mockRestore();
+      await client.cleanup();
+      await Promise.all([
+        rm(allowedRoot, { recursive: true, force: true }),
+        rm(outsideRoot, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it("rejects an ancestor symlink swap between validation and descriptor open", async () => {
+    const outsideRoot = await mkdtemp(
+      join(tmpdir(), "hackerai-direct-files-race-outside-"),
+    );
+    const { allowedRoot, client, socket } = await createDirectFileHarness(
+      async (root) => {
+        const ancestorPath = join(root, "race");
+        await rename(ancestorPath, join(root, "race-verified"));
+        await symlink(outsideRoot, ancestorPath, "dir");
+      },
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await Promise.all([
+      mkdir(join(allowedRoot, "race", "parent"), { recursive: true }),
+      mkdir(join(outsideRoot, "parent"), { recursive: true }),
+    ]);
+
+    try {
+      await expect(
+        sendFileMutation(socket, {
+          type: "file_write",
+          requestId: "ancestor-symlink-race",
+          path: join(allowedRoot, "race", "parent", "outside.json"),
+          content: "e30=",
+          isBase64: true,
+          allowedRoot,
+        }),
+      ).resolves.toMatchObject({
+        type: "file_error",
+        requestId: "ancestor-symlink-race",
+      });
+      await expect(
+        stat(join(outsideRoot, "parent", "outside.json")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await new Promise((resolve) => setTimeout(resolve, 0));
       errorSpy.mockRestore();
       await client.cleanup();
       await Promise.all([

--- a/packages/local/src/__tests__/cloud-direct-transport.test.ts
+++ b/packages/local/src/__tests__/cloud-direct-transport.test.ts
@@ -100,4 +100,44 @@ describe("CloudDirectTransport", () => {
     });
     expect(onMessage).not.toHaveBeenCalled();
   });
+
+  it("routes file acknowledgements only to the requesting socket", async () => {
+    const transport = new CloudDirectTransport();
+    const onMessage = jest.fn();
+    transport.start({ onMessage, onDisconnect: jest.fn() });
+    const owner = new FakeSocket();
+    const other = new FakeSocket();
+    transport.accept(owner as unknown as WebSocket);
+    transport.accept(other as unknown as WebSocket);
+
+    owner.receive({
+      type: "file_write",
+      requestId: "file-1",
+      path: "/home/user/transcript.json",
+      content: "e30=",
+      isBase64: true,
+      allowedRoot: "/home/user",
+      targetConnectionId: "microvm-1",
+    });
+    other.receive({
+      type: "file_append",
+      requestId: "file-1",
+      path: "/home/user/transcript.json",
+      content: "Cg==",
+      isBase64: true,
+      allowedRoot: "/home/user",
+      targetConnectionId: "microvm-1",
+    });
+    await transport.publish({ type: "file_ok", requestId: "file-1" });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(owner.sent).toContainEqual({
+      type: "file_ok",
+      requestId: "file-1",
+    });
+    expect(other.sent).not.toContainEqual(
+      expect.objectContaining({ requestId: "file-1" }),
+    );
+    await transport.stop();
+  });
 });

--- a/packages/local/src/cloud-direct-transport.ts
+++ b/packages/local/src/cloud-direct-transport.ts
@@ -23,6 +23,9 @@ function correlationKey(message: DirectMessage): string | null {
   if (typeof message.sessionId === "string") {
     return `pty:${message.sessionId}`;
   }
+  if (typeof message.requestId === "string") {
+    return `file:${message.requestId}`;
+  }
   return null;
 }
 
@@ -33,6 +36,8 @@ function isTerminalResponse(message: DirectMessage): boolean {
   return (
     message.type === "exit" ||
     message.type === "error" ||
+    message.type === "file_ok" ||
+    message.type === "file_error" ||
     message.type === "pty_exit" ||
     message.type === "pty_error"
   );
@@ -104,7 +109,12 @@ export class CloudDirectTransport {
     const remove = () => this.removeClient(socket);
     socket.once("close", remove);
     socket.once("error", remove);
-    socket.send(JSON.stringify({ type: "transport_ready" }));
+    socket.send(
+      JSON.stringify({
+        type: "transport_ready",
+        capabilities: { fileMutations: true },
+      }),
+    );
   }
 
   async publish(message: DirectMessage): Promise<void> {

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -336,11 +336,25 @@ async function prepareFileMutationPath(
   }
 
   const parentPath = dirname(targetPath);
+  const realAllowedRoot = await realpath(allowedRoot);
+  let existingAncestor = parentPath;
+  for (;;) {
+    try {
+      existingAncestor = await realpath(existingAncestor);
+      break;
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+      const nextAncestor = dirname(existingAncestor);
+      if (nextAncestor === existingAncestor) throw error;
+      existingAncestor = nextAncestor;
+    }
+  }
+  if (!isPathInside(realAllowedRoot, existingAncestor)) {
+    throw new Error("Direct file mutation parent escapes its allowed root");
+  }
+
   await mkdir(parentPath, { recursive: true });
-  const [realAllowedRoot, realParentPath] = await Promise.all([
-    realpath(allowedRoot),
-    realpath(parentPath),
-  ]);
+  const realParentPath = await realpath(parentPath);
   if (!isPathInside(realAllowedRoot, realParentPath)) {
     throw new Error("Direct file mutation parent escapes its allowed root");
   }

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -17,8 +17,10 @@ import { ConvexHttpClient } from "convex/browser";
 import { Centrifuge, Subscription, PublicationContext } from "centrifuge";
 import WebSocket, { WebSocketServer } from "ws";
 import { spawn, ChildProcess } from "child_process";
+import { appendFile, lstat, mkdir, realpath, writeFile } from "fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import os from "os";
+import { dirname, isAbsolute, relative, resolve, sep } from "path";
 import {
   truncateOutput,
   MAX_OUTPUT_SIZE,
@@ -152,6 +154,27 @@ interface CentrifugoCommandCancelResultMessage {
   canceled: boolean;
 }
 
+interface FileMutationMessage {
+  type: "file_write" | "file_append";
+  requestId: string;
+  path: string;
+  content: string;
+  isBase64?: boolean;
+  allowedRoot?: string;
+  targetConnectionId: string;
+}
+
+interface FileOkMessage {
+  type: "file_ok";
+  requestId: string;
+}
+
+interface FileErrorMessage {
+  type: "file_error";
+  requestId: string;
+  message: string;
+}
+
 // --- PTY incoming message types ---
 
 interface PtyCreateMessage {
@@ -193,6 +216,7 @@ type CentrifugoPtyIncomingMessage =
 type TargetedIncomingMessage =
   | CentrifugoCommandMessage
   | CentrifugoCommandCancelMessage
+  | FileMutationMessage
   | CentrifugoPtyIncomingMessage;
 
 function isTargetedIncomingMessage(
@@ -205,14 +229,28 @@ function isTargetedIncomingMessage(
     type?: unknown;
     targetConnectionId?: unknown;
   };
+  if (typeof targetConnectionId !== "string") return false;
+  if (type === "file_write" || type === "file_append") {
+    const { requestId, path, content, allowedRoot } = message as {
+      requestId?: unknown;
+      path?: unknown;
+      content?: unknown;
+      allowedRoot?: unknown;
+    };
+    return (
+      typeof requestId === "string" &&
+      typeof path === "string" &&
+      typeof content === "string" &&
+      (allowedRoot === undefined || typeof allowedRoot === "string")
+    );
+  }
   return (
-    typeof targetConnectionId === "string" &&
-    (type === "command" ||
-      type === "command_cancel" ||
-      type === "pty_create" ||
-      type === "pty_input" ||
-      type === "pty_resize" ||
-      type === "pty_kill")
+    type === "command" ||
+    type === "command_cancel" ||
+    type === "pty_create" ||
+    type === "pty_input" ||
+    type === "pty_resize" ||
+    type === "pty_kill"
   );
 }
 
@@ -248,10 +286,75 @@ type CentrifugoOutgoingMessage =
   | CentrifugoExitMessage
   | CentrifugoErrorMessage
   | CentrifugoCommandCancelResultMessage
+  | FileOkMessage
+  | FileErrorMessage
   | CentrifugoPtyReadyMessage
   | CentrifugoPtyDataMessage
   | CentrifugoPtyExitMessage
   | CentrifugoPtyErrorMessage;
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return (
+    relativePath === "" ||
+    (relativePath !== ".." &&
+      !relativePath.startsWith(`..${sep}`) &&
+      !isAbsolute(relativePath))
+  );
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+function decodeFileMutationContent(message: FileMutationMessage): Buffer {
+  if (!message.isBase64) return Buffer.from(message.content, "utf8");
+  const decoded = Buffer.from(message.content, "base64");
+  if (decoded.toString("base64") !== message.content) {
+    throw new Error("Invalid base64 file content");
+  }
+  return decoded;
+}
+
+async function prepareFileMutationPath(
+  rawPath: string,
+  rawAllowedRoot?: string,
+): Promise<string> {
+  if (!rawAllowedRoot) {
+    throw new Error("Direct file mutation is missing its allowed root");
+  }
+
+  const allowedRoot = resolve(rawAllowedRoot);
+  const targetPath = resolve(rawPath);
+  if (!isPathInside(allowedRoot, targetPath) || targetPath === allowedRoot) {
+    throw new Error("Direct file mutation path is outside its allowed root");
+  }
+
+  const parentPath = dirname(targetPath);
+  await mkdir(parentPath, { recursive: true });
+  const [realAllowedRoot, realParentPath] = await Promise.all([
+    realpath(allowedRoot),
+    realpath(parentPath),
+  ]);
+  if (!isPathInside(realAllowedRoot, realParentPath)) {
+    throw new Error("Direct file mutation parent escapes its allowed root");
+  }
+
+  try {
+    const target = await lstat(targetPath);
+    if (target.isSymbolicLink()) {
+      throw new Error("Direct file mutation cannot target a symbolic link");
+    }
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
+  }
+  return targetPath;
+}
 
 interface ConnectResult {
   success: boolean;
@@ -780,6 +883,18 @@ export class LocalSandboxClient {
           );
         });
         break;
+      case "file_write":
+      case "file_append":
+        this.handleFileMutation(message).catch((error: unknown) => {
+          console.error(
+            chalk.red(
+              this.config.authMode === "direct-cloud"
+                ? "[FILE] Direct file mutation failed"
+                : `[FILE] File mutation failed: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          );
+        });
+        break;
       case "pty_create":
         this.handlePtyCreate(message).catch((error: unknown) => {
           const errorMsg =
@@ -796,6 +911,46 @@ export class LocalSandboxClient {
       case "pty_kill":
         this.handlePtyKill(message);
         break;
+    }
+  }
+
+  private async handleFileMutation(
+    message: FileMutationMessage,
+  ): Promise<void> {
+    const requestId =
+      typeof message.requestId === "string" ? message.requestId : "invalid";
+    try {
+      if (this.config.authMode !== "direct-cloud") {
+        throw new Error("Native file mutations require direct cloud transport");
+      }
+      if (
+        typeof message.requestId !== "string" ||
+        typeof message.path !== "string" ||
+        typeof message.content !== "string" ||
+        (message.allowedRoot !== undefined &&
+          typeof message.allowedRoot !== "string")
+      ) {
+        throw new Error("Invalid direct file mutation request");
+      }
+
+      const targetPath = await prepareFileMutationPath(
+        message.path,
+        message.allowedRoot,
+      );
+      const content = decodeFileMutationContent(message);
+      if (message.type === "file_write") {
+        await writeFile(targetPath, content);
+      } else {
+        await appendFile(targetPath, content);
+      }
+      await this.publishToChannel({ type: "file_ok", requestId });
+    } catch (error) {
+      await this.publishToChannel({
+        type: "file_error",
+        requestId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
     }
   }
 

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -17,10 +17,19 @@ import { ConvexHttpClient } from "convex/browser";
 import { Centrifuge, Subscription, PublicationContext } from "centrifuge";
 import WebSocket, { WebSocketServer } from "ws";
 import { spawn, ChildProcess } from "child_process";
-import { appendFile, lstat, mkdir, realpath, writeFile } from "fs/promises";
+import { constants as fsConstants } from "fs";
+import { lstat, mkdir, open, realpath } from "fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import os from "os";
-import { dirname, isAbsolute, relative, resolve, sep } from "path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "path";
 import {
   truncateOutput,
   MAX_OUTPUT_SIZE,
@@ -231,16 +240,18 @@ function isTargetedIncomingMessage(
   };
   if (typeof targetConnectionId !== "string") return false;
   if (type === "file_write" || type === "file_append") {
-    const { requestId, path, content, allowedRoot } = message as {
+    const { requestId, path, content, isBase64, allowedRoot } = message as {
       requestId?: unknown;
       path?: unknown;
       content?: unknown;
+      isBase64?: unknown;
       allowedRoot?: unknown;
     };
     return (
       typeof requestId === "string" &&
       typeof path === "string" &&
       typeof content === "string" &&
+      (isBase64 === undefined || typeof isBase64 === "boolean") &&
       (allowedRoot === undefined || typeof allowedRoot === "string")
     );
   }
@@ -324,7 +335,11 @@ function decodeFileMutationContent(message: FileMutationMessage): Buffer {
 async function prepareFileMutationPath(
   rawPath: string,
   rawAllowedRoot?: string,
-): Promise<string> {
+): Promise<{
+  parentPath: string;
+  targetName: string;
+  realAllowedRoot: string;
+}> {
   if (!rawAllowedRoot) {
     throw new Error("Direct file mutation is missing its allowed root");
   }
@@ -367,7 +382,57 @@ async function prepareFileMutationPath(
   } catch (error) {
     if (!isMissingPathError(error)) throw error;
   }
-  return targetPath;
+  return {
+    parentPath,
+    targetName: basename(targetPath),
+    realAllowedRoot,
+  };
+}
+
+async function mutatePreparedFile(
+  prepared: Awaited<ReturnType<typeof prepareFileMutationPath>>,
+  content: Buffer,
+  append: boolean,
+): Promise<void> {
+  const parentHandle = await open(
+    prepared.parentPath,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    // AWS MicroVM guests are Linux, where /proc keeps the final lookup anchored
+    // to this verified directory descriptor even if its pathname is replaced.
+    // The pathname fallback supports non-Linux local package tests only.
+    const anchoredParentPath =
+      os.platform() === "linux"
+        ? `/proc/self/fd/${parentHandle.fd}`
+        : prepared.parentPath;
+    const openedParentPath = await realpath(anchoredParentPath);
+    if (!isPathInside(prepared.realAllowedRoot, openedParentPath)) {
+      throw new Error("Direct file mutation parent escapes its allowed root");
+    }
+
+    const flags = append
+      ? fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_APPEND |
+        fsConstants.O_NOFOLLOW
+      : fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_TRUNC |
+        fsConstants.O_NOFOLLOW;
+    const targetHandle = await open(
+      join(anchoredParentPath, prepared.targetName),
+      flags,
+      0o600,
+    );
+    try {
+      await targetHandle.writeFile(content);
+    } finally {
+      await targetHandle.close();
+    }
+  } finally {
+    await parentHandle.close();
+  }
 }
 
 interface ConnectResult {
@@ -415,6 +480,7 @@ function isInvalidTokenError(error: unknown): boolean {
 type LocalSandboxClientOptions = {
   onExitRequested?: (code: number, error: Error) => void;
   directTransport?: CloudDirectTransport;
+  beforeDirectFileDescriptorOpen?: () => void | Promise<void>;
 };
 
 export class LocalSandboxClient {
@@ -941,22 +1007,25 @@ export class LocalSandboxClient {
         typeof message.requestId !== "string" ||
         typeof message.path !== "string" ||
         typeof message.content !== "string" ||
+        (message.isBase64 !== undefined &&
+          typeof message.isBase64 !== "boolean") ||
         (message.allowedRoot !== undefined &&
           typeof message.allowedRoot !== "string")
       ) {
         throw new Error("Invalid direct file mutation request");
       }
 
-      const targetPath = await prepareFileMutationPath(
+      const prepared = await prepareFileMutationPath(
         message.path,
         message.allowedRoot,
       );
       const content = decodeFileMutationContent(message);
-      if (message.type === "file_write") {
-        await writeFile(targetPath, content);
-      } else {
-        await appendFile(targetPath, content);
-      }
+      await this.options.beforeDirectFileDescriptorOpen?.();
+      await mutatePreparedFile(
+        prepared,
+        content,
+        message.type === "file_append",
+      );
       await this.publishToChannel({ type: "file_ok", requestId });
     } catch (error) {
       await this.publishToChannel({


### PR DESCRIPTION
## Summary\n\n- route AWS direct-endpoint file writes/appends through correlated WebSocket messages instead of embedding transcript bytes in shell commands\n- write bounded base64 chunks with Node filesystem APIs inside the guest, with allowed-root and symlink protections\n- negotiate the new capability so updated Trigger workers remain compatible with older MicroVM images\n- allow the native Desktop file request in Tauri and fall back to the authenticated loopback bridge for already-installed builds whose ACL blocks it\n- pin a cloud fallback for the remainder of an Agent run so later Desktop reconnection cannot split commands and transcripts across filesystems\n- preserve socket ownership across concurrent Trigger runs and fail pending file requests on disconnect\n\n## Validation\n\n- 413 Jest suites / 4,141 tests passed\n- root TypeScript typecheck passed\n- full ESLint passed (7 pre-existing UI warnings, no errors)\n- aws:microvm:package passed and packaged output contains the new guest handlers\n- focused controller/guest regression tests cover a 256 KiB transcript and byte-for-byte reconstruction\n- focused Desktop tests cover the exact "Command desktop_file_request not allowed by ACL" production failure\n- formatting and git diff --check passed\n- local Rust check was unavailable because cargo is not installed; CI validates the Tauri permission\n\n## Manual verification after release\n\n1. Start an AWS Lambda MicroVM Agent conversation with enough history to trigger summarization.\n2. Confirm summarization completes without spawn E2BIG, desktop_file_request ACL errors, or Failed to save transcript.\n3. Ask the Agent to inspect the saved pre-summary transcript path and confirm it can retrieve early conversation content.\n4. For a Desktop-selected chat, disconnect Desktop before the first sandbox acquisition, reconnect after Cloud fallback, and confirm the run remains on the same cloud sandbox.\n5. Confirm the MicroVM still winds down normally after the run.\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added direct file write and append support for connected cloud and MicroVM environments.
  - Large file operations are transferred in bounded, reliable chunks.
  - File operation results now provide success or error acknowledgements.

- **Bug Fixes**
  - Improved file path and content validation, including protection against unsafe paths and symlink traversal.
  - Ensured acknowledgements are delivered only to the originating connection.
  - Pending file operations are handled when connections close.
  - Environments without native file support continue using existing fallback behavior.
  - Existing cloud sandboxes remain selected during a session when desktop connectivity returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->