### PR TITLE
Recover agent streams after provider disconnects

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -1,6 +1,7 @@
 import {
   AUXILIARY_VISION_SLUG,
   createOpenRouterPatchFetch,
+  enrichOpenRouterStreamError,
   getModelCutoffDate,
   getModelDisplayName,
   isAnthropicModel,
@@ -78,6 +79,23 @@ const parserErrorResponse = (message: string) =>
       headers: { "content-type": "application/json" },
     },
   );
+
+describe("enrichOpenRouterStreamError", () => {
+  it("attaches response IDs to body errors that happen after headers", () => {
+    expect(
+      enrichOpenRouterStreamError(new Error("Network connection lost."), {
+        "x-generation-id": "gen-header-1",
+        "x-request-id": "req-header-1",
+      }),
+    ).toMatchObject({
+      message: "Network connection lost.",
+      responseHeaders: expect.objectContaining({
+        "x-generation-id": "gen-header-1",
+        "x-request-id": "req-header-1",
+      }),
+    });
+  });
+});
 
 describe("provider registry", () => {
   it("keeps active routes pointed at their provider slugs", () => {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -371,7 +371,7 @@ export const enrichOpenRouterStreamError = (
 export const attachOpenRouterStreamErrorMetadata = (
   response: Response,
 ): Response => {
-  if (!response.body) return response;
+  if (!response.ok || !response.body) return response;
 
   const reader = response.body.getReader();
   const responseHeaders = Object.fromEntries(response.headers.entries());

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -131,7 +131,7 @@ const patchKimiReasoningToolCalls = (
     : { body, changed: false };
 };
 
-const OPENROUTER_METADATA_HEADER = "X-OpenRouter-Experimental-Metadata";
+const OPENROUTER_METADATA_HEADER = "X-OpenRouter-Metadata";
 
 const withOpenRouterMetadataHeader = (
   headers: HeadersInit | undefined,
@@ -346,6 +346,60 @@ const logPdfParserRecovery = (
   );
 };
 
+/** Attach response headers to body-stream failures for later attribution. */
+export const enrichOpenRouterStreamError = (
+  error: unknown,
+  responseHeaders: Record<string, string>,
+): Error & { responseHeaders: Record<string, string> } => {
+  const enriched =
+    error instanceof Error
+      ? error
+      : new Error(
+          typeof error === "string" ? error : "OpenRouter stream failed",
+        );
+  try {
+    return Object.assign(enriched, { responseHeaders });
+  } catch {
+    return Object.assign(new Error(enriched.message, { cause: error }), {
+      name: enriched.name,
+      responseHeaders,
+    });
+  }
+};
+
+/** Retain response IDs when the response body fails after headers arrived. */
+export const attachOpenRouterStreamErrorMetadata = (
+  response: Response,
+): Response => {
+  if (!response.body) return response;
+
+  const reader = response.body.getReader();
+  const responseHeaders = Object.fromEntries(response.headers.entries());
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        controller.error(enrichOpenRouterStreamError(error, responseHeaders));
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+};
+
 // Custom fetch for OpenRouter provider-specific request-body repairs.
 //
 // - Kimi requires a `reasoning` field on assistant tool-call messages when
@@ -380,21 +434,27 @@ export const createOpenRouterPatchFetch =
 
     const initialResponse = await fetchImplementation(url, nextInit);
     const parserFailure = await classifyPdfParserFailure(initialResponse);
-    if (!parserFailure) return initialResponse;
+    if (!parserFailure) {
+      return attachOpenRouterStreamErrorMetadata(initialResponse);
+    }
 
     if (requestUsesPdfParserEngine(parsedRequestBody, "cloudflare-ai")) {
       const sandboxBody = createSandboxPdfRecoveryBody(parsedRequestBody);
-      if (!sandboxBody.changed) return initialResponse;
+      if (!sandboxBody.changed) {
+        return attachOpenRouterStreamErrorMetadata(initialResponse);
+      }
 
       logPdfParserRecovery("cloudflare-ai", "sandbox", parserFailure);
       const sandboxResponse = await fetchImplementation(url, {
         ...nextInit,
         body: JSON.stringify(sandboxBody.body),
       });
-      return withPrivateResponseHeader(
-        sandboxResponse,
-        PDF_PARSER_RECOVERY_HEADER,
-        "sandbox",
+      return attachOpenRouterStreamErrorMetadata(
+        withPrivateResponseHeader(
+          sandboxResponse,
+          PDF_PARSER_RECOVERY_HEADER,
+          "sandbox",
+        ),
       );
     }
 
@@ -403,7 +463,9 @@ export const createOpenRouterPatchFetch =
       "mistral-ocr",
       "cloudflare-ai",
     );
-    if (!cloudflareBody.changed) return initialResponse;
+    if (!cloudflareBody.changed) {
+      return attachOpenRouterStreamErrorMetadata(initialResponse);
+    }
 
     logPdfParserRecovery("mistral-ocr", "cloudflare-ai", parserFailure);
     const cloudflareResponse = await fetchImplementation(url, {
@@ -413,25 +475,31 @@ export const createOpenRouterPatchFetch =
     const cloudflareFailure =
       await classifyPdfParserFailure(cloudflareResponse);
     if (!cloudflareFailure) {
-      return withPrivateResponseHeader(
-        cloudflareResponse,
-        PDF_PARSER_ENGINE_HEADER,
-        "cloudflare-ai",
+      return attachOpenRouterStreamErrorMetadata(
+        withPrivateResponseHeader(
+          cloudflareResponse,
+          PDF_PARSER_ENGINE_HEADER,
+          "cloudflare-ai",
+        ),
       );
     }
 
     const sandboxBody = createSandboxPdfRecoveryBody(cloudflareBody.body);
-    if (!sandboxBody.changed) return cloudflareResponse;
+    if (!sandboxBody.changed) {
+      return attachOpenRouterStreamErrorMetadata(cloudflareResponse);
+    }
 
     logPdfParserRecovery("cloudflare-ai", "sandbox", cloudflareFailure);
     const sandboxResponse = await fetchImplementation(url, {
       ...nextInit,
       body: JSON.stringify(sandboxBody.body),
     });
-    return withPrivateResponseHeader(
-      sandboxResponse,
-      PDF_PARSER_RECOVERY_HEADER,
-      "sandbox",
+    return attachOpenRouterStreamErrorMetadata(
+      withPrivateResponseHeader(
+        sandboxResponse,
+        PDF_PARSER_RECOVERY_HEADER,
+        "sandbox",
+      ),
     );
   };
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1275,14 +1275,14 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(returnIdx).toBeGreaterThan(handledRateLimitIdx);
   });
 
-  test("non-rate-limit stream errors are still rethrown after the handled branch", () => {
+  test("non-rate-limit stream errors are wrapped with provider attribution after the handled branch", () => {
     const streamErrorIdx = taskSrc.indexOf("if (terminalStreamError)");
     const handledRateLimitIdx = taskSrc.indexOf(
       "isHandledUserRateLimitError(terminalStreamError)",
       streamErrorIdx,
     );
     const throwIdx = taskSrc.indexOf(
-      "throw terminalStreamError",
+      "throw wrapProviderTerminalError(terminalStreamError",
       handledRateLimitIdx,
     );
     expect(streamErrorIdx).toBeGreaterThan(-1);
@@ -1297,7 +1297,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       waitIdx,
     );
     const throwIdx = taskSrc.indexOf(
-      "throw terminalStreamError",
+      "throw wrapProviderTerminalError(terminalStreamError",
       terminalErrorIdx,
     );
 
@@ -1356,6 +1356,21 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(terminalHelperIdx).toBeGreaterThan(-1);
     expect(contentFilterIdx).toBeGreaterThan(terminalHelperIdx);
     expect(terminalCheckIdx).toBeGreaterThan(contentFilterIdx);
+  });
+
+  test("mid-stream disconnect continuation is bounded and preserves a replay-safe transcript", () => {
+    expect(taskSrc).toMatch(
+      /prepareProviderDisconnectContinuation\(\s*normalizedFinishedMessages/,
+    );
+    expect(taskSrc).toMatch(
+      /shouldContinueAfterProviderDisconnect\)\s*&&\s*!isRetryWithFallback/,
+    );
+    expect(taskSrc).toMatch(
+      /state\.finalMessages\s*=\s*\[\s*\.\.\.state\.finalMessages,\s*\.\.\.providerDisconnectContinuation\.messages/,
+    );
+    expect(taskSrc).toContain(
+      "Do not repeat completed tool calls or their side effects.",
+    );
   });
 
   test("direct context-limit finish reasons trigger auto-continue in both agent paths", () => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1363,6 +1363,9 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       /prepareProviderDisconnectContinuation\(\s*normalizedFinishedMessages/,
     );
     expect(taskSrc).toMatch(
+      /hasTerminalProviderStreamError\s*&&\s*isRetriableProviderStreamDisconnectError\(\s*state\.providerError/,
+    );
+    expect(taskSrc).toMatch(
       /shouldContinueAfterProviderDisconnect\)\s*&&\s*!isRetryWithFallback/,
     );
     expect(taskSrc).toMatch(
@@ -1371,6 +1374,48 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toContain(
       "Do not repeat completed tool calls or their side effects.",
     );
+  });
+
+  test("persists replay-safe output before fallback stream creation can fail", () => {
+    const recoveryIdx = taskSrc.indexOf(
+      "if (providerDisconnectContinuation) {",
+      taskSrc.indexOf("state.finalMessages ="),
+    );
+    const persistenceIdx = taskSrc.indexOf("await saveMessage({", recoveryIdx);
+    const fallbackCreationIdx = taskSrc.indexOf(
+      "const retryResult = await createStream(",
+      persistenceIdx,
+    );
+
+    expect(recoveryIdx).toBeGreaterThan(-1);
+    expect(persistenceIdx).toBeGreaterThan(recoveryIdx);
+    expect(fallbackCreationIdx).toBeGreaterThan(persistenceIdx);
+  });
+
+  test("looks up generation attribution only after failure cleanup and outside interactive chat", () => {
+    const onErrorIdx = agentStreamRunnerSrc.indexOf("onError: async");
+    const refundIdx = agentStreamRunnerSrc.indexOf(
+      "ctx.usageRefundTracker.refund()",
+      onErrorIdx,
+    );
+    const closeIdx = agentStreamRunnerSrc.indexOf(
+      ".closeAll(ctx.chatId)",
+      refundIdx,
+    );
+    const lookupGuardIdx = agentStreamRunnerSrc.indexOf(
+      'ctx.endpoint !== "/api/chat"',
+      closeIdx,
+    );
+    const lookupIdx = agentStreamRunnerSrc.indexOf(
+      "await fetchOpenRouterGenerationMetadata(",
+      lookupGuardIdx,
+    );
+
+    expect(onErrorIdx).toBeGreaterThan(-1);
+    expect(refundIdx).toBeGreaterThan(onErrorIdx);
+    expect(closeIdx).toBeGreaterThan(refundIdx);
+    expect(lookupGuardIdx).toBeGreaterThan(closeIdx);
+    expect(lookupIdx).toBeGreaterThan(lookupGuardIdx);
   });
 
   test("direct context-limit finish reasons trigger auto-continue in both agent paths", () => {

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -98,6 +98,8 @@ jest.mock("@/lib/ai/tools/prompt-serialization", () => ({
 }));
 jest.mock("@/lib/api/openrouter-metadata", () => ({
   extractOpenRouterMetadata: () => ({}),
+  extractOpenRouterMetadataFromError: () => ({}),
+  fetchOpenRouterGenerationMetadata: async () => ({}),
   mergeOpenRouterMetadata: () => ({}),
 }));
 jest.mock("@/lib/provider-usage-cost", () => ({

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -1573,6 +1573,46 @@ describe("createChatLogger ChatSDKError metadata", () => {
 });
 
 describe("createChatLogger OpenRouter metadata", () => {
+  it("records request and upstream IDs for failed provider streams", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_provider_failure_metadata",
+        endpoint: "/api/agent-long",
+      });
+      const error = new Error("Network connection lost.");
+
+      chatLogger.recordProviderError(error, {
+        mode: "agent",
+        model: "model-deepseek-v4-flash-0731",
+        requestedModelSlug: "deepseek/deepseek-v4-flash-0731",
+        openRouterMetadata: {
+          provider_name: "DeepInfra",
+          openrouter_generation_id: "gen-failed",
+          openrouter_request_id: "req-failed",
+          openrouter_upstream_id: "upstream-failed",
+        },
+      });
+      chatLogger.emitUnexpectedError(error);
+
+      const warning = warnSpy.mock.calls.flat().map(String).join("\n");
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+      expect(warning).toContain('"openrouter_request_id":"req-failed"');
+      expect(warning).toContain('"openrouter_upstream_id":"upstream-failed"');
+      expect(wideEvent.provider_error).toMatchObject({
+        provider_name: "DeepInfra",
+        openrouter_generation_id: "gen-failed",
+        openrouter_request_id: "req-failed",
+        openrouter_upstream_id: "upstream-failed",
+      });
+    } finally {
+      warnSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
   it("adds provider attribution fields to the wide event model block", () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
 

--- a/lib/api/__tests__/openrouter-metadata.test.ts
+++ b/lib/api/__tests__/openrouter-metadata.test.ts
@@ -209,6 +209,23 @@ describe("OpenRouter metadata extraction", () => {
     });
   });
 
+  it("does not treat generic error payload IDs or requested models as generation attribution", () => {
+    const error = {
+      data: {
+        id: "chatcmpl-request-id",
+        model: "deepseek/deepseek-v4-flash-0731",
+        error: {
+          message: "Network connection lost.",
+          metadata: { provider_name: "DeepInfra" },
+        },
+      },
+    };
+
+    expect(extractOpenRouterMetadataFromError(error)).toEqual({
+      provider_name: "DeepInfra",
+    });
+  });
+
   it("looks up generation request and upstream IDs without exposing credentials", async () => {
     const fetchMock = jest.fn(async () => ({
       ok: true,
@@ -224,12 +241,15 @@ describe("OpenRouter metadata extraction", () => {
       }),
     }));
 
-    await expect(
-      fetchOpenRouterGenerationMetadata("gen-stream-failure", {
+    const metadata = await fetchOpenRouterGenerationMetadata(
+      "gen-stream-failure",
+      {
         apiKey: "test-secret",
-        fetch: fetchMock,
-      }),
-    ).resolves.toEqual({
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      },
+    );
+
+    expect(metadata).toEqual({
       provider_name: "DeepInfra",
       openrouter_generation_id: "gen-stream-failure",
       openrouter_request_id: "req-generation-record",
@@ -237,11 +257,66 @@ describe("OpenRouter metadata extraction", () => {
       openrouter_upstream_id: "upstream-generation-record",
       openrouter_selected_model: "deepseek/deepseek-v4-flash-0731",
     });
+    expect(JSON.stringify(metadata)).not.toContain("test-secret");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://openrouter.ai/api/v1/generation?id=gen-stream-failure",
       expect.objectContaining({
         headers: { Authorization: "Bearer test-secret" },
       }),
     );
+  });
+
+  it("retries once when a generation record is not immediately available", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            id: "gen-delayed",
+            provider_name: "Novita",
+            upstream_id: "upstream-delayed",
+          },
+        }),
+      });
+
+    await expect(
+      fetchOpenRouterGenerationMetadata("gen-delayed", {
+        apiKey: "test-secret",
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      }),
+    ).resolves.toEqual({
+      provider_name: "Novita",
+      openrouter_generation_id: "gen-delayed",
+      openrouter_upstream_id: "upstream-delayed",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs lookup failures without logging credentials", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+    try {
+      await expect(
+        fetchOpenRouterGenerationMetadata("gen-unavailable", {
+          apiKey: "test-secret",
+          fetch: fetchMock as unknown as typeof globalThis.fetch,
+        }),
+      ).resolves.toEqual({});
+      expect(warn).toHaveBeenCalledWith(
+        "[openrouter-metadata] generation lookup failed",
+        expect.objectContaining({
+          event: "openrouter_generation_lookup_failed",
+          generationId: "gen-unavailable",
+          statusCode: 503,
+          attempt: 1,
+        }),
+      );
+      expect(JSON.stringify(warn.mock.calls)).not.toContain("test-secret");
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/lib/api/__tests__/openrouter-metadata.test.ts
+++ b/lib/api/__tests__/openrouter-metadata.test.ts
@@ -1,5 +1,7 @@
 import {
   extractOpenRouterMetadata,
+  extractOpenRouterMetadataFromError,
+  fetchOpenRouterGenerationMetadata,
   mergeOpenRouterMetadata,
 } from "../openrouter-metadata";
 
@@ -176,5 +178,70 @@ describe("OpenRouter metadata extraction", () => {
       openrouter_generation_id: "gen-finish-only",
       provider_name: "Novita",
     });
+  });
+
+  it("extracts response IDs and upstream attribution from wrapped stream errors", () => {
+    const error = Object.assign(new Error("Network connection lost."), {
+      responseHeaders: {
+        "x-generation-id": "gen-stream-failure",
+        "x-request-id": "req-stream-failure",
+      },
+      data: {
+        error: {
+          code: 502,
+          message: "Network connection lost.",
+          metadata: { provider_name: "DeepInfra" },
+        },
+        openrouter_metadata: {
+          request_id: "req-router-metadata",
+          upstream_id: "upstream-deepseek-1",
+          router: "openrouter/auto",
+        },
+      },
+    });
+
+    expect(extractOpenRouterMetadataFromError(error)).toEqual({
+      provider_name: "DeepInfra",
+      openrouter_generation_id: "gen-stream-failure",
+      openrouter_request_id: "req-router-metadata",
+      openrouter_router: "openrouter/auto",
+      openrouter_upstream_id: "upstream-deepseek-1",
+    });
+  });
+
+  it("looks up generation request and upstream IDs without exposing credentials", async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: {
+          id: "gen-stream-failure",
+          provider_name: "DeepInfra",
+          request_id: "req-generation-record",
+          upstream_id: "upstream-generation-record",
+          router: "openrouter/auto",
+          model: "deepseek/deepseek-v4-flash-0731",
+        },
+      }),
+    }));
+
+    await expect(
+      fetchOpenRouterGenerationMetadata("gen-stream-failure", {
+        apiKey: "test-secret",
+        fetch: fetchMock,
+      }),
+    ).resolves.toEqual({
+      provider_name: "DeepInfra",
+      openrouter_generation_id: "gen-stream-failure",
+      openrouter_request_id: "req-generation-record",
+      openrouter_router: "openrouter/auto",
+      openrouter_upstream_id: "upstream-generation-record",
+      openrouter_selected_model: "deepseek/deepseek-v4-flash-0731",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/generation?id=gen-stream-failure",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer test-secret" },
+      }),
+    );
   });
 });

--- a/lib/api/__tests__/provider-terminal-error.test.ts
+++ b/lib/api/__tests__/provider-terminal-error.test.ts
@@ -1,0 +1,49 @@
+import { wrapProviderTerminalError } from "../provider-terminal-error";
+
+describe("wrapProviderTerminalError", () => {
+  it("creates stable provider/model/category fingerprint fields and retains IDs", () => {
+    const cause = Object.assign(new Error("Network connection lost."), {
+      statusCode: 502,
+    });
+    const error = wrapProviderTerminalError(cause, {
+      model: "deepseek/deepseek-v4-flash-0731",
+      openRouterMetadata: {
+        provider_name: "DeepInfra",
+        openrouter_generation_id: "gen-1",
+        openrouter_request_id: "req-1",
+        openrouter_upstream_id: "upstream-1",
+      },
+    });
+
+    expect(error.message).toBe(
+      "Provider terminal error provider=deepinfra model=deepseek_deepseek-v4-flash-0731 category=provider_5xx status=502",
+    );
+    expect(error).toMatchObject({
+      name: "ProviderTerminalError",
+      provider: "DeepInfra",
+      model: "deepseek/deepseek-v4-flash-0731",
+      category: "provider_5xx",
+      statusCode: 502,
+      openrouterGenerationId: "gen-1",
+      openrouterRequestId: "req-1",
+      openrouterUpstreamId: "upstream-1",
+      cause,
+    });
+  });
+
+  it("produces a different Trigger fingerprint message for xAI failures", () => {
+    const error = wrapProviderTerminalError(
+      Object.assign(new Error("Internal error during token generation"), {
+        statusCode: 502,
+      }),
+      {
+        model: "x-ai/grok-4.5",
+        openRouterMetadata: { provider_name: "xAI" },
+      },
+    );
+
+    expect(error.message).toBe(
+      "Provider terminal error provider=xai model=x-ai_grok-4.5 category=provider_5xx status=502",
+    );
+  });
+});

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -1698,18 +1698,9 @@ export async function createAgentStream(
     onError: async ({ error }) => {
       state.providerError = error;
       const errorOpenRouterMetadata = extractOpenRouterMetadataFromError(error);
-      const generationMetadata =
-        errorOpenRouterMetadata.openrouter_generation_id &&
-        (!errorOpenRouterMetadata.openrouter_request_id ||
-          !errorOpenRouterMetadata.openrouter_upstream_id ||
-          !errorOpenRouterMetadata.provider_name)
-          ? await fetchOpenRouterGenerationMetadata(
-              errorOpenRouterMetadata.openrouter_generation_id,
-            )
-          : {};
       state.openRouterMetadata = mergeOpenRouterMetadata(
         errorOpenRouterMetadata,
-        mergeOpenRouterMetadata(generationMetadata, state.openRouterMetadata),
+        state.openRouterMetadata,
       );
       await refundProviderContentBlockedIfSettled({
         error,
@@ -1732,6 +1723,36 @@ export async function createAgentStream(
           hadSummarization: ctx.summarizationTracker.hasSummarized,
         });
       }
+      if (
+        !isProviderContentBlockedFinishReasonError(error) &&
+        !ctx.usageTracker.hasUsage
+      ) {
+        await ctx.usageRefundTracker.refund();
+      }
+      await ptySessionManager
+        .closeAll(ctx.chatId)
+        .catch((err) =>
+          console.error("[agent-stream] PTY closeAll (onError) failed:", err),
+        );
+
+      // The generation endpoint can lag the stream failure. Keep it out of the
+      // latency-sensitive /api/chat path and run it only after refunds/cleanup.
+      if (
+        ctx.endpoint !== "/api/chat" &&
+        errorOpenRouterMetadata.openrouter_generation_id &&
+        (!errorOpenRouterMetadata.openrouter_request_id ||
+          !errorOpenRouterMetadata.openrouter_upstream_id ||
+          !errorOpenRouterMetadata.provider_name)
+      ) {
+        const generationMetadata = await fetchOpenRouterGenerationMetadata(
+          errorOpenRouterMetadata.openrouter_generation_id,
+        );
+        state.openRouterMetadata = mergeOpenRouterMetadata(
+          errorOpenRouterMetadata,
+          mergeOpenRouterMetadata(generationMetadata, state.openRouterMetadata),
+        );
+      }
+
       if (!isXaiSafetyError(error)) {
         const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode, {
           hasMultimodalToolResults: streamHasImageViewResults,
@@ -1748,17 +1769,6 @@ export async function createAgentStream(
           openRouterMetadata: state.openRouterMetadata,
         });
       }
-      if (
-        !isProviderContentBlockedFinishReasonError(error) &&
-        !ctx.usageTracker.hasUsage
-      ) {
-        await ctx.usageRefundTracker.refund();
-      }
-      await ptySessionManager
-        .closeAll(ctx.chatId)
-        .catch((err) =>
-          console.error("[agent-stream] PTY closeAll (onError) failed:", err),
-        );
     },
 
     onAbort: async ({ steps }) => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -95,7 +95,10 @@ import {
 } from "@/lib/utils/stream-writer-utils";
 import {
   extractOpenRouterMetadata,
+  extractOpenRouterMetadataFromError,
+  fetchOpenRouterGenerationMetadata,
   mergeOpenRouterMetadata,
+  type OpenRouterModelMetadata,
 } from "@/lib/api/openrouter-metadata";
 import { getOpenRouterUpstreamInferenceCostFromUsageRaw } from "@/lib/provider-usage-cost";
 import {
@@ -288,6 +291,8 @@ export type AgentStreamState = {
   fallbackServed: boolean | undefined;
   /** Original provider/AI SDK error captured from streamText.onError. */
   providerError: unknown;
+  /** Best-effort OpenRouter IDs/provider attribution, including failed streams. */
+  openRouterMetadata: OpenRouterModelMetadata;
   /** True when a provider rejected an image-bearing tool result. */
   providerRejectedMultimodalToolResults: boolean;
   /** Stop-condition flags set by the respective onFired callbacks. */
@@ -324,6 +329,7 @@ export function initAgentStreamState(
     responseModel: undefined,
     fallbackServed: undefined,
     providerError: undefined,
+    openRouterMetadata: {},
     providerRejectedMultimodalToolResults: false,
     configuredMaxSteps: 0,
     agentStepCount: 0,
@@ -1525,6 +1531,10 @@ export async function createAgentStream(
         response,
         providerMetadata,
       });
+      state.openRouterMetadata = mergeOpenRouterMetadata(
+        stepOpenRouterMetadata,
+        state.openRouterMetadata,
+      );
       ctx.usageTracker.setAuthoritativeModelCostForStep(
         stepUsageCostIndex,
         stepOpenRouterMetadata.openrouter_upstream_inference_cost,
@@ -1641,6 +1651,10 @@ export async function createAgentStream(
         finishOpenRouterMetadata,
         stepOpenRouterMetadatas.at(-1),
       );
+      state.openRouterMetadata = mergeOpenRouterMetadata(
+        openRouterMetadata,
+        state.openRouterMetadata,
+      );
 
       ctx.usageTracker.setAuthoritativeModelCostForStep(
         stepUsageCostIndexes.at(-1),
@@ -1683,6 +1697,20 @@ export async function createAgentStream(
 
     onError: async ({ error }) => {
       state.providerError = error;
+      const errorOpenRouterMetadata = extractOpenRouterMetadataFromError(error);
+      const generationMetadata =
+        errorOpenRouterMetadata.openrouter_generation_id &&
+        (!errorOpenRouterMetadata.openrouter_request_id ||
+          !errorOpenRouterMetadata.openrouter_upstream_id ||
+          !errorOpenRouterMetadata.provider_name)
+          ? await fetchOpenRouterGenerationMetadata(
+              errorOpenRouterMetadata.openrouter_generation_id,
+            )
+          : {};
+      state.openRouterMetadata = mergeOpenRouterMetadata(
+        errorOpenRouterMetadata,
+        mergeOpenRouterMetadata(generationMetadata, state.openRouterMetadata),
+      );
       await refundProviderContentBlockedIfSettled({
         error,
         settled: false,
@@ -1717,6 +1745,7 @@ export async function createAgentStream(
           userId: ctx.userId,
           subscription: ctx.subscription,
           providerRequest: latestProviderRequestDiagnostics,
+          openRouterMetadata: state.openRouterMetadata,
         });
       }
       if (

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -47,7 +47,11 @@ import type { UsageCostRecord } from "@/lib/usage-tracker";
 import type { SandboxSessionUsage } from "@/lib/ai/tools";
 import type { UsageDeductionResult } from "@/lib/rate-limit";
 import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
-import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
+import {
+  extractOpenRouterMetadataFromError,
+  mergeOpenRouterMetadata,
+  type OpenRouterModelMetadata,
+} from "@/lib/api/openrouter-metadata";
 import {
   extractErrorDetails,
   extractRetryAttempts,
@@ -725,15 +729,26 @@ export function createChatLogger(config: ChatLoggerConfig) {
         userId?: string;
         subscription?: string;
         providerRequest?: ProviderRequestDiagnostics;
+        openRouterMetadata?: OpenRouterModelMetadata;
       },
     ) {
-      const { providerRequest, ...providerContext } = context;
+      const {
+        providerRequest,
+        openRouterMetadata: providedOpenRouterMetadata,
+        ...providerContext
+      } = context;
       const details = extractErrorDetails(error);
+      const openRouterMetadata = mergeOpenRouterMetadata(
+        providedOpenRouterMetadata ?? {},
+        extractOpenRouterMetadataFromError(error),
+      );
       const attempts = extractRetryAttempts(error);
       const category = getProviderErrorCategory(details);
       const providerStatusCode = getProviderStatusCode(details);
       const diagnosticMessage = getProviderDiagnosticMessage(details);
       const providerName = nonEmptyString(details.providerName);
+      const attributedProviderName =
+        nonEmptyString(openRouterMetadata.provider_name) ?? providerName;
       const configuredModel =
         nonEmptyString(providerContext.model) ??
         nonEmptyString(providerRequest?.model);
@@ -742,18 +757,19 @@ export function createChatLogger(config: ChatLoggerConfig) {
         nonEmptyString(providerRequest?.requested_model_slug);
       const modelProviderSlug = getModelProviderSlug(requestedModelSlug);
       const openrouterGenerationId = nonEmptyString(
-        details.openrouterGenerationId,
+        openRouterMetadata.openrouter_generation_id ??
+          details.openrouterGenerationId,
       );
       const providerErrorFingerprint = buildProviderErrorFingerprint({
         category,
         statusCode: providerStatusCode,
         requestedModelSlug,
         modelProviderSlug,
-        providerName,
+        providerName: attributedProviderName,
       });
       const normalizedProviderContext = {
-        ...(providerName && {
-          provider_name: providerName,
+        ...(attributedProviderName && {
+          provider_name: attributedProviderName,
           provider_name_source: "openrouter_error_metadata",
         }),
         ...(configuredModel && { configured_model: configuredModel }),
@@ -761,6 +777,12 @@ export function createChatLogger(config: ChatLoggerConfig) {
         ...(modelProviderSlug && { model_provider_slug: modelProviderSlug }),
         ...(openrouterGenerationId && {
           openrouter_generation_id: openrouterGenerationId,
+        }),
+        ...(openRouterMetadata.openrouter_request_id && {
+          openrouter_request_id: openRouterMetadata.openrouter_request_id,
+        }),
+        ...(openRouterMetadata.openrouter_upstream_id && {
+          openrouter_upstream_id: openRouterMetadata.openrouter_upstream_id,
         }),
       };
       lastProviderErrorCategory = category;
@@ -829,14 +851,16 @@ export function createChatLogger(config: ChatLoggerConfig) {
           typeof details.isRetryable === "boolean"
             ? details.isRetryable
             : isRetriableProviderCategory(category),
-        providerName,
-        providerNameSource: providerName
+        providerName: attributedProviderName,
+        providerNameSource: attributedProviderName
           ? "openrouter_error_metadata"
           : undefined,
         configuredModel,
         requestedModelSlug,
         modelProviderSlug,
         openrouterGenerationId,
+        openrouterRequestId: openRouterMetadata.openrouter_request_id,
+        openrouterUpstreamId: openRouterMetadata.openrouter_upstream_id,
         providerErrorFingerprint,
         attempts,
       });

--- a/lib/api/openrouter-metadata.ts
+++ b/lib/api/openrouter-metadata.ts
@@ -26,12 +26,19 @@ type ResponseLike = {
 };
 
 const MAX_ATTEMPTS_TO_LOG = 8;
+const MAX_ERROR_SOURCE_DEPTH = 4;
+const OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS = 2_500;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const pickString = (value: unknown): string | undefined =>
   typeof value === "string" && value.length > 0 ? value : undefined;
+
+const pickIdentifier = (value: unknown): string | undefined => {
+  const identifier = pickString(value);
+  return identifier && identifier.length <= 512 ? identifier : undefined;
+};
 
 const pickNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? value : undefined;
@@ -136,12 +143,15 @@ const pickAttempts = (
     .slice(0, MAX_ATTEMPTS_TO_LOG)
     .map((attempt): OpenRouterAttemptMetadata | undefined => {
       if (!isRecord(attempt)) return undefined;
-      const item: OpenRouterAttemptMetadata = {
-        provider: pickString(attempt.provider),
-        model: pickString(attempt.model),
-        status: pickNumber(attempt.status),
-        selected: pickBoolean(attempt.selected),
-      };
+      const item: OpenRouterAttemptMetadata = {};
+      const provider = pickString(attempt.provider);
+      const model = pickString(attempt.model);
+      const status = pickNumber(attempt.status);
+      const selected = pickBoolean(attempt.selected);
+      if (provider) item.provider = provider;
+      if (model) item.model = model;
+      if (status !== undefined) item.status = status;
+      if (selected !== undefined) item.selected = selected;
       return Object.values(item).some((value) => value !== undefined)
         ? item
         : undefined;
@@ -188,6 +198,9 @@ const metadataFromRouterPayload = (
     openrouter_strategy: pickString(metadata.strategy),
     openrouter_region: pickString(metadata.region),
     openrouter_attempt: pickNumber(metadata.attempt),
+    openrouter_request_id: pickIdentifier(metadata.request_id),
+    openrouter_router: pickString(metadata.router),
+    openrouter_upstream_id: pickIdentifier(metadata.upstream_id),
     openrouter_upstream_inference_cost: pickUpstreamInferenceCost(metadata),
     openrouter_selected_model:
       pickString(selectedEndpoint?.model) ??
@@ -196,15 +209,160 @@ const metadataFromRouterPayload = (
   };
 };
 
+const parseJsonRecord = (
+  value: unknown,
+): Record<string, unknown> | undefined => {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string") return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const collectErrorRecords = (
+  value: unknown,
+  records: Record<string, unknown>[] = [],
+  seen = new WeakSet<object>(),
+  depth = 0,
+): Record<string, unknown>[] => {
+  if (!isRecord(value) || seen.has(value) || depth > MAX_ERROR_SOURCE_DEPTH) {
+    return records;
+  }
+  seen.add(value);
+  records.push(value);
+
+  for (const key of ["error", "cause"] as const) {
+    collectErrorRecords(value[key], records, seen, depth + 1);
+  }
+  if (Array.isArray(value.errors)) {
+    for (const nested of value.errors.slice(0, MAX_ATTEMPTS_TO_LOG)) {
+      collectErrorRecords(nested, records, seen, depth + 1);
+    }
+  }
+  return records;
+};
+
+const metadataFromGenerationPayload = (
+  source: unknown,
+): OpenRouterModelMetadata => {
+  const payload =
+    isRecord(source) && isRecord(source.data) ? source.data : source;
+  if (!isRecord(payload)) return {};
+
+  return compactOpenRouterMetadata({
+    provider_name: pickString(payload.provider_name),
+    openrouter_generation_id: pickIdentifier(payload.id),
+    openrouter_request_id: pickIdentifier(payload.request_id),
+    openrouter_router: pickString(payload.router),
+    openrouter_upstream_id: pickIdentifier(payload.upstream_id),
+    openrouter_upstream_inference_cost: pickPositiveNumber(
+      payload.upstream_inference_cost,
+    ),
+    openrouter_selected_model: pickString(payload.model),
+  });
+};
+
+/** Extract IDs and provider attribution retained on a failed OpenRouter call. */
+export function extractOpenRouterMetadataFromError(
+  error: unknown,
+): OpenRouterModelMetadata {
+  let metadata: OpenRouterModelMetadata = {};
+
+  for (const source of collectErrorRecords(error)) {
+    const response = isRecord(source.response) ? source.response : undefined;
+    const responseHeaders = source.responseHeaders ?? response?.headers;
+    const data = parseJsonRecord(source.data);
+    const responseBody = parseJsonRecord(source.responseBody);
+
+    // Parsed payload metadata is more specific than wrapper response headers,
+    // so visit it first and let primary-first merging retain those IDs.
+    for (const payload of [data, responseBody, source]) {
+      if (!payload) continue;
+      const routerMetadata = findOpenRouterMetadata(payload);
+      const nestedError = isRecord(payload.error) ? payload.error : undefined;
+      const errorMetadata = isRecord(nestedError?.metadata)
+        ? nestedError.metadata
+        : undefined;
+      const generationMetadata = metadataFromGenerationPayload(payload);
+      const routerPayloadMetadata = metadataFromRouterPayload(routerMetadata);
+      metadata = mergeOpenRouterMetadata(metadata, {
+        ...generationMetadata,
+        ...routerPayloadMetadata,
+        openrouter_generation_id:
+          generationMetadata.openrouter_generation_id ??
+          pickGenerationId({ id: payload.id, headers: responseHeaders }),
+        openrouter_request_id:
+          generationMetadata.openrouter_request_id ??
+          pickRequestId({ headers: responseHeaders }, routerMetadata),
+        provider_name:
+          pickString(errorMetadata?.provider_name) ??
+          routerPayloadMetadata.provider_name,
+      });
+    }
+
+    metadata = mergeOpenRouterMetadata(metadata, {
+      openrouter_generation_id: pickGenerationId({
+        id: source.id,
+        headers: responseHeaders,
+      }),
+      openrouter_request_id: pickRequestId({ headers: responseHeaders }),
+    });
+  }
+
+  return compactOpenRouterMetadata(metadata);
+}
+
+/** Best-effort lookup for IDs OpenRouter only exposes on its generation record. */
+export async function fetchOpenRouterGenerationMetadata(
+  generationId: string,
+  options: {
+    apiKey?: string;
+    fetch?: typeof globalThis.fetch;
+    timeoutMs?: number;
+  } = {},
+): Promise<OpenRouterModelMetadata> {
+  const apiKey = options.apiKey ?? process.env.OPENROUTER_API_KEY;
+  if (!apiKey || !generationId.startsWith("gen-")) {
+    return {};
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    options.timeoutMs ?? OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS,
+  );
+  try {
+    const response = await (options.fetch ?? globalThis.fetch)(
+      `https://openrouter.ai/api/v1/generation?id=${encodeURIComponent(generationId)}`,
+      {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: controller.signal,
+      },
+    );
+    if (!response.ok) return {};
+    const payload = (await response.json()) as unknown;
+    return mergeOpenRouterMetadata(metadataFromGenerationPayload(payload), {
+      openrouter_generation_id: generationId,
+    });
+  } catch {
+    return {};
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export function extractOpenRouterMetadata(args: {
   response?: ResponseLike;
   providerMetadata?: unknown;
 }): OpenRouterModelMetadata {
   const routerMetadata = findOpenRouterMetadata(args.providerMetadata);
   return compactOpenRouterMetadata({
+    ...metadataFromRouterPayload(routerMetadata),
     openrouter_generation_id: pickGenerationId(args.response),
     openrouter_request_id: pickRequestId(args.response, routerMetadata),
-    ...metadataFromRouterPayload(routerMetadata),
   });
 }
 

--- a/lib/api/openrouter-metadata.ts
+++ b/lib/api/openrouter-metadata.ts
@@ -28,6 +28,7 @@ type ResponseLike = {
 const MAX_ATTEMPTS_TO_LOG = 8;
 const MAX_ERROR_SOURCE_DEPTH = 4;
 const OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS = 2_500;
+const OPENROUTER_GENERATION_LOOKUP_RETRY_DELAY_MS = 150;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -247,6 +248,7 @@ const collectErrorRecords = (
 
 const metadataFromGenerationPayload = (
   source: unknown,
+  options: { includeSelectedModel?: boolean } = {},
 ): OpenRouterModelMetadata => {
   const payload =
     isRecord(source) && isRecord(source.data) ? source.data : source;
@@ -254,14 +256,16 @@ const metadataFromGenerationPayload = (
 
   return compactOpenRouterMetadata({
     provider_name: pickString(payload.provider_name),
-    openrouter_generation_id: pickIdentifier(payload.id),
+    openrouter_generation_id: pickGenerationId({ id: payload.id }),
     openrouter_request_id: pickIdentifier(payload.request_id),
     openrouter_router: pickString(payload.router),
     openrouter_upstream_id: pickIdentifier(payload.upstream_id),
     openrouter_upstream_inference_cost: pickPositiveNumber(
       payload.upstream_inference_cost,
     ),
-    openrouter_selected_model: pickString(payload.model),
+    openrouter_selected_model: options.includeSelectedModel
+      ? pickString(payload.model)
+      : undefined,
   });
 };
 
@@ -335,19 +339,47 @@ export async function fetchOpenRouterGenerationMetadata(
     options.timeoutMs ?? OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS,
   );
   try {
-    const response = await (options.fetch ?? globalThis.fetch)(
-      `https://openrouter.ai/api/v1/generation?id=${encodeURIComponent(generationId)}`,
-      {
-        headers: { Authorization: `Bearer ${apiKey}` },
-        signal: controller.signal,
-      },
-    );
-    if (!response.ok) return {};
-    const payload = (await response.json()) as unknown;
-    return mergeOpenRouterMetadata(metadataFromGenerationPayload(payload), {
-      openrouter_generation_id: generationId,
-    });
-  } catch {
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      try {
+        const response = await (options.fetch ?? globalThis.fetch)(
+          `https://openrouter.ai/api/v1/generation?id=${encodeURIComponent(generationId)}`,
+          {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            signal: controller.signal,
+          },
+        );
+        if (response.ok) {
+          const payload = (await response.json()) as unknown;
+          return mergeOpenRouterMetadata(
+            metadataFromGenerationPayload(payload, {
+              includeSelectedModel: true,
+            }),
+            { openrouter_generation_id: generationId },
+          );
+        }
+        if (response.status === 404 && attempt === 1) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, OPENROUTER_GENERATION_LOOKUP_RETRY_DELAY_MS),
+          );
+          continue;
+        }
+        console.warn("[openrouter-metadata] generation lookup failed", {
+          event: "openrouter_generation_lookup_failed",
+          generationId,
+          statusCode: response.status,
+          attempt,
+        });
+        return {};
+      } catch (error) {
+        console.warn("[openrouter-metadata] generation lookup failed", {
+          event: "openrouter_generation_lookup_failed",
+          generationId,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+          attempt,
+        });
+        return {};
+      }
+    }
     return {};
   } finally {
     clearTimeout(timeout);

--- a/lib/api/provider-terminal-error.ts
+++ b/lib/api/provider-terminal-error.ts
@@ -16,6 +16,7 @@ const fingerprintToken = (value: string | undefined): string =>
 const providerFromModel = (model: string | undefined): string | undefined =>
   model?.includes("/") ? model.split("/", 1)[0] : undefined;
 
+/** Stable provider failure envelope used by Trigger.dev error fingerprinting. */
 export class ProviderTerminalError extends Error {
   readonly provider: string;
   readonly model: string;
@@ -67,6 +68,7 @@ export class ProviderTerminalError extends Error {
   }
 }
 
+/** Preserve the original cause while adding stable provider failure fields. */
 export const wrapProviderTerminalError = (
   error: unknown,
   context: {

--- a/lib/api/provider-terminal-error.ts
+++ b/lib/api/provider-terminal-error.ts
@@ -1,0 +1,79 @@
+import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
+import {
+  extractErrorDetails,
+  getProviderErrorCategory,
+  getProviderStatusCode,
+  type ProviderErrorCategory,
+} from "@/lib/utils/error-utils";
+
+const fingerprintToken = (value: string | undefined): string =>
+  (value ?? "unknown")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "_")
+    .replace(/^_+|_+$/g, "") || "unknown";
+
+const providerFromModel = (model: string | undefined): string | undefined =>
+  model?.includes("/") ? model.split("/", 1)[0] : undefined;
+
+export class ProviderTerminalError extends Error {
+  readonly provider: string;
+  readonly model: string;
+  readonly category: ProviderErrorCategory;
+  readonly statusCode?: number;
+  readonly openrouterGenerationId?: string;
+  readonly openrouterRequestId?: string;
+  readonly openrouterUpstreamId?: string;
+
+  constructor(
+    cause: unknown,
+    context: {
+      model?: string;
+      openRouterMetadata?: OpenRouterModelMetadata;
+    },
+  ) {
+    const details = extractErrorDetails(cause);
+    const category = getProviderErrorCategory(details);
+    const model =
+      context.openRouterMetadata?.openrouter_selected_model ?? context.model;
+    const provider =
+      context.openRouterMetadata?.provider_name ??
+      (typeof details.providerName === "string"
+        ? details.providerName
+        : providerFromModel(model));
+    const statusCode = getProviderStatusCode(details);
+    const message = [
+      "Provider terminal error",
+      `provider=${fingerprintToken(provider)}`,
+      `model=${fingerprintToken(model)}`,
+      `category=${fingerprintToken(category)}`,
+      statusCode ? `status=${statusCode}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    super(message, { cause });
+    this.name = "ProviderTerminalError";
+    this.provider = provider ?? "unknown";
+    this.model = model ?? "unknown";
+    this.category = category;
+    this.statusCode = statusCode;
+    this.openrouterGenerationId =
+      context.openRouterMetadata?.openrouter_generation_id;
+    this.openrouterRequestId =
+      context.openRouterMetadata?.openrouter_request_id;
+    this.openrouterUpstreamId =
+      context.openRouterMetadata?.openrouter_upstream_id;
+  }
+}
+
+export const wrapProviderTerminalError = (
+  error: unknown,
+  context: {
+    model?: string;
+    openRouterMetadata?: OpenRouterModelMetadata;
+  },
+): ProviderTerminalError =>
+  error instanceof ProviderTerminalError
+    ? error
+    : new ProviderTerminalError(error, context);

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -1,10 +1,102 @@
 import {
   createAssistantContentLoopMonitor,
   detectAssistantContentLoopFromText,
+  prepareProviderDisconnectContinuation,
   shouldRetryAgentLongWithFallback,
   shouldRetryProviderStreamAfterReasoningOnlyOutput,
   shouldRetryProviderStreamAfterInterruptedToolInput,
 } from "../agent-long-provider-retry";
+import type { UIMessage } from "ai";
+
+describe("prepareProviderDisconnectContinuation", () => {
+  it("preserves completed text and tool output while removing only the failed step", () => {
+    const messages = [
+      { id: "user-1", role: "user", parts: [{ type: "text", text: "fix it" }] },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          { type: "text", text: "I found the issue.", state: "done" },
+          {
+            type: "tool-run_terminal_cmd",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { command: "npm test" },
+            output: { result: { exitCode: 0, output: "ok" } },
+          },
+          { type: "step-start" },
+          { type: "text", text: "The final answer was cut", state: "done" },
+        ],
+      },
+    ] as UIMessage[];
+
+    const recovery = prepareProviderDisconnectContinuation(messages);
+
+    expect(recovery).toMatchObject({
+      removedPartCount: 2,
+      preservedCompletedToolCount: 1,
+      preservedTextPartCount: 1,
+    });
+    expect(recovery?.messages.at(-1)?.parts).toEqual([
+      { type: "step-start" },
+      { type: "text", text: "I found the issue.", state: "done" },
+      {
+        type: "tool-run_terminal_cmd",
+        toolCallId: "call-1",
+        state: "output-available",
+        input: { command: "npm test" },
+        output: { result: { exitCode: 0, output: "ok" } },
+      },
+    ]);
+  });
+
+  it("keeps a completed tool result in the failed step and drops its partial tail", () => {
+    const messages = [
+      { id: "user-1", role: "user", parts: [{ type: "text", text: "fix it" }] },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          {
+            type: "tool-file",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { action: "write", path: "/repo/a.ts" },
+            output: { ok: true },
+          },
+          { type: "text", text: "Now I will", state: "streaming" },
+        ],
+      },
+    ] as UIMessage[];
+
+    const recovery = prepareProviderDisconnectContinuation(messages);
+
+    expect(recovery?.removedPartCount).toBe(1);
+    expect(recovery?.preservedCompletedToolCount).toBe(1);
+    expect(recovery?.messages.at(-1)?.parts).toHaveLength(2);
+  });
+
+  it("removes an entirely incomplete first assistant step", () => {
+    const messages = [
+      { id: "user-1", role: "user", parts: [{ type: "text", text: "answer" }] },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          { type: "text", text: "partial", state: "done" },
+        ],
+      },
+    ] as UIMessage[];
+
+    const recovery = prepareProviderDisconnectContinuation(messages);
+
+    expect(recovery?.removedPartCount).toBe(2);
+    expect(recovery?.messages).toEqual([messages[0]]);
+  });
+});
 
 describe("shouldRetryAgentLongWithFallback", () => {
   it("preserves the legacy retry for streams that only emitted step-start", () => {

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -1,4 +1,5 @@
 import { hasMeaningfulToolInput } from "@/lib/chat/tool-abort-utils";
+import type { UIMessage } from "ai";
 
 type MessagePartLike = {
   type?: unknown;
@@ -81,6 +82,77 @@ const hasToolOutputOrError = (part: unknown): boolean => {
     candidate.state === "output-available" ||
     candidate.state === "output-error"
   );
+};
+
+const isCompletedToolPart = (part: unknown): boolean =>
+  isToolPart(part) && hasToolOutputOrError(part);
+
+const hasDurableAssistantPart = (parts: unknown[]): boolean =>
+  parts.some((part) => {
+    const type = getPartType(part);
+    if (type === "text") return Boolean(getPartText(part)?.trim());
+    return isCompletedToolPart(part);
+  });
+
+export type ProviderDisconnectContinuation = {
+  messages: UIMessage[];
+  removedPartCount: number;
+  preservedCompletedToolCount: number;
+  preservedTextPartCount: number;
+};
+
+/**
+ * Build a replay-safe transcript after a provider socket dies mid-step.
+ *
+ * AI SDK agent output uses `step-start` boundaries. Everything before the
+ * final boundary belongs to completed model/tool steps and is safe to retain.
+ * The final step is incomplete even when the provider adapter closes its text
+ * part during error cleanup, so it must not be treated as durable. A completed
+ * tool result is the exception: preserve it and trim only the tail after it so
+ * a continuation cannot repeat an already-executed side effect.
+ */
+export const prepareProviderDisconnectContinuation = (
+  messages: UIMessage[],
+): ProviderDisconnectContinuation | undefined => {
+  const assistantIndex = messages.findLastIndex(
+    (message) => message.role === "assistant",
+  );
+  if (assistantIndex < 0) return undefined;
+
+  const assistant = messages[assistantIndex];
+  const parts = assistant.parts ?? [];
+  const lastStepStartIndex = parts.findLastIndex(
+    (part) => getPartType(part) === "step-start",
+  );
+  if (lastStepStartIndex < 0) return undefined;
+
+  const lastCompletedToolIndex = parts.findLastIndex(isCompletedToolPart);
+  const preserveUntil = Math.max(
+    lastStepStartIndex,
+    lastCompletedToolIndex >= lastStepStartIndex
+      ? lastCompletedToolIndex + 1
+      : lastStepStartIndex,
+  );
+  const removedPartCount = parts.length - preserveUntil;
+  if (removedPartCount <= 0) return undefined;
+
+  const preservedParts = parts.slice(0, preserveUntil);
+  const normalizedMessages = messages.slice(0, assistantIndex);
+  if (hasDurableAssistantPart(preservedParts)) {
+    normalizedMessages.push({ ...assistant, parts: preservedParts });
+  }
+  normalizedMessages.push(...messages.slice(assistantIndex + 1));
+
+  return {
+    messages: normalizedMessages,
+    removedPartCount,
+    preservedCompletedToolCount:
+      preservedParts.filter(isCompletedToolPart).length,
+    preservedTextPartCount: preservedParts.filter(
+      (part) =>
+        getPartType(part) === "text" && Boolean(getPartText(part)?.trim()),
+    ).length,
+  };
 };
 
 const isRestartableInterruptedToolInput = (part: unknown): boolean => {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -215,6 +215,8 @@ export interface ChatWideEvent {
     requested_model_slug?: string;
     model_provider_slug?: string;
     openrouter_generation_id?: string;
+    openrouter_request_id?: string;
+    openrouter_upstream_id?: string;
     provider_error_fingerprint?: string;
     // Per-attempt breakdown when the SDK retried internally. Each entry is one
     // upstream call. Lets you tell consistent-500 from a mixed cascade and
@@ -589,6 +591,8 @@ export class WideEventBuilder {
     requestedModelSlug?: string;
     modelProviderSlug?: string;
     openrouterGenerationId?: string;
+    openrouterRequestId?: string;
+    openrouterUpstreamId?: string;
     providerErrorFingerprint?: string;
     attempts?: NonNullable<ChatWideEvent["provider_error"]>["attempts"];
   }): this {
@@ -606,6 +610,8 @@ export class WideEventBuilder {
       requested_model_slug: details.requestedModelSlug,
       model_provider_slug: details.modelProviderSlug,
       openrouter_generation_id: details.openrouterGenerationId,
+      openrouter_request_id: details.openrouterRequestId,
+      openrouter_upstream_id: details.openrouterUpstreamId,
       provider_error_fingerprint: details.providerErrorFingerprint,
       attempts: details.attempts,
     };

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -12,6 +12,7 @@ import {
   isProviderContentBlockedFinishReasonError,
   isProviderContentFilterFinishReason,
   isProviderStreamTerminatedError,
+  isRetriableProviderStreamDisconnectError,
 } from "../error-utils";
 
 const apiCallError = (overrides: Record<string, unknown>) =>
@@ -379,6 +380,23 @@ describe("provider error classification", () => {
       "stream_terminated",
     );
     expect(isProviderStreamTerminatedError(err)).toBe(true);
+    expect(isRetriableProviderStreamDisconnectError(err)).toBe(true);
+  });
+
+  it("allows 5xx network disconnects but rejects non-disconnect provider failures", () => {
+    expect(
+      isRetriableProviderStreamDisconnectError(
+        apiCallError({ statusCode: 502, message: "Network connection lost." }),
+      ),
+    ).toBe(true);
+    expect(
+      isRetriableProviderStreamDisconnectError(
+        apiCallError({
+          statusCode: 502,
+          message: "Internal error during token generation",
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("classifies provider status codes before message patterns", () => {

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -346,6 +346,11 @@ export type ProviderErrorCategory =
   | "timeout"
   | "unknown";
 
+const PROVIDER_STREAM_TERMINATION_PATTERN =
+  /terminated|aborted|abort|network connection lost|connection (?:reset|closed|lost)|socket hang up|unexpected eof/i;
+const PROVIDER_STREAM_DISCONNECT_PATTERN =
+  /terminated|network connection lost|connection (?:reset|closed|lost)|socket hang up|unexpected eof/i;
+
 const parseHttpStatus = (value: unknown): number | undefined => {
   const code =
     typeof value === "number"
@@ -451,11 +456,7 @@ export const getProviderErrorCategory = (
   if (statusCode != null && statusCode >= 400) return "provider_4xx";
 
   const message = getProviderMessageText(details);
-  if (
-    /terminated|aborted|abort|network connection lost|connection (?:reset|closed|lost)|socket hang up|unexpected eof/i.test(
-      message,
-    )
-  ) {
+  if (PROVIDER_STREAM_TERMINATION_PATTERN.test(message)) {
     return "stream_terminated";
   }
   if (/timeout|timed out/i.test(message)) return "timeout";
@@ -472,6 +473,24 @@ export const getProviderErrorCategory = (
 
 export const isProviderStreamTerminatedError = (error: unknown): boolean =>
   getProviderErrorCategory(extractErrorDetails(error)) === "stream_terminated";
+
+/** Allow one continuation only for errors that explicitly describe a disconnect. */
+export const isRetriableProviderStreamDisconnectError = (
+  error: unknown,
+): boolean => {
+  const details = extractErrorDetails(error);
+  if (
+    !PROVIDER_STREAM_DISCONNECT_PATTERN.test(getProviderMessageText(details))
+  ) {
+    return false;
+  }
+  const category = getProviderErrorCategory(details);
+  return (
+    category === "stream_terminated" ||
+    category === "timeout" ||
+    category === "provider_5xx"
+  );
+};
 
 export interface ProviderAttempt {
   status_code?: number;

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -254,10 +254,12 @@ import {
 } from "@/lib/chat/stop-conditions";
 import {
   detectAssistantContentLoopFromParts,
+  prepareProviderDisconnectContinuation,
   shouldRetryProviderStreamAfterReasoningOnlyOutput,
   shouldRetryProviderStreamAfterInterruptedToolInput,
   shouldRetryAgentLongWithFallback,
 } from "@/lib/chat/agent-long-provider-retry";
+import { wrapProviderTerminalError } from "@/lib/api/provider-terminal-error";
 import {
   omitImageViewToolResultsForProviderRetry,
   omitTrailingStepStartAssistantMessage,
@@ -1670,6 +1672,9 @@ const isTerminalProviderStreamError = (
   state?.streamFinishReason === "error" ||
   isProviderContentFilterFinishReason(state?.streamFinishReason);
 
+const PROVIDER_DISCONNECT_CONTINUATION_PROMPT =
+  "The previous model connection ended mid-response. Continue from the preserved completed text and tool results. Do not repeat completed tool calls or their side effects. Finish the task from the last durable result.";
+
 type RecordedAgentLongFailure = {
   userCorrectable: boolean;
 };
@@ -2603,6 +2608,7 @@ export const agentLongTask = task({
       const summarizationTracker = new SummarizationTracker();
       chatLogger.startStream();
       let terminalAgentState: AgentStreamState | undefined;
+      let terminalRequestedModelSlug: string | undefined;
       let agentLongDurationExceeded = false;
       const markAgentLongDurationExceeded = () => {
         agentLongDurationExceeded = true;
@@ -3941,6 +3947,8 @@ export const agentLongTask = task({
               excludedProviderModelSlugs?: readonly string[],
             ) => {
               activeModelName = modelName;
+              terminalRequestedModelSlug =
+                trackedProvider.languageModel(modelName).modelId;
               streamCtx.tools = getToolsForModel(modelName);
               streamCtx.excludedProviderModelSlugs = excludedProviderModelSlugs;
               setCurrentModelName(modelName);
@@ -4117,10 +4125,33 @@ export const agentLongTask = task({
                           : { messages: finishedMessages, omittedCount: 0 };
                       const shouldRetryWithoutImageToolResults =
                         imageRecovery.omittedCount > 0 && !isAborted;
+                      const normalizedFinishedMessages = finishedMessages
+                        .map((message) =>
+                          message.role === "assistant"
+                            ? stripAgentLongHeartbeatParts(message)
+                            : message,
+                        )
+                        .filter(
+                          (message) =>
+                            message.role !== "assistant" ||
+                            (message.parts?.length ?? 0) > 0,
+                        );
+                      const providerDisconnectContinuation =
+                        hasTerminalProviderStreamError &&
+                        !providerContentBlocked &&
+                        !isAborted
+                          ? prepareProviderDisconnectContinuation(
+                              normalizedFinishedMessages,
+                            )
+                          : undefined;
+                      const shouldContinueAfterProviderDisconnect = Boolean(
+                        providerDisconnectContinuation,
+                      );
 
                       if (
                         (shouldRetryWithFallback ||
-                          shouldRetryWithoutImageToolResults) &&
+                          shouldRetryWithoutImageToolResults ||
+                          shouldContinueAfterProviderDisconnect) &&
                         !isRetryWithFallback &&
                         (!isAborted || stoppedDueToAssistantContentLoop) &&
                         (isAutoModel ||
@@ -4129,21 +4160,24 @@ export const agentLongTask = task({
                           stoppedDueToAssistantContentLoop ||
                           state.stoppedDueToDoomLoop ||
                           shouldRetryInterruptedToolInput ||
-                          shouldRetryExplicitDeepSeekProReasoning)
+                          shouldRetryExplicitDeepSeekProReasoning ||
+                          shouldContinueAfterProviderDisconnect)
                       ) {
                         const retryReason = shouldRetryWithoutImageToolResults
                           ? "image_tool_result_rejection"
-                          : providerContentBlocked
-                            ? "content_filter"
-                            : stoppedDueToAssistantContentLoop
-                              ? "assistant_content_loop"
-                              : state.stoppedDueToDoomLoop
-                                ? "doom_loop"
-                                : shouldRetryInterruptedToolInput
-                                  ? "interrupted_tool_input"
-                                  : shouldRetryReasoningOnlyProviderError
-                                    ? "reasoning_only_provider_error"
-                                    : "incomplete_stream";
+                          : shouldContinueAfterProviderDisconnect
+                            ? "provider_disconnect_continuation"
+                            : providerContentBlocked
+                              ? "content_filter"
+                              : stoppedDueToAssistantContentLoop
+                                ? "assistant_content_loop"
+                                : state.stoppedDueToDoomLoop
+                                  ? "doom_loop"
+                                  : shouldRetryInterruptedToolInput
+                                    ? "interrupted_tool_input"
+                                    : shouldRetryReasoningOnlyProviderError
+                                      ? "reasoning_only_provider_error"
+                                      : "incomplete_stream";
                         const blockedProviderModel = providerContentBlocked
                           ? state.responseModel
                           : undefined;
@@ -4179,9 +4213,17 @@ export const agentLongTask = task({
                                 : undefined,
                             shouldRetryInterruptedToolInput,
                             imageToolResultsOmitted: imageRecovery.omittedCount,
+                            disconnectRemovedPartCount:
+                              providerDisconnectContinuation?.removedPartCount,
+                            disconnectPreservedCompletedToolCount:
+                              providerDisconnectContinuation?.preservedCompletedToolCount,
+                            disconnectPreservedTextPartCount:
+                              providerDisconnectContinuation?.preservedTextPartCount,
                           },
                         );
                         isRetryWithFallback = true;
+                        streamError = undefined;
+                        state.openRouterMetadata = {};
                         state.lastStepInputTokens = 0;
                         state.stoppedDueToStepLimit = false;
                         state.streamFinishReason = undefined;
@@ -4206,7 +4248,22 @@ export const agentLongTask = task({
                           retryUsesDifferentModel(selectedModel, retryModel) ||
                           providerContentBlocked;
                         resetServedModelTelemetryForRetry(state);
-                        if (shouldRetryWithoutImageToolResults) {
+                        if (providerDisconnectContinuation) {
+                          state.finalMessages = [
+                            ...state.finalMessages,
+                            ...providerDisconnectContinuation.messages,
+                            {
+                              id: generateId(),
+                              role: "user",
+                              parts: [
+                                {
+                                  type: "text",
+                                  text: PROVIDER_DISCONNECT_CONTINUATION_PROMPT,
+                                },
+                              ],
+                            },
+                          ];
+                        } else if (shouldRetryWithoutImageToolResults) {
                           const normalizedRetryMessages = imageRecovery.messages
                             .map((message) =>
                               message.role === "assistant"
@@ -4396,6 +4453,22 @@ export const agentLongTask = task({
                                     );
                                     const fallbackGenerationTimeMs =
                                       Date.now() - fallbackStartTime;
+                                    for (const message of providerDisconnectContinuation?.messages ??
+                                      []) {
+                                      if (message.role !== "assistant")
+                                        continue;
+                                      await saveMessage({
+                                        chatId,
+                                        userId,
+                                        message,
+                                        extraFileIds: newFileIds,
+                                        model: configuredModelId,
+                                        mode,
+                                        generationStartedAt: streamStartTime,
+                                        generationTimeMs:
+                                          fallbackStartTime - streamStartTime,
+                                      });
+                                    }
                                     for (const msg of retryMessages) {
                                       if (msg.role !== "assistant") continue;
                                       const processed =
@@ -4826,7 +4899,10 @@ export const agentLongTask = task({
           await phLogger.flush().catch(() => {});
           return { chatId, assistantMessageId };
         }
-        throw terminalStreamError;
+        throw wrapProviderTerminalError(terminalStreamError, {
+          model: terminalRequestedModelSlug,
+          openRouterMetadata: terminalAgentState?.openRouterMetadata,
+        });
       }
 
       metadata.set("status", "done");

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -176,6 +176,7 @@ import {
   getUserFriendlyProviderError,
   isInvalidImageInputError,
   isProviderContentFilterFinishReason,
+  isRetriableProviderStreamDisconnectError,
 } from "@/lib/utils/error-utils";
 import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -4138,6 +4139,9 @@ export const agentLongTask = task({
                         );
                       const providerDisconnectContinuation =
                         hasTerminalProviderStreamError &&
+                        isRetriableProviderStreamDisconnectError(
+                          state.providerError,
+                        ) &&
                         !providerContentBlocked &&
                         !isAborted
                           ? prepareProviderDisconnectContinuation(
@@ -4281,6 +4285,25 @@ export const agentLongTask = task({
                             );
                         } else {
                           usageTracker.resetModelLeg();
+                        }
+                        if (providerDisconnectContinuation) {
+                          const preservedFileIds = getFileAccumulator()
+                            .getAll()
+                            .map((file) => file.fileId);
+                          for (const message of providerDisconnectContinuation.messages) {
+                            if (message.role !== "assistant") continue;
+                            await saveMessage({
+                              chatId,
+                              userId,
+                              message,
+                              extraFileIds: preservedFileIds,
+                              model: configuredModelId,
+                              mode,
+                              generationStartedAt: streamStartTime,
+                              generationTimeMs:
+                                fallbackStartTime - streamStartTime,
+                            });
+                          }
                         }
                         const retryResult = await createStream(
                           retryModel,
@@ -4453,22 +4476,6 @@ export const agentLongTask = task({
                                     );
                                     const fallbackGenerationTimeMs =
                                       Date.now() - fallbackStartTime;
-                                    for (const message of providerDisconnectContinuation?.messages ??
-                                      []) {
-                                      if (message.role !== "assistant")
-                                        continue;
-                                      await saveMessage({
-                                        chatId,
-                                        userId,
-                                        message,
-                                        extraFileIds: newFileIds,
-                                        model: configuredModelId,
-                                        mode,
-                                        generationStartedAt: streamStartTime,
-                                        generationTimeMs:
-                                          fallbackStartTime - streamStartTime,
-                                      });
-                                    }
                                     for (const msg of retryMessages) {
                                       if (msg.role !== "assistant") continue;
                                       const processed =


### PR DESCRIPTION
## Summary\n\n- continue once on the configured fallback after a terminal mid-stream provider disconnect\n- preserve completed text and completed tool results while trimming only the incomplete final assistant step\n- retain OpenRouter generation headers and look up request/upstream/provider attribution for failed streams\n- wrap unrecovered terminal errors with stable provider, model, category, and status fields so Trigger fingerprints no longer combine unrelated providers\n\n## Validation\n\n- full pre-commit suite: 415 suites, 4,188 tests passed\n- pnpm typecheck\n- ESLint on all changed files\n- focused recovery, OpenRouter metadata, logger, shared runner, and Trigger contract tests: 230 passed\n\n## Manual verification\n\nIn a Trigger staging run, force an OpenRouter disconnect after a completed tool call. Confirm the completed result remains in the transcript, the fallback continues in a new assistant response without executing that tool again, and only one continuation attempt occurs. If the fallback also fails, confirm the Trigger error message contains distinct provider/model/category fields and the logs include OpenRouter generation, request, and upstream IDs.\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for eligible provider disconnections while preserving completed text and tool results.
  * Added PDF failure recovery, including fallback processing and removal of unsupported PDF attachments when needed.
  * Added richer provider error details, including provider, model, request, upstream, and generation information.
  * Improved OpenRouter metadata tracking for failed and interrupted streams.

* **Bug Fixes**
  * Prevented incomplete assistant content and repeated tool calls during retries.
  * Preserved diagnostic context and saved conversation content during provider failures.

* **Tests**
  * Expanded coverage for retries, PDF recovery, error reporting, metadata extraction, and failure categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->