### PR TITLE
Recover failed E2B attachment staging on AWS

### DIFF
--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -39,6 +39,17 @@ describe("ChatSDKError messages", () => {
       "The computer attachment upload failed.",
     );
   });
+
+  it("surfaces a classified sandbox recovery message when available", () => {
+    expect(
+      new ChatSDKError(
+        "bad_request:sandbox",
+        "The Cloud sandbox could not start to receive the attachment. Please try again.",
+      ).message,
+    ).toBe(
+      "The Cloud sandbox could not start to receive the attachment. Please try again.",
+    );
+  });
 });
 
 describe("ChatSDKError stream serialization", () => {

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-recovery.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-recovery.test.ts
@@ -7,43 +7,72 @@ import {
 import type { CloudSandboxAcquisitionContext } from "../cloud-sandbox";
 
 describe("cloud sandbox placement recovery", () => {
-  const originalE2BApiKey = process.env.E2B_API_KEY;
-
-  afterEach(() => {
-    if (originalE2BApiKey === undefined) delete process.env.E2B_API_KEY;
-    else process.env.E2B_API_KEY = originalE2BApiKey;
-  });
-
-  it("switches an AWS-assigned run once to the established E2B backend", () => {
-    process.env.E2B_API_KEY = "configured";
+  it("switches an eligible E2B-assigned paid run once to AWS", () => {
     const context: CloudSandboxAcquisitionContext = {
-      provider: "aws-lambda-microvm",
+      provider: "e2b",
+      subscription: "pro",
+      rollout: {
+        key: "aws_lambda_microvm_ultra_rollout_v1",
+        provider: "e2b",
+        eligible: true,
+        variant: "e2b",
+        flagValue: false,
+        reason: "flag_disabled",
+      },
     };
 
-    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBe("e2b");
-    expect(context.provider).toBe("e2b");
+    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBe(
+      "aws-lambda-microvm",
+    );
+    expect(context.provider).toBe("aws-lambda-microvm");
     expect(getCloudSandboxRecoveryTelemetryProperties(context)).toEqual({
-      cloud_sandbox_recovery_from_provider: "aws-lambda-microvm",
-      cloud_sandbox_recovery_to_provider: "e2b",
+      cloud_sandbox_recovery_from_provider: "e2b",
+      cloud_sandbox_recovery_to_provider: "aws-lambda-microvm",
       cloud_sandbox_recovery_reason: "attachment_placement_failure",
     });
   });
 
-  it("does not bypass the AWS rollout for an E2B-assigned run", () => {
-    process.env.E2B_API_KEY = "configured";
-    const context: CloudSandboxAcquisitionContext = { provider: "e2b" };
-
-    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBeNull();
-    expect(context).toEqual({ provider: "e2b" });
-  });
-
-  it("fails closed when E2B is not configured", () => {
-    delete process.env.E2B_API_KEY;
+  it("does not mask an AWS-assigned run failure with E2B", () => {
     const context: CloudSandboxAcquisitionContext = {
       provider: "aws-lambda-microvm",
+      subscription: "pro",
     };
 
     expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBeNull();
     expect(context.provider).toBe("aws-lambda-microvm");
+  });
+
+  it("does not bypass rollout eligibility for an E2B-assigned run", () => {
+    const context: CloudSandboxAcquisitionContext = {
+      provider: "e2b",
+      subscription: "pro",
+      rollout: {
+        key: "aws_lambda_microvm_ultra_rollout_v1",
+        provider: "e2b",
+        eligible: false,
+        variant: "e2b",
+        reason: "provider_disabled",
+      },
+    };
+
+    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBeNull();
+    expect(context.provider).toBe("e2b");
+  });
+
+  it("keeps free users out of cloud recovery", () => {
+    const context: CloudSandboxAcquisitionContext = {
+      provider: "e2b",
+      subscription: "free",
+      rollout: {
+        key: "aws_lambda_microvm_ultra_rollout_v1",
+        provider: "e2b",
+        eligible: true,
+        variant: "e2b",
+        reason: "flag_disabled",
+      },
+    };
+
+    expect(selectAlternateCloudSandboxProviderForRecovery(context)).toBeNull();
+    expect(context.provider).toBe("e2b");
   });
 });

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -297,6 +297,58 @@ describe("E2B sandbox lease lifecycle", () => {
     }
   });
 
+  it("quarantines a paused sandbox after a placement failure", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      listSandbox({ state: "paused" });
+      sandboxApi.connect.mockRejectedValue(
+        new Error("500: Failed to place sandbox"),
+      );
+      sandboxApi.kill.mockResolvedValue(true);
+
+      await expect(
+        ensureSandboxConnection({
+          userID: "user-1",
+          setSandbox: jest.fn(),
+        }),
+      ).rejects.toThrow("Failed to place sandbox");
+
+      expect(sandboxApi.kill).toHaveBeenCalledWith("sandbox-1");
+      expect(sandboxApi.create).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "e2b_paused_sandbox_quarantined_after_resume_failure",
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("preserves a running sandbox after a placement failure", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      listSandbox({ state: "running" });
+      sandboxApi.connect.mockRejectedValue(
+        new Error("500: Failed to place sandbox"),
+      );
+
+      await expect(
+        ensureSandboxConnection({
+          userID: "user-1",
+          setSandbox: jest.fn(),
+        }),
+      ).rejects.toThrow("Failed to place sandbox");
+
+      expect(sandboxApi.kill).not.toHaveBeenCalled();
+      expect(sandboxApi.create).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("creates a replacement without killing when the listed sandbox is gone", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     try {

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -297,15 +297,13 @@ describe("E2B sandbox lease lifecycle", () => {
     }
   });
 
-  it("quarantines a paused sandbox after a placement failure", async () => {
+  it("preserves a paused sandbox after a placement failure", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     try {
       listSandbox({ state: "paused" });
       sandboxApi.connect.mockRejectedValue(
         new Error("500: Failed to place sandbox"),
       );
-      sandboxApi.kill.mockResolvedValue(true);
 
       await expect(
         ensureSandboxConnection({
@@ -314,15 +312,31 @@ describe("E2B sandbox lease lifecycle", () => {
         }),
       ).rejects.toThrow("Failed to place sandbox");
 
-      expect(sandboxApi.kill).toHaveBeenCalledWith("sandbox-1");
+      expect(sandboxApi.kill).not.toHaveBeenCalled();
       expect(sandboxApi.create).not.toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "e2b_paused_sandbox_quarantined_after_resume_failure",
-        ),
-      );
     } finally {
-      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("preserves a paused sandbox after an operation timeout", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      listSandbox({ state: "paused" });
+      sandboxApi.connect.mockRejectedValue(
+        new Error("sandbox operation timed out"),
+      );
+
+      await expect(
+        ensureSandboxConnection({
+          userID: "user-1",
+          setSandbox: jest.fn(),
+        }),
+      ).rejects.toThrow("sandbox operation timed out");
+
+      expect(sandboxApi.kill).not.toHaveBeenCalled();
+      expect(sandboxApi.create).not.toHaveBeenCalled();
+    } finally {
       errorSpy.mockRestore();
     }
   });

--- a/lib/ai/tools/utils/cloud-sandbox-recovery.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-recovery.ts
@@ -13,19 +13,25 @@ export class AlternateCloudSandboxUnavailableError extends Error {
 export function selectAlternateCloudSandboxProviderForRecovery(
   context?: CloudSandboxAcquisitionContext,
 ): CloudSandboxProvider | null {
-  // AWS-assigned runs may safely fall back to the established E2B backend.
-  // E2B-assigned runs must not bypass the AWS rollout gate during recovery.
-  if (context?.provider !== "aws-lambda-microvm" || !process.env.E2B_API_KEY) {
+  // Keep AWS failures visible while the product migrates away from E2B.
+  // A paid run that was eligible for the AWS rollout may use AWS for one
+  // bounded recovery attempt when its E2B attachment placement fails, even
+  // when the normal rollout assignment selected the E2B control variant.
+  if (
+    context?.provider !== "e2b" ||
+    context.rollout?.eligible !== true ||
+    context.subscription === "free"
+  ) {
     return null;
   }
 
   context.recovery = {
-    fromProvider: "aws-lambda-microvm",
-    toProvider: "e2b",
+    fromProvider: "e2b",
+    toProvider: "aws-lambda-microvm",
     reason: "attachment_placement_failure",
   };
-  context.provider = "e2b";
-  return "e2b";
+  context.provider = "aws-lambda-microvm";
+  return "aws-lambda-microvm";
 }
 
 export function getCloudSandboxRecoveryTelemetryProperties(

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -2,7 +2,6 @@ import { Sandbox } from "@e2b/code-interpreter";
 import type { SandboxBootInfo, SandboxContext } from "@/types";
 import { NotFoundError, getUserFacingE2BErrorMessage } from "./e2b-errors";
 import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
-import { classifySandboxReadinessFailureSignal } from "./sandbox-readiness-failure";
 
 type SandboxReadyPath = SandboxBootInfo["path"];
 
@@ -249,43 +248,10 @@ export const ensureSandboxConnection = async (
             `[${userID}] Unexpected error resuming sandbox ${existingSandbox.sandboxId}:`,
             e,
           );
-          const failureReason = classifySandboxReadinessFailureSignal(e);
-          const canQuarantinePausedSandbox =
-            existingSandbox.state === "paused" &&
-            (failureReason === "placement_failure" ||
-              failureReason === "operation_timeout");
-          if (canQuarantinePausedSandbox) {
-            console.warn(
-              JSON.stringify({
-                timestamp: new Date().toISOString(),
-                level: "warn",
-                event: "e2b_paused_sandbox_quarantined_after_resume_failure",
-                service: "chat-handler",
-                environment:
-                  process.env.TRIGGER_ENV ??
-                  process.env.VERCEL_ENV ??
-                  process.env.NODE_ENV ??
-                  "unknown",
-                request_id: process.env.VERCEL_REQUEST_ID ?? null,
-                user_id: userID,
-                sandbox_id: existingSandbox.sandboxId,
-                failure_reason: failureReason,
-              }),
-            );
-            try {
-              await Sandbox.kill(existingSandbox.sandboxId);
-            } catch (killError) {
-              logSandboxKillFailure(
-                userID,
-                `Failed to quarantine paused sandbox ${existingSandbox.sandboxId}`,
-                killError,
-              );
-            }
-          }
-          // Never destroy a shared user sandbox for a transient connection
-          // error while it is running. A paused sandbox cannot own active
-          // commands, so placement/timeout failures quarantine it before the
-          // caller attempts bounded recovery on AWS.
+          // The listed state can become stale while connect is pending. Never
+          // destroy a shared user sandbox here: another run may have resumed
+          // it by the time this failure is observed. The attachment path owns
+          // bounded provider recovery and can retry safely on AWS.
           throw e;
         }
       }

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -2,6 +2,7 @@ import { Sandbox } from "@e2b/code-interpreter";
 import type { SandboxBootInfo, SandboxContext } from "@/types";
 import { NotFoundError, getUserFacingE2BErrorMessage } from "./e2b-errors";
 import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
+import { classifySandboxReadinessFailureSignal } from "./sandbox-readiness-failure";
 
 type SandboxReadyPath = SandboxBootInfo["path"];
 
@@ -248,8 +249,43 @@ export const ensureSandboxConnection = async (
             `[${userID}] Unexpected error resuming sandbox ${existingSandbox.sandboxId}:`,
             e,
           );
+          const failureReason = classifySandboxReadinessFailureSignal(e);
+          const canQuarantinePausedSandbox =
+            existingSandbox.state === "paused" &&
+            (failureReason === "placement_failure" ||
+              failureReason === "operation_timeout");
+          if (canQuarantinePausedSandbox) {
+            console.warn(
+              JSON.stringify({
+                timestamp: new Date().toISOString(),
+                level: "warn",
+                event: "e2b_paused_sandbox_quarantined_after_resume_failure",
+                service: "chat-handler",
+                environment:
+                  process.env.TRIGGER_ENV ??
+                  process.env.VERCEL_ENV ??
+                  process.env.NODE_ENV ??
+                  "unknown",
+                request_id: process.env.VERCEL_REQUEST_ID ?? null,
+                user_id: userID,
+                sandbox_id: existingSandbox.sandboxId,
+                failure_reason: failureReason,
+              }),
+            );
+            try {
+              await Sandbox.kill(existingSandbox.sandboxId);
+            } catch (killError) {
+              logSandboxKillFailure(
+                userID,
+                `Failed to quarantine paused sandbox ${existingSandbox.sandboxId}`,
+                killError,
+              );
+            }
+          }
           // Never destroy a shared user sandbox for a transient connection
-          // error. Another Agent run may still own active commands inside it.
+          // error while it is running. A paused sandbox cannot own active
+          // commands, so placement/timeout failures quarantine it before the
+          // caller attempts bounded recovery on AWS.
           throw e;
         }
       }

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -1379,7 +1379,8 @@ describe("createChatLogger ChatSDKError metadata", () => {
       const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
       expect(wideEvent.error).toMatchObject({
         code: "bad_request:sandbox",
-        message: "The computer attachment upload failed.",
+        message:
+          "The selected computer stopped responding while preparing the attachment. Reconnect it in Remote Control, then try again.",
         cause:
           "The selected computer stopped responding while preparing the attachment. Reconnect it in Remote Control, then try again.",
         retriable: true,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -131,6 +131,7 @@ import { createTrackedProvider } from "@/lib/ai/providers";
 import {
   getSandboxUploadFailureMetadata,
   getSandboxUploadUserMessage,
+  recoverProviderVisibleImagesAfterSandboxUploadFailure,
   uploadSandboxFiles,
   getUploadBasePath,
   rewriteSandboxFilePathsInMessages,
@@ -871,23 +872,40 @@ export const createChatHandler = () => {
                 writeUploadCompleteStatus(writer);
               }
               if (uploadResult.failedCount > 0) {
-                const uploadError = new ChatSDKError(
-                  "bad_request:sandbox",
-                  getSandboxUploadUserMessage(uploadResult),
-                  getSandboxUploadFailureMetadata(uploadResult),
+                const recoveredMessages =
+                  recoverProviderVisibleImagesAfterSandboxUploadFailure(
+                    processedMessages,
+                    sandboxFiles,
+                    uploadResult,
+                    {
+                      service: "chat-handler",
+                      requestId: req.headers.get("x-vercel-id") ?? undefined,
+                      userId,
+                      chatId,
+                    },
+                  );
+                if (recoveredMessages) {
+                  processedMessages = recoveredMessages;
+                } else {
+                  const uploadError = new ChatSDKError(
+                    "bad_request:sandbox",
+                    getSandboxUploadUserMessage(uploadResult),
+                    getSandboxUploadFailureMetadata(uploadResult),
+                  );
+                  // Errors thrown from execute are caught by createUIMessageStream's
+                  // onError and never reach the outer catch, so refund / timeout
+                  // clear / error logging must happen here. refund() is idempotent.
+                  preemptiveTimeout?.clear();
+                  await usageRefundTracker.refund();
+                  chatLogger?.emitChatError(uploadError);
+                  throw uploadError;
+                }
+              } else {
+                processedMessages = rewriteSandboxFilePathsInMessages(
+                  processedMessages,
+                  uploadResult.pathRewrites,
                 );
-                // Errors thrown from execute are caught by createUIMessageStream's
-                // onError and never reach the outer catch, so refund / timeout
-                // clear / error logging must happen here. refund() is idempotent.
-                preemptiveTimeout?.clear();
-                await usageRefundTracker.refund();
-                chatLogger?.emitChatError(uploadError);
-                throw uploadError;
               }
-              processedMessages = rewriteSandboxFilePathsInMessages(
-                processedMessages,
-                uploadResult.pathRewrites,
-              );
             }
 
             if (auxiliaryVisionFailover.isEnabled()) {

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -57,7 +57,10 @@ export class ChatSDKError extends Error {
     this.type = type as ErrorType;
     this.cause = cause;
     this.surface = surface as Surface;
-    this.message = getMessageByErrorCode(errorCode);
+    this.message =
+      this.surface === "sandbox" && cause
+        ? cause
+        : getMessageByErrorCode(errorCode);
     this.statusCode = getStatusCodeByType(this.type);
     this.metadata = metadata;
   }

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -7,6 +7,7 @@ import {
   getSandboxUploadFailureMetadata,
   getSandboxUploadUserMessage,
   prepareLocalDesktopAttachmentsForTrigger,
+  recoverProviderVisibleImagesAfterSandboxUploadFailure,
   rewriteSandboxFilePathsInMessages,
   stripLocalDesktopSourcePaths,
   uploadSandboxFiles,
@@ -1245,5 +1246,147 @@ describe("desktop-local sandbox file helpers", () => {
     expect(rewritten[0].parts?.[0]).toMatchObject({
       text: '<attachment filename="report.pdf" local_path="/home/alice/hackerai-upload/report.pdf" />',
     });
+  });
+
+  it("keeps provider-visible images when cloud staging is unavailable", () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const messages = [
+      {
+        id: "m1",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            url: "https://storage.example/screenshot.png",
+            mediaType: "image/png",
+            name: "screenshot.png",
+          },
+          {
+            type: "text",
+            text: '<inline_image_attachment filename="screenshot.png" sandbox_path="/home/user/upload/screenshot.png" already_visible_to_model="true" use_sandbox_path_for="file_operations_only" />',
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    try {
+      const recovered = recoverProviderVisibleImagesAfterSandboxUploadFailure(
+        messages,
+        [
+          {
+            kind: "url",
+            url: "https://storage.example/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        {
+          failedCount: 1,
+          pathRewrites: [],
+          failureDetails: [
+            {
+              kind: "url",
+              error: "sandbox placement failed",
+              reason: "sandbox_placement_failure",
+              transientSandboxCommand: false,
+              sandboxReadinessReason: "placement_failure",
+            },
+          ],
+        },
+        {
+          service: "agent-long",
+          requestId: "run-1",
+          userId: "user-1",
+          chatId: "chat-1",
+        },
+      );
+
+      expect(recovered).not.toBeNull();
+      expect(recovered?.[0].parts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "file",
+            url: "https://storage.example/screenshot.png",
+          }),
+          expect.objectContaining({
+            type: "text",
+            text: expect.stringContaining('images_visible_inline="true"'),
+          }),
+        ]),
+      );
+      expect(JSON.stringify(recovered)).not.toContain(
+        "/home/user/upload/screenshot.png",
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("sandbox_image_attachment_staging_bypassed"),
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("does not bypass failed staging for non-image attachments", () => {
+    const messages = [
+      {
+        id: "m1",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            url: "https://storage.example/report.pdf",
+            mediaType: "application/pdf",
+            name: "report.pdf",
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    expect(
+      recoverProviderVisibleImagesAfterSandboxUploadFailure(
+        messages,
+        [
+          {
+            kind: "url",
+            url: "https://storage.example/report.pdf",
+            localPath: "/home/user/upload/report.pdf",
+          },
+        ],
+        { failedCount: 1, pathRewrites: [] },
+        {
+          service: "chat-handler",
+          userId: "user-1",
+          chatId: "chat-1",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not bypass a partial batch upload failure", () => {
+    const imageFiles = [
+      {
+        kind: "url" as const,
+        url: "https://storage.example/one.png",
+        localPath: "/home/user/upload/one.png",
+      },
+      {
+        kind: "url" as const,
+        url: "https://storage.example/two.png",
+        localPath: "/home/user/upload/two.png",
+      },
+    ];
+
+    expect(
+      recoverProviderVisibleImagesAfterSandboxUploadFailure(
+        [],
+        imageFiles,
+        { failedCount: 1, pathRewrites: [] },
+        {
+          service: "agent-long",
+          userId: "user-1",
+          chatId: "chat-1",
+        },
+      ),
+    ).toBeNull();
   });
 });

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -80,6 +80,13 @@ type UploadSandboxFilesOptions = {
   };
 };
 
+type ProviderVisibleImageFallbackOptions = {
+  service: "agent-long" | "chat-handler";
+  requestId?: string;
+  userId: string;
+  chatId: string;
+};
+
 type SandboxAttachmentTagKind = "attachment" | "inline-image";
 
 type CollectSandboxFilesOptions = {
@@ -542,6 +549,100 @@ export const rewriteSandboxFilePathsInMessages = <T extends { parts?: any[] }>(
       }),
     };
   });
+};
+
+/**
+ * Preserve an Agent request when every failed sandbox upload is an image that
+ * remains visible to the model through its owner-checked signed URL. The
+ * sandbox-only path hints are removed so the model does not try to read files
+ * that were never staged. Non-image, local, and partial failures still fail
+ * closed because the provider cannot safely replace sandbox file access.
+ */
+export const recoverProviderVisibleImagesAfterSandboxUploadFailure = (
+  messages: UIMessage[],
+  sandboxFiles: SandboxFile[],
+  uploadResult: SandboxUploadResult,
+  options: ProviderVisibleImageFallbackOptions,
+): UIMessage[] | null => {
+  if (
+    sandboxFiles.length === 0 ||
+    uploadResult.failedCount !== sandboxFiles.length ||
+    sandboxFiles.some((file) => file.kind !== "url")
+  ) {
+    return null;
+  }
+
+  const providerVisibleImageUrls = new Set<string>();
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      if (
+        part?.type === "file" &&
+        typeof part.url === "string" &&
+        part.mediaType?.startsWith("image/")
+      ) {
+        providerVisibleImageUrls.add(part.url);
+      }
+    }
+  }
+
+  const failedImageFiles = sandboxFiles as Array<
+    Extract<SandboxFile, { kind: "url" }>
+  >;
+  if (
+    failedImageFiles.some((file) => !providerVisibleImageUrls.has(file.url))
+  ) {
+    return null;
+  }
+
+  const failedPaths = new Set(failedImageFiles.map((file) => file.localPath));
+  const recoveredMessages = messages.map((message) => {
+    if (!message.parts) return message;
+    const parts = message.parts.flatMap((part) => {
+      if (!("text" in part) || typeof part.text !== "string") return [part];
+      const remainingLines = part.text.split("\n").filter((line) => {
+        if (!line.startsWith("<inline_image_attachment ")) return true;
+        return !Array.from(failedPaths).some((path) =>
+          line.includes(`sandbox_path="${path}"`),
+        );
+      });
+      const text = remainingLines.join("\n").trim();
+      return text ? [{ ...part, text }] : [];
+    });
+    return { ...message, parts } as UIMessage;
+  });
+
+  const lastUserIndex = getLastUserMessageIndex(recoveredMessages);
+  if (lastUserIndex >= 0) {
+    recoveredMessages[lastUserIndex].parts ??= [];
+    recoveredMessages[lastUserIndex].parts!.push({
+      type: "text",
+      text: '<attachment_staging_status cloud_computer="unavailable" images_visible_inline="true">The image attachments are still visible inline. Answer from the images and user text; do not claim the files exist in the cloud computer.</attachment_staging_status>',
+    });
+  }
+
+  const failure = uploadResult.failureDetails?.[0];
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: "warn",
+      event: "sandbox_image_attachment_staging_bypassed",
+      service: options.service,
+      environment:
+        process.env.TRIGGER_ENV ??
+        process.env.VERCEL_ENV ??
+        process.env.NODE_ENV ??
+        "unknown",
+      request_id: options.requestId ?? null,
+      user_id: options.userId,
+      chat_id: options.chatId,
+      failed_image_count: failedImageFiles.length,
+      failure_reason: failure?.reason ?? "unknown",
+      sandbox_readiness_reason: failure?.sandboxReadinessReason ?? "unknown",
+      retried_with_fresh_sandbox: uploadResult.retriedWithFreshSandbox ?? false,
+    }),
+  );
+
+  return recoveredMessages;
 };
 
 export const prepareLocalDesktopAttachmentsForTrigger = (

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -118,6 +118,7 @@ import {
 import {
   getSandboxUploadFailureMetadata,
   getSandboxUploadUserMessage,
+  recoverProviderVisibleImagesAfterSandboxUploadFailure,
   uploadSandboxFiles,
   getUploadBasePath,
   rewriteSandboxFilePathsInMessages,
@@ -3415,19 +3416,36 @@ export const agentLongTask = task({
                 writeUploadCompleteStatus(writer);
               }
               if (uploadResult.failedCount > 0) {
-                const uploadError = new ChatSDKError(
-                  "bad_request:sandbox",
-                  getSandboxUploadUserMessage(uploadResult),
-                  getSandboxUploadFailureMetadata(uploadResult),
+                const recoveredMessages =
+                  recoverProviderVisibleImagesAfterSandboxUploadFailure(
+                    processedMessages,
+                    sandboxFiles,
+                    uploadResult,
+                    {
+                      service: "agent-long",
+                      requestId: ctx.run.id,
+                      userId,
+                      chatId,
+                    },
+                  );
+                if (recoveredMessages) {
+                  processedMessages = recoveredMessages;
+                } else {
+                  const uploadError = new ChatSDKError(
+                    "bad_request:sandbox",
+                    getSandboxUploadUserMessage(uploadResult),
+                    getSandboxUploadFailureMetadata(uploadResult),
+                  );
+                  await usageRefundTracker.refund();
+                  chatLogger?.emitChatError(uploadError);
+                  throw uploadError;
+                }
+              } else {
+                processedMessages = rewriteSandboxFilePathsInMessages(
+                  processedMessages,
+                  uploadResult.pathRewrites,
                 );
-                await usageRefundTracker.refund();
-                chatLogger?.emitChatError(uploadError);
-                throw uploadError;
               }
-              processedMessages = rewriteSandboxFilePathsInMessages(
-                processedMessages,
-                uploadResult.pathRewrites,
-              );
             }
 
             if (auxiliaryVisionFailover.isEnabled()) {

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -29,7 +29,7 @@ export interface SandboxManager {
   getSandbox(): Promise<{ sandbox: AnySandbox }>;
   setSandbox(sandbox: AnySandbox): void;
   resetSandbox?(reason?: string): Promise<void>;
-  /** Select a rollout-authorized alternate cloud provider for one recovery attempt. */
+  /** Select AWS for one rollout-authorized recovery attempt after an E2B placement failure. */
   selectAlternateCloudProviderForRecovery?(): CloudSandboxProvider | null;
   /** Quarantine an unresponsive local connection and keep retry acquisition bound to that explicit selection. */
   quarantineLocalConnection?(


### PR DESCRIPTION
## Summary
- reverse cloud recovery from AWS-to-E2B to E2B-to-AWS for AWS-eligible paid Agent runs
- preserve shared E2B sandboxes on failed reconnects so a stale paused-state observation cannot terminate a concurrently resumed run
- let image-only requests continue from provider-visible attachments when cloud file staging still fails
- surface classified, safe sandbox errors instead of the generic upload message

## Why
A persistent paused E2B sandbox can repeatedly fail placement during attachment staging. The former recovery direction masked AWS failures by moving AWS-assigned runs back to E2B and could not recover affected E2B-assigned users. This aligns bounded recovery with the AWS migration and keeps AWS failures observable without destructively cleaning up shared E2B state.

Owning rollout issue: HAC-63. The hypothesis, eligible population, metrics, guardrails, exposure event, rollback condition, owner, readout date, and cleanup plan are documented there.

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm lint` (passes with 7 pre-existing unrelated warnings)
- commit hook: 416 suites, 4,227 tests
- `corepack pnpm run check:local-dependencies`

## Manual verification
1. In Preview, run Agent mode as a paid E2B-control user with an image attachment and simulate an E2B placement failure. The run should recover once on AWS and answer from the image.
2. Simulate the same failure with a PDF or local-only attachment. The run should stop with the classified sandbox message and refund usage.
3. Start an AWS-assigned run and simulate AWS acquisition failure. The AWS error should remain visible and the run must not fall back to E2B.
4. Verify `cloud_sandbox_provider_selected`, `sandbox_attachment_acquisition_*`, and `sandbox_image_attachment_staging_bypassed` events contain provider/recovery metadata without attachment URLs or content.

No visual browser verification is needed because this is backend Agent orchestration and error propagation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image-based chat requests can continue when sandbox image uploads fail, provided the images remain accessible.
  - Eligible paid sandbox runs can retry on an alternate environment after placement failures.
- **Bug Fixes**
  - Active and paused sandboxes are no longer unnecessarily terminated or replaced after connection, placement, or timeout failures.
  - Sandbox errors now surface more specific recovery details.
- **Reliability**
  - Existing refund, timeout, cleanup, and error handling is preserved when image recovery is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->