### PR TITLE
Recover Agent PDF parser failures

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -1,5 +1,6 @@
 import {
   AUXILIARY_VISION_SLUG,
+  createOpenRouterPatchFetch,
   getModelCutoffDate,
   getModelDisplayName,
   isAnthropicModel,
@@ -7,9 +8,76 @@ import {
   isKimiModel,
   createTrackedProvider,
   myProvider,
+  MALFORMED_PDF_USER_RESPONSE,
+  PDF_PARSER_ENGINE_HEADER,
+  PDF_PARSER_RECOVERY_HEADER,
   sanitizeOpenRouterRequestForXai,
   supportsMultimodalToolResults,
 } from "@/lib/ai/providers";
+
+const edgeFetchPrimitives =
+  require("next/dist/compiled/@edge-runtime/primitives/fetch") as {
+    Headers: typeof Headers;
+    Response: typeof Response;
+  };
+const originalHeaders = globalThis.Headers;
+const originalResponse = globalThis.Response;
+
+beforeAll(() => {
+  globalThis.Headers = edgeFetchPrimitives.Headers;
+  globalThis.Response = edgeFetchPrimitives.Response;
+});
+
+afterAll(() => {
+  globalThis.Headers = originalHeaders;
+  globalThis.Response = originalResponse;
+});
+
+const PDF_PARSER_RATE_LIMIT_ERROR =
+  "The document parsing engine is currently rate limited. Please retry shortly.";
+const PDF_PARSER_INVALID_DOCUMENT_ERROR =
+  "The file could not be read as a valid document. It may be corrupt, truncated, or not actually a PDF.";
+
+const createPdfParserRequest = (includeSandboxPath = true) => ({
+  model: "deepseek/deepseek-v4-flash-0731",
+  plugins: [{ id: "file-parser", pdf: { engine: "mistral-ocr" } }],
+  messages: [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: includeSandboxPath
+            ? '<attachment filename="report.pdf" local_path="/home/user/upload/report.pdf" />\nReview this PDF.'
+            : "Review this PDF.",
+        },
+        {
+          type: "file",
+          file: {
+            filename: "report.pdf",
+            file_data: "data:application/pdf;base64,JVBERi0=",
+          },
+        },
+        {
+          type: "file",
+          file: {
+            filename: "notes.txt",
+            file_data: "data:text/plain;base64,bm90ZXM=",
+          },
+        },
+      ],
+    },
+  ],
+});
+
+const parserErrorResponse = (message: string) =>
+  new Response(
+    JSON.stringify({ error: { message: `Failed to parse : ${message}` } }),
+    {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    },
+  );
 
 describe("provider registry", () => {
   it("keeps active routes pointed at their provider slugs", () => {
@@ -305,6 +373,162 @@ describe("sanitizeOpenRouterRequestForXai", () => {
       "user-owned-reasoning-shaped-data",
     );
     expect(JSON.stringify(result.body)).toContain("tool-owned-data");
+  });
+});
+
+describe("OpenRouter PDF parser recovery", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("falls back from Mistral OCR to Cloudflare AI", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(parserErrorResponse(PDF_PARSER_RATE_LIMIT_ERROR))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    const response = await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body: JSON.stringify(createPdfParserRequest()),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const cloudflareRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(cloudflareRequest.plugins).toEqual([
+      { id: "file-parser", pdf: { engine: "cloudflare-ai" } },
+    ]);
+    expect(response.headers.get(PDF_PARSER_ENGINE_HEADER)).toBe(
+      "cloudflare-ai",
+    );
+  });
+
+  it.each([PDF_PARSER_RATE_LIMIT_ERROR, PDF_PARSER_INVALID_DOCUMENT_ERROR])(
+    "uses one sandbox-only recovery after both parsers return %s",
+    async (parserError) => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(parserErrorResponse(parserError))
+        .mockResolvedValueOnce(parserErrorResponse(parserError))
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+      const patchedFetch = createOpenRouterPatchFetch(
+        fetchMock as unknown as typeof fetch,
+      );
+
+      const response = await patchedFetch("https://openrouter.test/chat", {
+        method: "POST",
+        body: JSON.stringify(createPdfParserRequest()),
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const sandboxRequest = JSON.parse(fetchMock.mock.calls[2][1].body);
+      expect(sandboxRequest.plugins).toEqual([]);
+      const remainingFiles = sandboxRequest.messages.flatMap(
+        (message: { content?: Array<{ type?: string; file?: unknown }> }) =>
+          (message.content ?? []).filter((part) => part.type === "file"),
+      );
+      expect(remainingFiles).toEqual([
+        {
+          type: "file",
+          file: {
+            filename: "notes.txt",
+            file_data: "data:text/plain;base64,bm90ZXM=",
+          },
+        },
+      ]);
+      expect(JSON.stringify(sandboxRequest)).toContain(
+        "/home/user/upload/report.pdf",
+      );
+      expect(JSON.stringify(sandboxRequest)).toContain(
+        MALFORMED_PDF_USER_RESPONSE,
+      );
+      expect(response.headers.get(PDF_PARSER_RECOVERY_HEADER)).toBe("sandbox");
+    },
+  );
+
+  it("does not remove a PDF when no sandbox attachment path is available", async () => {
+    const cloudflareError = parserErrorResponse(
+      PDF_PARSER_INVALID_DOCUMENT_ERROR,
+    );
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        parserErrorResponse(PDF_PARSER_INVALID_DOCUMENT_ERROR),
+      )
+      .mockResolvedValueOnce(cloudflareError);
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    const response = await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body: JSON.stringify(createPdfParserRequest(false)),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response).toBe(cloudflareError);
+    expect(response.headers.get(PDF_PARSER_RECOVERY_HEADER)).toBeNull();
+  });
+
+  it("recovers directly to the sandbox when a later step already uses Cloudflare", async () => {
+    const request = createPdfParserRequest();
+    request.plugins[0].pdf.engine = "cloudflare-ai";
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        parserErrorResponse(PDF_PARSER_INVALID_DOCUMENT_ERROR),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    const response = await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const sandboxRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(sandboxRequest.plugins).toEqual([]);
+    const remainingFiles = sandboxRequest.messages.flatMap(
+      (message: { content?: Array<{ type?: string; file?: unknown }> }) =>
+        (message.content ?? []).filter((part) => part.type === "file"),
+    );
+    expect(remainingFiles).toEqual([
+      {
+        type: "file",
+        file: {
+          filename: "notes.txt",
+          file_data: "data:text/plain;base64,bm90ZXM=",
+        },
+      },
+    ]);
+    expect(response.headers.get(PDF_PARSER_RECOVERY_HEADER)).toBe("sandbox");
+  });
+
+  it("does not retry unrelated provider errors", async () => {
+    const originalResponse = parserErrorResponse("Unrelated provider error");
+    const fetchMock = jest.fn().mockResolvedValueOnce(originalResponse);
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    const response = await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body: JSON.stringify(createPdfParserRequest()),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response).toBe(originalResponse);
   });
 });
 

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -143,6 +143,209 @@ const withOpenRouterMetadataHeader = (
   return nextHeaders;
 };
 
