### PR TITLE
Fallback when Grok 4.6 is at capacity

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -12,6 +12,7 @@ import {
   getRetryFallbackModel,
   isAutoModelSelectionForRetry,
   isExplicitDeepSeekProSelectionForRetry,
+  isProviderApiError,
   resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 
@@ -643,11 +644,66 @@ describe("isAutoModelSelectionForRetry", () => {
     ).toBe(true);
   });
 
+  it("keeps explicitly selected HackerAI Max Grok 4.6 retryable", () => {
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "model-grok-4.6",
+        selectedModelOverride: "hackerai-max",
+      }),
+    ).toBe(true);
+  });
+
   it("preserves retry behavior for legacy auto-router model keys", () => {
     expect(
       isAutoModelSelectionForRetry({
         selectedModel: "ask-model-free",
         selectedModelOverride: "hackerai-standard",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isProviderApiError", () => {
+  it("retries the xAI Grok capacity response", () => {
+    expect(
+      isProviderApiError({
+        code: 502,
+        message:
+          "The model is currently at capacity due to high demand. Please try again in a few minutes.",
+        metadata: { error_type: "provider_unavailable" },
+      }),
+    ).toBe(true);
+  });
+
+  it("retries a nested OpenRouter provider_unavailable response", () => {
+    expect(
+      isProviderApiError({
+        statusCode: 502,
+        data: {
+          error: {
+            code: 502,
+            message: "Provider unavailable",
+            metadata: { error_type: "provider_unavailable" },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry unrelated provider 5xx responses through this path", () => {
+    expect(
+      isProviderApiError({
+        statusCode: 502,
+        message: "Bad gateway",
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves invalid-argument fallback handling", () => {
+    expect(
+      isProviderApiError({
+        statusCode: 400,
+        responseBody: '{"error":"INVALID_ARGUMENT"}',
       }),
     ).toBe(true);
   });

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -57,6 +57,10 @@ import {
 } from "@/lib/extra-usage";
 import { systemPrompt } from "@/lib/system-prompt";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
+import {
+  extractErrorDetails,
+  getProviderStatusCode,
+} from "@/lib/utils/error-utils";
 
 /**
  * Check if messages contain file attachments
@@ -299,12 +303,44 @@ export function isXaiSafetyError(error: unknown): boolean {
   );
 }
 
-/**
- * Check if an error is a provider API error that should trigger fallback
- * Specifically targets provider-side invalid argument errors before streaming.
- */
+const PROVIDER_CAPACITY_ERROR_PATTERN =
+  /\bprovider_unavailable\b|\bcurrently at capacity\b|\bhigh demand\b/i;
+
+const stringifyErrorField = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+};
+
+/** Check if a pre-stream provider API error should trigger model fallback. */
 export function isProviderApiError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
+
+  const details = extractErrorDetails(error);
+  const statusCode = getProviderStatusCode(details);
+  const providerErrorText = [
+    details.errorMessage,
+    details.providerErrorMessage,
+    details.providerRawError,
+    details.responseBody,
+    details.providerData,
+  ]
+    .map(stringifyErrorField)
+    .join(" ");
+
+  // xAI returns this when Grok is temporarily saturated. It is safe to retry
+  // with the configured fallback because the request never produced output.
+  if (
+    statusCode != null &&
+    statusCode >= 500 &&
+    PROVIDER_CAPACITY_ERROR_PATTERN.test(providerErrorText)
+  ) {
+    return true;
+  }
 
   const err = error as {
     statusCode?: number;
@@ -593,7 +629,10 @@ const AUTO_MODEL_KEYS = new Set<string>([
   "agent-model",
   "agent-model-free",
 ]);
-const EXPLICIT_RETRY_MODEL_KEYS = new Set<string>(["model-grok-4.6-pro"]);
+const EXPLICIT_RETRY_MODEL_KEYS = new Set<string>([
+  "model-grok-4.6",
+  "model-grok-4.6-pro",
+]);
 const EXPLICIT_DEEPSEEK_PRO_RETRY_MODEL_KEYS = new Set<string>([
   "model-deepseek-v4-pro",
   "model-deepseek-v4-pro-0813",


### PR DESCRIPTION
## Summary
- classify xAI/OpenRouter capacity responses as fallback-eligible provider errors
- allow explicitly selected HackerAI Max Grok 4.6 requests to use the existing bounded Kimi K3 retry
- cover direct xAI and nested OpenRouter error shapes

## Validation
- `corepack pnpm exec jest lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand` (109 passed)
- focused ESLint passed
- Prettier and dependency-link guard passed
- full local typecheck could not complete because the shared host killed it for memory usage; CI is the merge gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of provider capacity errors so eligible requests can be retried automatically.
  * Added retry support for the explicitly selected HackerAI Max Grok 4.6 model.
  * Preserved existing handling for invalid-argument errors and prevented unrelated server errors from being treated as retryable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->