### PR TITLE
Fix settings dialog first-load flicker

### DIFF
--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -6,29 +6,14 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useGlobalState } from "../contexts/GlobalState";
 import { useChats } from "../hooks/useChats";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import Loading from "@/components/ui/loading";
 import MainSidebar from "./Sidebar";
 import { onOpenSettingsDialog } from "@/lib/utils/settings-dialog";
-
-function SettingsDialogLoading() {
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      role="status"
-      aria-label="Loading settings"
-    >
-      <div className="flex h-[calc(80dvh+55px)] max-h-[95%] w-[380px] max-w-[98%] items-center justify-center overflow-hidden rounded-[20px] border bg-background shadow-lg md:h-[672px] md:w-[95vw] md:max-w-[920px]">
-        <Loading size={6} />
-      </div>
-    </div>
-  );
-}
 
 const SettingsDialog = dynamic(
   () => import("./SettingsDialog").then((module) => module.SettingsDialog),
   {
     ssr: false,
-    loading: SettingsDialogLoading,
+    loading: () => null,
   },
 );
 

--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -10,21 +10,25 @@ import Loading from "@/components/ui/loading";
 import MainSidebar from "./Sidebar";
 import { onOpenSettingsDialog } from "@/lib/utils/settings-dialog";
 
+function SettingsDialogLoading() {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="status"
+      aria-label="Loading settings"
+    >
+      <div className="flex h-[calc(80dvh+55px)] max-h-[95%] w-[380px] max-w-[98%] items-center justify-center overflow-hidden rounded-[20px] border bg-background shadow-lg md:h-[672px] md:w-[95vw] md:max-w-[920px]">
+        <Loading size={6} />
+      </div>
+    </div>
+  );
+}
+
 const SettingsDialog = dynamic(
   () => import("./SettingsDialog").then((module) => module.SettingsDialog),
   {
     ssr: false,
-    loading: () => (
-      <div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        role="status"
-        aria-label="Loading settings"
-      >
-        <div className="rounded-xl border bg-background p-6 shadow-lg">
-          <Loading size={6} />
-        </div>
-      </div>
-    ),
+    loading: SettingsDialogLoading,
   },
 );
 

--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -7,10 +7,13 @@ import { useGlobalState } from "../contexts/GlobalState";
 import { useChats } from "../hooks/useChats";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import MainSidebar from "./Sidebar";
-import { onOpenSettingsDialog } from "@/lib/utils/settings-dialog";
+import {
+  loadSettingsDialog,
+  onOpenSettingsDialog,
+} from "@/lib/utils/settings-dialog";
 
 const SettingsDialog = dynamic(
-  () => import("./SettingsDialog").then((module) => module.SettingsDialog),
+  () => loadSettingsDialog().then((module) => module.SettingsDialog),
   {
     ssr: false,
     loading: () => null,

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -43,7 +43,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { clientLogout } from "@/lib/utils/logout";
-import { openSettingsDialog } from "@/lib/utils/settings-dialog";
+import {
+  openSettingsDialog,
+  preloadSettingsDialog,
+} from "@/lib/utils/settings-dialog";
 import { ReferralRewardDialog } from "./ReferralRewardDialog";
 
 const NEXT_PUBLIC_HELP_CENTER_URL =
@@ -303,7 +306,11 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
       {/* Upgrade banner above user nav */}
       <UpgradeBanner isCollapsed={isCollapsed} />
 
-      <DropdownMenu>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (open) preloadSettingsDialog();
+        }}
+      >
         <DropdownMenuTrigger asChild>
           {isCollapsed ? (
             /* Collapsed state - only show avatar */
@@ -314,6 +321,8 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
                 className="flex items-center justify-center p-2 cursor-pointer hover:bg-sidebar-accent/50 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 w-full"
                 aria-haspopup="menu"
                 aria-label={`Open user menu for ${getDisplayName()}`}
+                onPointerEnter={preloadSettingsDialog}
+                onFocus={preloadSettingsDialog}
               >
                 <Avatar data-testid="user-avatar" className="h-7 w-7">
                   <AvatarImage
@@ -334,6 +343,8 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
               className="flex items-center gap-3 p-3 cursor-pointer hover:bg-sidebar-accent/50 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 w-full text-left"
               aria-haspopup="menu"
               aria-label={`Open user menu for ${getDisplayName()}`}
+              onPointerEnter={preloadSettingsDialog}
+              onFocus={preloadSettingsDialog}
             >
               <Avatar data-testid="user-avatar" className="h-7 w-7">
                 <AvatarImage

--- a/lib/utils/settings-dialog.ts
+++ b/lib/utils/settings-dialog.ts
@@ -1,7 +1,30 @@
 const EVENT_NAME = "open-settings-dialog";
 
+type SettingsDialogModule = typeof import("@/app/components/SettingsDialog");
+
+let settingsDialogModulePromise: Promise<SettingsDialogModule> | null = null;
+
 interface OpenSettingsDetail {
   tab?: string;
+}
+
+/** Load the Settings dialog bundle once, resetting the cache if loading fails. */
+export function loadSettingsDialog(): Promise<SettingsDialogModule> {
+  if (!settingsDialogModulePromise) {
+    settingsDialogModulePromise =
+      import("@/app/components/SettingsDialog").catch((error) => {
+        settingsDialogModulePromise = null;
+        throw error;
+      });
+  }
+
+  return settingsDialogModulePromise;
+}
+
+/** Warm the Settings dialog bundle from browser user intent. */
+export function preloadSettingsDialog(): void {
+  if (typeof window === "undefined") return;
+  void loadSettingsDialog().catch(() => undefined);
 }
 
 /** Fire from anywhere to open the Settings dialog (optionally to a specific tab). */


### PR DESCRIPTION
## Summary

- keep the settings bundle lazily loaded without a temporary popup
- preload the bundle on user-menu hover, keyboard focus, and menu-open for touch users
- share one retry-safe loading promise between preloading and the real dialog
- let the user menu close normally, then mount and animate the settings dialog exactly once

## Validation

- full Jest suite: 416 suites, 4,227 tests passed
- TypeScript typecheck passed
- ESLint and Prettier passed
- Google Chrome verification with the settings chunk deliberately delayed by one second:
  - desktop hover requested the settings chunk before the menu click
  - touch menu-open requested the settings chunk before the Settings selection
  - completed dialog opened in about 56 ms on desktop and 66 ms on mobile
  - no loading popup rendered
  - settings dialog mounted once without a close/reopen cycle
  - no Next.js error overlay

## Manual verification

1. Open the app in Preview on a fresh desktop or mobile session.
2. Hover/focus or open the user menu, then select Settings.
3. Confirm the menu closes and the completed settings dialog opens once, without a temporary popup or close/reopen flicker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved settings dialog loading for a smoother opening experience.
  * Settings begin preloading when the account menu is opened or focused, reducing wait time when accessed.
  * Preserved existing settings dialog behavior while improving loading reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->