### PR TITLE
Improve extra usage purchase recovery

### DIFF
--- a/app/api/extra-usage/confirm/route.ts
+++ b/app/api/extra-usage/confirm/route.ts
@@ -8,6 +8,7 @@ import {
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
 import { logExtraUsagePurchase } from "@/lib/billing/extra-usage-purchase-logging";
+import { getExtraUsageReturnUrl } from "@/lib/billing/extra-usage-return";
 
 const ROUTE = "/api/extra-usage/confirm" as const;
 
@@ -82,7 +83,10 @@ export async function GET(req: NextRequest) {
       result: "session_seen",
     });
 
-    const redirectUrl = new URL(origin);
+    const redirectUrl = getExtraUsageReturnUrl(
+      origin,
+      session.metadata.returnPath,
+    );
     redirectUrl.searchParams.set("extra-usage-purchased", "true");
     redirectUrl.searchParams.set("amount", String(amountDollars));
 
@@ -129,6 +133,8 @@ export async function GET(req: NextRequest) {
         stripePaymentIntentId,
         stripeInvoiceId,
         purchaseRoute: "confirm",
+        enableExtraUsage:
+          session.metadata.enableExtraUsageAfterPurchase === "true",
       });
     } catch (error) {
       try {
@@ -226,6 +232,10 @@ export async function GET(req: NextRequest) {
         result: result.alreadyProcessed ? "already_processed" : "credited",
         error: analyticsError,
       });
+    }
+
+    if (session.metadata.resumeAfterPurchase === "true") {
+      redirectUrl.searchParams.set("extra-usage-resume", "true");
     }
 
     return NextResponse.redirect(redirectUrl, { status: 303 });

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -227,6 +227,8 @@ export async function POST(req: NextRequest) {
           stripePaymentIntentId,
           stripeInvoiceId,
           purchaseRoute: "webhook",
+          enableExtraUsage:
+            session.metadata.enableExtraUsageAfterPurchase === "true",
         });
 
         logExtraUsagePurchase(

--- a/app/components/ExtraUsageSection.tsx
+++ b/app/components/ExtraUsageSection.tsx
@@ -14,6 +14,10 @@ import {
   AutoReloadDisabledAlert,
 } from "@/app/components/extra-usage";
 import {
+  getApproximateWeeklyExtraUsageSpend,
+  getRecommendedExtraUsagePurchaseAmount,
+} from "@/app/components/extra-usage/BuyExtraUsageDialog";
+import {
   captureAddCreditCtaClick,
   captureAddCreditCtaImpression,
   captureAuthenticatedEvent,
@@ -203,6 +207,12 @@ const ExtraUsageSection = () => {
   const autoReloadDisabledReason = extraUsageSettings?.autoReloadDisabledReason;
   const monthlyCapDollars = extraUsageSettings?.monthlyCapDollars;
   const monthlySpentDollars = extraUsageSettings?.monthlySpentDollars ?? 0;
+  const recommendedPurchaseAmountDollars =
+    getRecommendedExtraUsagePurchaseAmount(
+      getApproximateWeeklyExtraUsageSpend(
+        extraUsageSettings?.monthlySpentDollars,
+      ),
+    );
   const effectiveCapDollars = monthlyCapDollars;
 
   useEffect(() => {
@@ -394,6 +404,7 @@ const ExtraUsageSection = () => {
         onOpenChange={setShowBuyDialog}
         onPurchase={handlePurchaseCredits}
         isLoading={isPurchasing}
+        recommendedAmountDollars={recommendedPurchaseAmountDollars}
       />
 
       <AdjustSpendingLimitDialog

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -64,7 +64,10 @@ const formatCountdown = (ms: number): string => {
 
 const getCurrentReturnPath = (): string => {
   const fullPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-  return fullPath.length <= 400 ? fullPath : window.location.pathname;
+  if (fullPath.length <= 400) return fullPath;
+  return window.location.pathname.length <= 400
+    ? window.location.pathname
+    : "/";
 };
 
 export const MessageErrorState = ({

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect, useMemo, useRef } from "react";
+import { useAction, useQuery } from "convex/react";
 import { Button } from "@/components/ui/button";
+import {
+  BuyExtraUsageDialog,
+  getApproximateWeeklyExtraUsageSpend,
+  getRecommendedExtraUsagePurchaseAmount,
+} from "@/app/components/extra-usage/BuyExtraUsageDialog";
+import { api } from "@/convex/_generated/api";
+import { toast } from "sonner";
 import { MemoizedMarkdown } from "./MemoizedMarkdown";
 import {
   ChatSDKError,
@@ -12,10 +20,16 @@ import { openSettingsDialog } from "@/lib/utils/settings-dialog";
 import {
   captureAddCreditCtaClick,
   captureAddCreditCtaImpression,
+  captureAuthenticatedEvent,
+  newCheckoutAttemptId,
   capturePaidDailyFreeAllowanceClick,
   capturePaidDailyFreeAllowanceImpression,
   captureUpgradeCtaImpression,
 } from "@/lib/analytics/client";
+import {
+  PAID_FUNNEL_EVENTS,
+  paidFunnelProperties,
+} from "@/lib/analytics/paid-funnel";
 import type { ChatMode } from "@/types";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
@@ -48,6 +62,11 @@ const formatCountdown = (ms: number): string => {
   return `${seconds}s`;
 };
 
+const getCurrentReturnPath = (): string => {
+  const fullPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  return fullPath.length <= 400 ? fullPath : window.location.pathname;
+};
+
 export const MessageErrorState = ({
   error,
   onRetry,
@@ -72,6 +91,19 @@ export const MessageErrorState = ({
   const paidDailyFreeAllowanceImpressionRef = useRef(false);
 
   const [timeRemaining, setTimeRemaining] = useState<number>(0);
+  const [showBuyDialog, setShowBuyDialog] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isUpdatingPayment, setIsUpdatingPayment] = useState(false);
+  const createPurchaseSession = useAction(
+    api.extraUsageActions.createPurchaseSession,
+  );
+  const createBillingPortalSession = useAction(
+    api.extraUsageActions.createBillingPortalSession,
+  );
+  const extraUsageSettings = useQuery(
+    api.extraUsage.getExtraUsageSettings,
+    showBuyDialog ? {} : "skip",
+  );
 
   useEffect(() => {
     if (!resetTimestamp) return;
@@ -137,6 +169,99 @@ export const MessageErrorState = ({
   const showRateLimitRetry = !shouldFocusPaidAllowanceActions;
   const showRateLimitUsage = !shouldFocusPaidAllowanceActions;
   const showUpgrade = canUpgrade && !shouldFocusPaidAllowanceActions;
+  const isDirectAddCredits = extraUsageCta?.analyticsText === "Add Credits";
+  const isPaymentRecovery = capReason === "auto_reload_failed";
+  const extraUsageCtaText = isDirectAddCredits
+    ? "Add $15 and continue"
+    : isPaymentRecovery
+      ? "Update card and retry"
+      : extraUsageCta?.label;
+  const recommendedPurchaseAmountDollars =
+    getRecommendedExtraUsagePurchaseAmount(
+      getApproximateWeeklyExtraUsageSpend(
+        extraUsageSettings?.monthlySpentDollars,
+      ),
+    );
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const shouldResume =
+      url.searchParams.get("extra-usage-resume") === "true" ||
+      url.searchParams.get("extra-usage-payment-retry") === "true";
+
+    if (!shouldResume) return;
+
+    url.searchParams.delete("extra-usage-resume");
+    url.searchParams.delete("extra-usage-payment-retry");
+    window.history.replaceState(
+      window.history.state,
+      "",
+      url.pathname + url.search + url.hash,
+    );
+    onRetry();
+  }, [onRetry]);
+
+  const handlePurchaseCredits = async (amountDollars: number) => {
+    setIsPurchasing(true);
+    try {
+      const checkoutAttemptId = newCheckoutAttemptId();
+      const result = await createPurchaseSession({
+        amountDollars,
+        baseUrl: window.location.origin,
+        checkoutAttemptId,
+        returnPath: getCurrentReturnPath(),
+        resumeAfterPurchase: true,
+        enableExtraUsageAfterPurchase: true,
+      });
+
+      if (!result.url) {
+        toast.error(result.error || "Failed to create checkout session");
+        return;
+      }
+
+      captureAuthenticatedEvent(
+        PAID_FUNNEL_EVENTS.addCreditCheckoutStarted,
+        paidFunnelProperties({
+          checkout_attempt_id: checkoutAttemptId,
+          checkout_type: "extra_usage_purchase",
+          surface: "message_error_state",
+          source: "rate_limit_error",
+          amount_dollars: amountDollars,
+          stripe_checkout_session_id: result.checkoutSessionId,
+        }),
+      );
+      window.location.href = result.url;
+    } catch (error) {
+      console.error("Failed to purchase credits:", error);
+      toast.error("Failed to purchase credits");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleUpdatePaymentMethod = async () => {
+    setIsUpdatingPayment(true);
+    try {
+      const returnUrl = new URL(window.location.href);
+      returnUrl.searchParams.set("extra-usage-payment-retry", "true");
+      const result = await createBillingPortalSession({
+        flow: "payment_method",
+        baseUrl: returnUrl.toString(),
+      });
+
+      if (!result.url) {
+        toast.error(result.error || "Failed to open billing portal");
+        return;
+      }
+
+      window.location.href = result.url;
+    } catch (error) {
+      console.error("Failed to update payment method:", error);
+      toast.error("Failed to open billing portal");
+    } finally {
+      setIsUpdatingPayment(false);
+    }
+  };
 
   useEffect(() => {
     if (!isRateLimitError || !showUpgrade || upgradeImpressionRef.current)
@@ -176,9 +301,16 @@ export const MessageErrorState = ({
       source: "rate_limit_error",
       from_tier: subscription,
       cap_reason: capReason,
-      cta_text: extraUsageCta.analyticsText,
+      cta_text: extraUsageCtaText ?? extraUsageCta.analyticsText,
     });
-  }, [capReason, extraUsageCta, isPaidUser, isRateLimitError, subscription]);
+  }, [
+    capReason,
+    extraUsageCta,
+    extraUsageCtaText,
+    isPaidUser,
+    isRateLimitError,
+    subscription,
+  ]);
 
   useEffect(() => {
     if (
@@ -282,24 +414,27 @@ export const MessageErrorState = ({
             )}
             {extraUsageCta && (
               <Button
-                variant={
-                  extraUsageCta.analyticsText === "Add Credits"
-                    ? "default"
-                    : "outline"
-                }
+                variant={isDirectAddCredits ? "default" : "outline"}
                 size="sm"
+                disabled={isPurchasing || isUpdatingPayment}
                 onClick={() => {
                   captureAddCreditCtaClick({
                     surface: "message_error_state",
                     source: "rate_limit_error",
                     from_tier: subscription,
                     cap_reason: capReason,
-                    cta_text: extraUsageCta.analyticsText,
+                    cta_text: extraUsageCtaText ?? extraUsageCta.analyticsText,
                   });
-                  openSettingsDialog(extraUsageCta.settingsTab);
+                  if (isDirectAddCredits) {
+                    setShowBuyDialog(true);
+                  } else if (isPaymentRecovery) {
+                    void handleUpdatePaymentMethod();
+                  } else {
+                    openSettingsDialog(extraUsageCta.settingsTab);
+                  }
                 }}
               >
-                {extraUsageCta.label}
+                {isUpdatingPayment ? "Opening billing..." : extraUsageCtaText}
               </Button>
             )}
             {canUsePaidDailyFreeAllowance && (
@@ -388,6 +523,15 @@ export const MessageErrorState = ({
           </>
         )}
       </div>
+      <BuyExtraUsageDialog
+        open={showBuyDialog}
+        onOpenChange={setShowBuyDialog}
+        onPurchase={handlePurchaseCredits}
+        isLoading={isPurchasing}
+        recommendedAmountDollars={recommendedPurchaseAmountDollars}
+        title="Add credits and continue"
+        description="Choose how much extra usage to add. Your stopped task will retry after payment succeeds."
+      />
     </div>
   );
 };

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { describe, expect, it, jest, beforeEach } from "@jest/globals";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
@@ -22,9 +22,17 @@ jest.mock("@/app/hooks/usePricingDialog", () => ({
 jest.mock("@/lib/analytics/client", () => ({
   captureAddCreditCtaClick: jest.fn(),
   captureAddCreditCtaImpression: jest.fn(),
+  captureAuthenticatedEvent: jest.fn(),
+  newCheckoutAttemptId: jest.fn(() => "ca_test"),
   capturePaidDailyFreeAllowanceClick: jest.fn(),
   capturePaidDailyFreeAllowanceImpression: jest.fn(),
   captureUpgradeCtaImpression: jest.fn(),
+}));
+
+const mockConvexAction = jest.fn();
+jest.mock("convex/react", () => ({
+  useAction: () => mockConvexAction,
+  useQuery: () => ({ monthlySpentDollars: 66 }),
 }));
 
 const { TestWrapper } = require("../testUtils");
@@ -33,10 +41,17 @@ const {
   capturePaidDailyFreeAllowanceClick,
   capturePaidDailyFreeAllowanceImpression,
 } = require("@/lib/analytics/client");
+const { openSettingsDialog } = require("@/lib/utils/settings-dialog");
 
 describe("MessageErrorState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockConvexAction.mockResolvedValue({
+      hasPaymentMethod: true,
+      paymentMethodLast4: "4242",
+      paymentMethodBrand: "visa",
+      url: null,
+    });
   });
 
   it("does not offer same-payload retry for provider content blocks", () => {
@@ -111,7 +126,9 @@ describe("MessageErrorState", () => {
       </TestWrapper>,
     );
 
-    expect(screen.getByRole("button", { name: "Add Credits" })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Add $15 and continue" }),
+    ).toBeVisible();
     expect(screen.queryByRole("button", { name: "Try Again" })).toBeNull();
     expect(screen.queryByRole("button", { name: "View Usage" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Upgrade Plan" })).toBeNull();
@@ -140,6 +157,95 @@ describe("MessageErrorState", () => {
     expect(onRetry).toHaveBeenCalledWith({
       limitRescue: { type: "paid_daily_free_allowance" },
     });
+  });
+
+  it("opens Checkout directly and marks the stopped task for resume", async () => {
+    const user = userEvent.setup();
+    const error = new ChatSDKError(
+      "rate_limit:chat",
+      "You've hit your monthly usage limit.",
+      { capReason: "monthly_exhausted" },
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState error={error} onRetry={jest.fn()} />
+      </TestWrapper>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Add $15 and continue" }),
+    );
+    expect(screen.getByRole("dialog")).toBeVisible();
+    expect(
+      screen.getByText("$30 should cover approximately your next week."),
+    ).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Purchase" }));
+
+    await waitFor(() =>
+      expect(mockConvexAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amountDollars: 30,
+          returnPath: expect.stringMatching(/^\//),
+          resumeAfterPurchase: true,
+          enableExtraUsageAfterPurchase: true,
+        }),
+      ),
+    );
+    expect(openSettingsDialog).not.toHaveBeenCalled();
+  });
+
+  it("opens payment-method recovery directly for auto-reload failures", async () => {
+    const user = userEvent.setup();
+    const error = new ChatSDKError(
+      "rate_limit:chat",
+      "Your automatic reload failed.",
+      { capReason: "auto_reload_failed" },
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState error={error} onRetry={jest.fn()} />
+      </TestWrapper>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Update card and retry" }),
+    );
+
+    await waitFor(() =>
+      expect(mockConvexAction).toHaveBeenCalledWith({
+        flow: "payment_method",
+        baseUrl: expect.stringContaining("extra-usage-payment-retry=true"),
+      }),
+    );
+    expect(openSettingsDialog).not.toHaveBeenCalled();
+  });
+
+  it("retries once after a successful purchase returns to the task", () => {
+    const onRetry = jest.fn();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/?extra-usage-resume=true",
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState
+          error={
+            new ChatSDKError("rate_limit:chat", "Limit reached", {
+              capReason: "monthly_exhausted",
+            })
+          }
+          onRetry={onRetry}
+        />
+      </TestWrapper>,
+    );
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(window.location.search).not.toContain("extra-usage-resume");
   });
 
   it("offers the daily allowance for a structured Agent stream error", () => {

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -223,6 +223,40 @@ describe("MessageErrorState", () => {
     expect(openSettingsDialog).not.toHaveBeenCalled();
   });
 
+  it("uses a bounded return path when the current pathname is too long", async () => {
+    const user = userEvent.setup();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `/${"a".repeat(401)}`,
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState
+          error={
+            new ChatSDKError("rate_limit:chat", "Limit reached", {
+              capReason: "monthly_exhausted",
+            })
+          }
+          onRetry={jest.fn()}
+        />
+      </TestWrapper>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Add $15 and continue" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Purchase" }));
+
+    await waitFor(() =>
+      expect(mockConvexAction).toHaveBeenCalledWith(
+        expect.objectContaining({ returnPath: "/" }),
+      ),
+    );
+    window.history.replaceState(window.history.state, "", "/");
+  });
+
   it("retries once after a successful purchase returns to the task", () => {
     const onRetry = jest.fn();
     window.history.replaceState(

--- a/app/components/extra-usage/BuyExtraUsageDialog.tsx
+++ b/app/components/extra-usage/BuyExtraUsageDialog.tsx
@@ -23,6 +23,7 @@ type BuyExtraUsageDialogProps = {
   description?: string;
   lineItemLabel?: string;
   paymentMethodMode?: "personal" | "checkout";
+  recommendedAmountDollars?: number;
 };
 
 /** Format card brand name for display */
@@ -32,6 +33,45 @@ const formatCardBrand = (brand: string | null): string => {
 };
 
 const MAX_AMOUNT = 999_999;
+const PRESET_AMOUNTS = [15, 30, 50] as const;
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+export const getApproximateWeeklyExtraUsageSpend = (
+  monthlySpentDollars: number | undefined,
+  now = Date.now(),
+): number | undefined => {
+  if (
+    monthlySpentDollars === undefined ||
+    !Number.isFinite(monthlySpentDollars) ||
+    monthlySpentDollars <= 0
+  ) {
+    return undefined;
+  }
+
+  const date = new Date(now);
+  const monthStart = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1);
+  const elapsedDays = Math.max(1, (now - monthStart) / DAY_MS);
+  return (monthlySpentDollars / elapsedDays) * 7;
+};
+
+export const getRecommendedExtraUsagePurchaseAmount = (
+  recentExtraUsageSpendDollars: number | undefined,
+): number | undefined => {
+  if (
+    recentExtraUsageSpendDollars === undefined ||
+    !Number.isFinite(recentExtraUsageSpendDollars) ||
+    recentExtraUsageSpendDollars <= 0
+  ) {
+    return undefined;
+  }
+
+  const preset = PRESET_AMOUNTS.find(
+    (amount) => amount >= recentExtraUsageSpendDollars,
+  );
+  if (preset !== undefined) return preset;
+
+  return Math.min(MAX_AMOUNT, Math.ceil(recentExtraUsageSpendDollars / 5) * 5);
+};
 
 /** Format number with commas (e.g., 1000 -> 1,000) */
 const formatWithCommas = (value: string): string => {
@@ -52,6 +92,7 @@ type ContentProps = {
   description: string;
   lineItemLabel: string;
   paymentMethodMode: "personal" | "checkout";
+  recommendedAmountDollars?: number;
 };
 
 const BuyExtraUsageDialogContent = ({
@@ -61,8 +102,13 @@ const BuyExtraUsageDialogContent = ({
   description,
   lineItemLabel,
   paymentMethodMode,
+  recommendedAmountDollars,
 }: ContentProps) => {
-  const [purchaseAmount, setPurchaseAmount] = useState<string>("15");
+  const [purchaseAmountOverride, setPurchaseAmountOverride] = useState<
+    string | null
+  >(null);
+  const purchaseAmount =
+    purchaseAmountOverride ?? String(recommendedAmountDollars ?? 15);
   const [paymentMethod, setPaymentMethod] = useState<{
     hasPaymentMethod: boolean;
     last4: string | null;
@@ -137,10 +183,47 @@ const BuyExtraUsageDialogContent = ({
       </DialogHeader>
       <div className="flex flex-col gap-5 pt-4">
         <div>
-          <label className="block text-muted-foreground text-sm mb-3">
-            {description}
+          <p className="text-muted-foreground text-sm mb-3">{description}</p>
+          <div className="grid grid-cols-3 gap-2 mb-3">
+            {PRESET_AMOUNTS.map((amount) => {
+              const isSelected = parsedAmount === amount;
+              const isRecommended = recommendedAmountDollars === amount;
+
+              return (
+                <Button
+                  key={amount}
+                  type="button"
+                  variant={isSelected ? "default" : "outline"}
+                  className="h-auto min-h-11 flex-col gap-0.5 py-2"
+                  aria-pressed={isSelected}
+                  onClick={() => {
+                    setPurchaseAmountOverride(String(amount));
+                  }}
+                >
+                  <span>${amount}</span>
+                  {isRecommended && (
+                    <span className="text-[10px] font-normal opacity-80">
+                      Recommended
+                    </span>
+                  )}
+                </Button>
+              );
+            })}
+          </div>
+          {recommendedAmountDollars !== undefined && (
+            <p className="text-sm text-muted-foreground mb-3">
+              ${formatWithCommas(String(recommendedAmountDollars))} should cover
+              approximately your next week.
+            </p>
+          )}
+          <label
+            htmlFor="extra-usage-purchase-amount"
+            className="block text-sm font-medium mb-2"
+          >
+            Custom amount
           </label>
           <Input
+            id="extra-usage-purchase-amount"
             placeholder="$15"
             className="w-full"
             type="text"
@@ -148,7 +231,7 @@ const BuyExtraUsageDialogContent = ({
             onChange={(e) => {
               // Remove $ and commas, keep only digits (whole dollars only)
               const val = e.target.value.replace(/[^0-9]/g, "");
-              setPurchaseAmount(val);
+              setPurchaseAmountOverride(val);
             }}
             aria-label="Purchase amount"
           />
@@ -232,6 +315,7 @@ const BuyExtraUsageDialog = ({
   description = "Get extra usage to keep using HackerAI when you hit a limit.",
   lineItemLabel = "Extra usage",
   paymentMethodMode = "personal",
+  recommendedAmountDollars,
 }: BuyExtraUsageDialogProps) => {
   const handleOpenChange = (newOpen: boolean) => {
     onOpenChange(newOpen);
@@ -249,6 +333,7 @@ const BuyExtraUsageDialog = ({
             description={description}
             lineItemLabel={lineItemLabel}
             paymentMethodMode={paymentMethodMode}
+            recommendedAmountDollars={recommendedAmountDollars}
           />
         )}
       </DialogContent>

--- a/app/components/extra-usage/__tests__/BuyExtraUsageDialog.test.tsx
+++ b/app/components/extra-usage/__tests__/BuyExtraUsageDialog.test.tsx
@@ -1,0 +1,59 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  BuyExtraUsageDialog,
+  getApproximateWeeklyExtraUsageSpend,
+  getRecommendedExtraUsagePurchaseAmount,
+} from "../BuyExtraUsageDialog";
+
+describe("BuyExtraUsageDialog", () => {
+  it("projects a weekly burn from month-to-date extra usage", () => {
+    const august15 = Date.UTC(2026, 7, 15);
+
+    expect(getApproximateWeeklyExtraUsageSpend(44, august15)).toBeCloseTo(22);
+    expect(getApproximateWeeklyExtraUsageSpend(0, august15)).toBeUndefined();
+  });
+
+  it.each([
+    [undefined, undefined],
+    [0, undefined],
+    [9, 15],
+    [22, 30],
+    [41, 50],
+    [51, 55],
+  ])("sizes a recent weekly burn of %s to %s", (recentSpend, expected) => {
+    expect(getRecommendedExtraUsagePurchaseAmount(recentSpend)).toBe(expected);
+  });
+
+  it("offers presets, explains the recommendation, and keeps custom amounts", () => {
+    const onPurchase = jest.fn(async () => {});
+
+    render(
+      <BuyExtraUsageDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        onPurchase={onPurchase}
+        isLoading={false}
+        paymentMethodMode="checkout"
+        recommendedAmountDollars={30}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /\$15/i })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /\$30 recommended/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /\$50/i })).toBeVisible();
+    expect(
+      screen.getByText("$30 should cover approximately your next week."),
+    ).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Purchase amount"), {
+      target: { value: "$75" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Purchase" }));
+
+    expect(onPurchase).toHaveBeenCalledWith(75);
+  });
+});

--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -261,6 +261,16 @@ describe("extraUsageActions billing authorization", () => {
     expect(mockCheckoutSessionCreate).not.toHaveBeenCalled();
   });
 
+  it("rejects a similarly named Vercel project outside the exact allowlist", async () => {
+    const result = await callCreatePurchaseSession(makeCtx(), {
+      baseUrl: "https://attacker-hackerai.vercel.app",
+    });
+
+    expect(result).toEqual({ url: null, error: "Invalid base URL" });
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(mockCheckoutSessionCreate).not.toHaveBeenCalled();
+  });
+
   it("rejects a non-admin active org member before creating a Billing Portal session", async () => {
     mockListOrganizationMemberships.mockResolvedValue({
       data: [

--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -241,6 +241,16 @@ describe("extraUsageActions billing authorization", () => {
     });
   });
 
+  it("rejects a return path that resolves outside the application origin", async () => {
+    const result = await callCreatePurchaseSession(makeCtx(), {
+      baseUrl: "https://hackerai.example",
+      returnPath: "/\\evil.example",
+    });
+
+    expect(result).toEqual({ url: null, error: "Invalid return path" });
+    expect(mockCheckoutSessionCreate).not.toHaveBeenCalled();
+  });
+
   it("rejects a non-admin active org member before creating a Billing Portal session", async () => {
     mockListOrganizationMemberships.mockResolvedValue({
       data: [

--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -129,11 +129,15 @@ function makeCtx(userId = "user_member") {
   };
 }
 
-async function callCreatePurchaseSession(ctx: any) {
+async function callCreatePurchaseSession(
+  ctx: any,
+  overrides: Record<string, unknown> = {},
+) {
   const { createPurchaseSession } = await import("../extraUsageActions");
   return (createPurchaseSession as any).handler(ctx, {
     amountDollars: 15,
     baseUrl: "https://hackerai.example/settings",
+    ...overrides,
   });
 }
 
@@ -310,6 +314,38 @@ describe("extraUsageActions billing authorization", () => {
       url: "https://checkout.stripe.test/session",
       checkoutSessionId: "cs_test",
     });
+  });
+
+  it("returns a resumable direct-purchase Checkout session to the stopped task", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          status: "active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+
+    await callCreatePurchaseSession(makeCtx("user_admin"), {
+      baseUrl: "https://hackerai.example",
+      returnPath: "/chat-123?view=task",
+      resumeAfterPurchase: true,
+      enableExtraUsageAfterPurchase: true,
+    });
+
+    expect(mockCheckoutSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url:
+          "https://hackerai.example/api/extra-usage/confirm?session_id={CHECKOUT_SESSION_ID}",
+        cancel_url: "https://hackerai.example/chat-123?view=task",
+        metadata: expect.objectContaining({
+          returnPath: "/chat-123?view=task",
+          resumeAfterPurchase: "true",
+          enableExtraUsageAfterPurchase: "true",
+        }),
+      }),
+    );
   });
 
   it("still returns the Checkout session when purchase recording fails", async () => {

--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -136,7 +136,7 @@ async function callCreatePurchaseSession(
   const { createPurchaseSession } = await import("../extraUsageActions");
   return (createPurchaseSession as any).handler(ctx, {
     amountDollars: 15,
-    baseUrl: "https://hackerai.example/settings",
+    baseUrl: "https://hackerai.co/settings",
     ...overrides,
   });
 }
@@ -243,11 +243,21 @@ describe("extraUsageActions billing authorization", () => {
 
   it("rejects a return path that resolves outside the application origin", async () => {
     const result = await callCreatePurchaseSession(makeCtx(), {
-      baseUrl: "https://hackerai.example",
+      baseUrl: "https://hackerai.co",
       returnPath: "/\\evil.example",
     });
 
     expect(result).toEqual({ url: null, error: "Invalid return path" });
+    expect(mockCheckoutSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller-controlled external application origin", async () => {
+    const result = await callCreatePurchaseSession(makeCtx(), {
+      baseUrl: "https://evil.example",
+    });
+
+    expect(result).toEqual({ url: null, error: "Invalid base URL" });
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
     expect(mockCheckoutSessionCreate).not.toHaveBeenCalled();
   });
 
@@ -338,7 +348,7 @@ describe("extraUsageActions billing authorization", () => {
     } as never);
 
     await callCreatePurchaseSession(makeCtx("user_admin"), {
-      baseUrl: "https://hackerai.example",
+      baseUrl: "https://hackerai.co",
       returnPath: "/chat-123?view=task",
       resumeAfterPurchase: true,
       enableExtraUsageAfterPurchase: true,
@@ -347,8 +357,8 @@ describe("extraUsageActions billing authorization", () => {
     expect(mockCheckoutSessionCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         success_url:
-          "https://hackerai.example/api/extra-usage/confirm?session_id={CHECKOUT_SESSION_ID}",
-        cancel_url: "https://hackerai.example/chat-123?view=task",
+          "https://hackerai.co/api/extra-usage/confirm?session_id={CHECKOUT_SESSION_ID}",
+        cancel_url: "https://hackerai.co/chat-123?view=task",
         metadata: expect.objectContaining({
           returnPath: "/chat-123?view=task",
           resumeAfterPurchase: "true",

--- a/convex/__tests__/extraUsagePurchases.test.ts
+++ b/convex/__tests__/extraUsagePurchases.test.ts
@@ -51,6 +51,9 @@ const INDEX_FIELDS: Record<string, Record<string, string[]>> = {
   extra_usage: {
     by_user_id: ["user_id"],
   },
+  user_customization: {
+    by_user_id: ["user_id"],
+  },
   extra_usage_purchases: {
     by_stripe_checkout_session_id: ["stripe_checkout_session_id"],
   },
@@ -104,6 +107,7 @@ function createQueryBuilder(tables: Tables, table: string) {
 function createMockCtx(initialTables: Partial<Tables> = {}) {
   const tables: Tables = {
     extra_usage: [],
+    user_customization: [],
     extra_usage_purchases: [],
     processed_checkout_sessions: [],
     processed_webhooks: [],
@@ -159,7 +163,7 @@ async function callRecordPurchaseFailed(ctx: any) {
   });
 }
 
-async function callAddCredits(ctx: any) {
+async function callAddCredits(ctx: any, enableExtraUsage = false) {
   const { addCredits } = await import("../extraUsage");
   return (addCredits as any).handler(ctx, {
     serviceKey: SERVICE_KEY,
@@ -173,6 +177,7 @@ async function callAddCredits(ctx: any) {
     stripePaymentIntentId: "pi_test",
     stripeInvoiceId: "in_test",
     purchaseRoute: "confirm",
+    enableExtraUsage,
   });
 }
 
@@ -300,6 +305,27 @@ describe("extra usage purchase ledger", () => {
       credited_at: 950_000,
     });
     expect(mockRecordRevenueEventInternal).not.toHaveBeenCalled();
+  });
+
+  it("enables extra usage atomically for a direct purchase", async () => {
+    const { ctx, tables } = createMockCtx({
+      user_customization: [
+        {
+          _id: "customization-1",
+          user_id: "user_123",
+          include_notes: true,
+          extra_usage_enabled: false,
+          updated_at: 900_000,
+        },
+      ],
+    });
+
+    await callAddCredits(ctx, true);
+
+    expect(tables.user_customization[0]).toMatchObject({
+      extra_usage_enabled: true,
+      updated_at: 1_000_000,
+    });
   });
 
   it("does not mark legacy webhook duplicates as credited without session-key proof", async () => {

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -533,6 +533,7 @@ export const addCredits = mutation({
     purchaseRoute: v.optional(
       v.union(v.literal("confirm"), v.literal("webhook"), v.literal("repair")),
     ),
+    enableExtraUsage: v.optional(v.boolean()),
   },
   returns: v.object({
     newBalance: v.number(), // Returns dollars
@@ -638,6 +639,27 @@ export const addCredits = mutation({
         balance_points: newBalancePoints,
         updated_at: now,
       });
+    }
+
+    if (args.enableExtraUsage) {
+      const customization = await ctx.db
+        .query("user_customization")
+        .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+        .first();
+
+      if (customization) {
+        await ctx.db.patch(customization._id, {
+          extra_usage_enabled: true,
+          updated_at: now,
+        });
+      } else {
+        await ctx.db.insert("user_customization", {
+          user_id: args.userId,
+          include_notes: true,
+          extra_usage_enabled: true,
+          updated_at: now,
+        });
+      }
     }
 
     // Mark processed after success (so retries work if above fails)
@@ -1359,7 +1381,9 @@ export const getExtraUsageSettings = query({
         settings.monthly_cap_points === undefined
           ? undefined
           : pointsToDollars(settings.monthly_cap_points),
-      monthlySpentDollars: pointsToDollars(settings.monthly_spent_points ?? 0),
+      monthlySpentDollars: pointsToDollars(
+        getMonthlySpentPointsForCurrentMonth(settings),
+      ),
       autoReloadDisabledReason: settings.auto_reload_disabled_reason,
     };
   },

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -525,17 +525,29 @@ export const createPurchaseSession = action({
       return { url: null, error: "Maximum amount is $999,999" };
     }
 
-    // Basic URL validation
-    if (!args.baseUrl || !args.baseUrl.startsWith("http")) {
+    let applicationOrigin: string;
+    try {
+      const applicationUrl = new URL(args.baseUrl);
+      if (!["http:", "https:"].includes(applicationUrl.protocol)) {
+        return { url: null, error: "Invalid base URL" };
+      }
+      applicationOrigin = applicationUrl.origin;
+    } catch {
       return { url: null, error: "Invalid base URL" };
     }
+
+    let returnUrl: URL | undefined;
     if (
       args.returnPath !== undefined &&
-      (!args.returnPath.startsWith("/") ||
-        args.returnPath.startsWith("//") ||
-        args.returnPath.length > 400)
+      (!args.returnPath.startsWith("/") || args.returnPath.length > 400)
     ) {
       return { url: null, error: "Invalid return path" };
+    }
+    if (args.returnPath) {
+      returnUrl = new URL(args.returnPath, applicationOrigin);
+      if (returnUrl.origin !== applicationOrigin) {
+        return { url: null, error: "Invalid return path" };
+      }
     }
 
     try {
@@ -586,10 +598,8 @@ export const createPurchaseSession = action({
             enableExtraUsageAfterPurchase: "true",
           }),
         },
-        success_url: `${args.baseUrl}/api/extra-usage/confirm?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: args.returnPath
-          ? new URL(args.returnPath, args.baseUrl).toString()
-          : args.baseUrl,
+        success_url: `${applicationOrigin}/api/extra-usage/confirm?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: returnUrl?.toString() ?? applicationOrigin,
       });
 
       try {

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -499,6 +499,9 @@ export const createPurchaseSession = action({
     amountDollars: v.number(),
     baseUrl: v.string(),
     checkoutAttemptId: v.optional(v.string()),
+    returnPath: v.optional(v.string()),
+    resumeAfterPurchase: v.optional(v.boolean()),
+    enableExtraUsageAfterPurchase: v.optional(v.boolean()),
   },
   returns: v.object({
     url: v.union(v.string(), v.null()),
@@ -525,6 +528,14 @@ export const createPurchaseSession = action({
     // Basic URL validation
     if (!args.baseUrl || !args.baseUrl.startsWith("http")) {
       return { url: null, error: "Invalid base URL" };
+    }
+    if (
+      args.returnPath !== undefined &&
+      (!args.returnPath.startsWith("/") ||
+        args.returnPath.startsWith("//") ||
+        args.returnPath.length > 400)
+    ) {
+      return { url: null, error: "Invalid return path" };
     }
 
     try {
@@ -569,9 +580,16 @@ export const createPurchaseSession = action({
           ...(args.checkoutAttemptId && {
             checkoutAttemptId: args.checkoutAttemptId,
           }),
+          ...(args.returnPath && { returnPath: args.returnPath }),
+          ...(args.resumeAfterPurchase && { resumeAfterPurchase: "true" }),
+          ...(args.enableExtraUsageAfterPurchase && {
+            enableExtraUsageAfterPurchase: "true",
+          }),
         },
         success_url: `${args.baseUrl}/api/extra-usage/confirm?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: args.baseUrl,
+        cancel_url: args.returnPath
+          ? new URL(args.returnPath, args.baseUrl).toString()
+          : args.baseUrl,
       });
 
       try {

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -58,10 +58,9 @@ function canManageOrganizationBilling(membership: BillingMembership): boolean {
   return (status === undefined || status === "active") && !!hasBillingRole;
 }
 
-/**
- * Restrict Stripe return URLs to application origins controlled by HackerAI.
- * Local HTTP origins remain available for development and automated tests.
- */
+const DEFAULT_APPLICATION_ORIGINS = new Set(["https://hackerai.co"]);
+
+/** Restrict Stripe return URLs to exact server-configured application origins. */
 function isAllowedApplicationOrigin(url: URL): boolean {
   const hostname = url.hostname.toLowerCase();
   const isLocalhost =
@@ -77,12 +76,21 @@ function isAllowedApplicationOrigin(url: URL): boolean {
     return false;
   }
 
-  return (
-    hostname === "hackerai.co" ||
-    hostname.endsWith(".hackerai.co") ||
-    hostname === "hackerai.vercel.app" ||
-    hostname.endsWith("-hackerai.vercel.app")
-  );
+  const allowedOrigins = new Set(DEFAULT_APPLICATION_ORIGINS);
+  for (const configuredOrigin of (
+    process.env.EXTRA_USAGE_CHECKOUT_ALLOWED_ORIGINS ?? ""
+  ).split(",")) {
+    const value = configuredOrigin.trim();
+    if (!value) continue;
+
+    try {
+      allowedOrigins.add(new URL(value).origin);
+    } catch {
+      // Ignore malformed server configuration rather than trusting it.
+    }
+  }
+
+  return allowedOrigins.has(url.origin);
 }
 
 async function getStripeCustomerId(userId: string): Promise<string | null> {

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -58,6 +58,33 @@ function canManageOrganizationBilling(membership: BillingMembership): boolean {
   return (status === undefined || status === "active") && !!hasBillingRole;
 }
 
+/**
+ * Restrict Stripe return URLs to application origins controlled by HackerAI.
+ * Local HTTP origins remain available for development and automated tests.
+ */
+function isAllowedApplicationOrigin(url: URL): boolean {
+  const hostname = url.hostname.toLowerCase();
+  const isLocalhost =
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]";
+
+  if (isLocalhost) {
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
+
+  if (url.protocol !== "https:") {
+    return false;
+  }
+
+  return (
+    hostname === "hackerai.co" ||
+    hostname.endsWith(".hackerai.co") ||
+    hostname === "hackerai.vercel.app" ||
+    hostname.endsWith("-hackerai.vercel.app")
+  );
+}
+
 async function getStripeCustomerId(userId: string): Promise<string | null> {
   const workos = getWorkOS();
 
@@ -528,7 +555,7 @@ export const createPurchaseSession = action({
     let applicationOrigin: string;
     try {
       const applicationUrl = new URL(args.baseUrl);
-      if (!["http:", "https:"].includes(applicationUrl.protocol)) {
+      if (!isAllowedApplicationOrigin(applicationUrl)) {
         return { url: null, error: "Invalid base URL" };
       }
       applicationOrigin = applicationUrl.origin;

--- a/lib/billing/__tests__/extra-usage-return.test.ts
+++ b/lib/billing/__tests__/extra-usage-return.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "@jest/globals";
+import { getExtraUsageReturnUrl } from "../extra-usage-return";
+
+describe("getExtraUsageReturnUrl", () => {
+  it("preserves a same-origin chat path and its query", () => {
+    expect(
+      getExtraUsageReturnUrl(
+        "https://hackerai.co",
+        "/chat-123?view=task",
+      ).toString(),
+    ).toBe("https://hackerai.co/chat-123?view=task");
+  });
+
+  it.each([undefined, "https://evil.example", "//evil.example/path"])(
+    "falls back to the origin for unsafe return path %s",
+    (returnPath) => {
+      expect(
+        getExtraUsageReturnUrl("https://hackerai.co", returnPath).toString(),
+      ).toBe("https://hackerai.co/");
+    },
+  );
+});

--- a/lib/billing/extra-usage-return.ts
+++ b/lib/billing/extra-usage-return.ts
@@ -1,0 +1,21 @@
+export const getExtraUsageReturnUrl = (
+  origin: string,
+  returnPath: string | undefined,
+): URL => {
+  const fallback = new URL(origin);
+
+  if (
+    !returnPath ||
+    !returnPath.startsWith("/") ||
+    returnPath.startsWith("//")
+  ) {
+    return fallback;
+  }
+
+  try {
+    const returnUrl = new URL(returnPath, fallback);
+    return returnUrl.origin === fallback.origin ? returnUrl : fallback;
+  } catch {
+    return fallback;
+  }
+};


### PR DESCRIPTION
## Summary
- open Extra Usage Checkout directly from stopped paid-plan tasks, then enable Extra Usage and resume only after credits are confirmed
- add $15, $30, and $50 purchase presets with a recommendation derived from the current month spend rate while preserving custom amounts and the $15 minimum
- send auto-reload failures directly to Stripe payment-method recovery and retry when the user returns
- preserve safe same-origin return paths across Checkout and keep webhook/confirm crediting idempotent

## Validation
- `pnpm typecheck`
- focused ESLint on changed files
- 418 Jest suites / 4,236 tests passed in the pre-commit hook
- post-rebase focused suite: 5 suites / 41 tests
- authenticated Playwright visual check: Settings → Extra Usage → Buy extra usage; presets and recommendation rendered with no console errors or Next.js overlay

## Manual verification
1. On a Pro/Pro+ task stopped by monthly exhaustion, click **Add $15 and continue**. Confirm the purchase dialog opens without Settings.
2. Complete a test Checkout. Confirm the user returns to the same task, Extra Usage is enabled, credits are visible, and the stopped request retries once.
3. Trigger `auto_reload_failed`, click **Update card and retry**, update the card in Stripe, and confirm the same task retries on return.
4. In Settings → Extra Usage, confirm $15/$30/$50 presets, the weekly recommendation, and a custom whole-dollar amount of at least $15 all work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recommended Extra Usage purchase amounts based on recent spending.
  - Added preset purchase options, guidance, and custom amount entry.
  - Rate-limit errors now support credit purchases, payment recovery, and automatic retries.
  - Purchases can resume interrupted actions and enable Extra Usage automatically.
  - Valid in-app chat paths are preserved after checkout.

- **Bug Fixes**
  - Improved handling of canceled, completed, and resumed purchases.
  - Monthly spending resets correctly at the start of a new month.
  - Invalid or external return paths safely fall back to the app.
  - Checkout redirects reject unauthorized destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->