### PR TITLE
Recover DeepSeek agent streams with bounded fallbacks

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1404,6 +1404,15 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toContain(
       "Do not repeat completed tool calls or their side effects.",
     );
+    expect(taskSrc).toMatch(
+      /getNextDeepSeekProDisconnectRetryModel\(\{[\s\S]{0,250}failedModel: retryModel,[\s\S]{0,250}completedRetryCount:[\s\S]{0,100}providerRecoveryAttempts/,
+    );
+    expect(taskSrc).toMatch(
+      /const finalRetryResult =\s*await createStream\(finalRetryModel\)/,
+    );
+    expect(taskSrc).not.toMatch(
+      /finalRetryResult[\s\S]{0,2500}getNextDeepSeekProDisconnectRetryModel/,
+    );
   });
 
   test("persists replay-safe output before fallback stream creation can fail", () => {
@@ -1558,10 +1567,13 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   });
 
   test("retry streams reset served-model telemetry and distinguish same-model recovery", () => {
-    for (const source of [taskSrc, chatHandlerSrc]) {
+    for (const [source, expectedResetCount] of [
+      [taskSrc, 3],
+      [chatHandlerSrc, 2],
+    ] as const) {
       expect(
         source.match(/resetServedModelTelemetryForRetry\(state\)/g),
-      ).toHaveLength(2);
+      ).toHaveLength(expectedResetCount);
 
       const catchModelSwitchIdx = source.indexOf(
         "retryUsedFallbackModel = retryUsesDifferentModel(",

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1410,9 +1410,19 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(
       /const finalRetryResult =\s*await createStream\(finalRetryModel\)/,
     );
-    expect(taskSrc).not.toMatch(
-      /finalRetryResult[\s\S]{0,2500}getNextDeepSeekProDisconnectRetryModel/,
+    expect(
+      taskSrc.match(/getNextDeepSeekProDisconnectRetryModel\(\{/g),
+    ).toHaveLength(1);
+    const finalRetryCacheBaselineIdx = taskSrc.indexOf(
+      "preFallbackCacheRead =",
+      taskSrc.indexOf("const finalRetryStartTime = Date.now()"),
     );
+    const finalRetryStreamIdx = taskSrc.indexOf(
+      "await createStream(finalRetryModel)",
+      finalRetryCacheBaselineIdx,
+    );
+    expect(finalRetryCacheBaselineIdx).toBeGreaterThan(-1);
+    expect(finalRetryStreamIdx).toBeGreaterThan(finalRetryCacheBaselineIdx);
   });
 
   test("persists replay-safe output before fallback stream creation can fail", () => {
@@ -1567,21 +1577,16 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   });
 
   test("retry streams reset served-model telemetry and distinguish same-model recovery", () => {
-    for (const [source, expectedResetCount] of [
-      [taskSrc, 3],
-      [chatHandlerSrc, 2],
+    for (const [source, resetCall, expectedResetCount] of [
+      [taskSrc, "resetAgentStreamStateForRetry(state)", 3],
+      [chatHandlerSrc, "resetServedModelTelemetryForRetry(state)", 2],
     ] as const) {
-      expect(
-        source.match(/resetServedModelTelemetryForRetry\(state\)/g),
-      ).toHaveLength(expectedResetCount);
+      expect(source.split(resetCall)).toHaveLength(expectedResetCount + 1);
 
       const catchModelSwitchIdx = source.indexOf(
         "retryUsedFallbackModel = retryUsesDifferentModel(",
       );
-      const catchResetIdx = source.indexOf(
-        "resetServedModelTelemetryForRetry(state)",
-        catchModelSwitchIdx,
-      );
+      const catchResetIdx = source.indexOf(resetCall, catchModelSwitchIdx);
       const catchRetryStreamIdx = source.indexOf(
         "createStream(fallbackModel)",
         catchResetIdx,
@@ -1598,10 +1603,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
         "retryUsedFallbackModel =",
         retryModelIdx,
       );
-      const resetIdx = source.indexOf(
-        "resetServedModelTelemetryForRetry(state)",
-        modelSwitchIdx,
-      );
+      const resetIdx = source.indexOf(resetCall, modelSwitchIdx);
       const retryStreamIdx = source.indexOf("createStream(", resetIdx);
 
       expect(modelSwitchIdx).toBeGreaterThan(retryModelIdx);

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -91,6 +91,13 @@ describe("captureAgentRun", () => {
       activeModelStreamDurationMs: 30_000,
       activeTerminalWaitDurationMs: 10_000,
       activeSandboxRecoveryDurationMs: 2_000,
+      upstreamProvider: "Cloudflare",
+      providerErrorProvider: "DeepInfra",
+      providerErrorCategory: "timeout",
+      providerErrorStatusCode: 504,
+      providerRecoveryAttempts: 2,
+      providerRecoveryModels: ["model-grok-4.6", "model-kimi-k3"],
+      providerRecoverySucceeded: true,
     });
 
     expect(capture).toHaveBeenCalledWith({
@@ -113,6 +120,13 @@ describe("captureAgentRun", () => {
         active_model_stream_duration_ms: 30_000,
         active_terminal_wait_duration_ms: 10_000,
         active_sandbox_recovery_duration_ms: 2_000,
+        upstream_provider: "Cloudflare",
+        provider_error_provider: "DeepInfra",
+        provider_error_category: "timeout",
+        provider_error_status_code: 504,
+        provider_recovery_attempts: 2,
+        provider_recovery_models: ["model-grok-4.6", "model-kimi-k3"],
+        provider_recovery_succeeded: true,
         response_model: "deepseek/deepseek-v4-pro",
         fallback_served: false,
         sandbox_type: "remote-connection",

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1306,41 +1306,7 @@ export function captureAgentRun({
   providerRecoveryAttempts,
   providerRecoveryModels,
   providerRecoverySucceeded,
-}: {
-  posthog: PostHog | null;
-  userId: string;
-  chatId: string;
-  mode: ChatMode;
-  subscription: string;
-  sandboxInfo: SandboxInfo | null;
-  outcome: AgentRunOutcome;
-  abortSource?: AgentAbortSource;
-  selectedModel: string;
-  configuredModelId: string;
-  responseModel?: string;
-  fallbackServed?: boolean;
-  finishReason?: string;
-  budgetAbortDetails?: BudgetAbortDetails;
-  agentPermissionMode?: AgentPermissionMode;
-  triggerRunId?: string;
-  triggerUsageDurationMs?: number;
-  triggerTotalCostUsd?: number;
-  approvalWaitCount?: number;
-  approvalWaitDurationMs?: number;
-  activeModelStreamDurationMs?: number;
-  activeTerminalWaitDurationMs?: number;
-  activeSandboxRecoveryDurationMs?: number;
-  isAutoContinue?: boolean;
-  stepLimitTelemetry?: AgentStepLimitTelemetry;
-  experiment?: ExperimentAnalyticsContext;
-  upstreamProvider?: string;
-  providerErrorProvider?: string;
-  providerErrorCategory?: string;
-  providerErrorStatusCode?: number;
-  providerRecoveryAttempts?: number;
-  providerRecoveryModels?: readonly string[];
-  providerRecoverySucceeded?: boolean;
-}) {
+}: Omit<AgentCompletionAnalyticsArgs, "endpoint" | "chatLogger">) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
     distinctId: userId,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1263,6 +1263,13 @@ type AgentCompletionAnalyticsArgs = {
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
   experiment?: ExperimentAnalyticsContext;
+  upstreamProvider?: string;
+  providerErrorProvider?: string;
+  providerErrorCategory?: string;
+  providerErrorStatusCode?: number;
+  providerRecoveryAttempts?: number;
+  providerRecoveryModels?: readonly string[];
+  providerRecoverySucceeded?: boolean;
 };
 
 export function captureAgentRun({
@@ -1292,6 +1299,13 @@ export function captureAgentRun({
   isAutoContinue,
   stepLimitTelemetry,
   experiment,
+  upstreamProvider,
+  providerErrorProvider,
+  providerErrorCategory,
+  providerErrorStatusCode,
+  providerRecoveryAttempts,
+  providerRecoveryModels,
+  providerRecoverySucceeded,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1319,6 +1333,13 @@ export function captureAgentRun({
   isAutoContinue?: boolean;
   stepLimitTelemetry?: AgentStepLimitTelemetry;
   experiment?: ExperimentAnalyticsContext;
+  upstreamProvider?: string;
+  providerErrorProvider?: string;
+  providerErrorCategory?: string;
+  providerErrorStatusCode?: number;
+  providerRecoveryAttempts?: number;
+  providerRecoveryModels?: readonly string[];
+  providerRecoverySucceeded?: boolean;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1372,6 +1393,25 @@ export function captureAgentRun({
         sandbox_provider: sandboxInfo.provider,
       }),
       ...(finishReason && { finish_reason: finishReason }),
+      ...(upstreamProvider && { upstream_provider: upstreamProvider }),
+      ...(providerErrorProvider && {
+        provider_error_provider: providerErrorProvider,
+      }),
+      ...(providerErrorCategory && {
+        provider_error_category: providerErrorCategory,
+      }),
+      ...(providerErrorStatusCode !== undefined && {
+        provider_error_status_code: providerErrorStatusCode,
+      }),
+      ...(providerRecoveryAttempts !== undefined && {
+        provider_recovery_attempts: providerRecoveryAttempts,
+      }),
+      ...(providerRecoveryModels && {
+        provider_recovery_models: [...providerRecoveryModels],
+      }),
+      ...(providerRecoverySucceeded !== undefined && {
+        provider_recovery_succeeded: providerRecoverySucceeded,
+      }),
       ...(stepLimitTelemetry && {
         step_limit_telemetry_version: stepLimitTelemetry.version,
         configured_max_steps: stepLimitTelemetry.configuredMaxSteps,
@@ -1432,6 +1472,13 @@ export function captureAgentCompletionAnalytics(
     isAutoContinue: args.isAutoContinue,
     stepLimitTelemetry: args.stepLimitTelemetry,
     experiment: args.experiment,
+    upstreamProvider: args.upstreamProvider,
+    providerErrorProvider: args.providerErrorProvider,
+    providerErrorCategory: args.providerErrorCategory,
+    providerErrorStatusCode: args.providerErrorStatusCode,
+    providerRecoveryAttempts: args.providerRecoveryAttempts,
+    providerRecoveryModels: args.providerRecoveryModels,
+    providerRecoverySucceeded: args.providerRecoverySucceeded,
   });
 }
 

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -1,6 +1,7 @@
 import {
   createAssistantContentLoopMonitor,
   detectAssistantContentLoopFromText,
+  getNextDeepSeekProDisconnectRetryModel,
   prepareProviderDisconnectContinuation,
   shouldRetryAgentLongWithFallback,
   shouldRetryProviderStreamAfterReasoningOnlyOutput,
@@ -95,6 +96,43 @@ describe("prepareProviderDisconnectContinuation", () => {
 
     expect(recovery?.removedPartCount).toBe(2);
     expect(recovery?.messages).toEqual([messages[0]]);
+  });
+});
+
+describe("getNextDeepSeekProDisconnectRetryModel", () => {
+  it("uses Grok and then one final Kimi retry", () => {
+    expect(
+      getNextDeepSeekProDisconnectRetryModel({
+        originalModel: "model-deepseek-v4-pro-0813",
+        failedModel: "model-deepseek-v4-pro-0813",
+        completedRetryCount: 0,
+      }),
+    ).toBe("model-grok-4.6");
+
+    expect(
+      getNextDeepSeekProDisconnectRetryModel({
+        originalModel: "model-deepseek-v4-pro-0813",
+        failedModel: "model-grok-4.6",
+        completedRetryCount: 1,
+      }),
+    ).toBe("model-kimi-k3");
+  });
+
+  it("stops after Kimi and does not affect other original models", () => {
+    expect(
+      getNextDeepSeekProDisconnectRetryModel({
+        originalModel: "model-deepseek-v4-pro-0813",
+        failedModel: "model-kimi-k3",
+        completedRetryCount: 2,
+      }),
+    ).toBeUndefined();
+    expect(
+      getNextDeepSeekProDisconnectRetryModel({
+        originalModel: "model-grok-4.6",
+        failedModel: "model-grok-4.6",
+        completedRetryCount: 0,
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -122,6 +122,13 @@ describe("getNextDeepSeekProDisconnectRetryModel", () => {
     expect(
       getNextDeepSeekProDisconnectRetryModel({
         originalModel: "model-deepseek-v4-pro-0813",
+        failedModel: "model-glm-5.2",
+        completedRetryCount: 1,
+      }),
+    ).toBeUndefined();
+    expect(
+      getNextDeepSeekProDisconnectRetryModel({
+        originalModel: "model-deepseek-v4-pro-0813",
         failedModel: "model-kimi-k3",
         completedRetryCount: 2,
       }),

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -101,6 +101,7 @@ export type ProviderDisconnectContinuation = {
   preservedTextPartCount: number;
 };
 
+const DEEPSEEK_PRO_MODEL = "model-deepseek-v4-pro-0813";
 const DEEPSEEK_PRO_RECOVERY_CHAIN = [
   "model-grok-4.6",
   "model-kimi-k3",
@@ -120,12 +121,9 @@ export const getNextDeepSeekProDisconnectRetryModel = ({
   failedModel: string;
   completedRetryCount: number;
 }): (typeof DEEPSEEK_PRO_RECOVERY_CHAIN)[number] | undefined => {
-  if (originalModel !== "model-deepseek-v4-pro-0813") return undefined;
+  if (originalModel !== DEEPSEEK_PRO_MODEL) return undefined;
 
-  if (
-    completedRetryCount === 0 &&
-    failedModel === "model-deepseek-v4-pro-0813"
-  ) {
+  if (completedRetryCount === 0 && failedModel === DEEPSEEK_PRO_MODEL) {
     return DEEPSEEK_PRO_RECOVERY_CHAIN[0];
   }
 

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -101,6 +101,44 @@ export type ProviderDisconnectContinuation = {
   preservedTextPartCount: number;
 };
 
+const DEEPSEEK_PRO_RECOVERY_CHAIN = [
+  "model-grok-4.6",
+  "model-kimi-k3",
+] as const;
+
+/**
+ * Return the next bounded app-side recovery model for a DeepSeek Pro stream
+ * disconnect. `completedRetryCount` counts retries already started, so the
+ * only valid transitions are DeepSeek -> Grok -> Kimi.
+ */
+export const getNextDeepSeekProDisconnectRetryModel = ({
+  originalModel,
+  failedModel,
+  completedRetryCount,
+}: {
+  originalModel: string;
+  failedModel: string;
+  completedRetryCount: number;
+}): (typeof DEEPSEEK_PRO_RECOVERY_CHAIN)[number] | undefined => {
+  if (originalModel !== "model-deepseek-v4-pro-0813") return undefined;
+
+  if (
+    completedRetryCount === 0 &&
+    failedModel === "model-deepseek-v4-pro-0813"
+  ) {
+    return DEEPSEEK_PRO_RECOVERY_CHAIN[0];
+  }
+
+  if (
+    completedRetryCount === 1 &&
+    failedModel === DEEPSEEK_PRO_RECOVERY_CHAIN[0]
+  ) {
+    return DEEPSEEK_PRO_RECOVERY_CHAIN[1];
+  }
+
+  return undefined;
+};
+
 /**
  * Build a replay-safe transcript after a provider socket dies mid-step.
  *

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1696,6 +1696,28 @@ const isTerminalProviderStreamError = (
 const PROVIDER_DISCONNECT_CONTINUATION_PROMPT =
   "The previous model connection ended mid-response. Continue from the preserved completed text and tool results. Do not repeat completed tool calls or their side effects. Finish the task from the last durable result.";
 
+const resetAgentStreamStateForRetry = (state: AgentStreamState): void => {
+  state.openRouterMetadata = {};
+  state.lastStepInputTokens = 0;
+  state.stoppedDueToStepLimit = false;
+  state.streamFinishReason = undefined;
+  state.providerError = undefined;
+  state.providerRejectedMultimodalToolResults = false;
+  state.stoppedDueToTokenExhaustion = false;
+  state.stoppedDueToElapsedTimeout = false;
+  state.stoppedDueToDoomLoop = false;
+  state.stoppedDueToAssistantContentLoop = false;
+  state.assistantContentLoopDetection = undefined;
+  state.stoppedDueToBudgetExhaustion = false;
+  state.stoppedDueToAgentRunSpendCap = false;
+  state.stoppedDueToPostSummarizationIncomplete = false;
+  state.postSummarizationContinuationActive = false;
+  state.postSummarizationToolCallCount = 0;
+  state.postSummarizationText = "";
+  state.budgetAbortDetails = undefined;
+  resetServedModelTelemetryForRetry(state);
+};
+
 type RecordedAgentLongFailure = {
   userCorrectable: boolean;
 };
@@ -4515,21 +4537,8 @@ export const agentLongTask = task({
                   selectedModel,
                   fallbackModel,
                 );
-                resetServedModelTelemetryForRetry(state);
-                state.lastStepInputTokens = 0;
-                state.stoppedDueToStepLimit = false;
-                state.stoppedDueToTokenExhaustion = false;
-                state.stoppedDueToElapsedTimeout = false;
-                state.stoppedDueToDoomLoop = false;
-                state.stoppedDueToAssistantContentLoop = false;
-                state.assistantContentLoopDetection = undefined;
-                state.stoppedDueToBudgetExhaustion = false;
-                state.stoppedDueToAgentRunSpendCap = false;
-                state.stoppedDueToPostSummarizationIncomplete = false;
-                state.postSummarizationContinuationActive = false;
-                state.postSummarizationToolCallCount = 0;
-                state.postSummarizationText = "";
-                state.budgetAbortDetails = undefined;
+                streamError = undefined;
+                resetAgentStreamStateForRetry(state);
                 preFallbackCacheRead = usageTracker.cacheReadTokens;
                 preFallbackCacheWrite = usageTracker.cacheWriteTokens;
                 usageTracker.resetModelLeg();
@@ -4739,31 +4748,13 @@ export const agentLongTask = task({
                         }
                         isRetryWithFallback = true;
                         streamError = undefined;
-                        state.openRouterMetadata = {};
-                        state.lastStepInputTokens = 0;
-                        state.stoppedDueToStepLimit = false;
-                        state.streamFinishReason = undefined;
-                        state.providerError = undefined;
-                        state.providerRejectedMultimodalToolResults = false;
-                        state.stoppedDueToTokenExhaustion = false;
-                        state.stoppedDueToElapsedTimeout = false;
-                        state.stoppedDueToDoomLoop = false;
-                        state.stoppedDueToAssistantContentLoop = false;
-                        state.assistantContentLoopDetection = undefined;
-                        state.stoppedDueToBudgetExhaustion = false;
-                        state.stoppedDueToAgentRunSpendCap = false;
-                        state.stoppedDueToPostSummarizationIncomplete = false;
-                        state.postSummarizationContinuationActive = false;
-                        state.postSummarizationToolCallCount = 0;
-                        state.postSummarizationText = "";
-                        state.budgetAbortDetails = undefined;
                         const fallbackStartTime = Date.now();
                         preFallbackCacheRead = usageTracker.cacheReadTokens;
                         preFallbackCacheWrite = usageTracker.cacheWriteTokens;
                         retryUsedFallbackModel =
                           retryUsesDifferentModel(selectedModel, retryModel) ||
                           providerContentBlocked;
-                        resetServedModelTelemetryForRetry(state);
+                        resetAgentStreamStateForRetry(state);
                         if (providerDisconnectContinuation) {
                           state.finalMessages = [
                             ...state.finalMessages,
@@ -4892,26 +4883,7 @@ export const agentLongTask = task({
                                       continuation: nextContinuation,
                                     });
                                     streamError = undefined;
-                                    state.openRouterMetadata = {};
-                                    state.lastStepInputTokens = 0;
-                                    state.stoppedDueToStepLimit = false;
-                                    state.streamFinishReason = undefined;
-                                    state.providerError = undefined;
-                                    state.providerRejectedMultimodalToolResults = false;
-                                    state.stoppedDueToTokenExhaustion = false;
-                                    state.stoppedDueToElapsedTimeout = false;
-                                    state.stoppedDueToDoomLoop = false;
-                                    state.stoppedDueToAssistantContentLoop = false;
-                                    state.assistantContentLoopDetection =
-                                      undefined;
-                                    state.stoppedDueToBudgetExhaustion = false;
-                                    state.stoppedDueToAgentRunSpendCap = false;
-                                    state.stoppedDueToPostSummarizationIncomplete = false;
-                                    state.postSummarizationContinuationActive = false;
-                                    state.postSummarizationToolCallCount = 0;
-                                    state.postSummarizationText = "";
-                                    state.budgetAbortDetails = undefined;
-                                    resetServedModelTelemetryForRetry(state);
+                                    resetAgentStreamStateForRetry(state);
                                     retryUsedFallbackModel = true;
                                     state.finalMessages = [
                                       ...state.finalMessages,
@@ -4951,6 +4923,10 @@ export const agentLongTask = task({
                                           fallbackStartTime,
                                       });
                                     }
+                                    preFallbackCacheRead =
+                                      usageTracker.cacheReadTokens;
+                                    preFallbackCacheWrite =
+                                      usageTracker.cacheWriteTokens;
                                     const finalRetryResult =
                                       await createStream(finalRetryModel);
                                     const finalRetryMessageId = generateId();

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -256,12 +256,16 @@ import {
 } from "@/lib/chat/stop-conditions";
 import {
   detectAssistantContentLoopFromParts,
+  getNextDeepSeekProDisconnectRetryModel,
   prepareProviderDisconnectContinuation,
   shouldRetryProviderStreamAfterReasoningOnlyOutput,
   shouldRetryProviderStreamAfterInterruptedToolInput,
   shouldRetryAgentLongWithFallback,
 } from "@/lib/chat/agent-long-provider-retry";
-import { wrapProviderTerminalError } from "@/lib/api/provider-terminal-error";
+import {
+  ProviderTerminalError,
+  wrapProviderTerminalError,
+} from "@/lib/api/provider-terminal-error";
 import {
   omitImageViewToolResultsForProviderRetry,
   omitTrailingStepStartAssistantMessage,
@@ -3593,6 +3597,9 @@ export const agentLongTask = task({
 
             let isRetryWithFallback = false;
             let retryUsedFallbackModel = false;
+            let providerRecoveryAttempts = 0;
+            const providerRecoveryModels: string[] = [];
+            let lastProviderRecoveryError: ProviderTerminalError | undefined;
             const isAutoModel = isAutoModelSelectionForRetry({
               selectedModel,
               selectedModelOverride,
@@ -4198,6 +4205,262 @@ export const agentLongTask = task({
               return createAgentStream(modelName, streamCtx, state);
             };
 
+            const getProviderRecoveryAnalytics = (
+              outcome: "success" | "error" | "aborted",
+            ) => {
+              const terminalError = getTerminalProviderStreamError(state);
+              const providerError = terminalError
+                ? wrapProviderTerminalError(terminalError, {
+                    model: terminalRequestedModelSlug,
+                    openRouterMetadata: state.openRouterMetadata,
+                  })
+                : lastProviderRecoveryError;
+
+              return {
+                upstreamProvider: state.openRouterMetadata.provider_name,
+                providerErrorProvider: providerError?.provider,
+                providerErrorCategory: providerError?.category,
+                providerErrorStatusCode: providerError?.statusCode,
+                providerRecoveryAttempts,
+                providerRecoveryModels,
+                providerRecoverySucceeded:
+                  providerRecoveryAttempts > 0 && outcome === "success",
+              };
+            };
+
+            const recordProviderDisconnectRecoveryAttempt = ({
+              failedModel,
+              retryModel,
+              continuation,
+            }: {
+              failedModel: string;
+              retryModel: string;
+              continuation: NonNullable<
+                ReturnType<typeof prepareProviderDisconnectContinuation>
+              >;
+            }) => {
+              const failure = wrapProviderTerminalError(state.providerError, {
+                model: trackedProvider.languageModel(failedModel).modelId,
+                openRouterMetadata: state.openRouterMetadata,
+              });
+              providerRecoveryAttempts += 1;
+              providerRecoveryModels.push(retryModel);
+              lastProviderRecoveryError = failure;
+              const fields = {
+                event: "agent_provider_disconnect_recovery_attempted",
+                service: "agent-long",
+                environment:
+                  process.env.TRIGGER_ENV ??
+                  process.env.VERCEL_ENV ??
+                  process.env.NODE_ENV ??
+                  "unknown",
+                timestamp: new Date().toISOString(),
+                request_id: ctx.run.id,
+                run_id: ctx.run.id,
+                chat_id: chatId,
+                userId,
+                original_model: selectedModel,
+                failed_model: failedModel,
+                retry_model: retryModel,
+                retry_attempt: providerRecoveryAttempts,
+                max_retry_attempts: 2,
+                provider: failure.provider,
+                error_category: failure.category,
+                error_status_code: failure.statusCode,
+                openrouter_generation_id: failure.openrouterGenerationId,
+                openrouter_request_id: failure.openrouterRequestId,
+                openrouter_upstream_id: failure.openrouterUpstreamId,
+                checkpoint_removed_part_count: continuation.removedPartCount,
+                checkpoint_completed_tool_count:
+                  continuation.preservedCompletedToolCount,
+                checkpoint_text_part_count: continuation.preservedTextPartCount,
+              };
+              phLogger.warn(
+                "[agent-long] Retrying provider disconnect from checkpoint",
+                fields,
+              );
+              phLogger.event("agent_provider_disconnect_recovery_attempted", {
+                ...fields,
+                userId,
+              });
+              metadata
+                .set("providerRecoveryAttempts", providerRecoveryAttempts)
+                .set("providerRecoveryModel", retryModel)
+                .set("providerRecoveryProvider", failure.provider)
+                .set("providerRecoveryErrorCategory", failure.category);
+            };
+
+            const finalizeRetryStream = async ({
+              retryMessages,
+              retryAborted,
+              retryMessageId,
+              retryStartTime,
+            }: {
+              retryMessages: UIMessage[];
+              retryAborted: boolean;
+              retryMessageId: string;
+              retryStartTime: number;
+            }) => {
+              const fallbackCacheRead =
+                usageTracker.cacheReadTokens - preFallbackCacheRead;
+              const fallbackCacheWrite =
+                usageTracker.cacheWriteTokens - preFallbackCacheWrite;
+              const fallbackCacheTotal = fallbackCacheRead + fallbackCacheWrite;
+              const sandboxInfo = sandboxManager.getSandboxInfo();
+              chatLogger?.setSandbox(sandboxInfo);
+              chatLogger?.setCacheMetrics({
+                cacheHitRate:
+                  fallbackCacheTotal > 0
+                    ? fallbackCacheRead / fallbackCacheTotal
+                    : null,
+                cacheReadTokens: fallbackCacheRead,
+                cacheWriteTokens: fallbackCacheWrite,
+              });
+              captureToolCalls({ posthog, chatLogger, userId, mode });
+              // Final reconciliation can change the finish reason to
+              // budget-exhausted; do it before analytics and persistence.
+              await deductAccumulatedUsage();
+              const outcome = retryAborted
+                ? "aborted"
+                : isTerminalProviderStreamError(state)
+                  ? "error"
+                  : "success";
+              captureAgentCompletionAnalytics({
+                posthog,
+                userId,
+                chatId,
+                endpoint,
+                mode,
+                subscription,
+                sandboxInfo,
+                outcome,
+                abortSource: resolveAgentAbortSource({
+                  outcome,
+                  stoppedDueToBudgetExhaustion:
+                    state.stoppedDueToBudgetExhaustion,
+                  stoppedDueToAgentRunSpendCap:
+                    state.stoppedDueToAgentRunSpendCap,
+                  stoppedDueToElapsedTimeout: state.stoppedDueToElapsedTimeout,
+                  requestCancelled: triggerSignal.aborted,
+                }),
+                chatLogger,
+                selectedModel,
+                configuredModelId,
+                responseModel: state.responseModel,
+                fallbackServed:
+                  state.responseModel && retryUsedFallbackModel
+                    ? true
+                    : state.fallbackServed,
+                finishReason: state.streamFinishReason,
+                budgetAbortDetails: state.budgetAbortDetails,
+                agentPermissionMode,
+                isAutoContinue: !!isAutoContinue,
+                experiment: routingExperimentContext,
+                stepLimitTelemetry: buildAgentStepLimitTelemetry({
+                  configuredMaxSteps: state.configuredMaxSteps,
+                  stepCount: state.agentStepCount,
+                  stepLimitReached: state.stoppedDueToStepLimit,
+                  todoRunMetrics: getTodoManager().getRunMetrics(),
+                }),
+                ...getProviderRecoveryAnalytics(outcome),
+                ...getTriggerRunTelemetry(),
+              });
+              if (!isTerminalProviderStreamError(state)) {
+                chatLogger?.emitSuccess({
+                  finishReason: state.streamFinishReason,
+                  wasAborted: retryAborted,
+                  wasPreemptiveTimeout: false,
+                  hadSummarization: summarizationTracker.hasSummarized,
+                });
+              }
+
+              const generatedTitle = await titlePromise;
+              const mergedTodos = getTodoManager().mergeWith(
+                baseTodos,
+                retryMessageId,
+              );
+              if (
+                generatedTitle ||
+                state.streamFinishReason ||
+                mergedTodos.length > 0
+              ) {
+                try {
+                  await updateChat({
+                    chatId,
+                    title: generatedTitle,
+                    finishReason: state.streamFinishReason,
+                    todos: mergedTodos,
+                    defaultModelSlug: "agent",
+                    sandboxType: sandboxManager.getEffectivePreference(),
+                    selectedModel: selectedModelOverride,
+                  });
+                } catch (error) {
+                  recordAgentLongChatMetadataUpdateFailure(error, {
+                    chatId,
+                    userId,
+                    runId: ctx.run.id,
+                  });
+                }
+              } else {
+                await prepareForNewStream({ chatId });
+              }
+              const accumulatedFiles = getFileAccumulator().getAll();
+              const newFileIds = accumulatedFiles.map((file) => file.fileId);
+              const fallbackGenerationTimeMs = Date.now() - retryStartTime;
+              for (const message of retryMessages) {
+                if (message.role !== "assistant") continue;
+                const processed = stripAgentLongHeartbeatParts(
+                  summarizationTracker.processMessageForSave(message),
+                );
+                await saveMessage({
+                  chatId,
+                  userId,
+                  message: processed,
+                  extraFileIds: newFileIds,
+                  usage: state.streamUsage,
+                  model: state.responseModel,
+                  mode,
+                  generationStartedAt: retryStartTime,
+                  generationTimeMs: fallbackGenerationTimeMs,
+                  finishReason: state.streamFinishReason,
+                });
+              }
+              writer.write({
+                type: "message-metadata",
+                messageMetadata: {
+                  mode,
+                  createdAt: retryStartTime,
+                  generationStartedAt: retryStartTime,
+                  generationTimeMs: fallbackGenerationTimeMs,
+                },
+              });
+              sendFileMetadataToStream(accumulatedFiles);
+              if (providerRecoveryAttempts > 0) {
+                const recoveryFields = {
+                  userId,
+                  run_id: ctx.run.id,
+                  chat_id: chatId,
+                  original_model: selectedModel,
+                  final_model: activeModelName,
+                  recovery_attempts: providerRecoveryAttempts,
+                  recovery_models: providerRecoveryModels,
+                  outcome,
+                };
+                phLogger.info(
+                  "[agent-long] Provider disconnect recovery completed",
+                  {
+                    ...recoveryFields,
+                    event: "agent_provider_disconnect_recovery_completed",
+                  },
+                );
+                phLogger.event(
+                  "agent_provider_disconnect_recovery_completed",
+                  recoveryFields,
+                );
+              }
+              posthog?.shutdown();
+            };
+
             let result;
             try {
               captureProPlusUltraDeepSeekProDefaultExposure({
@@ -4467,6 +4730,13 @@ export const agentLongTask = task({
                               providerDisconnectContinuation?.preservedTextPartCount,
                           },
                         );
+                        if (providerDisconnectContinuation) {
+                          recordProviderDisconnectRecoveryAttempt({
+                            failedModel: selectedModel,
+                            retryModel,
+                            continuation: providerDisconnectContinuation,
+                          });
+                        }
                         isRetryWithFallback = true;
                         streamError = undefined;
                         state.openRouterMetadata = {};
@@ -4583,178 +4853,170 @@ export const agentLongTask = task({
                                 messages: retryMessages,
                                 isAborted: retryAborted,
                               }) => {
+                                let finalRetryScheduled = false;
                                 try {
-                                  const fallbackCacheRead =
-                                    usageTracker.cacheReadTokens -
-                                    preFallbackCacheRead;
-                                  const fallbackCacheWrite =
-                                    usageTracker.cacheWriteTokens -
-                                    preFallbackCacheWrite;
-                                  const fallbackCacheTotal =
-                                    fallbackCacheRead + fallbackCacheWrite;
-                                  const sandboxInfo =
-                                    sandboxManager.getSandboxInfo();
-                                  chatLogger?.setSandbox(sandboxInfo);
-                                  chatLogger?.setCacheMetrics({
-                                    cacheHitRate:
-                                      fallbackCacheTotal > 0
-                                        ? fallbackCacheRead / fallbackCacheTotal
-                                        : null,
-                                    cacheReadTokens: fallbackCacheRead,
-                                    cacheWriteTokens: fallbackCacheWrite,
-                                  });
-                                  captureToolCalls({
-                                    posthog,
-                                    chatLogger,
-                                    userId,
-                                    mode,
-                                  });
-                                  // Final reconciliation can change the finish
-                                  // reason to budget-exhausted; do it before
-                                  // analytics and persistence consume state.
-                                  await deductAccumulatedUsage();
-                                  const outcome = retryAborted
-                                    ? "aborted"
-                                    : isTerminalProviderStreamError(state)
-                                      ? "error"
-                                      : "success";
-                                  captureAgentCompletionAnalytics({
-                                    posthog,
-                                    userId,
-                                    chatId,
-                                    endpoint,
-                                    mode,
-                                    subscription,
-                                    sandboxInfo,
-                                    outcome,
-                                    abortSource: resolveAgentAbortSource({
-                                      outcome,
-                                      stoppedDueToBudgetExhaustion:
-                                        state.stoppedDueToBudgetExhaustion,
-                                      stoppedDueToAgentRunSpendCap:
-                                        state.stoppedDueToAgentRunSpendCap,
-                                      stoppedDueToElapsedTimeout:
-                                        state.stoppedDueToElapsedTimeout,
-                                      requestCancelled: triggerSignal.aborted,
-                                    }),
-                                    chatLogger,
-                                    selectedModel,
-                                    configuredModelId,
-                                    responseModel: state.responseModel,
-                                    fallbackServed:
-                                      state.responseModel &&
-                                      retryUsedFallbackModel
-                                        ? true
-                                        : state.fallbackServed,
-                                    finishReason: state.streamFinishReason,
-                                    budgetAbortDetails:
-                                      state.budgetAbortDetails,
-                                    agentPermissionMode,
-                                    isAutoContinue: !!isAutoContinue,
-                                    experiment: routingExperimentContext,
-                                    stepLimitTelemetry:
-                                      buildAgentStepLimitTelemetry({
-                                        configuredMaxSteps:
-                                          state.configuredMaxSteps,
-                                        stepCount: state.agentStepCount,
-                                        stepLimitReached:
-                                          state.stoppedDueToStepLimit,
-                                        todoRunMetrics:
-                                          getTodoManager().getRunMetrics(),
-                                      }),
-                                    ...getTriggerRunTelemetry(),
-                                  });
-                                  if (!isTerminalProviderStreamError(state)) {
-                                    chatLogger?.emitSuccess({
-                                      finishReason: state.streamFinishReason,
-                                      wasAborted: retryAborted,
-                                      wasPreemptiveTimeout: false,
-                                      hadSummarization:
-                                        summarizationTracker.hasSummarized,
-                                    });
-                                  }
-
-                                  const generatedTitle = await titlePromise;
-                                  {
-                                    const mergedTodos =
-                                      getTodoManager().mergeWith(
-                                        baseTodos,
-                                        retryMessageId,
-                                      );
-                                    if (
-                                      generatedTitle ||
-                                      state.streamFinishReason ||
-                                      mergedTodos.length > 0
-                                    ) {
-                                      try {
-                                        await updateChat({
-                                          chatId,
-                                          title: generatedTitle,
-                                          finishReason:
-                                            state.streamFinishReason,
-                                          todos: mergedTodos,
-                                          defaultModelSlug: "agent",
-                                          sandboxType:
-                                            sandboxManager.getEffectivePreference(),
-                                          selectedModel: selectedModelOverride,
-                                        });
-                                      } catch (error) {
-                                        recordAgentLongChatMetadataUpdateFailure(
-                                          error,
-                                          {
-                                            chatId,
-                                            userId,
-                                            runId: ctx.run.id,
-                                          },
-                                        );
-                                      }
-                                    } else {
-                                      await prepareForNewStream({ chatId });
-                                    }
-                                    const accumulatedFiles =
-                                      getFileAccumulator().getAll();
-                                    const newFileIds = accumulatedFiles.map(
-                                      (f) => f.fileId,
+                                  const normalizedRetryMessages = retryMessages
+                                    .map((message) =>
+                                      message.role === "assistant"
+                                        ? stripAgentLongHeartbeatParts(message)
+                                        : message,
+                                    )
+                                    .filter(
+                                      (message) =>
+                                        message.role !== "assistant" ||
+                                        (message.parts?.length ?? 0) > 0,
                                     );
-                                    const fallbackGenerationTimeMs =
-                                      Date.now() - fallbackStartTime;
-                                    for (const msg of retryMessages) {
-                                      if (msg.role !== "assistant") continue;
-                                      const processed =
-                                        stripAgentLongHeartbeatParts(
-                                          summarizationTracker.processMessageForSave(
-                                            msg,
-                                          ),
-                                        );
+                                  const nextContinuation =
+                                    isTerminalProviderStreamError(state) &&
+                                    isRetriableProviderStreamDisconnectError(
+                                      state.providerError,
+                                    ) &&
+                                    !retryAborted
+                                      ? prepareProviderDisconnectContinuation(
+                                          normalizedRetryMessages,
+                                        )
+                                      : undefined;
+                                  const finalRetryModel = nextContinuation
+                                    ? getNextDeepSeekProDisconnectRetryModel({
+                                        originalModel: selectedModel,
+                                        failedModel: retryModel,
+                                        completedRetryCount:
+                                          providerRecoveryAttempts,
+                                      })
+                                    : undefined;
+
+                                  if (nextContinuation && finalRetryModel) {
+                                    recordProviderDisconnectRecoveryAttempt({
+                                      failedModel: retryModel,
+                                      retryModel: finalRetryModel,
+                                      continuation: nextContinuation,
+                                    });
+                                    streamError = undefined;
+                                    state.openRouterMetadata = {};
+                                    state.lastStepInputTokens = 0;
+                                    state.stoppedDueToStepLimit = false;
+                                    state.streamFinishReason = undefined;
+                                    state.providerError = undefined;
+                                    state.providerRejectedMultimodalToolResults = false;
+                                    state.stoppedDueToTokenExhaustion = false;
+                                    state.stoppedDueToElapsedTimeout = false;
+                                    state.stoppedDueToDoomLoop = false;
+                                    state.stoppedDueToAssistantContentLoop = false;
+                                    state.assistantContentLoopDetection =
+                                      undefined;
+                                    state.stoppedDueToBudgetExhaustion = false;
+                                    state.stoppedDueToAgentRunSpendCap = false;
+                                    state.stoppedDueToPostSummarizationIncomplete = false;
+                                    state.postSummarizationContinuationActive = false;
+                                    state.postSummarizationToolCallCount = 0;
+                                    state.postSummarizationText = "";
+                                    state.budgetAbortDetails = undefined;
+                                    resetServedModelTelemetryForRetry(state);
+                                    retryUsedFallbackModel = true;
+                                    state.finalMessages = [
+                                      ...state.finalMessages,
+                                      ...nextContinuation.messages,
+                                      {
+                                        id: generateId(),
+                                        role: "user",
+                                        parts: [
+                                          {
+                                            type: "text",
+                                            text: PROVIDER_DISCONNECT_CONTINUATION_PROMPT,
+                                          },
+                                        ],
+                                      },
+                                    ];
+                                    const finalRetryStartTime = Date.now();
+                                    const preservedFileIds =
+                                      getFileAccumulator()
+                                        .getAll()
+                                        .map((file) => file.fileId);
+                                    for (const message of nextContinuation.messages) {
+                                      if (message.role !== "assistant")
+                                        continue;
                                       await saveMessage({
                                         chatId,
                                         userId,
-                                        message: processed,
-                                        extraFileIds: newFileIds,
-                                        usage: state.streamUsage,
-                                        model: state.responseModel,
+                                        message,
+                                        extraFileIds: preservedFileIds,
+                                        model:
+                                          trackedProvider.languageModel(
+                                            retryModel,
+                                          ).modelId,
                                         mode,
                                         generationStartedAt: fallbackStartTime,
                                         generationTimeMs:
-                                          fallbackGenerationTimeMs,
-                                        finishReason: state.streamFinishReason,
+                                          finalRetryStartTime -
+                                          fallbackStartTime,
                                       });
                                     }
-                                    writer.write({
-                                      type: "message-metadata",
-                                      messageMetadata: {
-                                        mode,
-                                        createdAt: fallbackStartTime,
-                                        generationStartedAt: fallbackStartTime,
-                                        generationTimeMs:
-                                          fallbackGenerationTimeMs,
-                                      },
-                                    });
-                                    sendFileMetadataToStream(accumulatedFiles);
+                                    const finalRetryResult =
+                                      await createStream(finalRetryModel);
+                                    const finalRetryMessageId = generateId();
+                                    writer.merge(
+                                      withAgentLongStreamHeartbeat(
+                                        finalRetryResult.toUIMessageStream({
+                                          generateMessageId: () =>
+                                            finalRetryMessageId,
+                                          sendReasoning: true,
+                                          messageMetadata: ({ part }) => {
+                                            if (part.type === "start") {
+                                              return {
+                                                mode,
+                                                createdAt: finalRetryStartTime,
+                                                generationStartedAt:
+                                                  finalRetryStartTime,
+                                              };
+                                            }
+                                            if (part.type === "finish") {
+                                              return {
+                                                mode,
+                                                createdAt: finalRetryStartTime,
+                                                generationStartedAt:
+                                                  finalRetryStartTime,
+                                                generationTimeMs:
+                                                  Date.now() -
+                                                  finalRetryStartTime,
+                                              };
+                                            }
+                                          },
+                                          onFinish: async ({
+                                            messages: finalRetryMessages,
+                                            isAborted: finalRetryAborted,
+                                          }) => {
+                                            try {
+                                              await finalizeRetryStream({
+                                                retryMessages:
+                                                  finalRetryMessages,
+                                                retryAborted: finalRetryAborted,
+                                                retryMessageId:
+                                                  finalRetryMessageId,
+                                                retryStartTime:
+                                                  finalRetryStartTime,
+                                              });
+                                            } finally {
+                                              await releaseFreeRunLockOnce();
+                                            }
+                                          },
+                                        }),
+                                        userStopSignal.signal,
+                                      ),
+                                    );
+                                    finalRetryScheduled = true;
+                                    return;
                                   }
-                                  posthog?.shutdown();
+
+                                  await finalizeRetryStream({
+                                    retryMessages,
+                                    retryAborted,
+                                    retryMessageId,
+                                    retryStartTime: fallbackStartTime,
+                                  });
                                 } finally {
-                                  await releaseFreeRunLockOnce();
+                                  if (!finalRetryScheduled) {
+                                    await releaseFreeRunLockOnce();
+                                  }
                                 }
                               },
                             }),
@@ -4831,6 +5093,7 @@ export const agentLongTask = task({
                           stepLimitReached: state.stoppedDueToStepLimit,
                           todoRunMetrics: getTodoManager().getRunMetrics(),
                         }),
+                        ...getProviderRecoveryAnalytics(outcome),
                         ...getTriggerRunTelemetry(),
                       });
                       if (!isTerminalProviderStreamError(state)) {


### PR DESCRIPTION
## Summary
- resume DeepSeek Pro timeout/disconnect failures from the replay-safe checkpoint on Grok 4.6
- if the Grok continuation also disconnects, discard only its incomplete step and make one final bounded continuation on Kimi K3
- add provider attribution and recovery-attempt telemetry to agent-run analytics, structured logs, Trigger metadata, and dedicated PostHog events

## Safety
- completed tool outputs and earlier text remain durable
- incomplete final-step content is removed before each continuation
- Kimi is terminal: no retry loop after the second fallback

## Validation
- `pnpm run check:local-dependencies`
- `pnpm run typecheck`
- `pnpm lint` (0 errors; 7 existing warnings)
- `pnpm test` (416 suites, 4,221 tests)
- targeted provider recovery/analytics/contracts suite (282 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recovery when AI providers disconnect, allowing responses to continue from preserved checkpoints.
  * Added fallback models for eligible DeepSeek Pro failures.
  * Added provider recovery details to completion analytics, including attempts, selected models, errors, and outcomes.

* **Bug Fixes**
  * Ensured retries follow the supported recovery sequence and finalize responses correctly.
  * Improved consistency of error, retry, and recovery reporting across normal and retry flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->