### PR TITLE
Recover actionable Agent provider failures

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -11,6 +11,8 @@ import {
   createTrackedProvider,
   myProvider,
   MALFORMED_PDF_USER_RESPONSE,
+  makeOpenRouterToolChoiceCompatibleWithXaiReasoning,
+  normalizeOpenRouterRequestForKimi,
   PDF_PARSER_ENGINE_HEADER,
   PDF_PARSER_RECOVERY_HEADER,
   sanitizeOpenRouterRequestForXai,
@@ -397,6 +399,174 @@ describe("sanitizeOpenRouterRequestForXai", () => {
   });
 });
 
+describe("normalizeOpenRouterRequestForKimi", () => {
+  it("repairs missing chat tool-call IDs and removes unmatchable results", () => {
+    const body = {
+      model: "moonshotai/kimi-k3",
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            { id: "call_1", function: { name: "first", arguments: "{}" } },
+            { id: "", function: { name: "second", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "first result" },
+        { role: "tool", content: "second result" },
+        { role: "tool", tool_call_id: "orphan", content: "orphan result" },
+      ],
+    };
+
+    const result = normalizeOpenRouterRequestForKimi(body);
+
+    expect(result.changed).toBe(true);
+    expect(result.body).toEqual({
+      ...body,
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            { id: "call_1", function: { name: "first", arguments: "{}" } },
+            {
+              id: "hackerai_recovered_0_1",
+              function: { name: "second", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "first result" },
+        {
+          role: "tool",
+          tool_call_id: "hackerai_recovered_0_1",
+          content: "second result",
+        },
+      ],
+    });
+  });
+
+  it("repairs Responses API function-call output IDs", () => {
+    const body = {
+      model: "moonshotai/kimi-k3",
+      input: [
+        { type: "function_call", call_id: "", name: "lookup" },
+        { type: "function_call_output", output: "done" },
+      ],
+    };
+
+    expect(normalizeOpenRouterRequestForKimi(body)).toEqual({
+      changed: true,
+      body: {
+        ...body,
+        input: [
+          {
+            type: "function_call",
+            call_id: "hackerai_recovered_0",
+            name: "lookup",
+          },
+          {
+            type: "function_call_output",
+            call_id: "hackerai_recovered_0",
+            output: "done",
+          },
+        ],
+      },
+    });
+  });
+
+  it("leaves non-Kimi requests untouched", () => {
+    const body = {
+      model: "deepseek/deepseek-v4-flash-0731",
+      messages: [{ role: "tool", content: "missing id" }],
+    };
+
+    expect(normalizeOpenRouterRequestForKimi(body)).toEqual({
+      body,
+      changed: false,
+    });
+  });
+});
+
+describe("makeOpenRouterToolChoiceCompatibleWithXaiReasoning", () => {
+  it("preserves forced tool choice and disables reasoning for xAI routes", () => {
+    const body = {
+      model: "x-ai/grok-4.6",
+      reasoning: { enabled: true, effort: "high" },
+      tool_choice: { type: "function", function: { name: "wait_for_agents" } },
+    };
+
+    expect(makeOpenRouterToolChoiceCompatibleWithXaiReasoning(body)).toEqual({
+      changed: true,
+      body: {
+        ...body,
+        reasoning: { enabled: false, effort: "high" },
+      },
+    });
+  });
+
+  it("leaves automatic tool choice unchanged", () => {
+    const body = {
+      model: "x-ai/grok-4.6",
+      reasoning: { enabled: true, effort: "high" },
+      tool_choice: "auto",
+    };
+
+    expect(makeOpenRouterToolChoiceCompatibleWithXaiReasoning(body)).toEqual({
+      body,
+      changed: false,
+    });
+  });
+});
+
+describe("OpenRouter request normalization", () => {
+  it("applies Kimi transcript repair and xAI tool-choice compatibility together", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "moonshotai/kimi-k3",
+        models: ["x-ai/grok-4.6"],
+        reasoning: { enabled: true, effort: "high" },
+        tool_choice: {
+          type: "function",
+          function: { name: "wait_for_agents" },
+        },
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [{ id: "", function: { name: "wait_for_agents" } }],
+          },
+          { role: "tool", content: "agents complete" },
+        ],
+      }),
+    });
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestBody.reasoning).toEqual({ enabled: false, effort: "high" });
+    expect(requestBody.messages).toEqual([
+      {
+        role: "assistant",
+        reasoning: ".",
+        tool_calls: [
+          {
+            id: "hackerai_recovered_0_0",
+            function: { name: "wait_for_agents" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "hackerai_recovered_0_0",
+        content: "agents complete",
+      },
+    ]);
+  });
+});
+
 describe("OpenRouter PDF parser recovery", () => {
   let warnSpy: jest.SpyInstance;
 
@@ -550,6 +720,38 @@ describe("OpenRouter PDF parser recovery", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response).toBe(originalResponse);
+  });
+
+  it("falls back to sandbox paths when generic file parsing fails", async () => {
+    const genericParseError = new Response(
+      JSON.stringify({ error: { message: "Failed to parse " } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(genericParseError)
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    const response = await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body: JSON.stringify(createPdfParserRequest()),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const sandboxRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(
+      sandboxRequest.messages.flatMap(
+        (message: { content?: Array<{ type?: string }> }) =>
+          (message.content ?? []).filter((part) => part.type === "file"),
+      ),
+    ).toEqual([]);
+    expect(JSON.stringify(sandboxRequest)).toContain(
+      "inspect the files with sandbox tools",
+    );
+    expect(response.headers.get(PDF_PARSER_RECOVERY_HEADER)).toBe("sandbox");
   });
 });
 

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -730,7 +730,10 @@ describe("OpenRouter PDF parser recovery", () => {
   });
 
   it("does not retry unrelated provider errors", async () => {
-    const originalResponse = parserErrorResponse("Unrelated provider error");
+    const originalResponse = new Response(
+      JSON.stringify({ error: { message: "Unrelated provider error" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
     const fetchMock = jest.fn().mockResolvedValueOnce(originalResponse);
     const patchedFetch = createOpenRouterPatchFetch(
       fetchMock as unknown as typeof fetch,
@@ -745,41 +748,44 @@ describe("OpenRouter PDF parser recovery", () => {
     expect(response).toBe(originalResponse);
   });
 
-  it("falls back to sandbox paths when generic file parsing fails", async () => {
-    const genericParseError = new Response(
-      JSON.stringify({ error: { message: "Failed to parse " } }),
-      { status: 400, headers: { "content-type": "application/json" } },
-    );
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValueOnce(genericParseError)
-      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
-    const patchedFetch = createOpenRouterPatchFetch(
-      fetchMock as unknown as typeof fetch,
-    );
+  it.each(["Failed to parse ", "Failed to parse : report.pdf"])(
+    "falls back to sandbox paths for generic file parsing error %s",
+    async (providerMessage) => {
+      const genericParseError = new Response(
+        JSON.stringify({ error: { message: providerMessage } }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(genericParseError)
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+      const patchedFetch = createOpenRouterPatchFetch(
+        fetchMock as unknown as typeof fetch,
+      );
 
-    const response = await patchedFetch("https://openrouter.test/chat", {
-      method: "POST",
-      body: JSON.stringify(createPdfParserRequest()),
-    });
+      const response = await patchedFetch("https://openrouter.test/chat", {
+        method: "POST",
+        body: JSON.stringify(createPdfParserRequest()),
+      });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const sandboxRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(
-      sandboxRequest.messages.flatMap(
-        (message: {
-          content?: Array<{ type?: string; file?: { filename?: string } }>;
-        }) =>
-          (message.content ?? [])
-            .filter((part) => part.type === "file")
-            .map((part) => part.file?.filename),
-      ),
-    ).toEqual(["notes.txt"]);
-    expect(JSON.stringify(sandboxRequest)).toContain(
-      "inspect the files with sandbox tools",
-    );
-    expect(response.headers.get(PDF_PARSER_RECOVERY_HEADER)).toBe("sandbox");
-  });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const sandboxRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(
+        sandboxRequest.messages.flatMap(
+          (message: {
+            content?: Array<{ type?: string; file?: { filename?: string } }>;
+          }) =>
+            (message.content ?? [])
+              .filter((part) => part.type === "file")
+              .map((part) => part.file?.filename),
+        ),
+      ).toEqual(["notes.txt"]);
+      expect(JSON.stringify(sandboxRequest)).toContain(
+        "inspect the files with sandbox tools",
+      );
+      expect(response.headers.get(PDF_PARSER_RECOVERY_HEADER)).toBe("sandbox");
+    },
+  );
 });
 
 describe("supportsMultimodalToolResults", () => {

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -514,6 +514,29 @@ describe("makeOpenRouterToolChoiceCompatibleWithXaiReasoning", () => {
       changed: false,
     });
   });
+
+  it.each([
+    ["required", true],
+    ["none", false],
+  ] as const)(
+    "handles string tool choice %s with changed=%s",
+    (toolChoice, changed) => {
+      const body = {
+        model: "x-ai/grok-4.6",
+        reasoning: { enabled: true, effort: "high" },
+        tool_choice: toolChoice,
+      };
+
+      const result = makeOpenRouterToolChoiceCompatibleWithXaiReasoning(body);
+
+      expect(result.changed).toBe(changed);
+      expect(result.body).toEqual(
+        changed
+          ? { ...body, reasoning: { enabled: false, effort: "high" } }
+          : body,
+      );
+    },
+  );
 });
 
 describe("OpenRouter request normalization", () => {
@@ -744,10 +767,14 @@ describe("OpenRouter PDF parser recovery", () => {
     const sandboxRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(
       sandboxRequest.messages.flatMap(
-        (message: { content?: Array<{ type?: string }> }) =>
-          (message.content ?? []).filter((part) => part.type === "file"),
+        (message: {
+          content?: Array<{ type?: string; file?: { filename?: string } }>;
+        }) =>
+          (message.content ?? [])
+            .filter((part) => part.type === "file")
+            .map((part) => part.file?.filename),
       ),
-    ).toEqual([]);
+    ).toEqual(["notes.txt"]);
     expect(JSON.stringify(sandboxRequest)).toContain(
       "inspect the files with sandbox tools",
     );

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -9,10 +9,162 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isXaiModelSlug = (value: unknown): boolean =>
   typeof value === "string" && value.toLowerCase().startsWith("x-ai/");
 
+const isKimiModelSlug = (value: unknown): boolean =>
+  typeof value === "string" &&
+  value.toLowerCase().startsWith("moonshotai/kimi-");
+
 const requestCanRouteToXai = (body: unknown): boolean => {
   if (!isRecord(body)) return false;
   if (isXaiModelSlug(body.model)) return true;
   return Array.isArray(body.models) && body.models.some(isXaiModelSlug);
+};
+
+const requestCanRouteToKimi = (body: unknown): boolean => {
+  if (!isRecord(body)) return false;
+  if (isKimiModelSlug(body.model)) return true;
+  return Array.isArray(body.models) && body.models.some(isKimiModelSlug);
+};
+
+const nonEmptyString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+
+const takePendingToolCallId = (
+  pendingToolCallIds: string[],
+  requestedId: unknown,
+): string | undefined => {
+  const toolCallId = nonEmptyString(requestedId);
+  if (toolCallId) {
+    const matchingIndex = pendingToolCallIds.indexOf(toolCallId);
+    if (matchingIndex >= 0) {
+      pendingToolCallIds.splice(matchingIndex, 1);
+      return toolCallId;
+    }
+    return undefined;
+  }
+  return pendingToolCallIds.shift();
+};
+
+const normalizeKimiChatToolResults = (
+  messages: unknown[],
+): { messages: unknown[]; changed: boolean } => {
+  const pendingToolCallIds: string[] = [];
+  let changed = false;
+  const normalized: unknown[] = [];
+
+  messages.forEach((message, messageIndex) => {
+    if (!isRecord(message)) {
+      normalized.push(message);
+      return;
+    }
+
+    if (message.role === "assistant" && Array.isArray(message.tool_calls)) {
+      const toolCalls = message.tool_calls.map((toolCall, toolCallIndex) => {
+        if (!isRecord(toolCall)) return toolCall;
+        const existingId = nonEmptyString(toolCall.id);
+        const id =
+          existingId ?? `hackerai_recovered_${messageIndex}_${toolCallIndex}`;
+        const idChanged = id !== toolCall.id;
+        if (idChanged) changed = true;
+        pendingToolCallIds.push(id);
+        return idChanged ? { ...toolCall, id } : toolCall;
+      });
+      normalized.push(
+        changed ? { ...message, tool_calls: toolCalls } : message,
+      );
+      return;
+    }
+
+    if (message.role === "tool") {
+      const toolCallId = takePendingToolCallId(
+        pendingToolCallIds,
+        message.tool_call_id,
+      );
+      if (!toolCallId) {
+        changed = true;
+        return;
+      }
+      if (toolCallId !== message.tool_call_id) {
+        changed = true;
+        normalized.push({ ...message, tool_call_id: toolCallId });
+        return;
+      }
+    }
+
+    normalized.push(message);
+  });
+
+  return { messages: changed ? normalized : messages, changed };
+};
+
+const normalizeKimiResponsesToolResults = (
+  input: unknown[],
+): { input: unknown[]; changed: boolean } => {
+  const pendingToolCallIds: string[] = [];
+  let changed = false;
+  const normalized: unknown[] = [];
+
+  input.forEach((item, itemIndex) => {
+    if (!isRecord(item)) {
+      normalized.push(item);
+      return;
+    }
+
+    if (item.type === "function_call") {
+      const existingId = nonEmptyString(item.call_id);
+      const callId = existingId ?? `hackerai_recovered_${itemIndex}`;
+      const idChanged = callId !== item.call_id;
+      if (idChanged) changed = true;
+      pendingToolCallIds.push(callId);
+      normalized.push(idChanged ? { ...item, call_id: callId } : item);
+      return;
+    }
+
+    if (item.type === "function_call_output") {
+      const callId = takePendingToolCallId(pendingToolCallIds, item.call_id);
+      if (!callId) {
+        changed = true;
+        return;
+      }
+      if (callId !== item.call_id) {
+        changed = true;
+        normalized.push({ ...item, call_id: callId });
+        return;
+      }
+    }
+
+    normalized.push(item);
+  });
+
+  return { input: changed ? normalized : input, changed };
+};
+
+export const normalizeOpenRouterRequestForKimi = (
+  body: unknown,
+): { body: unknown; changed: boolean } => {
+  if (!isRecord(body) || !requestCanRouteToKimi(body)) {
+    return { body, changed: false };
+  }
+
+  const chatResult = Array.isArray(body.messages)
+    ? normalizeKimiChatToolResults(body.messages)
+    : undefined;
+  const responsesResult = Array.isArray(body.input)
+    ? normalizeKimiResponsesToolResults(body.input)
+    : undefined;
+  if (!chatResult?.changed && !responsesResult?.changed) {
+    return { body, changed: false };
+  }
+
+  return {
+    body: {
+      ...body,
+      ...(chatResult?.changed ? { messages: chatResult.messages } : {}),
+      ...(responsesResult?.changed ? { input: responsesResult.input } : {}),
+    },
+    changed: true,
+  };
 };
 
 const hasOwnEncryptedContent = (value: unknown): boolean =>
@@ -99,6 +251,30 @@ export const sanitizeOpenRouterRequestForXai = (
   return { body: { ...body, messages }, changed: true };
 };
 
+export const makeOpenRouterToolChoiceCompatibleWithXaiReasoning = (
+  body: unknown,
+): { body: unknown; changed: boolean } => {
+  if (
+    !isRecord(body) ||
+    !requestCanRouteToXai(body) ||
+    !isRecord(body.reasoning) ||
+    body.reasoning.enabled !== true ||
+    body.tool_choice == null ||
+    body.tool_choice === "auto" ||
+    body.tool_choice === "none"
+  ) {
+    return { body, changed: false };
+  }
+
+  return {
+    body: {
+      ...body,
+      reasoning: { ...body.reasoning, enabled: false },
+    },
+    changed: true,
+  };
+};
+
 const patchKimiReasoningToolCalls = (
   body: unknown,
 ): { body: unknown; changed: boolean } => {
@@ -156,7 +332,7 @@ const PDF_PARSER_INVALID_DOCUMENT_ERROR =
   "The file could not be read as a valid document. It may be corrupt, truncated, or not actually a PDF.";
 const SANDBOX_PDF_RECOVERY_INSTRUCTION = `The provider PDF parsers could not read the attached PDF. Inspect the corresponding local_path in the sandbox using terminal or PDF tools. If sandbox tools also cannot open it as a valid PDF, respond exactly: “${MALFORMED_PDF_USER_RESPONSE}” Treat this as a user-correctable attachment issue, not an infrastructure failure.`;
 
-type PdfParserFailure = "rate_limited" | "invalid_document";
+type PdfParserFailure = "rate_limited" | "invalid_document" | "generic_parse";
 
 const classifyPdfParserFailure = async (
   response: Response,
@@ -170,6 +346,9 @@ const classifyPdfParserFailure = async (
     }
     if (responseText.includes(PDF_PARSER_INVALID_DOCUMENT_ERROR)) {
       return "invalid_document";
+    }
+    if (/failed to parse(?:\s*:)?\s*(?:"|[}\]])/i.test(responseText)) {
+      return "generic_parse";
     }
   } catch {
     // Preserve the original provider response when its body cannot be read.
@@ -255,8 +434,15 @@ const isPdfRequestPart = (part: unknown): boolean => {
   );
 };
 
+const isFileRequestPart = (part: unknown): boolean =>
+  isRecord(part) && part.type === "file";
+
+const GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION =
+  "The provider could not parse one or more attached files. Use the corresponding local_path values and inspect the files with sandbox tools instead of asking the provider to parse them again.";
+
 const createSandboxPdfRecoveryBody = (
   body: unknown,
+  removeAllFileParts = false,
 ): { body: unknown; changed: boolean } => {
   if (!isRecord(body) || !Array.isArray(body.messages)) {
     return { body, changed: false };
@@ -273,7 +459,9 @@ const createSandboxPdfRecoveryBody = (
     if (!Array.isArray(message.content)) return message;
 
     const content = message.content.filter((part) => {
-      const shouldRemove = isPdfRequestPart(part);
+      const shouldRemove = removeAllFileParts
+        ? isFileRequestPart(part)
+        : isPdfRequestPart(part);
       removedFilePart ||= shouldRemove;
       return !shouldRemove;
     });
@@ -294,13 +482,23 @@ const createSandboxPdfRecoveryBody = (
   const content = Array.isArray(existingContent)
     ? [
         ...existingContent,
-        { type: "text", text: SANDBOX_PDF_RECOVERY_INSTRUCTION },
+        {
+          type: "text",
+          text: removeAllFileParts
+            ? GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION
+            : SANDBOX_PDF_RECOVERY_INSTRUCTION,
+        },
       ]
     : [
         ...(typeof existingContent === "string" && existingContent.length > 0
           ? [{ type: "text", text: existingContent }]
           : []),
-        { type: "text", text: SANDBOX_PDF_RECOVERY_INSTRUCTION },
+        {
+          type: "text",
+          text: removeAllFileParts
+            ? GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION
+            : SANDBOX_PDF_RECOVERY_INSTRUCTION,
+        },
       ];
   messages[lastUserMessageIndex] = { ...lastUserMessage, content };
 
@@ -331,14 +529,21 @@ const withPrivateResponseHeader = (
 };
 
 const logPdfParserRecovery = (
-  fromEngine: "mistral-ocr" | "cloudflare-ai",
+  fromEngine: "mistral-ocr" | "cloudflare-ai" | "unknown",
   toEngine: "cloudflare-ai" | "sandbox",
   reason: PdfParserFailure,
 ) => {
   console.warn(
     JSON.stringify({
+      timestamp: new Date().toISOString(),
       level: "warn",
       event: "openrouter_pdf_parser_recovery",
+      service: "openrouter",
+      environment:
+        process.env.TRIGGER_ENV ??
+        process.env.VERCEL_ENV ??
+        process.env.NODE_ENV ??
+        "unknown",
       from_engine: fromEngine,
       to_engine: toEngine,
       reason,
@@ -402,11 +607,15 @@ export const attachOpenRouterStreamErrorMetadata = (
 
 // Custom fetch for OpenRouter provider-specific request-body repairs.
 //
+// - Kimi rejects missing or orphaned tool-result IDs. Repair IDs when the
+//   transcript order makes the match deterministic and omit unmatchable output.
 // - Kimi requires a `reasoning` field on assistant tool-call messages when
 //   reasoning mode is enabled, but the AI SDK does not always include one.
 // - xAI rejects encrypted reasoning blobs generated by a different provider
 //   when OpenRouter falls back to Grok. The visible assistant text remains in
 //   the prompt, so these provider-private blobs are safe to omit for xAI routes.
+// - xAI rejects forced tool choice while reasoning is enabled. Preserve the
+//   forced tool and disable reasoning for that single provider request.
 // - The metadata header opts into OpenRouter routing metadata for attribution.
 export const createOpenRouterPatchFetch =
   (fetchImplementation: typeof fetch = globalThis.fetch): typeof fetch =>
@@ -421,11 +630,22 @@ export const createOpenRouterPatchFetch =
     if (nextInit.body && typeof nextInit.body === "string") {
       try {
         const parsedBody = JSON.parse(nextInit.body) as unknown;
-        const kimiPatched = patchKimiReasoningToolCalls(parsedBody);
+        const kimiNormalized = normalizeOpenRouterRequestForKimi(parsedBody);
+        const kimiPatched = patchKimiReasoningToolCalls(kimiNormalized.body);
         const xaiPatched = sanitizeOpenRouterRequestForXai(kimiPatched.body);
-        parsedRequestBody = xaiPatched.body;
-        if (kimiPatched.changed || xaiPatched.changed) {
-          nextInit = { ...nextInit, body: JSON.stringify(xaiPatched.body) };
+        const xaiCompatible =
+          makeOpenRouterToolChoiceCompatibleWithXaiReasoning(xaiPatched.body);
+        parsedRequestBody = xaiCompatible.body;
+        if (
+          kimiNormalized.changed ||
+          kimiPatched.changed ||
+          xaiPatched.changed ||
+          xaiCompatible.changed
+        ) {
+          nextInit = {
+            ...nextInit,
+            body: JSON.stringify(xaiCompatible.body),
+          };
         }
       } catch {
         // If parsing fails, send the request as-is
@@ -436,6 +656,26 @@ export const createOpenRouterPatchFetch =
     const parserFailure = await classifyPdfParserFailure(initialResponse);
     if (!parserFailure) {
       return attachOpenRouterStreamErrorMetadata(initialResponse);
+    }
+
+    if (parserFailure === "generic_parse") {
+      const sandboxBody = createSandboxPdfRecoveryBody(parsedRequestBody, true);
+      if (!sandboxBody.changed) {
+        return attachOpenRouterStreamErrorMetadata(initialResponse);
+      }
+
+      logPdfParserRecovery("unknown", "sandbox", parserFailure);
+      const sandboxResponse = await fetchImplementation(url, {
+        ...nextInit,
+        body: JSON.stringify(sandboxBody.body),
+      });
+      return attachOpenRouterStreamErrorMetadata(
+        withPrivateResponseHeader(
+          sandboxResponse,
+          PDF_PARSER_RECOVERY_HEADER,
+          "sandbox",
+        ),
+      );
     }
 
     if (requestUsesPdfParserEngine(parsedRequestBody, "cloudflare-ai")) {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -60,18 +60,22 @@ const normalizeKimiChatToolResults = (
     }
 
     if (message.role === "assistant" && Array.isArray(message.tool_calls)) {
+      let messageChanged = false;
       const toolCalls = message.tool_calls.map((toolCall, toolCallIndex) => {
         if (!isRecord(toolCall)) return toolCall;
         const existingId = nonEmptyString(toolCall.id);
         const id =
           existingId ?? `hackerai_recovered_${messageIndex}_${toolCallIndex}`;
         const idChanged = id !== toolCall.id;
-        if (idChanged) changed = true;
+        if (idChanged) {
+          changed = true;
+          messageChanged = true;
+        }
         pendingToolCallIds.push(id);
         return idChanged ? { ...toolCall, id } : toolCall;
       });
       normalized.push(
-        changed ? { ...message, tool_calls: toolCalls } : message,
+        messageChanged ? { ...message, tool_calls: toolCalls } : message,
       );
       return;
     }
@@ -398,28 +402,47 @@ const requestUsesPdfParserEngine = (
       plugin.pdf.engine === engine,
   );
 
-const textHasSandboxAttachmentPath = (text: string): boolean =>
-  text.includes("<attachment") &&
-  text.includes('local_path="/home/user/upload/');
+const getAttributeFromAttachmentTag = (
+  tag: string,
+  attribute: string,
+): string | undefined =>
+  new RegExp(`\\b${attribute}="([^"]+)"`, "i").exec(tag)?.[1];
 
-const hasSandboxAttachmentPath = (messages: unknown[]): boolean =>
-  messages.some((message) => {
-    if (!isRecord(message)) return false;
-    const content = message.content;
-    if (typeof content === "string") {
-      return textHasSandboxAttachmentPath(content);
+const collectSandboxAttachmentFilenames = (
+  messages: unknown[],
+): Set<string> => {
+  const filenames = new Set<string>();
+  const collectFromText = (text: string) => {
+    for (const match of text.matchAll(/<attachment\b[^>]*>/gi)) {
+      const tag = match[0];
+      const localPath = getAttributeFromAttachmentTag(tag, "local_path");
+      const filename = getAttributeFromAttachmentTag(tag, "filename");
+      if (localPath?.startsWith("/home/user/upload/") && filename) {
+        filenames.add(filename);
+      }
     }
-    return (
-      Array.isArray(content) &&
-      content.some(
-        (part) =>
-          isRecord(part) &&
-          part.type === "text" &&
-          typeof part.text === "string" &&
-          textHasSandboxAttachmentPath(part.text),
-      )
-    );
+  };
+
+  messages.forEach((message) => {
+    if (!isRecord(message)) return;
+    if (typeof message.content === "string") {
+      collectFromText(message.content);
+      return;
+    }
+    if (!Array.isArray(message.content)) return;
+    message.content.forEach((part) => {
+      if (
+        isRecord(part) &&
+        part.type === "text" &&
+        typeof part.text === "string"
+      ) {
+        collectFromText(part.text);
+      }
+    });
   });
+
+  return filenames;
+};
 
 const isPdfRequestPart = (part: unknown): boolean => {
   if (!isRecord(part) || part.type !== "file" || !isRecord(part.file)) {
@@ -437,6 +460,11 @@ const isPdfRequestPart = (part: unknown): boolean => {
 const isFileRequestPart = (part: unknown): boolean =>
   isRecord(part) && part.type === "file";
 
+const getFileRequestFilename = (part: unknown): string | undefined =>
+  isRecord(part) && isRecord(part.file)
+    ? nonEmptyString(part.file.filename)
+    : undefined;
+
 const GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION =
   "The provider could not parse one or more attached files. Use the corresponding local_path values and inspect the files with sandbox tools instead of asking the provider to parse them again.";
 
@@ -447,7 +475,10 @@ const createSandboxPdfRecoveryBody = (
   if (!isRecord(body) || !Array.isArray(body.messages)) {
     return { body, changed: false };
   }
-  if (!hasSandboxAttachmentPath(body.messages)) {
+  const sandboxAttachmentFilenames = collectSandboxAttachmentFilenames(
+    body.messages,
+  );
+  if (sandboxAttachmentFilenames.size === 0) {
     return { body, changed: false };
   }
 
@@ -459,9 +490,10 @@ const createSandboxPdfRecoveryBody = (
     if (!Array.isArray(message.content)) return message;
 
     const content = message.content.filter((part) => {
-      const shouldRemove = removeAllFileParts
-        ? isFileRequestPart(part)
-        : isPdfRequestPart(part);
+      const filename = getFileRequestFilename(part);
+      const shouldRemove =
+        Boolean(filename && sandboxAttachmentFilenames.has(filename)) &&
+        (removeAllFileParts ? isFileRequestPart(part) : isPdfRequestPart(part));
       removedFilePart ||= shouldRemove;
       return !shouldRemove;
     });
@@ -478,27 +510,17 @@ const createSandboxPdfRecoveryBody = (
   if (!isRecord(lastUserMessage)) {
     return { body, changed: false };
   }
+  const recoveryInstruction = removeAllFileParts
+    ? GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION
+    : SANDBOX_PDF_RECOVERY_INSTRUCTION;
   const existingContent = lastUserMessage.content;
   const content = Array.isArray(existingContent)
-    ? [
-        ...existingContent,
-        {
-          type: "text",
-          text: removeAllFileParts
-            ? GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION
-            : SANDBOX_PDF_RECOVERY_INSTRUCTION,
-        },
-      ]
+    ? [...existingContent, { type: "text", text: recoveryInstruction }]
     : [
         ...(typeof existingContent === "string" && existingContent.length > 0
           ? [{ type: "text", text: existingContent }]
           : []),
-        {
-          type: "text",
-          text: removeAllFileParts
-            ? GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION
-            : SANDBOX_PDF_RECOVERY_INSTRUCTION,
-        },
+        { type: "text", text: recoveryInstruction },
       ];
   messages[lastUserMessageIndex] = { ...lastUserMessage, content };
 

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -351,7 +351,7 @@ const classifyPdfParserFailure = async (
     if (responseText.includes(PDF_PARSER_INVALID_DOCUMENT_ERROR)) {
       return "invalid_document";
     }
-    if (/failed to parse(?:\s*:)?\s*(?:"|[}\]])/i.test(responseText)) {
+    if (/failed to parse\b/i.test(responseText)) {
       return "generic_parse";
     }
   } catch {

--- a/lib/api/__tests__/agent-trigger-route.test.ts
+++ b/lib/api/__tests__/agent-trigger-route.test.ts
@@ -382,7 +382,7 @@ describe("Agent trigger route lifecycle", () => {
 
   it.each([
     ["free", "small-1x"],
-    ["pro", "small-1x"],
+    ["pro", "small-2x"],
     ["pro-plus", "small-2x"],
     ["ultra", "small-2x"],
     ["team", "small-2x"],

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -139,7 +139,10 @@ const AGENT_TRIGGER_MACHINE_BY_SUBSCRIPTION: Record<
   AgentTriggerMachinePreset
 > = {
   free: "small-1x",
-  pro: "small-1x",
+  // Long Pro runs can exceed the 512 MB small-1x ceiling while retaining
+  // provider checkpoints and tool output. Match the other paid tiers so a
+  // recoverable stream does not become an unrecoverable worker OOM.
+  pro: "small-2x",
   "pro-plus": "small-2x",
   ultra: "small-2x",
   team: "small-2x",

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -383,7 +383,7 @@ describe("provider error classification", () => {
     expect(isRetriableProviderStreamDisconnectError(err)).toBe(true);
   });
 
-  it("allows 5xx network disconnects but rejects non-disconnect provider failures", () => {
+  it("allows transient 5xx failures without requiring provider-specific wording", () => {
     expect(
       isRetriableProviderStreamDisconnectError(
         apiCallError({ statusCode: 502, message: "Network connection lost." }),
@@ -396,7 +396,21 @@ describe("provider error classification", () => {
           message: "Internal error during token generation",
         }),
       ),
+    ).toBe(true);
+    expect(
+      isRetriableProviderStreamDisconnectError(
+        apiCallError({ statusCode: 400, message: "Invalid request" }),
+      ),
     ).toBe(false);
+  });
+
+  it("allows upstream idle timeouts to use replay-safe continuation", () => {
+    expect(
+      isRetriableProviderStreamDisconnectError({
+        code: 502,
+        message: "Upstream idle timeout exceeded",
+      }),
+    ).toBe(true);
   });
 
   it("classifies provider status codes before message patterns", () => {

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -407,8 +407,13 @@ describe("provider error classification", () => {
   it("allows upstream idle timeouts to use replay-safe continuation", () => {
     expect(
       isRetriableProviderStreamDisconnectError({
-        code: 502,
         message: "Upstream idle timeout exceeded",
+      }),
+    ).toBe(true);
+    expect(
+      isRetriableProviderStreamDisconnectError({
+        code: 502,
+        message: "Bad Gateway",
       }),
     ).toBe(true);
   });

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -474,21 +474,16 @@ export const getProviderErrorCategory = (
 export const isProviderStreamTerminatedError = (error: unknown): boolean =>
   getProviderErrorCategory(extractErrorDetails(error)) === "stream_terminated";
 
-/** Allow one continuation only for errors that explicitly describe a disconnect. */
+/** Allow one replay-safe continuation for provider disconnects and transient failures. */
 export const isRetriableProviderStreamDisconnectError = (
   error: unknown,
 ): boolean => {
   const details = extractErrorDetails(error);
-  if (
-    !PROVIDER_STREAM_DISCONNECT_PATTERN.test(getProviderMessageText(details))
-  ) {
-    return false;
-  }
   const category = getProviderErrorCategory(details);
+  if (category === "timeout" || category === "provider_5xx") return true;
   return (
-    category === "stream_terminated" ||
-    category === "timeout" ||
-    category === "provider_5xx"
+    category === "stream_terminated" &&
+    PROVIDER_STREAM_DISCONNECT_PATTERN.test(getProviderMessageText(details))
   );
 };
 


### PR DESCRIPTION
## Summary
- repair missing and orphaned Kimi tool-call/result IDs before OpenRouter submission
- recover generic attachment parse failures through sandbox-local paths
- allow bounded replay-safe continuation for provider 5xx and idle timeouts
- preserve forced Grok tool choice by disabling reasoning for that provider step
- move Pro Agent runs from `small-1x` to `small-2x` after a production OOM

## Production evidence
This addresses the actionable root causes found across the current unresolved Trigger.dev production error groups: Kimi 400/422 transcript errors, DeepSeek attachment parse failures, provider 504 idle timeouts, Grok reasoning/tool-choice incompatibility, and the Pro Agent OOM.

## Validation
- `pnpm run typecheck`
- `pnpm run lint` (passes with 7 pre-existing warnings)
- `pnpm exec jest --runInBand` (416 suites, 4,237 tests)
- `pnpm run check:local-dependencies`
- changed files pass Prettier and `git diff --check`

Repository-wide `pnpm run format:check` still reports 11 pre-existing files outside this diff.

## Manual verification
After the Trigger Preview deployment:
1. Run a long Agent task on a Pro account and confirm Trigger selects `small-2x`.
2. Exercise a Kimi fallback after completed tool calls; confirm no missing `call_id` provider rejection.
3. Upload several files, force a provider parser failure, and confirm the Agent continues using sandbox paths.
4. Force a Grok parent-gate `wait_for_agents` step and confirm the provider accepts the request.
5. Simulate a 504 after partial output and confirm one bounded checkpoint continuation occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI provider compatibility by repairing tool-call references and handling forced tool selections more reliably.
  - Added recovery when file parsing fails, allowing affected requests to continue through sandbox processing.
  - Improved retry behavior for transient provider failures, timeouts, and idle stream disconnects.
  - Upgraded the machine size for Pro Agent runs to improve execution capacity.

- **Tests**
  - Added coverage for provider request repairs, file-parse recovery, retry handling, and Pro Agent machine selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->