### PR TITLE
Fix local runner relay readiness and fallback

### DIFF
--- a/app/components/SandboxSelector.tsx
+++ b/app/components/SandboxSelector.tsx
@@ -34,6 +34,7 @@ interface ConnectionOption {
   label: string;
   shortLabel: string;
   icon: typeof Cloud;
+  disabled?: boolean;
 }
 
 export function SandboxSelector({
@@ -69,15 +70,19 @@ export function SandboxSelector({
         ? "Local reconnecting"
         : "Local unavailable"
       : "Local";
-  const desktopOptions: ConnectionOption[] =
-    connections
-      ?.filter((conn) => conn.isDesktop)
-      .map(() => ({
-        id: "desktop" as string,
-        label: desktopLabel,
-        shortLabel: desktopLabel,
-        icon: Monitor,
-      })) || [];
+  const desktopConnection = connections?.find((conn) => conn.isDesktop);
+  const desktopIsSelectable = !isTauri || desktopBridgeStatus === "connected";
+  const desktopOptions: ConnectionOption[] = desktopConnection
+    ? [
+        {
+          id: "desktop",
+          label: desktopLabel,
+          shortLabel: desktopLabel,
+          icon: Monitor,
+          disabled: !desktopIsSelectable,
+        },
+      ]
+    : [];
   const remoteOptions: ConnectionOption[] =
     connections
       ?.filter((conn) => !conn.isDesktop)
@@ -115,13 +120,33 @@ export function SandboxSelector({
     }
   }, [connections, valueMatchesOption, value, onChange, isFreeUser]);
 
-  // Auto-select first local option for free users who default to Cloud
+  // Keep free users on a usable local connection. A stale Desktop presence can
+  // outlive the embedded bridge, so prefer a healthy remote runner while the
+  // bridge reconnects instead of repeatedly selecting the unavailable bridge.
   useEffect(() => {
-    if (!isFreeUser || value !== "e2b" || !connections?.length) return;
-    const desktop = connections.find((c) => c.isDesktop);
-    onChange?.(desktop ? "desktop" : connections[0].connectionId);
+    if (!isFreeUser || !connections?.length) return;
+
+    const firstRemote = connections.find((connection) => !connection.isDesktop);
+    const preferredLocal =
+      desktopConnection && desktopIsSelectable
+        ? "desktop"
+        : firstRemote?.connectionId;
+    if (!preferredLocal) return;
+
+    const desktopUnavailable =
+      isTauri && value === "desktop" && !desktopIsSelectable;
+    if (value === "e2b" || desktopUnavailable) {
+      onChange?.(preferredLocal);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFreeUser, value, connections]);
+  }, [
+    isFreeUser,
+    value,
+    connections,
+    desktopConnection,
+    desktopIsSelectable,
+    isTauri,
+  ]);
 
   const unavailableLocalOption: ConnectionOption | null =
     value !== "e2b" && !valueMatchesOption
@@ -216,14 +241,18 @@ export function SandboxSelector({
             return (
               <button
                 key={option.id}
+                disabled={option.disabled}
                 onClick={() => {
+                  if (option.disabled) return;
                   onChange?.(option.id);
                   setOpen(false);
                 }}
                 className={`w-full flex items-center gap-2.5 p-2 rounded-md text-left transition-colors ${
-                  value === option.id
-                    ? "bg-accent text-accent-foreground"
-                    : "hover:bg-muted"
+                  option.disabled
+                    ? "opacity-60 cursor-not-allowed"
+                    : value === option.id
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-muted"
                 }`}
               >
                 <OptionIcon className="h-4 w-4 shrink-0" />

--- a/app/components/SandboxSelector.tsx
+++ b/app/components/SandboxSelector.tsx
@@ -52,8 +52,6 @@ export function SandboxSelector({
     desktopBridgeStatus,
   } = useGlobalState();
   const isFreeUser = subscription === "free";
-  const [onlineRemoteConnectionIds, setOnlineRemoteConnectionIds] =
-    useState<Set<string> | null>(null);
 
   const detectedPlatform = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -101,6 +99,21 @@ export function SandboxSelector({
     isTauri &&
     desktopBridgeStatus !== "connected" &&
     remoteConnections.length > 0;
+  const remotePresenceRequest = useMemo(
+    () => ({
+      enabled: shouldVerifyRemotePresence,
+      connectionIds: remoteConnectionIds,
+    }),
+    [remoteConnectionIds, shouldVerifyRemotePresence],
+  );
+  const [remotePresence, setRemotePresence] = useState<{
+    request: typeof remotePresenceRequest;
+    onlineConnectionIds: Set<string>;
+  } | null>(null);
+  const onlineRemoteConnectionIds =
+    remotePresence?.request === remotePresenceRequest
+      ? remotePresence.onlineConnectionIds
+      : null;
   const liveRemoteConnections = useMemo(
     () =>
       shouldVerifyRemotePresence && onlineRemoteConnectionIds
@@ -124,13 +137,9 @@ export function SandboxSelector({
   // subscribed. Confirm live Centrifugo presence before automatically choosing
   // a remote runner over a reconnecting embedded bridge.
   useEffect(() => {
-    if (!shouldVerifyRemotePresence) {
-      setOnlineRemoteConnectionIds(null);
-      return;
-    }
+    if (!remotePresenceRequest.enabled) return;
 
     let cancelled = false;
-    setOnlineRemoteConnectionIds(null);
     fetch("/api/sandbox/presence")
       .then((response) => {
         if (!response.ok) throw new Error("Presence check failed");
@@ -140,8 +149,9 @@ export function SandboxSelector({
       })
       .then((presence) => {
         if (cancelled) return;
-        setOnlineRemoteConnectionIds(
-          new Set(
+        setRemotePresence({
+          request: remotePresenceRequest,
+          onlineConnectionIds: new Set(
             (presence.connections ?? [])
               .filter(
                 (connection) =>
@@ -150,7 +160,7 @@ export function SandboxSelector({
               )
               .map((connection) => connection.connectionId as string),
           ),
-        );
+        });
       })
       .catch(() => {
         // Keep the remote options visible for manual selection, but do not
@@ -160,7 +170,7 @@ export function SandboxSelector({
     return () => {
       cancelled = true;
     };
-  }, [shouldVerifyRemotePresence, remoteConnectionIds]);
+  }, [remotePresenceRequest]);
 
   // Trigger presence cleanup when dropdown opens
   useEffect(() => {

--- a/app/components/SandboxSelector.tsx
+++ b/app/components/SandboxSelector.tsx
@@ -52,6 +52,8 @@ export function SandboxSelector({
     desktopBridgeStatus,
   } = useGlobalState();
   const isFreeUser = subscription === "free";
+  const [onlineRemoteConnectionIds, setOnlineRemoteConnectionIds] =
+    useState<Set<string> | null>(null);
 
   const detectedPlatform = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -83,16 +85,82 @@ export function SandboxSelector({
         },
       ]
     : [];
-  const remoteOptions: ConnectionOption[] =
-    connections
-      ?.filter((conn) => !conn.isDesktop)
-      .map((conn) => ({
-        id: conn.connectionId,
-        label: conn.osInfo?.hostname || conn.name,
-        shortLabel: conn.osInfo?.hostname || conn.name,
-        icon: Laptop,
-      })) || [];
+  const remoteConnections = useMemo(
+    () => connections?.filter((conn) => !conn.isDesktop) ?? [],
+    [connections],
+  );
+  const remoteConnectionIds = useMemo(
+    () =>
+      remoteConnections
+        .map((connection) => connection.connectionId)
+        .sort()
+        .join(","),
+    [remoteConnections],
+  );
+  const shouldVerifyRemotePresence =
+    isTauri &&
+    desktopBridgeStatus !== "connected" &&
+    remoteConnections.length > 0;
+  const liveRemoteConnections = useMemo(
+    () =>
+      shouldVerifyRemotePresence && onlineRemoteConnectionIds
+        ? remoteConnections.filter((connection) =>
+            onlineRemoteConnectionIds.has(connection.connectionId),
+          )
+        : remoteConnections,
+    [onlineRemoteConnectionIds, remoteConnections, shouldVerifyRemotePresence],
+  );
+  const remoteOptions: ConnectionOption[] = liveRemoteConnections.map(
+    (conn) => ({
+      id: conn.connectionId,
+      label: conn.osInfo?.hostname || conn.name,
+      shortLabel: conn.osInfo?.hostname || conn.name,
+      icon: Laptop,
+    }),
+  );
   const options = [cloudOption, ...desktopOptions, ...remoteOptions];
+
+  // A connected Convex row can briefly exist before the command relay has
+  // subscribed. Confirm live Centrifugo presence before automatically choosing
+  // a remote runner over a reconnecting embedded bridge.
+  useEffect(() => {
+    if (!shouldVerifyRemotePresence) {
+      setOnlineRemoteConnectionIds(null);
+      return;
+    }
+
+    let cancelled = false;
+    setOnlineRemoteConnectionIds(null);
+    fetch("/api/sandbox/presence")
+      .then((response) => {
+        if (!response.ok) throw new Error("Presence check failed");
+        return response.json() as Promise<{
+          connections?: Array<{ connectionId?: string; online?: boolean }>;
+        }>;
+      })
+      .then((presence) => {
+        if (cancelled) return;
+        setOnlineRemoteConnectionIds(
+          new Set(
+            (presence.connections ?? [])
+              .filter(
+                (connection) =>
+                  connection.online &&
+                  typeof connection.connectionId === "string",
+              )
+              .map((connection) => connection.connectionId as string),
+          ),
+        );
+      })
+      .catch(() => {
+        // Keep the remote options visible for manual selection, but do not
+        // auto-select one without authoritative presence.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldVerifyRemotePresence, remoteConnectionIds]);
 
   // Trigger presence cleanup when dropdown opens
   useEffect(() => {
@@ -126,7 +194,11 @@ export function SandboxSelector({
   useEffect(() => {
     if (!isFreeUser || !connections?.length) return;
 
-    const firstRemote = connections.find((connection) => !connection.isDesktop);
+    const firstRemote = shouldVerifyRemotePresence
+      ? onlineRemoteConnectionIds
+        ? liveRemoteConnections[0]
+        : undefined
+      : remoteConnections[0];
     const preferredLocal =
       desktopConnection && desktopIsSelectable
         ? "desktop"
@@ -146,6 +218,10 @@ export function SandboxSelector({
     desktopConnection,
     desktopIsSelectable,
     isTauri,
+    shouldVerifyRemotePresence,
+    onlineRemoteConnectionIds,
+    liveRemoteConnections,
+    remoteConnections,
   ]);
 
   const unavailableLocalOption: ConnectionOption | null =

--- a/app/components/__tests__/SandboxSelector.test.tsx
+++ b/app/components/__tests__/SandboxSelector.test.tsx
@@ -12,6 +12,10 @@ const mockGlobalState = {
   }>,
   desktopBridgeStatus: "connecting",
 };
+let mockPresenceConnections: Array<{
+  connectionId: string;
+  online: boolean;
+}> = [];
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => mockGlobalState,
@@ -37,6 +41,11 @@ describe("SandboxSelector", () => {
     mockGlobalState.subscription = "free";
     mockGlobalState.localConnections = [];
     mockGlobalState.desktopBridgeStatus = "connecting";
+    mockPresenceConnections = [];
+    global.fetch = jest.fn().mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({ connections: mockPresenceConnections }),
+    })) as typeof fetch;
   });
 
   it("shows Local reconnecting instead of Cloud while Desktop reconnects", () => {
@@ -61,6 +70,7 @@ describe("SandboxSelector", () => {
   });
 
   it("shows the selected remote runner when it is connected", () => {
+    mockGlobalState.desktopBridgeStatus = "connected";
     mockGlobalState.localConnections = [
       {
         connectionId: "remote-kali",
@@ -86,10 +96,43 @@ describe("SandboxSelector", () => {
         osInfo: { hostname: "4p3x" },
       },
     ];
+    mockPresenceConnections = [
+      { connectionId: "stale-desktop", online: false },
+      { connectionId: "remote-kali", online: true },
+    ];
 
     render(<SandboxSelector value="desktop" onChange={onChange} />);
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith("remote-kali"));
+  });
+
+  it("does not select a remote runner without live relay presence", async () => {
+    const onChange = jest.fn();
+    mockGlobalState.localConnections = [
+      { connectionId: "stale-desktop", isDesktop: true },
+      {
+        connectionId: "remote-kali",
+        isDesktop: false,
+        name: "Kali VM",
+        osInfo: { hostname: "4p3x" },
+      },
+    ];
+    mockPresenceConnections = [
+      { connectionId: "stale-desktop", online: false },
+      { connectionId: "remote-kali", online: false },
+    ];
+
+    render(<SandboxSelector value="desktop" onChange={onChange} />);
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/sandbox/presence"),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /4p3x/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(onChange).not.toHaveBeenCalledWith("remote-kali");
   });
 
   it("does not auto-select a reconnecting embedded bridge", async () => {

--- a/app/components/__tests__/SandboxSelector.test.tsx
+++ b/app/components/__tests__/SandboxSelector.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
 const mockGlobalState = {
@@ -73,5 +73,46 @@ describe("SandboxSelector", () => {
     render(<SandboxSelector value="remote-kali" />);
 
     expect(screen.getByRole("button", { name: /4p3x/i })).toBeInTheDocument();
+  });
+
+  it("selects a healthy remote runner while the embedded bridge reconnects", async () => {
+    const onChange = jest.fn();
+    mockGlobalState.localConnections = [
+      { connectionId: "stale-desktop", isDesktop: true },
+      {
+        connectionId: "remote-kali",
+        isDesktop: false,
+        name: "Kali VM",
+        osInfo: { hostname: "4p3x" },
+      },
+    ];
+
+    render(<SandboxSelector value="desktop" onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith("remote-kali"));
+  });
+
+  it("does not auto-select a reconnecting embedded bridge", async () => {
+    const onChange = jest.fn();
+    mockGlobalState.localConnections = [
+      { connectionId: "stale-desktop", isDesktop: true },
+    ];
+
+    render(<SandboxSelector value="e2b" onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).not.toHaveBeenCalled());
+  });
+
+  it("continues to prefer a connected embedded bridge", async () => {
+    const onChange = jest.fn();
+    mockGlobalState.desktopBridgeStatus = "connected";
+    mockGlobalState.localConnections = [
+      { connectionId: "desktop-connection", isDesktop: true },
+      { connectionId: "remote-kali", isDesktop: false, name: "Kali VM" },
+    ];
+
+    render(<SandboxSelector value="e2b" onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith("desktop"));
   });
 });

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -24,9 +24,11 @@ const mockClient = {
   ready: jest.fn().mockResolvedValue(undefined),
 };
 let mockClientOptions: { getToken?: () => Promise<string> } | null = null;
+let mockClientEndpoint: unknown = null;
 
 jest.mock("centrifuge", () => ({
-  Centrifuge: jest.fn().mockImplementation((_, options) => {
+  Centrifuge: jest.fn().mockImplementation((endpoint, options) => {
+    mockClientEndpoint = endpoint;
     mockClientOptions = options;
     return mockClient;
   }),
@@ -119,6 +121,7 @@ function getPublicationHandler(): (ctx: { data: unknown }) => void {
 beforeEach(() => {
   jest.clearAllMocks();
   capturedChannel = null;
+  mockClientEndpoint = null;
   mockClientOptions = null;
   global.fetch = originalFetch;
 
@@ -165,6 +168,16 @@ it("waits for the relay and subscription before reporting ready", async () => {
   await bridge.start();
   await Promise.resolve();
 
+  expect(mockClientEndpoint).toEqual([
+    {
+      transport: "websocket",
+      endpoint: "ws://localhost:8000/connection/websocket",
+    },
+    {
+      transport: "http_stream",
+      endpoint: "http://localhost:8000/connection/http_stream",
+    },
+  ]);
   expect(mockClient.ready).toHaveBeenCalledWith(15_000);
   expect(mockSubscription.ready).toHaveBeenCalledWith(15_000);
   expect(config.heartbeatDesktop).toHaveBeenCalledWith({

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -23,7 +23,10 @@ const mockClient = {
   on: jest.fn(),
   ready: jest.fn().mockResolvedValue(undefined),
 };
-let mockClientOptions: { getToken?: () => Promise<string> } | null = null;
+let mockClientOptions: {
+  getToken?: () => Promise<string>;
+  emulationEndpoint?: string;
+} | null = null;
 let mockClientEndpoint: unknown = null;
 
 jest.mock("centrifuge", () => ({
@@ -178,6 +181,9 @@ it("waits for the relay and subscription before reporting ready", async () => {
       endpoint: "http://localhost:8000/connection/http_stream",
     },
   ]);
+  expect(mockClientOptions?.emulationEndpoint).toBe(
+    "http://localhost:8000/emulation",
+  );
   expect(mockClient.ready).toHaveBeenCalledWith(15_000);
   expect(mockSubscription.ready).toHaveBeenCalledWith(15_000);
   expect(config.heartbeatDesktop).toHaveBeenCalledWith({

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -22,7 +22,7 @@ import {
   DEFAULT_PTY_ROWS,
 } from "@/lib/ai/tools/utils/pty-session-manager";
 import { CentrifugoPublishQueue } from "@/packages/local/src/centrifugo-transport";
-import { buildCentrifugoTransportEndpoints } from "@/packages/local/src/centrifugo-endpoints";
+import { buildCentrifugoTransportConfig } from "@/packages/local/src/centrifugo-endpoints";
 import { LOCAL_SANDBOX_HEARTBEAT_INTERVAL_MS } from "@/lib/centrifugo/presence";
 
 type RefreshTokenResult =
@@ -359,9 +359,10 @@ export class DesktopSandboxBridge {
 
     this.connectionId = connectionId;
 
-    const relayEndpoints = buildCentrifugoTransportEndpoints(centrifugoWsUrl);
-    this.client = new Centrifuge(relayEndpoints, {
+    const transportConfig = buildCentrifugoTransportConfig(centrifugoWsUrl);
+    this.client = new Centrifuge(transportConfig.endpoints, {
       token: centrifugoToken,
+      emulationEndpoint: transportConfig.emulationEndpoint,
       getToken: async () => {
         if (!this.connectionId) {
           throw new Error(

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_PTY_ROWS,
 } from "@/lib/ai/tools/utils/pty-session-manager";
 import { CentrifugoPublishQueue } from "@/packages/local/src/centrifugo-transport";
+import { buildCentrifugoTransportEndpoints } from "@/packages/local/src/centrifugo-endpoints";
 import { LOCAL_SANDBOX_HEARTBEAT_INTERVAL_MS } from "@/lib/centrifugo/presence";
 
 type RefreshTokenResult =
@@ -358,7 +359,8 @@ export class DesktopSandboxBridge {
 
     this.connectionId = connectionId;
 
-    this.client = new Centrifuge(centrifugoWsUrl, {
+    const relayEndpoints = buildCentrifugoTransportEndpoints(centrifugoWsUrl);
+    this.client = new Centrifuge(relayEndpoints, {
       token: centrifugoToken,
       getToken: async () => {
         if (!this.connectionId) {

--- a/docker/centrifugo/README.md
+++ b/docker/centrifugo/README.md
@@ -30,6 +30,10 @@ cd /opt/centrifugo
 
 Upload `config.json` from this repo (`docker/centrifugo/config.json`):
 
+The config enables bidirectional HTTP streaming as a fallback for clients whose
+network or proxy blocks WebSocket upgrades. Deploy this config and restart
+Centrifugo before publishing a local client release that uses the fallback.
+
 > Run this from your **local machine** (not the EC2 instance):
 
 ```bash

--- a/docker/centrifugo/config.json
+++ b/docker/centrifugo/config.json
@@ -19,6 +19,7 @@
   ],
   "uni_sse": true,
   "uni_http_stream": true,
+  "http_stream": true,
   "client_connection_limit": 5000,
   "internal_port": 9000
 }

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackerai/local",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "HackerAI Local Sandbox Client - Execute commands on your local machine",
   "bin": {
     "hackerai-local": "./dist/index.js"

--- a/packages/local/src/__tests__/centrifugo-endpoints.test.ts
+++ b/packages/local/src/__tests__/centrifugo-endpoints.test.ts
@@ -1,0 +1,40 @@
+import { buildCentrifugoTransportEndpoints } from "../centrifugo-endpoints";
+
+describe("buildCentrifugoTransportEndpoints", () => {
+  it("adds a secure HTTP stream fallback for a secure WebSocket endpoint", () => {
+    expect(
+      buildCentrifugoTransportEndpoints(
+        "wss://relay.example.test/connection/websocket",
+      ),
+    ).toEqual([
+      {
+        transport: "websocket",
+        endpoint: "wss://relay.example.test/connection/websocket",
+      },
+      {
+        transport: "http_stream",
+        endpoint: "https://relay.example.test/connection/http_stream",
+      },
+    ]);
+  });
+
+  it("preserves a path prefix when deriving the HTTP stream endpoint", () => {
+    expect(
+      buildCentrifugoTransportEndpoints(
+        "ws://localhost:8000/relay/connection/websocket",
+      )[1],
+    ).toEqual({
+      transport: "http_stream",
+      endpoint: "http://localhost:8000/relay/connection/http_stream",
+    });
+  });
+
+  it("rejects an endpoint that cannot safely derive the fallback", () => {
+    expect(() =>
+      buildCentrifugoTransportEndpoints("https://relay.example.test/socket"),
+    ).toThrow("must use ws:// or wss://");
+    expect(() =>
+      buildCentrifugoTransportEndpoints("wss://relay.example.test/socket"),
+    ).toThrow("must end with /websocket");
+  });
+});

--- a/packages/local/src/__tests__/centrifugo-endpoints.test.ts
+++ b/packages/local/src/__tests__/centrifugo-endpoints.test.ts
@@ -1,40 +1,52 @@
-import { buildCentrifugoTransportEndpoints } from "../centrifugo-endpoints";
+import { buildCentrifugoTransportConfig } from "../centrifugo-endpoints";
 
-describe("buildCentrifugoTransportEndpoints", () => {
+describe("buildCentrifugoTransportConfig", () => {
   it("adds a secure HTTP stream fallback for a secure WebSocket endpoint", () => {
     expect(
-      buildCentrifugoTransportEndpoints(
+      buildCentrifugoTransportConfig(
         "wss://relay.example.test/connection/websocket",
       ),
-    ).toEqual([
-      {
-        transport: "websocket",
-        endpoint: "wss://relay.example.test/connection/websocket",
-      },
-      {
-        transport: "http_stream",
-        endpoint: "https://relay.example.test/connection/http_stream",
-      },
-    ]);
+    ).toEqual({
+      endpoints: [
+        {
+          transport: "websocket",
+          endpoint: "wss://relay.example.test/connection/websocket",
+        },
+        {
+          transport: "http_stream",
+          endpoint: "https://relay.example.test/connection/http_stream",
+        },
+      ],
+      emulationEndpoint: "https://relay.example.test/emulation",
+    });
   });
 
   it("preserves a path prefix when deriving the HTTP stream endpoint", () => {
     expect(
-      buildCentrifugoTransportEndpoints(
+      buildCentrifugoTransportConfig(
         "ws://localhost:8000/relay/connection/websocket",
-      )[1],
+      ),
     ).toEqual({
-      transport: "http_stream",
-      endpoint: "http://localhost:8000/relay/connection/http_stream",
+      endpoints: [
+        {
+          transport: "websocket",
+          endpoint: "ws://localhost:8000/relay/connection/websocket",
+        },
+        {
+          transport: "http_stream",
+          endpoint: "http://localhost:8000/relay/connection/http_stream",
+        },
+      ],
+      emulationEndpoint: "http://localhost:8000/relay/emulation",
     });
   });
 
   it("rejects an endpoint that cannot safely derive the fallback", () => {
     expect(() =>
-      buildCentrifugoTransportEndpoints("https://relay.example.test/socket"),
+      buildCentrifugoTransportConfig("https://relay.example.test/socket"),
     ).toThrow("must use ws:// or wss://");
     expect(() =>
-      buildCentrifugoTransportEndpoints("wss://relay.example.test/socket"),
-    ).toThrow("must end with /websocket");
+      buildCentrifugoTransportConfig("wss://relay.example.test/socket"),
+    ).toThrow("must end with /connection/websocket");
   });
 });

--- a/packages/local/src/__tests__/local-sandbox-client-lifecycle.test.ts
+++ b/packages/local/src/__tests__/local-sandbox-client-lifecycle.test.ts
@@ -128,4 +128,69 @@ describe("LocalSandboxClient in-process cleanup", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
   });
+
+  it("does not report the local sandbox ready before relay subscription", async () => {
+    let relayStarted!: () => void;
+    const setupStarted = new Promise<void>((resolve) => {
+      relayStarted = resolve;
+    });
+    let markRelayReady!: () => void;
+    const relayReady = new Promise<void>((resolve) => {
+      markRelayReady = resolve;
+    });
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const client = new LocalSandboxClient({
+      convexUrl: "http://127.0.0.1:3210",
+      token: "test-token",
+      name: "test",
+      authMode: "local",
+    });
+    (
+      client as unknown as {
+        convexHttp: {
+          mutation: jest.Mock;
+        };
+      }
+    ).convexHttp.mutation = jest.fn().mockResolvedValue({
+      success: true,
+      userId: "user-1",
+      connectionId: "connection-1",
+      centrifugoToken: "relay-token",
+      centrifugoWsUrl: "wss://relay.example.test/connection/websocket",
+    });
+    (
+      client as unknown as {
+        setupCentrifugo: () => Promise<void>;
+        startIdleCheck: () => void;
+      }
+    ).setupCentrifugo = jest.fn(async () => {
+      relayStarted();
+      await relayReady;
+    });
+    (
+      client as unknown as {
+        startIdleCheck: () => void;
+      }
+    ).startIdleCheck = jest.fn();
+
+    const start = client.start();
+    await setupStarted;
+
+    const logsBeforeRelay = logSpy.mock.calls.flat().join("\n");
+    expect(logsBeforeRelay).toContain("✓ Authenticated");
+    expect(logsBeforeRelay).toContain("Connecting to command relay");
+    expect(logsBeforeRelay).not.toContain("Local sandbox is ready");
+
+    markRelayReady();
+    await start;
+
+    const logsAfterRelay = logSpy.mock.calls.flat().join("\n");
+    expect(logsAfterRelay).toContain("✓ Connected to command relay");
+    expect(logsAfterRelay).toContain("Local sandbox is ready");
+    expect(logsAfterRelay.indexOf("✓ Connected to command relay")).toBeLessThan(
+      logsAfterRelay.indexOf("Local sandbox is ready"),
+    );
+
+    logSpy.mockRestore();
+  });
 });

--- a/packages/local/src/centrifugo-endpoints.ts
+++ b/packages/local/src/centrifugo-endpoints.ts
@@ -1,0 +1,33 @@
+import type { TransportEndpoint } from "centrifuge";
+
+const WEBSOCKET_PATH_SUFFIX = "/websocket";
+const HTTP_STREAM_PATH_SUFFIX = "/http_stream";
+
+/**
+ * Prefer WebSocket, then fall back to Centrifugo's bidirectional HTTP stream
+ * for networks and proxies that reject the WebSocket upgrade handshake.
+ */
+export function buildCentrifugoTransportEndpoints(
+  websocketUrl: string,
+): TransportEndpoint[] {
+  const httpStreamUrl = new URL(websocketUrl);
+  if (httpStreamUrl.protocol !== "ws:" && httpStreamUrl.protocol !== "wss:") {
+    throw new Error("Centrifugo WebSocket URL must use ws:// or wss://");
+  }
+  if (!httpStreamUrl.pathname.endsWith(WEBSOCKET_PATH_SUFFIX)) {
+    throw new Error(
+      "Centrifugo WebSocket URL must end with /websocket to derive the HTTP stream endpoint",
+    );
+  }
+
+  httpStreamUrl.protocol =
+    httpStreamUrl.protocol === "wss:" ? "https:" : "http:";
+  httpStreamUrl.pathname = `${httpStreamUrl.pathname.slice(0, -WEBSOCKET_PATH_SUFFIX.length)}${HTTP_STREAM_PATH_SUFFIX}`;
+  httpStreamUrl.search = "";
+  httpStreamUrl.hash = "";
+
+  return [
+    { transport: "websocket", endpoint: websocketUrl },
+    { transport: "http_stream", endpoint: httpStreamUrl.toString() },
+  ];
+}

--- a/packages/local/src/centrifugo-endpoints.ts
+++ b/packages/local/src/centrifugo-endpoints.ts
@@ -1,33 +1,48 @@
 import type { TransportEndpoint } from "centrifuge";
 
-const WEBSOCKET_PATH_SUFFIX = "/websocket";
-const HTTP_STREAM_PATH_SUFFIX = "/http_stream";
+const WEBSOCKET_PATH_SUFFIX = "/connection/websocket";
+const HTTP_STREAM_PATH_SUFFIX = "/connection/http_stream";
+
+export interface CentrifugoTransportConfig {
+  endpoints: TransportEndpoint[];
+  emulationEndpoint: string;
+}
 
 /**
  * Prefer WebSocket, then fall back to Centrifugo's bidirectional HTTP stream
  * for networks and proxies that reject the WebSocket upgrade handshake.
  */
-export function buildCentrifugoTransportEndpoints(
+export function buildCentrifugoTransportConfig(
   websocketUrl: string,
-): TransportEndpoint[] {
+): CentrifugoTransportConfig {
   const httpStreamUrl = new URL(websocketUrl);
   if (httpStreamUrl.protocol !== "ws:" && httpStreamUrl.protocol !== "wss:") {
     throw new Error("Centrifugo WebSocket URL must use ws:// or wss://");
   }
   if (!httpStreamUrl.pathname.endsWith(WEBSOCKET_PATH_SUFFIX)) {
     throw new Error(
-      "Centrifugo WebSocket URL must end with /websocket to derive the HTTP stream endpoint",
+      "Centrifugo WebSocket URL must end with /connection/websocket to derive fallback endpoints",
     );
   }
 
+  const pathPrefix = httpStreamUrl.pathname.slice(
+    0,
+    -WEBSOCKET_PATH_SUFFIX.length,
+  );
   httpStreamUrl.protocol =
     httpStreamUrl.protocol === "wss:" ? "https:" : "http:";
-  httpStreamUrl.pathname = `${httpStreamUrl.pathname.slice(0, -WEBSOCKET_PATH_SUFFIX.length)}${HTTP_STREAM_PATH_SUFFIX}`;
+  httpStreamUrl.pathname = `${pathPrefix}${HTTP_STREAM_PATH_SUFFIX}`;
   httpStreamUrl.search = "";
   httpStreamUrl.hash = "";
 
-  return [
-    { transport: "websocket", endpoint: websocketUrl },
-    { transport: "http_stream", endpoint: httpStreamUrl.toString() },
-  ];
+  const emulationUrl = new URL(httpStreamUrl);
+  emulationUrl.pathname = `${pathPrefix}/emulation`;
+
+  return {
+    endpoints: [
+      { transport: "websocket", endpoint: websocketUrl },
+      { transport: "http_stream", endpoint: httpStreamUrl.toString() },
+    ],
+    emulationEndpoint: emulationUrl.toString(),
+  };
 }

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -36,6 +36,7 @@ import {
   isProcessTreeTerminationConfirmed,
 } from "./command-cancellation";
 import { CentrifugoPublishQueue } from "./centrifugo-transport";
+import { buildCentrifugoTransportEndpoints } from "./centrifugo-endpoints";
 import {
   CloudImagePrimeError,
   primeCloudImageWorkingSet,
@@ -314,6 +315,7 @@ export class LocalSandboxClient {
   private publishQueue?: CentrifugoPublishQueue;
   private cleanupPromise?: Promise<void>;
   private exitRequested = false;
+  private relayTransport: string | null = null;
 
   constructor(
     private config: Config,
@@ -521,14 +523,22 @@ export class LocalSandboxClient {
 
       if (this.config.authMode === "local") {
         console.log(chalk.green("✓ Authenticated"));
-        console.log(chalk.bold(chalk.green("🎉 Local sandbox is ready!")));
-        console.log(chalk.gray(`Connection: ${this.connectionId}`));
+        console.log(chalk.blue("Connecting to command relay..."));
       }
 
       await this.setupCentrifugo(
         result.centrifugoWsUrl,
         result.centrifugoToken,
       );
+      if (this.config.authMode === "local") {
+        console.log(
+          chalk.green(
+            `✓ Connected to command relay (${this.relayTransport ?? "unknown transport"})`,
+          ),
+        );
+        console.log(chalk.bold(chalk.green("🎉 Local sandbox is ready!")));
+        console.log(chalk.gray(`Connection: ${this.connectionId}`));
+      }
       if (this.config.authMode === "cloud") {
         const ready = (await this.convexHttp.mutation(
           api.localSandbox.markCloudRelayReady as never,
@@ -573,7 +583,7 @@ export class LocalSandboxClient {
     wsUrl: string,
     initialToken: string,
   ): Promise<void> {
-    this.centrifuge = new Centrifuge(wsUrl, {
+    this.centrifuge = new Centrifuge(buildCentrifugoTransportEndpoints(wsUrl), {
       websocket: WebSocket as unknown as typeof globalThis.WebSocket,
       token: initialToken,
       getToken: async (): Promise<string> => {
@@ -694,8 +704,13 @@ export class LocalSandboxClient {
       }
     });
 
-    this.centrifuge.on("connected", () => {
-      console.log(chalk.green("✓ Connected to command relay"));
+    this.centrifuge.on("connected", (ctx) => {
+      this.relayTransport = ctx.transport;
+      if (this.config.authMode !== "local") {
+        console.log(
+          chalk.green(`✓ Connected to command relay (${ctx.transport})`),
+        );
+      }
     });
 
     const ready = new Promise<void>((resolve, reject) => {

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -36,7 +36,7 @@ import {
   isProcessTreeTerminationConfirmed,
 } from "./command-cancellation";
 import { CentrifugoPublishQueue } from "./centrifugo-transport";
-import { buildCentrifugoTransportEndpoints } from "./centrifugo-endpoints";
+import { buildCentrifugoTransportConfig } from "./centrifugo-endpoints";
 import {
   CloudImagePrimeError,
   primeCloudImageWorkingSet,
@@ -583,8 +583,10 @@ export class LocalSandboxClient {
     wsUrl: string,
     initialToken: string,
   ): Promise<void> {
-    this.centrifuge = new Centrifuge(buildCentrifugoTransportEndpoints(wsUrl), {
+    const transportConfig = buildCentrifugoTransportConfig(wsUrl);
+    this.centrifuge = new Centrifuge(transportConfig.endpoints, {
       websocket: WebSocket as unknown as typeof globalThis.WebSocket,
+      emulationEndpoint: transportConfig.emulationEndpoint,
       token: initialToken,
       getToken: async (): Promise<string> => {
         if (!this.connectionId) {


### PR DESCRIPTION
## Summary

- prefer a healthy remote local runner when the embedded Desktop bridge is reconnecting or unavailable
- keep reconnecting Desktop unavailable for selection and deduplicate stale Desktop presence rows
- report @hackerai/local as ready only after the command-relay subscription succeeds
- add WebSocket to bidirectional HTTP-stream fallback for Desktop and @hackerai/local, including selected-transport logging
- enable the Centrifugo HTTP-stream endpoint and bump @hackerai/local to 0.8.5

## Validation

- pre-commit suite: 413 suites, 4,158 tests passed
- focused relay and selector suites: 55 tests passed
- pnpm typecheck
- pnpm lint (no errors; 7 existing warnings outside this change)
- pnpm local-sandbox:build
- Prettier and git diff checks
- Centrifugo v5.4.9 checkconfig against the updated deployment config
- real Centrifugo v5.4.9 integration: deliberately unreachable WebSocket fell back to http_stream and reached connected/subscribed

## Rollout order

1. Deploy docker/centrifugo/config.json and restart Centrifugo so /connection/http_stream and /emulation are available.
2. Deploy the web app and include this change in the next Desktop release.
3. Publish @hackerai/local@0.8.5.

## Manual verification

- In the Desktop app as a free user, connect a remote runner while the embedded bridge is reconnecting; the selector should switch to the healthy remote hostname.
- Block the WebSocket upgrade while allowing HTTPS; Desktop/local should connect over http_stream and report that transport in logs.
- Start @hackerai/local and confirm Local sandbox is ready appears only after the command relay is subscribed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sandbox selection during desktop connection or reconnection by automatically choosing an available runner.
  * Added HTTP streaming fallback for local sandbox connections when WebSockets are unavailable.
  * Connection status now reports the selected relay transport.

* **Bug Fixes**
  * Prevented unavailable desktop options from being selected.
  * Avoided stale remote availability results during reconnection.
  * Preserved manual runner selection when remote checks fail.
  * Improved local sandbox readiness timing so it appears only after relay setup completes.

* **Documentation**
  * Added deployment guidance for enabling HTTP streaming fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->