### PR TITLE
Preserve user-correctable agent stream errors

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1305,6 +1305,10 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       "terminalStreamError instanceof ChatSDKError",
       handledRateLimitIdx,
     );
+    const directThrowIdx = taskSrc.indexOf(
+      "throw terminalStreamError;",
+      chatSdkErrorIdx,
+    );
     const throwIdx = taskSrc.indexOf(
       "throw wrapProviderTerminalError(terminalStreamError",
       handledRateLimitIdx,
@@ -1312,7 +1316,8 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(streamErrorIdx).toBeGreaterThan(-1);
     expect(handledRateLimitIdx).toBeGreaterThan(streamErrorIdx);
     expect(chatSdkErrorIdx).toBeGreaterThan(handledRateLimitIdx);
-    expect(throwIdx).toBeGreaterThan(chatSdkErrorIdx);
+    expect(directThrowIdx).toBeGreaterThan(chatSdkErrorIdx);
+    expect(throwIdx).toBeGreaterThan(directThrowIdx);
   });
 
   test("provider finishReason error fails the task after the UI stream drains", () => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1295,11 +1295,15 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(returnIdx).toBeGreaterThan(handledRateLimitIdx);
   });
 
-  test("non-rate-limit stream errors are wrapped with provider attribution after the handled branch", () => {
+  test("ChatSDK stream errors preserve their user-correctable classification before provider wrapping", () => {
     const streamErrorIdx = taskSrc.indexOf("if (terminalStreamError)");
     const handledRateLimitIdx = taskSrc.indexOf(
       "isHandledUserRateLimitError(terminalStreamError)",
       streamErrorIdx,
+    );
+    const chatSdkErrorIdx = taskSrc.indexOf(
+      "terminalStreamError instanceof ChatSDKError",
+      handledRateLimitIdx,
     );
     const throwIdx = taskSrc.indexOf(
       "throw wrapProviderTerminalError(terminalStreamError",
@@ -1307,7 +1311,8 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
     expect(streamErrorIdx).toBeGreaterThan(-1);
     expect(handledRateLimitIdx).toBeGreaterThan(streamErrorIdx);
-    expect(throwIdx).toBeGreaterThan(streamErrorIdx);
+    expect(chatSdkErrorIdx).toBeGreaterThan(handledRateLimitIdx);
+    expect(throwIdx).toBeGreaterThan(chatSdkErrorIdx);
   });
 
   test("provider finishReason error fails the task after the UI stream drains", () => {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -5148,6 +5148,9 @@ export const agentLongTask = task({
           await phLogger.flush().catch(() => {});
           return { chatId, assistantMessageId };
         }
+        if (terminalStreamError instanceof ChatSDKError) {
+          throw terminalStreamError;
+        }
         throw wrapProviderTerminalError(terminalStreamError, {
           model: terminalRequestedModelSlug,
           openRouterMetadata: terminalAgentState?.openRouterMetadata,


### PR DESCRIPTION
## Summary

- preserve terminal ChatSDKError instances instead of wrapping them as provider failures
- retain the existing user-correctable classification for unavailable local sandbox requests
- add a regression contract that keeps ChatSDK handling ahead of provider attribution

## Validation

- `pnpm exec jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand` (98 tests)
- `pnpm run typecheck`
- pre-commit full suite before rebase: 415 suites, 4,202 tests

## Manual verification

1. Select a local computer that is unavailable or has no active connection.
2. Start an Agent run that requires that sandbox.
3. Confirm the user receives the friendly sandbox error and the Trigger run is classified as user-correctable instead of failing with ProviderTerminalError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for agent response streams.
  * Preserved specific SDK error classifications, including rate-limit errors, instead of replacing them with generic provider errors.
  * Terminal SDK errors are now surfaced directly for clearer diagnosis and more consistent handling.
  * Other terminal stream errors continue to receive appropriate provider error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->