+export const PDF_PARSER_ENGINE_HEADER =
+  "x-hackerai-openrouter-pdf-parser-engine";
+export const PDF_PARSER_RECOVERY_HEADER =
+  "x-hackerai-openrouter-pdf-parser-recovery";
+export const MALFORMED_PDF_USER_RESPONSE =
+  "This attachment isn’t a valid PDF; re-export or re-upload it.";
+
+const PDF_PARSER_RATE_LIMIT_ERROR =
+  "The document parsing engine is currently rate limited. Please retry shortly.";
+const PDF_PARSER_INVALID_DOCUMENT_ERROR =
+  "The file could not be read as a valid document. It may be corrupt, truncated, or not actually a PDF.";
+const SANDBOX_PDF_RECOVERY_INSTRUCTION = `The provider PDF parsers could not read the attached PDF. Inspect the corresponding local_path in the sandbox using terminal or PDF tools. If sandbox tools also cannot open it as a valid PDF, respond exactly: “${MALFORMED_PDF_USER_RESPONSE}” Treat this as a user-correctable attachment issue, not an infrastructure failure.`;
+
+type PdfParserFailure = "rate_limited" | "invalid_document";
+
+const classifyPdfParserFailure = async (
+  response: Response,
+): Promise<PdfParserFailure | undefined> => {
+  if (response.ok) return undefined;
+
+  try {
+    const responseText = await response.clone().text();
+    if (responseText.includes(PDF_PARSER_RATE_LIMIT_ERROR)) {
+      return "rate_limited";
+    }
+    if (responseText.includes(PDF_PARSER_INVALID_DOCUMENT_ERROR)) {
+      return "invalid_document";
+    }
+  } catch {
+    // Preserve the original provider response when its body cannot be read.
+  }
+  return undefined;
+};
+
+const replacePdfParserEngine = (
+  body: unknown,
+  fromEngine: "mistral-ocr" | "cloudflare-ai",
+  toEngine: "cloudflare-ai",
+): { body: unknown; changed: boolean } => {
+  if (!isRecord(body) || !Array.isArray(body.plugins)) {
+    return { body, changed: false };
+  }
+
+  let changed = false;
+  const plugins = body.plugins.map((plugin) => {
+    if (
+      !isRecord(plugin) ||
+      plugin.id !== "file-parser" ||
+      !isRecord(plugin.pdf) ||
+      plugin.pdf.engine !== fromEngine
+    ) {
+      return plugin;
+    }
+    changed = true;
+    return { ...plugin, pdf: { ...plugin.pdf, engine: toEngine } };
+  });
+
+  return changed
+    ? { body: { ...body, plugins }, changed: true }
+    : { body, changed: false };
+};
+
+const requestUsesPdfParserEngine = (
+  body: unknown,
+  engine: "mistral-ocr" | "cloudflare-ai",
+): boolean =>
+  isRecord(body) &&
+  Array.isArray(body.plugins) &&
+  body.plugins.some(
+    (plugin) =>
+      isRecord(plugin) &&
+      plugin.id === "file-parser" &&
+      isRecord(plugin.pdf) &&
+      plugin.pdf.engine === engine,
+  );
+
+const textHasSandboxAttachmentPath = (text: string): boolean =>
+  text.includes("<attachment") &&
+  text.includes('local_path="/home/user/upload/');
+
+const hasSandboxAttachmentPath = (messages: unknown[]): boolean =>
+  messages.some((message) => {
+    if (!isRecord(message)) return false;
+    const content = message.content;
+    if (typeof content === "string") {
+      return textHasSandboxAttachmentPath(content);
+    }
+    return (
+      Array.isArray(content) &&
+      content.some(
+        (part) =>
+          isRecord(part) &&
+          part.type === "text" &&
+          typeof part.text === "string" &&
+          textHasSandboxAttachmentPath(part.text),
+      )
+    );
+  });
+
+const isPdfRequestPart = (part: unknown): boolean => {
+  if (!isRecord(part) || part.type !== "file" || !isRecord(part.file)) {
+    return false;
+  }
+  const filename = part.file.filename;
+  const fileData = part.file.file_data;
+  return (
+    (typeof filename === "string" && filename.toLowerCase().endsWith(".pdf")) ||
+    (typeof fileData === "string" &&
+      fileData.toLowerCase().startsWith("data:application/pdf"))
+  );
+};
+
+const createSandboxPdfRecoveryBody = (
+  body: unknown,
+): { body: unknown; changed: boolean } => {
+  if (!isRecord(body) || !Array.isArray(body.messages)) {
+    return { body, changed: false };
+  }
+  if (!hasSandboxAttachmentPath(body.messages)) {
+    return { body, changed: false };
+  }
+
+  let removedFilePart = false;
+  let lastUserMessageIndex = -1;
+  const messages = body.messages.map((message, index) => {
+    if (!isRecord(message)) return message;
+    if (message.role === "user") lastUserMessageIndex = index;
+    if (!Array.isArray(message.content)) return message;
+
+    const content = message.content.filter((part) => {
+      const shouldRemove = isPdfRequestPart(part);
+      removedFilePart ||= shouldRemove;
+      return !shouldRemove;
+    });
+    return content.length === message.content.length
+      ? message
+      : { ...message, content };
+  });
+
+  if (!removedFilePart || lastUserMessageIndex < 0) {
+    return { body, changed: false };
+  }
+
+  const lastUserMessage = messages[lastUserMessageIndex];
+  if (!isRecord(lastUserMessage)) {
+    return { body, changed: false };
+  }
+  const existingContent = lastUserMessage.content;
+  const content = Array.isArray(existingContent)
+    ? [
+        ...existingContent,
+        { type: "text", text: SANDBOX_PDF_RECOVERY_INSTRUCTION },
+      ]
+    : [
+        ...(typeof existingContent === "string" && existingContent.length > 0
+          ? [{ type: "text", text: existingContent }]
+          : []),
+        { type: "text", text: SANDBOX_PDF_RECOVERY_INSTRUCTION },
+      ];
+  messages[lastUserMessageIndex] = { ...lastUserMessage, content };
+
+  const plugins = Array.isArray(body.plugins)
+    ? body.plugins.filter(
+        (plugin) => !isRecord(plugin) || plugin.id !== "file-parser",
+      )
+    : body.plugins;
+
+  return {
+    body: { ...body, messages, ...(plugins ? { plugins } : {}) },
+    changed: true,
+  };
+};
+
+const withPrivateResponseHeader = (
+  response: Response,
+  name: string,
+  value: string,
+): Response => {
+  const headers = new Headers(response.headers);
+  headers.set(name, value);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+const logPdfParserRecovery = (
+  fromEngine: "mistral-ocr" | "cloudflare-ai",
+  toEngine: "cloudflare-ai" | "sandbox",
+  reason: PdfParserFailure,
+) => {
+  console.warn(
+    JSON.stringify({
+      level: "warn",
+      event: "openrouter_pdf_parser_recovery",
+      from_engine: fromEngine,
+      to_engine: toEngine,
+      reason,
+    }),
+  );
+};
+
 // Custom fetch for OpenRouter provider-specific request-body repairs.
 //
 // - Kimi requires a `reasoning` field on assistant tool-call messages when
@@ -151,26 +354,88 @@ const withOpenRouterMetadataHeader = (
 //   when OpenRouter falls back to Grok. The visible assistant text remains in
 //   the prompt, so these provider-private blobs are safe to omit for xAI routes.
 // - The metadata header opts into OpenRouter routing metadata for attribution.
-const openrouterPatchFetch: typeof fetch = async (url, init) => {
-  let nextInit: RequestInit = {
-    ...init,
-    headers: withOpenRouterMetadataHeader(init?.headers),
+export const createOpenRouterPatchFetch =
+  (fetchImplementation: typeof fetch = globalThis.fetch): typeof fetch =>
+  async (url, init) => {
+    let nextInit: RequestInit = {
+      ...init,
+      headers: withOpenRouterMetadataHeader(init?.headers),
+    };
+
+    let parsedRequestBody: unknown;
+
+    if (nextInit.body && typeof nextInit.body === "string") {
+      try {
+        const parsedBody = JSON.parse(nextInit.body) as unknown;
+        const kimiPatched = patchKimiReasoningToolCalls(parsedBody);
+        const xaiPatched = sanitizeOpenRouterRequestForXai(kimiPatched.body);
+        parsedRequestBody = xaiPatched.body;
+        if (kimiPatched.changed || xaiPatched.changed) {
+          nextInit = { ...nextInit, body: JSON.stringify(xaiPatched.body) };
+        }
+      } catch {
+        // If parsing fails, send the request as-is
+      }
+    }
+
+    const initialResponse = await fetchImplementation(url, nextInit);
+    const parserFailure = await classifyPdfParserFailure(initialResponse);
+    if (!parserFailure) return initialResponse;
+
+    if (requestUsesPdfParserEngine(parsedRequestBody, "cloudflare-ai")) {
+      const sandboxBody = createSandboxPdfRecoveryBody(parsedRequestBody);
+      if (!sandboxBody.changed) return initialResponse;
+
+      logPdfParserRecovery("cloudflare-ai", "sandbox", parserFailure);
+      const sandboxResponse = await fetchImplementation(url, {
+        ...nextInit,
+        body: JSON.stringify(sandboxBody.body),
+      });
+      return withPrivateResponseHeader(
+        sandboxResponse,
+        PDF_PARSER_RECOVERY_HEADER,
+        "sandbox",
+      );
+    }
+
+    const cloudflareBody = replacePdfParserEngine(
+      parsedRequestBody,
+      "mistral-ocr",
+      "cloudflare-ai",
+    );
+    if (!cloudflareBody.changed) return initialResponse;
+
+    logPdfParserRecovery("mistral-ocr", "cloudflare-ai", parserFailure);
+    const cloudflareResponse = await fetchImplementation(url, {
+      ...nextInit,
+      body: JSON.stringify(cloudflareBody.body),
+    });
+    const cloudflareFailure =
+      await classifyPdfParserFailure(cloudflareResponse);
+    if (!cloudflareFailure) {
+      return withPrivateResponseHeader(
+        cloudflareResponse,
+        PDF_PARSER_ENGINE_HEADER,
+        "cloudflare-ai",
+      );
+    }
+
+    const sandboxBody = createSandboxPdfRecoveryBody(cloudflareBody.body);
+    if (!sandboxBody.changed) return cloudflareResponse;
+
+    logPdfParserRecovery("cloudflare-ai", "sandbox", cloudflareFailure);
+    const sandboxResponse = await fetchImplementation(url, {
+      ...nextInit,
+      body: JSON.stringify(sandboxBody.body),
+    });
+    return withPrivateResponseHeader(
+      sandboxResponse,
+      PDF_PARSER_RECOVERY_HEADER,
+      "sandbox",
+    );
   };
 
-  if (nextInit.body && typeof nextInit.body === "string") {
-    try {
-      const parsedBody = JSON.parse(nextInit.body) as unknown;
-      const kimiPatched = patchKimiReasoningToolCalls(parsedBody);
-      const xaiPatched = sanitizeOpenRouterRequestForXai(kimiPatched.body);
-      if (kimiPatched.changed || xaiPatched.changed) {
-        nextInit = { ...nextInit, body: JSON.stringify(xaiPatched.body) };
-      }
-    } catch {
-      // If parsing fails, send the request as-is
-    }
-  }
-  return globalThis.fetch(url, nextInit);
-};
+const openrouterPatchFetch = createOpenRouterPatchFetch();
 
 const openrouter = createOpenRouter({
   fetch: openrouterPatchFetch,

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -87,6 +87,8 @@ jest.mock("@/lib/ai/providers", () => ({
   isDeepSeekModel: (modelName: string) =>
     modelName === "agent-model-free" ||
     modelName.startsWith("model-deepseek-v4"),
+  PDF_PARSER_ENGINE_HEADER: "x-hackerai-openrouter-pdf-parser-engine",
+  PDF_PARSER_RECOVERY_HEADER: "x-hackerai-openrouter-pdf-parser-recovery",
 }));
 jest.mock("@/lib/ai/tools/utils/pty-session-manager", () => ({
   ptySessionManager: { closeAllSessions: jest.fn() },
@@ -108,6 +110,7 @@ jest.mock("@/lib/utils/error-utils", () => ({
 const {
   createAgentStream,
   initAgentStreamState,
+  omitPdfFilePartsFromModelMessages,
   resetServedModelTelemetryForRetry,
   resolveAgentModelAfterSummarization,
   resolveAgentModelForImageToolResults,
@@ -287,6 +290,41 @@ describe("resolveAgentModelAfterSummarization", () => {
     expect(
       resolveAgentModelAfterSummarization("model-grok-4.6", "agent", false),
     ).toBe("model-grok-4.6");
+  });
+});
+
+describe("omitPdfFilePartsFromModelMessages", () => {
+  it("removes provider PDF parts while preserving the sandbox attachment tag", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "text" as const,
+            text: '<attachment filename="report.pdf" local_path="/home/user/upload/report.pdf" />',
+          },
+          {
+            type: "file" as const,
+            data: "data:application/pdf;base64,JVBERi0=",
+            mediaType: "application/pdf",
+          },
+        ],
+      },
+    ] satisfies ModelMessage[];
+
+    const result = omitPdfFilePartsFromModelMessages(messages);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: '<attachment filename="report.pdf" local_path="/home/user/upload/report.pdf" />',
+          },
+        ],
+      },
+    ]);
   });
 });
 

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -326,6 +326,23 @@ describe("omitPdfFilePartsFromModelMessages", () => {
       },
     ]);
   });
