### PR TITLE
Prevent sandbox attachment path collisions

### DIFF
--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -403,13 +403,14 @@ describe("processMessageFiles image size guards", () => {
       "pro",
     );
 
-    expect(result.sandboxFiles).toEqual([
-      {
-        kind: "url",
-        url: "https://storage.example/small.png",
-        localPath: "/home/user/upload/small.png",
-      },
-    ]);
+    expect(result.sandboxFiles).toHaveLength(1);
+    expect(result.sandboxFiles[0]).toMatchObject({
+      kind: "url",
+      url: "https://storage.example/small.png",
+    });
+    expect(result.sandboxFiles[0].localPath).toMatch(
+      /^\/home\/user\/upload\/[a-f0-9]{64}\/small\.png$/,
+    );
     expect(result.messages[0].parts).toEqual([
       { type: "text", text: "what is this?" },
       expect.objectContaining({
@@ -421,7 +422,7 @@ describe("processMessageFiles image size guards", () => {
       }),
       {
         type: "text",
-        text: '<inline_image_attachment filename="small.png" sandbox_path="/home/user/upload/small.png" already_visible_to_model="true" use_sandbox_path_for="file_operations_only" />',
+        text: `<inline_image_attachment filename="small.png" sandbox_path="${result.sandboxFiles[0].localPath}" already_visible_to_model="true" use_sandbox_path_for="file_operations_only" />`,
       },
     ]);
   });
@@ -449,13 +450,14 @@ describe("processMessageFiles image size guards", () => {
       "pro",
     );
 
-    expect(result.sandboxFiles).toEqual([
-      {
-        kind: "url",
-        url: "https://storage.example/report.pdf",
-        localPath: "/home/user/upload/report.pdf",
-      },
-    ]);
+    expect(result.sandboxFiles).toHaveLength(1);
+    expect(result.sandboxFiles[0]).toMatchObject({
+      kind: "url",
+      url: "https://storage.example/report.pdf",
+    });
+    expect(result.sandboxFiles[0].localPath).toMatch(
+      /^\/home\/user\/upload\/[a-f0-9]{64}\/report\.pdf$/,
+    );
     expect(result.messages[0].parts).toEqual([
       { type: "text", text: "what is this?" },
       expect.objectContaining({
@@ -467,7 +469,7 @@ describe("processMessageFiles image size guards", () => {
       }),
       {
         type: "text",
-        text: '<attachment filename="report.pdf" local_path="/home/user/upload/report.pdf" />',
+        text: `<attachment filename="report.pdf" local_path="${result.sandboxFiles[0].localPath}" />`,
       },
     ]);
     expect(result.containsPdfFiles).toBe(true);
@@ -500,7 +502,7 @@ describe("processMessageFiles image size guards", () => {
       { type: "text", text: "what is this?" },
       {
         type: "text",
-        text: '<attachment filename="large.pdf" local_path="/home/user/upload/large.pdf" />',
+        text: `<attachment filename="large.pdf" local_path="${result.sandboxFiles[0].localPath}" />`,
       },
     ]);
     expect(result.containsPdfFiles).toBe(false);
@@ -643,18 +645,19 @@ describe("processMessageFiles image size guards", () => {
       "pro",
     );
 
-    expect(result.sandboxFiles).toEqual([
-      {
-        kind: "url",
-        url: "https://storage.example/broken.png",
-        localPath: "/home/user/upload/broken.png",
-      },
-    ]);
+    expect(result.sandboxFiles).toHaveLength(1);
+    expect(result.sandboxFiles[0]).toMatchObject({
+      kind: "url",
+      url: "https://storage.example/broken.png",
+    });
+    expect(result.sandboxFiles[0].localPath).toMatch(
+      /^\/home\/user\/upload\/[a-f0-9]{64}\/broken\.png$/,
+    );
     expect(result.messages[0].parts).toEqual([
       { type: "text", text: "what is this?" },
       {
         type: "text",
-        text: '<attachment filename="broken.png" local_path="/home/user/upload/broken.png" />',
+        text: `<attachment filename="broken.png" local_path="${result.sandboxFiles[0].localPath}" />`,
       },
     ]);
   });
@@ -737,18 +740,19 @@ describe("processMessageFiles image size guards", () => {
       "pro",
     );
 
-    expect(result.sandboxFiles).toEqual([
-      {
-        kind: "url",
-        url: "https://storage.example/large.png",
-        localPath: "/home/user/upload/large.png",
-      },
-    ]);
+    expect(result.sandboxFiles).toHaveLength(1);
+    expect(result.sandboxFiles[0]).toMatchObject({
+      kind: "url",
+      url: "https://storage.example/large.png",
+    });
+    expect(result.sandboxFiles[0].localPath).toMatch(
+      /^\/home\/user\/upload\/[a-f0-9]{64}\/large\.png$/,
+    );
     expect(result.messages[0].parts).toEqual([
       { type: "text", text: "what is this?" },
       {
         type: "text",
-        text: '<attachment filename="large.png" local_path="/home/user/upload/large.png" />',
+        text: `<attachment filename="large.png" local_path="${result.sandboxFiles[0].localPath}" />`,
       },
     ]);
   });
@@ -778,13 +782,14 @@ describe("processMessageFiles image size guards", () => {
     );
 
     expect(mockConvexAction).toHaveBeenCalledTimes(2);
-    expect(result.sandboxFiles).toEqual([
-      {
-        kind: "url",
-        url: "https://storage.example/secret.txt",
-        localPath: "/home/user/upload/secret.txt",
-      },
-    ]);
+    expect(result.sandboxFiles).toHaveLength(1);
+    expect(result.sandboxFiles[0]).toMatchObject({
+      kind: "url",
+      url: "https://storage.example/secret.txt",
+    });
+    expect(result.sandboxFiles[0].localPath).toMatch(
+      /^\/home\/user\/upload\/[a-f0-9]{64}\/secret\.txt$/,
+    );
     expect(JSON.stringify(result.messages)).not.toContain(
       "https://client.example/secret.txt",
     );

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -3,6 +3,7 @@ jest.mock("server-only", () => ({}), { virtual: true });
 import type { UIMessage } from "ai";
 import { AlternateCloudSandboxUnavailableError } from "@/lib/ai/tools/utils/cloud-sandbox-recovery";
 import {
+  collectSandboxFiles,
   getSandboxUploadFailureMetadata,
   getSandboxUploadUserMessage,
   prepareLocalDesktopAttachmentsForTrigger,
@@ -54,13 +55,14 @@ describe("desktop-local sandbox file helpers", () => {
       "/tmp/hackerai-upload",
     );
 
-    expect(sandboxFiles).toEqual([
-      {
-        kind: "localPath",
-        path: "/Users/alice/Secrets/report.pdf",
-        localPath: "/tmp/hackerai-upload/report.pdf",
-      },
-    ]);
+    expect(sandboxFiles).toHaveLength(1);
+    expect(sandboxFiles[0]).toMatchObject({
+      kind: "localPath",
+      path: "/Users/alice/Secrets/report.pdf",
+    });
+    expect(sandboxFiles[0].localPath).toMatch(
+      /^\/tmp\/hackerai-upload\/[a-f0-9]{64}\/report\.pdf$/,
+    );
     expect(JSON.stringify(messages)).not.toContain(
       "/Users/alice/Secrets/report.pdf",
     );
@@ -69,9 +71,91 @@ describe("desktop-local sandbox file helpers", () => {
         (part: any) =>
           part.type === "text" &&
           part.text ===
-            '<attachment filename="report.pdf" local_path="/tmp/hackerai-upload/report.pdf" />',
+            `<attachment filename="report.pdf" local_path="${sandboxFiles[0].localPath}" />`,
       ),
     ).toBe(true);
+  });
+
+  it("gives same-named desktop attachments distinct stable sandbox paths", () => {
+    const first = makeLocalMessage();
+    const second = {
+      ...first.parts?.[1],
+      localPath: "/Users/alice/Other/report.pdf",
+    };
+    first.parts?.push(second as never);
+
+    const { messages, sandboxFiles } = prepareLocalDesktopAttachmentsForTrigger(
+      [first],
+      "/tmp/hackerai-upload",
+    );
+
+    expect(sandboxFiles).toHaveLength(2);
+    expect(new Set(sandboxFiles.map((file) => file.localPath)).size).toBe(2);
+    expect(
+      sandboxFiles.every((file) => file.localPath.endsWith("/report.pdf")),
+    ).toBe(true);
+    const tags = messages[0].parts?.filter(
+      (part: any) => part.type === "text" && part.text.includes("<attachment"),
+    );
+    expect(tags?.[0]).toEqual({
+      type: "text",
+      text: sandboxFiles
+        .map(
+          (file) =>
+            `<attachment filename="report.pdf" local_path="${file.localPath}" />`,
+        )
+        .join("\n"),
+    });
+  });
+
+  it("keeps historical same-named stored attachments on distinct paths", () => {
+    const messages = [
+      {
+        id: "old-message",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            fileId: "file-old",
+            url: "https://storage.example/old-report.pdf",
+            name: "report.pdf",
+          },
+        ],
+      },
+      {
+        id: "new-message",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            fileId: "file-new",
+            url: "https://storage.example/new-report.pdf",
+            name: "report.pdf",
+          },
+        ],
+      },
+    ] as UIMessage[];
+    const sandboxFiles: Parameters<typeof collectSandboxFiles>[1] = [];
+
+    collectSandboxFiles(messages, sandboxFiles, "/home/user/upload");
+
+    expect(sandboxFiles).toHaveLength(1);
+    const oldTag = (messages[0].parts?.[1] as { text: string }).text;
+    const newTag = (messages[1].parts?.[1] as { text: string }).text;
+    const oldPath = oldTag.match(/local_path="([^"]+)"/)?.[1];
+    const newPath = newTag.match(/local_path="([^"]+)"/)?.[1];
+    expect(oldPath).toMatch(
+      /^\/home\/user\/upload\/[a-f0-9]{64}\/report\.pdf$/,
+    );
+    expect(oldTag).toContain(
+      'legacy_fallback_path="/home/user/upload/report.pdf"',
+    );
+    expect(oldTag).toContain(
+      'use_legacy_fallback_only_if_primary_missing="true"',
+    );
+    expect(newPath).toBe(sandboxFiles[0].localPath);
+    expect(newPath).not.toBe(oldPath);
+    expect(newTag).not.toContain("legacy_fallback_path");
   });
 
   it("copies desktop-local files through the local sandbox instead of downloading", async () => {

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -297,23 +297,68 @@ const getLastUserMessageIndex = (messages: UIMessage[]): number => {
 const formatSandboxAttachmentTag = (
   sanitizedName: string,
   localPath: string,
+  legacyFallbackPath?: string,
 ): string =>
-  `<attachment filename="${sanitizedName}" local_path="${localPath}" />`;
+  `<attachment filename="${sanitizedName}" local_path="${localPath}"${
+    legacyFallbackPath
+      ? ` legacy_fallback_path="${legacyFallbackPath}" use_legacy_fallback_only_if_primary_missing="true"`
+      : ""
+  } />`;
 
 const formatInlineImageAttachmentTag = (
   sanitizedName: string,
   localPath: string,
+  legacyFallbackPath?: string,
 ): string =>
-  `<inline_image_attachment filename="${sanitizedName}" sandbox_path="${localPath}" already_visible_to_model="true" use_sandbox_path_for="file_operations_only" />`;
+  `<inline_image_attachment filename="${sanitizedName}" sandbox_path="${localPath}"${
+    legacyFallbackPath
+      ? ` legacy_fallback_path="${legacyFallbackPath}" use_legacy_fallback_only_if_primary_missing="true"`
+      : ""
+  } already_visible_to_model="true" use_sandbox_path_for="file_operations_only" />`;
 
 const formatSandboxFileTag = (
   kind: SandboxAttachmentTagKind,
   sanitizedName: string,
   localPath: string,
+  legacyFallbackPath?: string,
 ): string =>
   kind === "inline-image"
-    ? formatInlineImageAttachmentTag(sanitizedName, localPath)
-    : formatSandboxAttachmentTag(sanitizedName, localPath);
+    ? formatInlineImageAttachmentTag(
+        sanitizedName,
+        localPath,
+        legacyFallbackPath,
+      )
+    : formatSandboxAttachmentTag(sanitizedName, localPath, legacyFallbackPath);
+
+const getSandboxAttachmentIdentity = (part: any): string => {
+  if (part?.storage === "local-desktop") {
+    const localId =
+      part.localAttachmentId ||
+      part.generatedTextAttachmentId ||
+      "local-attachment";
+    return `${String(localId)}:${String(part.localPath || "unknown-path")}`;
+  }
+
+  return String(part?.fileId || "stored-attachment");
+};
+
+const getSandboxAttachmentLocalPath = (
+  uploadBasePath: string,
+  sanitizedName: string,
+  part: any,
+): string => {
+  const storageKind =
+    part?.storage === "local-desktop" ? "local-desktop" : "stored";
+  const attachmentNamespace = createHash("sha256")
+    .update(`${storageKind}:${getSandboxAttachmentIdentity(part)}`)
+    .digest("hex");
+  return `${uploadBasePath.replace(/\/+$/, "")}/${attachmentNamespace}/${sanitizedName}`;
+};
+
+const getLegacySandboxAttachmentLocalPath = (
+  uploadBasePath: string,
+  sanitizedName: string,
+): string => `${uploadBasePath.replace(/\/+$/, "")}/${sanitizedName}`;
 
 export const sanitizeFilenameForTerminal = (filename: string): string => {
   const basename = filename.split(/[/\\]/g).pop() ?? "file";
@@ -356,6 +401,7 @@ export const collectSandboxFiles = (
 ): void => {
   const lastUserIdx = getLastUserMessageIndex(updatedMessages);
   if (lastUserIdx === -1) return;
+  const queuedPaths = new Set(sandboxFiles.map((file) => file.localPath));
 
   updatedMessages.forEach((msg, i) => {
     if (msg.role !== "user" || !msg.parts) return;
@@ -374,15 +420,31 @@ export const collectSandboxFiles = (
         const sanitizedName = sanitizeFilenameForTerminal(
           part.name || part.filename || "file",
         );
-        const localPath = `${uploadBasePath}/${sanitizedName}`;
-        if (i === lastUserIdx) {
+        const localPath = getSandboxAttachmentLocalPath(
+          uploadBasePath,
+          sanitizedName,
+          part,
+        );
+        if (i === lastUserIdx && !queuedPaths.has(localPath)) {
+          queuedPaths.add(localPath);
           sandboxFiles.push({
             kind: "localPath",
             path: part.localPath,
             localPath,
           });
         }
-        tags.push(formatSandboxAttachmentTag(sanitizedName, localPath));
+        tags.push(
+          formatSandboxAttachmentTag(
+            sanitizedName,
+            localPath,
+            i === lastUserIdx
+              ? undefined
+              : getLegacySandboxAttachmentLocalPath(
+                  uploadBasePath,
+                  sanitizedName,
+                ),
+          ),
+        );
         return;
       }
 
@@ -390,9 +452,14 @@ export const collectSandboxFiles = (
         const sanitizedName = sanitizeFilenameForTerminal(
           part.name || part.filename || "file",
         );
-        const localPath = `${uploadBasePath}/${sanitizedName}`;
+        const localPath = getSandboxAttachmentLocalPath(
+          uploadBasePath,
+          sanitizedName,
+          part,
+        );
 
-        if (i === lastUserIdx) {
+        if (i === lastUserIdx && !queuedPaths.has(localPath)) {
+          queuedPaths.add(localPath);
           sandboxFiles.push({ kind: "url", url: part.url, localPath });
         }
         tags.push(
@@ -400,6 +467,12 @@ export const collectSandboxFiles = (
             options.getAttachmentTagKind?.(part) ?? "attachment",
             sanitizedName,
             localPath,
+            i === lastUserIdx
+              ? undefined
+              : getLegacySandboxAttachmentLocalPath(
+                  uploadBasePath,
+                  sanitizedName,
+                ),
           ),
         );
       }
@@ -484,6 +557,7 @@ export const prepareLocalDesktopAttachmentsForTrigger = (
   ) as UIMessage[];
   const sandboxFiles: SandboxFile[] = [];
   const lastUserIdx = getLastUserMessageIndex(messages);
+  const queuedPaths = new Set<string>();
 
   messages.forEach((message, messageIndex) => {
     if (message.role !== "user" || !message.parts) return;
@@ -500,15 +574,31 @@ export const prepareLocalDesktopAttachmentsForTrigger = (
       const sanitizedName = sanitizeFilenameForTerminal(
         part.name || part.filename || "file",
       );
-      const localPath = `${uploadBasePath}/${sanitizedName}`;
-      if (messageIndex === lastUserIdx) {
+      const localPath = getSandboxAttachmentLocalPath(
+        uploadBasePath,
+        sanitizedName,
+        part,
+      );
+      if (messageIndex === lastUserIdx && !queuedPaths.has(localPath)) {
+        queuedPaths.add(localPath);
         sandboxFiles.push({
           kind: "localPath",
           path: part.localPath,
           localPath,
         });
       }
-      tags.push(formatSandboxAttachmentTag(sanitizedName, localPath));
+      tags.push(
+        formatSandboxAttachmentTag(
+          sanitizedName,
+          localPath,
+          messageIndex === lastUserIdx
+            ? undefined
+            : getLegacySandboxAttachmentLocalPath(
+                uploadBasePath,
+                sanitizedName,
+              ),
+        ),
+      );
     });
 
     if (tags.length > 0) {


### PR DESCRIPTION
## Summary

- stage each Agent attachment under a deterministic identity namespace while preserving its sanitized display filename
- avoid duplicate concurrent writes when repeated attachment parts resolve to the same destination
- give historical model-facing attachment tags a legacy flat-path fallback for continued chats on reused sandboxes, without using that collision-prone path for new uploads
- cover cloud, desktop, current, historical, and attachment-tag behavior with regression tests

## Validation

- `corepack pnpm exec jest --runInBand` — 413 suites, 4,137 tests passed
- `corepack pnpm run typecheck`
- scoped ESLint and Prettier checks
- `git diff --check`

## Manual verification

1. In Agent mode, attach two different files with the same filename and confirm both receive distinct sandbox paths and remain readable.
2. Continue a chat containing an older attachment and confirm its generated tag prefers the identity-namespaced path while retaining the legacy fallback only for a missing primary path.
3. Repeat with the HackerAI Desktop sandbox and confirm the local source path is not exposed to the model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented attachments with identical filenames from overwriting one another.
  - Improved attachment handling for desktop uploads and previously stored files.
  - Preserved compatibility with attachments created by older versions.
  - Prevented duplicate files from being added to upload queues.
- **Tests**
  - Expanded coverage for attachment naming, collision prevention, legacy fallback behavior, and invalid or oversized files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->