+
+  it("drops a user message when removing its PDF leaves empty content", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "file" as const,
+            data: "data:application/pdf;base64,JVBERi0=",
+            mediaType: "application/pdf",
+          },
+        ],
+      },
+    ] satisfies ModelMessage[];
+
+    expect(omitPdfFilePartsFromModelMessages(messages)).toEqual([]);
+  });
 });
 
 describe("resolveFallbackServedTelemetry", () => {

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -301,6 +301,23 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("plugins");
   });
 
+  it("can keep later PDF steps on the Cloudflare parser", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-deepseek-v4-flash-0731",
+      "agent",
+      {
+        hasPdfAttachments: true,
+        pdfParserEngine: "cloudflare-ai",
+      },
+    );
+
+    expect(opts.openrouter.plugins).toEqual([
+      { id: "file-parser", pdf: { engine: "cloudflare-ai" } },
+    ]);
+  });
+
   it("falls back from DeepSeek V4 Flash 0731 through Pro 0813, Grok, then Kimi K3", () => {
     const opts = buildProviderOptions(
       false,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -147,7 +147,7 @@ export const omitPdfFilePartsFromModelMessages = (
   messages: ModelMessage[],
 ): ModelMessage[] => {
   let changed = false;
-  const nextMessages = messages.map((message) => {
+  const nextMessages = messages.flatMap<ModelMessage>((message) => {
     if (message.role !== "user" || !Array.isArray(message.content)) {
       return message;
     }
@@ -157,9 +157,8 @@ export const omitPdfFilePartsFromModelMessages = (
       changed ||= shouldRemove;
       return !shouldRemove;
     });
-    return content.length === message.content.length
-      ? message
-      : { ...message, content };
+    if (content.length === message.content.length) return message;
+    return content.length === 0 ? [] : { ...message, content };
   });
   return changed ? nextMessages : messages;
 };
@@ -171,8 +170,11 @@ const getResponseHeader = (
   if (headers instanceof Headers) return headers.get(name) ?? undefined;
   if (!headers || typeof headers !== "object") return undefined;
   const headerRecord = headers as Record<string, unknown>;
-  const value = headerRecord[name] ?? headerRecord[name.toLowerCase()];
-  return typeof value === "string" ? value : undefined;
+  const target = name.toLowerCase();
+  const entry = Object.entries(headerRecord).find(
+    ([key]) => key.toLowerCase() === target,
+  );
+  return typeof entry?.[1] === "string" ? entry[1] : undefined;
 };
 
 export const resolveAgentModelAfterSummarization = (

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -65,7 +65,12 @@ import {
   toolResultsContainImageViewResult,
   uiMessagesContainImageViewResult,
 } from "@/lib/chat/multimodal-tool-result-recovery";
-import { isAnthropicModel, isDeepSeekModel } from "@/lib/ai/providers";
+import {
+  isAnthropicModel,
+  isDeepSeekModel,
+  PDF_PARSER_ENGINE_HEADER,
+  PDF_PARSER_RECOVERY_HEADER,
+} from "@/lib/ai/providers";
 import { MAX_OUTPUT_TOKENS } from "@/lib/ai/output-limits";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
@@ -137,6 +142,38 @@ const uiMessagesContainImageAttachment = (messages: UIMessage[]): boolean =>
         part.mediaType.startsWith("image/"),
     ),
   );
+
+export const omitPdfFilePartsFromModelMessages = (
+  messages: ModelMessage[],
+): ModelMessage[] => {
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    if (message.role !== "user" || !Array.isArray(message.content)) {
+      return message;
+    }
+    const content = message.content.filter((part) => {
+      const shouldRemove =
+        part.type === "file" && part.mediaType === "application/pdf";
+      changed ||= shouldRemove;
+      return !shouldRemove;
+    });
+    return content.length === message.content.length
+      ? message
+      : { ...message, content };
+  });
+  return changed ? nextMessages : messages;
+};
+
+const getResponseHeader = (
+  headers: unknown,
+  name: string,
+): string | undefined => {
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  if (!headers || typeof headers !== "object") return undefined;
+  const headerRecord = headers as Record<string, unknown>;
+  const value = headerRecord[name] ?? headerRecord[name.toLowerCase()];
+  return typeof value === "string" ? value : undefined;
+};
 
 export const resolveAgentModelAfterSummarization = (
   modelName: string,
@@ -795,11 +832,13 @@ export async function createAgentStream(
   let streamHasImageViewResults =
     !ctx.auxiliaryVisionEnabled &&
     uiMessagesContainImageViewResult(state.finalMessages);
-  const streamHasPdfAttachments = state.finalMessages.some((message) =>
+  let streamHasPdfAttachments = state.finalMessages.some((message) =>
     message.parts?.some(
       (part) => part.type === "file" && part.mediaType === "application/pdf",
     ),
   );
+  let pdfParserEngine: "mistral-ocr" | "cloudflare-ai" = "mistral-ocr";
+  let providerPdfAttachmentsDisabled = false;
   let openRouterFileAnnotations: unknown[] | undefined;
   const getEffectiveModelName = () =>
     resolveAgentModelForImageToolResults(
@@ -832,7 +871,9 @@ export async function createAgentStream(
       {
         requestedModelSlug,
         hasMultimodalToolResults: streamHasImageViewResults,
-        hasPdfAttachments: streamHasPdfAttachments,
+        hasPdfAttachments:
+          streamHasPdfAttachments && !providerPdfAttachmentsDisabled,
+        pdfParserEngine,
         excludedModelSlugs: ctx.excludedProviderModelSlugs,
         ...(ctx.providerReasoningOverride?.modelName === effectiveModelName && {
           reasoningOverride: ctx.providerReasoningOverride.reasoning,
@@ -844,7 +885,10 @@ export async function createAgentStream(
     messages: ModelMessage[],
     effectiveModelName = getEffectiveModelName(),
   ): ModelMessage[] => {
-    const nonEmptyMessages = filterEmptyAssistantMessages(messages);
+    const providerMessages = providerPdfAttachmentsDisabled
+      ? omitPdfFilePartsFromModelMessages(messages)
+      : messages;
+    const nonEmptyMessages = filterEmptyAssistantMessages(providerMessages);
     let repairedMessages = nonEmptyMessages;
 
     if (isAnthropicModel(effectiveModelName)) {
@@ -1434,6 +1478,20 @@ export async function createAgentStream(
     onStepFinish: async ({ usage, response, providerMetadata }) => {
       ctx.onModelStreamFinish?.();
       state.agentStepCount += 1;
+      const responsePdfParserEngine = getResponseHeader(
+        response?.headers,
+        PDF_PARSER_ENGINE_HEADER,
+      );
+      if (responsePdfParserEngine === "cloudflare-ai") {
+        pdfParserEngine = "cloudflare-ai";
+      }
+      if (
+        getResponseHeader(response?.headers, PDF_PARSER_RECOVERY_HEADER) ===
+        "sandbox"
+      ) {
+        providerPdfAttachmentsDisabled = true;
+        streamHasPdfAttachments = false;
+      }
       openRouterFileAnnotations =
         getOpenRouterFileAnnotations(providerMetadata) ??
         openRouterFileAnnotations;

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -683,6 +683,7 @@ const isHighReasoningModel = (modelName?: string): boolean =>
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
   hasPdfAttachments?: boolean;
+  pdfParserEngine?: "mistral-ocr" | "cloudflare-ai";
   reasoningOverride?: ProviderReasoningOverride;
   excludedModelSlugs?: readonly string[];
   requestedModelSlug?: string;
@@ -976,7 +977,7 @@ export function buildProviderOptions(
             plugins: [
               {
                 id: "file-parser" as const,
-                pdf: { engine: "mistral-ocr" as const },
+                pdf: { engine: options.pdfParserEngine ?? "mistral-ocr" },
               },
             ],
           }


### PR DESCRIPTION
## Summary
- retry exact OpenRouter PDF parser failures with `cloudflare-ai` after `mistral-ocr`
- fall back once to sandbox-only PDF inspection while preserving the `/home/user/upload/...` attachment tag
- keep later agent steps on the recovered parser path and give malformed PDFs a user-correctable response

## Validation
- `pnpm typecheck`
- full pre-commit suite: 414 suites, 4,180 tests
- post-rebase focused/contract suite: 4 suites, 265 tests
- ESLint on touched files
- Prettier check on touched files

Automated verification is sufficient; this is a backend-only recovery path with no visual UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery when PDF parsing fails.
  * PDF processing can fall back from Mistral OCR to Cloudflare AI or sandbox-based recovery.
  * Recovered PDFs continue processing without repeatedly attaching the original file.
  * Added support for selecting the PDF parsing engine for subsequent processing steps.

* **Bug Fixes**
  * Prevented retries for unrelated errors.
  * Preserved PDF content when sandbox recovery is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->