### PR TITLE
Fix Windows attachment transfers without curl

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1533,7 +1533,7 @@ describe("CentrifugoSandbox", () => {
         command.startsWith("powershell "),
       )!;
       expect(command).toMatch(
-        /^powershell -NoLogo -NoProfile -NonInteractive -File /,
+        /^powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File /,
       );
       expect(command.length).toBeLessThan(8_191);
       expect(command).not.toContain(signedUrl);
@@ -1585,7 +1585,7 @@ describe("CentrifugoSandbox", () => {
         if (command.startsWith("powershell ")) {
           return {
             stdout: "",
-            stderr: "The remote server returned an error",
+            stderr: `Upload failed for ${uploadUrl} from C:\\temp\\hackerai-upload\\report.txt`,
             exitCode: 1,
           };
         }
@@ -1594,20 +1594,25 @@ describe("CentrifugoSandbox", () => {
       (sandbox as any).commands.run = run;
 
       const uploadUrl = `https://example.com/upload?X-Amz-Signature=${"b".repeat(6_000)}`;
-      await expect(
-        sandbox.files.uploadToUrl(
-          "/tmp/hackerai-upload/report.txt",
-          uploadUrl,
-          "text/plain",
-        ),
-      ).rejects.toThrow("Failed to upload file");
+      const upload = sandbox.files.uploadToUrl(
+        "/tmp/hackerai-upload/report.txt",
+        uploadUrl,
+        "text/plain",
+      );
+      await expect(upload).rejects.toThrow(
+        "Failed to upload file: Upload failed for [redacted-url] from [redacted-destination-path]",
+      );
+      await expect(upload).rejects.not.toThrow(uploadUrl);
+      await expect(upload).rejects.not.toThrow(
+        "C:\\temp\\hackerai-upload\\report.txt",
+      );
 
       const commands = run.mock.calls.map(([command]) => command as string);
       const command = commands.find((command) =>
         command.startsWith("powershell "),
       )!;
       expect(command).toMatch(
-        /^powershell -NoLogo -NoProfile -NonInteractive -File /,
+        /^powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File /,
       );
       expect(command.length).toBeLessThan(8_191);
       expect(command).not.toContain(uploadUrl);

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1497,6 +1497,100 @@ describe("CentrifugoSandbox", () => {
       });
     });
 
+    it("falls back to PowerShell when curl is unavailable on Windows", async () => {
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "10.0.19045",
+          hostname: "WIN-DEV",
+        },
+      });
+      (sandbox as any).shellKind = "cmd";
+      const run = jest
+        .fn()
+        .mockResolvedValueOnce({
+          stdout: "",
+          stderr: "INFO: Could not find files for the given pattern(s).",
+          exitCode: 1,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      const signedUrl = "https://example.com/image.png?X-Amz-Signature=opaque";
+      await sandbox.files.downloadFromUrl(
+        signedUrl,
+        "/tmp/hackerai-upload/image.png",
+      );
+
+      expect(run).toHaveBeenNthCalledWith(1, "where curl 2>nul", {
+        displayName: "",
+        timeoutMs: 30000,
+      });
+      const command = run.mock.calls[1][0] as string;
+      expect(command).toMatch(
+        /^powershell -NoLogo -NoProfile -NonInteractive -EncodedCommand /,
+      );
+      expect(command).not.toContain(signedUrl);
+      expect(command).not.toContain("C:\\temp\\hackerai-upload");
+
+      const encodedCommand = command.split(" ").at(-1)!;
+      const script = Buffer.from(encodedCommand, "base64").toString("utf16le");
+      expect(script).toContain("Invoke-WebRequest -UseBasicParsing");
+      expect(script).toContain("-OutFile $destination");
+      expect(script).toContain(
+        Buffer.from(signedUrl, "utf8").toString("base64"),
+      );
+      expect(script).toContain(
+        Buffer.from("C:\\temp\\hackerai-upload\\image.png", "utf8").toString(
+          "base64",
+        ),
+      );
+    });
+
+    it("uses the Windows PowerShell fallback for presigned URL uploads", async () => {
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "10.0.19045",
+          hostname: "WIN-DEV",
+        },
+      });
+      (sandbox as any).shellKind = "cmd";
+      const run = jest
+        .fn()
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 1 })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      const uploadUrl = "https://example.com/upload?X-Amz-Signature=opaque";
+      await sandbox.files.uploadToUrl(
+        "/tmp/hackerai-upload/report.txt",
+        uploadUrl,
+        "text/plain",
+      );
+
+      const command = run.mock.calls[1][0] as string;
+      expect(command).toMatch(
+        /^powershell -NoLogo -NoProfile -NonInteractive -EncodedCommand /,
+      );
+      expect(command).not.toContain(uploadUrl);
+
+      const encodedCommand = command.split(" ").at(-1)!;
+      const script = Buffer.from(encodedCommand, "base64").toString("utf16le");
+      expect(script).toContain(
+        "Invoke-WebRequest -UseBasicParsing -Method Put",
+      );
+      expect(script).toContain("-InFile $source");
+      expect(script).toContain(
+        Buffer.from(uploadUrl, "utf8").toString("base64"),
+      );
+      expect(script).toContain(
+        Buffer.from("text/plain", "utf8").toString("base64"),
+      );
+    });
+
     it("downloadFromUrl omits --ssl-no-revoke when Windows curl lacks support", async () => {
       const { sandbox, runs } = createWindowsBashSandbox();
       (sandbox as any).curlCaps = {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1760,6 +1760,46 @@ describe("CentrifugoSandbox", () => {
       expect(remove).toHaveBeenCalledWith(nativeScriptPath);
     });
 
+    it("redacts the native destination from Git Bash PowerShell download errors", async () => {
+      const sandbox = createSandbox({
+        isDesktop: true,
+        capabilities: { commands: true, pty: true, files: true },
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "10.0.19045",
+          hostname: "WIN-DEV",
+        },
+      });
+      (sandbox as any).shellKind = "bash";
+      (sandbox as any).httpClient = "powershell";
+      sandbox.files.write = jest.fn(async () => undefined);
+      sandbox.files.remove = jest.fn(async () => undefined);
+      const nativeDestination = "C:\\temp\\hackerai-upload\\report.txt";
+      (sandbox as any).commands.run = jest.fn(async (command: string) =>
+        command.startsWith("powershell.exe ")
+          ? {
+              stdout: "",
+              stderr: `Download failed at ${nativeDestination}`,
+              exitCode: 1,
+            }
+          : {
+              stdout: "target_dir_exists=true",
+              stderr: "",
+              exitCode: 0,
+            },
+      );
+
+      await expect(
+        sandbox.files.downloadFromUrl(
+          "https://example.com/report.txt?X-Amz-Signature=opaque",
+          "/tmp/hackerai-upload/report.txt",
+        ),
+      ).rejects.toThrow(
+        "Failed to download file: Download failed at [redacted-destination-path]",
+      );
+    });
+
     it("downloadFromUrl omits --ssl-no-revoke when Windows curl lacks support", async () => {
       const { sandbox, runs } = createWindowsBashSandbox();
       (sandbox as any).curlCaps = {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1497,7 +1497,7 @@ describe("CentrifugoSandbox", () => {
       });
     });
 
-    it("falls back to PowerShell when curl is unavailable on Windows", async () => {
+    it("stages and cleans a PowerShell download script when curl is unavailable on Windows", async () => {
       const sandbox = createSandbox({
         osInfo: {
           platform: "win32",
@@ -1507,17 +1507,18 @@ describe("CentrifugoSandbox", () => {
         },
       });
       (sandbox as any).shellKind = "cmd";
-      const run = jest
-        .fn()
-        .mockResolvedValueOnce({
-          stdout: "",
-          stderr: "INFO: Could not find files for the given pattern(s).",
-          exitCode: 1,
-        })
-        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      const run = jest.fn(async (command: string) =>
+        command === "where curl 2>nul"
+          ? {
+              stdout: "",
+              stderr: "INFO: Could not find files for the given pattern(s).",
+              exitCode: 1,
+            }
+          : { stdout: "", stderr: "", exitCode: 0 },
+      );
       (sandbox as any).commands.run = run;
 
-      const signedUrl = "https://example.com/image.png?X-Amz-Signature=opaque";
+      const signedUrl = `https://example.com/image.png?X-Amz-Signature=${"a".repeat(6_000)}`;
       await sandbox.files.downloadFromUrl(
         signedUrl,
         "/tmp/hackerai-upload/image.png",
@@ -1527,15 +1528,29 @@ describe("CentrifugoSandbox", () => {
         displayName: "",
         timeoutMs: 30000,
       });
-      const command = run.mock.calls[1][0] as string;
+      const commands = run.mock.calls.map(([command]) => command as string);
+      const command = commands.find((command) =>
+        command.startsWith("powershell "),
+      )!;
       expect(command).toMatch(
-        /^powershell -NoLogo -NoProfile -NonInteractive -EncodedCommand /,
+        /^powershell -NoLogo -NoProfile -NonInteractive -File /,
       );
+      expect(command.length).toBeLessThan(8_191);
       expect(command).not.toContain(signedUrl);
       expect(command).not.toContain("C:\\temp\\hackerai-upload");
 
-      const encodedCommand = command.split(" ").at(-1)!;
-      const script = Buffer.from(encodedCommand, "base64").toString("utf16le");
+      const scriptChunks = commands
+        .filter((command) => command.startsWith("echo "))
+        .map((command) => command.match(/^echo (\S+) >{1,2} /)?.[1] ?? "");
+      expect(scriptChunks.length).toBeGreaterThan(1);
+      expect(
+        commands
+          .filter((command) => command.startsWith("echo "))
+          .every((command) => command.length < 8_191),
+      ).toBe(true);
+      const script = Buffer.from(scriptChunks.join(""), "base64").toString(
+        "utf8",
+      );
       expect(script).toContain("Invoke-WebRequest -UseBasicParsing");
       expect(script).toContain("-OutFile $destination");
       expect(script).toContain(
@@ -1546,9 +1561,14 @@ describe("CentrifugoSandbox", () => {
           "base64",
         ),
       );
+      const scriptPath = command.match(/-File ("[^"]+\.ps1")$/)?.[1];
+      expect(scriptPath).toBeDefined();
+      expect(commands).toContain(
+        `del /q /f ${scriptPath} 2>nul & rmdir /s /q ${scriptPath} 2>nul`,
+      );
     });
 
-    it("uses the Windows PowerShell fallback for presigned URL uploads", async () => {
+    it("cleans the staged PowerShell upload script after transfer failure", async () => {
       const sandbox = createSandbox({
         osInfo: {
           platform: "win32",
@@ -1558,27 +1578,52 @@ describe("CentrifugoSandbox", () => {
         },
       });
       (sandbox as any).shellKind = "cmd";
-      const run = jest
-        .fn()
-        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 1 })
-        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      const run = jest.fn(async (command: string) => {
+        if (command === "where curl 2>nul") {
+          return { stdout: "", stderr: "", exitCode: 1 };
+        }
+        if (command.startsWith("powershell ")) {
+          return {
+            stdout: "",
+            stderr: "The remote server returned an error",
+            exitCode: 1,
+          };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
       (sandbox as any).commands.run = run;
 
-      const uploadUrl = "https://example.com/upload?X-Amz-Signature=opaque";
-      await sandbox.files.uploadToUrl(
-        "/tmp/hackerai-upload/report.txt",
-        uploadUrl,
-        "text/plain",
-      );
+      const uploadUrl = `https://example.com/upload?X-Amz-Signature=${"b".repeat(6_000)}`;
+      await expect(
+        sandbox.files.uploadToUrl(
+          "/tmp/hackerai-upload/report.txt",
+          uploadUrl,
+          "text/plain",
+        ),
+      ).rejects.toThrow("Failed to upload file");
 
-      const command = run.mock.calls[1][0] as string;
+      const commands = run.mock.calls.map(([command]) => command as string);
+      const command = commands.find((command) =>
+        command.startsWith("powershell "),
+      )!;
       expect(command).toMatch(
-        /^powershell -NoLogo -NoProfile -NonInteractive -EncodedCommand /,
+        /^powershell -NoLogo -NoProfile -NonInteractive -File /,
       );
+      expect(command.length).toBeLessThan(8_191);
       expect(command).not.toContain(uploadUrl);
 
-      const encodedCommand = command.split(" ").at(-1)!;
-      const script = Buffer.from(encodedCommand, "base64").toString("utf16le");
+      const scriptChunks = commands
+        .filter((command) => command.startsWith("echo "))
+        .map((command) => command.match(/^echo (\S+) >{1,2} /)?.[1] ?? "");
+      expect(scriptChunks.length).toBeGreaterThan(1);
+      expect(
+        commands
+          .filter((command) => command.startsWith("echo "))
+          .every((command) => command.length < 8_191),
+      ).toBe(true);
+      const script = Buffer.from(scriptChunks.join(""), "base64").toString(
+        "utf8",
+      );
       expect(script).toContain(
         "Invoke-WebRequest -UseBasicParsing -Method Put",
       );
@@ -1588,6 +1633,11 @@ describe("CentrifugoSandbox", () => {
       );
       expect(script).toContain(
         Buffer.from("text/plain", "utf8").toString("base64"),
+      );
+      const scriptPath = command.match(/-File ("[^"]+\.ps1")$/)?.[1];
+      expect(scriptPath).toBeDefined();
+      expect(commands).toContain(
+        `del /q /f ${scriptPath} 2>nul & rmdir /s /q ${scriptPath} 2>nul`,
       );
     });
 

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1340,6 +1340,38 @@ describe("CentrifugoSandbox", () => {
         jest.useFakeTimers();
       }
     }, 15000);
+
+    it("cleans the cmd Base64 temporary file when a chunk command rejects", async () => {
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "10.0.19045",
+          hostname: "WIN-DEV",
+        },
+      });
+      (sandbox as any).shellKind = "cmd";
+      let echoCount = 0;
+      const commands: string[] = [];
+      (sandbox as any).commands.run = jest.fn(async (command: string) => {
+        commands.push(command);
+        if (command.startsWith("echo ") && ++echoCount === 2) {
+          throw new Error("relay disconnected");
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
+
+      await expect(
+        sandbox.files.write("/tmp/hackerai-transfer.ps1", "x".repeat(12_000)),
+      ).rejects.toThrow("relay disconnected");
+
+      const firstChunk = commands.find((command) =>
+        command.startsWith("echo "),
+      )!;
+      const tempFile = firstChunk.match(/ > (.+)$/)?.[1];
+      expect(tempFile).toBeDefined();
+      expect(commands).toContain(`del /q /f ${tempFile}`);
+    });
   });
 
   describe("git-bash on Windows", () => {
@@ -1469,6 +1501,31 @@ describe("CentrifugoSandbox", () => {
       expect(runs[1]).toContain(
         "'https://example.com/image.png?X-Amz-Algorithm=test&X-Amz-Signature=opaque'",
       );
+      expect(runs[1]).not.toContain("if not exist");
+      expect(sandbox.isWindows()).toBe(false);
+    });
+
+    it("keeps POSIX semantics when a legacy non-Bash shell leaves BASH_VERSION empty", async () => {
+      const sandbox = createSandbox();
+      (sandbox as any).httpClient = "curl";
+      (sandbox as any).curlCaps = {
+        retryAllErrors: true,
+        retryConnrefused: true,
+        sslNoRevoke: false,
+      };
+      const runs: string[] = [];
+      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
+        runs.push(cmd);
+        return { stdout: "\n", stderr: "", exitCode: 0 };
+      });
+
+      await sandbox.files.downloadFromUrl(
+        "https://example.com/image.png?X-Amz-Signature=opaque",
+        "/tmp/hackerai-upload/image.png",
+      );
+
+      expect(runs[0]).toBe("echo $BASH_VERSION");
+      expect(runs[1]).toContain("mkdir -p '/tmp/hackerai-upload'");
       expect(runs[1]).not.toContain("if not exist");
       expect(sandbox.isWindows()).toBe(false);
     });
@@ -1644,6 +1701,63 @@ describe("CentrifugoSandbox", () => {
       expect(commands).toContain(
         `del /q /f ${scriptPath} 2>nul & rmdir /s /q ${scriptPath} 2>nul`,
       );
+    });
+
+    it("uses the native relay path and redacts it from Git Bash PowerShell upload errors", async () => {
+      const sandbox = createSandbox({
+        isDesktop: true,
+        capabilities: { commands: true, pty: true, files: true },
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "10.0.19045",
+          hostname: "WIN-DEV",
+        },
+      });
+      (sandbox as any).shellKind = "bash";
+      (sandbox as any).httpClient = "powershell";
+      const write = jest.fn(async () => undefined);
+      const remove = jest.fn(async () => undefined);
+      sandbox.files.write = write;
+      sandbox.files.remove = remove;
+      const nativeSource = "C:\\temp\\hackerai-upload\\report.txt";
+      (sandbox as any).commands.run = jest.fn(async (command: string) =>
+        command.startsWith("powershell.exe ")
+          ? {
+              stdout: "",
+              stderr: `Upload failed from ${nativeSource}`,
+              exitCode: 1,
+            }
+          : { stdout: "", stderr: "", exitCode: 0 },
+      );
+
+      await expect(
+        sandbox.files.uploadToUrl(
+          "/tmp/hackerai-upload/report.txt",
+          "https://example.com/upload?X-Amz-Signature=opaque",
+          "text/plain",
+        ),
+      ).rejects.toThrow(
+        "Failed to upload file: Upload failed from [redacted-destination-path]",
+      );
+
+      const nativeScriptPath = write.mock.calls[0][0] as string;
+      expect(nativeScriptPath).toMatch(
+        /^C:\\temp\\hackerai-transfer-[\w-]+\.ps1$/,
+      );
+      const powerShellCommand = (sandbox as any).commands.run.mock.calls.find(
+        ([command]: [string]) => command.startsWith("powershell.exe "),
+      )[0] as string;
+      expect(powerShellCommand).toContain(
+        `-File '${nativeScriptPath
+          .replace(
+            /^([A-Za-z]):/,
+            (_, drive: string) => `/${drive.toLowerCase()}`,
+          )
+          .replace(/\\/g, "/")}'`,
+      );
+      expect(powerShellCommand).not.toContain(nativeSource);
+      expect(remove).toHaveBeenCalledWith(nativeScriptPath);
     });
 
     it("downloadFromUrl omits --ssl-no-revoke when Windows curl lacks support", async () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1104,8 +1104,8 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
    * Detect whether the remote shell is bash (git-bash on Windows, or any
    * POSIX host) or cmd.exe. Cached per sandbox instance.
    *
-   * Probe: `echo $BASH_VERSION` — bash substitutes the version string,
-   * cmd.exe echoes the literal `$BASH_VERSION`.
+   * Probe: `echo $BASH_VERSION` — cmd.exe echoes the literal variable while
+   * POSIX shells either expand it (Bash) or emit an empty line (sh/dash/zsh).
    */
   private async detectShell(): Promise<"bash" | "cmd"> {
     if (this.shellKind) return this.shellKind;
@@ -1120,7 +1120,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     const probe = await this.runSetupCommand("echo $BASH_VERSION", {
       displayName: "",
     });
-    this.shellKind = /^\d/.test(probe.stdout.trim()) ? "bash" : "cmd";
+    this.shellKind = probe.stdout.trim() === "$BASH_VERSION" ? "cmd" : "bash";
     return this.shellKind;
   }
 
@@ -1330,20 +1330,24 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     script: string,
   ): Promise<{ command: string; cleanup: () => Promise<void> }> {
     const scriptPath = `/tmp/hackerai-transfer-${crypto.randomUUID()}.ps1`;
+    const nativeScriptPath = this.toNativePath(
+      this.resolveWorkingPath(scriptPath),
+    );
     try {
       // files.write already chunks legacy cmd.exe writes below its command
       // length limit and uses the native file relay when the client supports it.
-      await this.files.write(scriptPath, script);
-      const { useBash, path, escapePath } = await this.shellContext(scriptPath);
+      await this.files.write(nativeScriptPath, script);
+      const { useBash, path, escapePath } =
+        await this.shellContext(nativeScriptPath);
       const executable = useBash ? "powershell.exe" : "powershell";
       return {
         command: `${executable} -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File ${escapePath(path)}`,
         cleanup: async () => {
-          await this.files.remove(scriptPath);
+          await this.files.remove(nativeScriptPath);
         },
       };
     } catch (error) {
-      await this.files.remove(scriptPath).catch(() => undefined);
+      await this.files.remove(nativeScriptPath).catch(() => undefined);
       throw error;
     }
   }
@@ -1579,30 +1583,30 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         // Write base64 to temp file, then certutil -decode to target
         // certutil adds header/footer lines, so we write raw base64 via echo
         const tempFile = this.escapeForTarget(`${path}.b64tmp.${Date.now()}`);
-        for (let i = 0; i < chunks.length; i++) {
-          const operator = i === 0 ? ">" : ">>";
-          const result = await this.commands.run(
-            `echo ${chunks[i]} ${operator} ${tempFile}`,
-            { displayName: i === 0 ? `Writing: ${fileName}` : "" },
-          );
-          if (result.exitCode !== 0) {
-            await this.commands
-              .run(`del /q /f ${tempFile}`, { displayName: "" })
-              .catch(() => undefined);
-            throw new Error(`Failed to write file: ${result.stderr}`);
+        try {
+          for (let i = 0; i < chunks.length; i++) {
+            const operator = i === 0 ? ">" : ">>";
+            const result = await this.commands.run(
+              `echo ${chunks[i]} ${operator} ${tempFile}`,
+              { displayName: i === 0 ? `Writing: ${fileName}` : "" },
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to write file: ${result.stderr}`);
+            }
           }
-        }
-        // Decode and clean up temp file
-        const decodeResult = await this.commands.run(
-          `certutil -decode ${tempFile} ${escapedPath} >nul & del /q /f ${tempFile}`,
-          { displayName: "" },
-        );
-        if (decodeResult.exitCode !== 0) {
-          // Clean up temp file on failure
-          await this.commands.run(`del /q /f ${tempFile}`, {
-            displayName: "",
-          });
-          throw new Error(`Failed to write file: ${decodeResult.stderr}`);
+          // Decode and clean up temp file
+          const decodeResult = await this.commands.run(
+            `certutil -decode ${tempFile} ${escapedPath} >nul & del /q /f ${tempFile}`,
+            { displayName: "" },
+          );
+          if (decodeResult.exitCode !== 0) {
+            throw new Error(`Failed to write file: ${decodeResult.stderr}`);
+          }
+        } catch (error) {
+          await this.commands
+            .run(`del /q /f ${tempFile}`, { displayName: "" })
+            .catch(() => undefined);
+          throw error;
         }
       } else if (
         isBinary &&
@@ -1975,6 +1979,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           const safeStderr = redactTransferDetails(result.stderr, uploadUrl, [
             rawPath,
             path,
+            nativePath,
           ]);
           throw new Error(`Failed to upload file: ${safeStderr}`);
         }

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1326,13 +1326,26 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     return `[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encoded}'))`;
   }
 
-  private static buildEncodedPowerShellCommand(
+  private async preparePowerShellCommand(
     script: string,
-    useBash: boolean,
-  ): string {
-    const executable = useBash ? "powershell.exe" : "powershell";
-    const encoded = Buffer.from(script, "utf16le").toString("base64");
-    return `${executable} -NoLogo -NoProfile -NonInteractive -EncodedCommand ${encoded}`;
+  ): Promise<{ command: string; cleanup: () => Promise<void> }> {
+    const scriptPath = `/tmp/hackerai-transfer-${crypto.randomUUID()}.ps1`;
+    try {
+      // files.write already chunks legacy cmd.exe writes below its command
+      // length limit and uses the native file relay when the client supports it.
+      await this.files.write(scriptPath, script);
+      const { useBash, path, escapePath } = await this.shellContext(scriptPath);
+      const executable = useBash ? "powershell.exe" : "powershell";
+      return {
+        command: `${executable} -NoLogo -NoProfile -NonInteractive -File ${escapePath(path)}`,
+        cleanup: async () => {
+          await this.files.remove(scriptPath);
+        },
+      };
+    } catch (error) {
+      await this.files.remove(scriptPath).catch(() => undefined);
+      throw error;
+    }
   }
 
   private async statNativeFile(
@@ -1573,6 +1586,9 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
             { displayName: i === 0 ? `Writing: ${fileName}` : "" },
           );
           if (result.exitCode !== 0) {
+            await this.commands
+              .run(`del /q /f ${tempFile}`, { displayName: "" })
+              .catch(() => undefined);
             throw new Error(`Failed to write file: ${result.stderr}`);
           }
         }
@@ -1755,6 +1771,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       const escapedPath = escapePath(path);
       const escapedUrl = escapeValue(url);
       const escapedDir = dir ? escapePath(dir) : "";
+      let cleanupPowerShellScript: (() => Promise<void>) | undefined;
 
       // Combine mkdir + download into a single command to avoid separate
       // round-trips through the sandbox bridge (e.g. Tauri desktop app),
@@ -1792,10 +1809,9 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           "if ($directory) { [IO.Directory]::CreateDirectory($directory) | Out-Null }",
           "Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $destination",
         ].join("; ");
-        downloadPart = CentrifugoSandbox.buildEncodedPowerShellCommand(
-          powerShellScript,
-          useBash,
-        );
+        const prepared = await this.preparePowerShellCommand(powerShellScript);
+        downloadPart = prepared.command;
+        cleanupPowerShellScript = prepared.cleanup;
       }
       const command =
         httpClient === "powershell"
@@ -1820,68 +1836,71 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
             : new Set<number>();
       const MAX_ATTEMPTS = 3;
 
-      let result: Awaited<ReturnType<typeof this.commands.run>> | null = null;
-      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        try {
-          result = await this.commands.run(command, {
-            displayName:
-              attempt === 1
-                ? `Downloading: ${fileName}`
-                : `Downloading: ${fileName} (retry ${attempt - 1})`,
-            timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
-          });
-        } catch (error) {
+      try {
+        let result: Awaited<ReturnType<typeof this.commands.run>> | null = null;
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+          try {
+            result = await this.commands.run(command, {
+              displayName:
+                attempt === 1
+                  ? `Downloading: ${fileName}`
+                  : `Downloading: ${fileName} (retry ${attempt - 1})`,
+              timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
+            });
+          } catch (error) {
+            if (
+              attempt === MAX_ATTEMPTS ||
+              !isTransientCommandTimeoutError(error)
+            ) {
+              throw error;
+            }
+            console.warn(
+              `[centrifugo-download] command timeout on attempt ${attempt}/${MAX_ATTEMPTS}, retrying: ${redactTransferDetails(getErrorMessage(error), url, [rawPath, path])}`,
+            );
+            await new Promise((r) => setTimeout(r, 500 * attempt));
+            continue;
+          }
+
+          if (result.exitCode === 0) break;
           if (
             attempt === MAX_ATTEMPTS ||
-            !isTransientCommandTimeoutError(error)
+            !transientExitCodes.has(result.exitCode)
           ) {
-            throw error;
+            break;
           }
           console.warn(
-            `[centrifugo-download] command timeout on attempt ${attempt}/${MAX_ATTEMPTS}, retrying: ${redactTransferDetails(getErrorMessage(error), url, [rawPath, path])}`,
+            `[centrifugo-download] ${httpClient} exit ${result.exitCode} on attempt ${attempt}/${MAX_ATTEMPTS}, retrying`,
           );
           await new Promise((r) => setTimeout(r, 500 * attempt));
-          continue;
         }
-
-        if (result.exitCode === 0) break;
-        if (
-          attempt === MAX_ATTEMPTS ||
-          !transientExitCodes.has(result.exitCode)
-        ) {
-          break;
+        if (!result) {
+          throw new Error("Download command failed without returning a result");
         }
-        console.warn(
-          `[centrifugo-download] ${httpClient} exit ${result.exitCode} on attempt ${attempt}/${MAX_ATTEMPTS}, retrying`,
-        );
-        await new Promise((r) => setTimeout(r, 500 * attempt));
-        continue;
-      }
-      if (!result) {
-        throw new Error("Download command failed without returning a result");
-      }
-      if (result.exitCode !== 0) {
-        // Gather diagnostic info to help debug write failures (e.g. curl exit 23).
-        // Fall back to the target's own directory context when the destination
-        // is a drive root and `dir` is empty. Avoid listing directory contents:
-        // this can be a user's local machine in desktop dangerous mode.
-        const diagDir = escapedDir || (useBash ? "/" : '"."');
-        const diagCmd = useBash
-          ? `test -d ${diagDir} && echo target_dir_exists=true || echo target_dir_exists=false; test -w ${diagDir} && echo target_dir_writable=true || echo target_dir_writable=false; df -h /tmp 2>&1 | sed -n '1,2p'`
-          : `if exist ${diagDir} (echo target_dir_exists=true) else (echo target_dir_exists=false) & (pushd ${diagDir} >nul 2>nul && (copy /Y NUL .hackerai_write_probe.tmp >nul 2>nul && del /q .hackerai_write_probe.tmp >nul 2>nul && echo target_dir_writable=true || echo target_dir_writable=false) & popd >nul 2>nul) || echo target_dir_writable=false`;
-        const diag = await this.commands.run(diagCmd, { displayName: "" });
-        const safeStderr = redactTransferDetails(result.stderr, url, [
-          rawPath,
-          path,
-        ]);
-        throw new Error(
-          `Failed to download file: ${safeStderr}\n` +
-            `  source: [redacted-url]\n` +
-            `  destination: [redacted-destination-path]\n` +
-            `  command: ${httpClient}\n` +
-            `  exitCode: ${result.exitCode}\n` +
-            `  diagnostics: ${diag.stdout}`,
-        );
+        if (result.exitCode !== 0) {
+          // Gather diagnostic info to help debug write failures (e.g. curl exit 23).
+          // Fall back to the target's own directory context when the destination
+          // is a drive root and `dir` is empty. Avoid listing directory contents:
+          // this can be a user's local machine in desktop dangerous mode.
+          const diagDir = escapedDir || (useBash ? "/" : '"."');
+          const diagCmd = useBash
+            ? `test -d ${diagDir} && echo target_dir_exists=true || echo target_dir_exists=false; test -w ${diagDir} && echo target_dir_writable=true || echo target_dir_writable=false; df -h /tmp 2>&1 | sed -n '1,2p'`
+            : `if exist ${diagDir} (echo target_dir_exists=true) else (echo target_dir_exists=false) & (pushd ${diagDir} >nul 2>nul && (copy /Y NUL .hackerai_write_probe.tmp >nul 2>nul && del /q .hackerai_write_probe.tmp >nul 2>nul && echo target_dir_writable=true || echo target_dir_writable=false) & popd >nul 2>nul) || echo target_dir_writable=false`;
+          const diag = await this.commands.run(diagCmd, { displayName: "" });
+          const safeStderr = redactTransferDetails(result.stderr, url, [
+            rawPath,
+            path,
+          ]);
+          throw new Error(
+            `Failed to download file: ${safeStderr}\n` +
+              `  source: [redacted-url]\n` +
+              `  destination: [redacted-destination-path]\n` +
+              `  command: ${httpClient}\n` +
+              `  exitCode: ${result.exitCode}\n` +
+              `  diagnostics: ${diag.stdout}`,
+          );
+        }
+      } finally {
+        await cleanupPowerShellScript?.().catch(() => undefined);
       }
     },
 
@@ -1890,7 +1909,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       uploadUrl: string,
       contentType: string,
     ): Promise<void> => {
-      const { useBash, path, nativePath, escapePath, escapeValue } =
+      const { path, nativePath, escapePath, escapeValue } =
         await this.shellContext(rawPath);
       const httpClient = await this.detectHttpClient();
 
@@ -1928,6 +1947,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           : "";
 
       let command: string;
+      let cleanupPowerShellScript: (() => Promise<void>) | undefined;
       if (httpClient === "curl") {
         command = `curl ${curlUploadFlags} -X PUT -H ${escapedContentType} --data-binary @${escapedPath} ${escapedUrl}`;
       } else if (httpClient === "wget") {
@@ -1941,18 +1961,21 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           `$contentType=${CentrifugoSandbox.encodePowerShellValue(contentType)}`,
           "Invoke-WebRequest -UseBasicParsing -Method Put -Uri $url -InFile $source -ContentType $contentType",
         ].join("; ");
-        command = CentrifugoSandbox.buildEncodedPowerShellCommand(
-          powerShellScript,
-          useBash,
-        );
+        const prepared = await this.preparePowerShellCommand(powerShellScript);
+        command = prepared.command;
+        cleanupPowerShellScript = prepared.cleanup;
       }
 
-      const result = await this.commands.run(command, {
-        timeoutMs: 120000,
-        displayName: `Uploading: ${fileName}`,
-      });
-      if (result.exitCode !== 0) {
-        throw new Error(`Failed to upload file: ${result.stderr}`);
+      try {
+        const result = await this.commands.run(command, {
+          timeoutMs: 120000,
+          displayName: `Uploading: ${fileName}`,
+        });
+        if (result.exitCode !== 0) {
+          throw new Error(`Failed to upload file: ${result.stderr}`);
+        }
+      } finally {
+        await cleanupPowerShellScript?.().catch(() => undefined);
       }
     },
   };

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -63,6 +63,8 @@ const COMMAND_CANCEL_ACK_TIMEOUT_MS = 5000;
 const TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN =
   /\b(?:deadline_exceeded|operation timed out:.*\btimeoutMs\b|exceeding ['"]?timeoutMs['"]?|Command timeout after \d+ms)\b/i;
 
+type HttpClient = "curl" | "wget" | "powershell";
+
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
@@ -1160,6 +1162,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
   private async shellContext(rawPath: string): Promise<{
     useBash: boolean;
     path: string;
+    nativePath: string;
     escapePath: (value: string) => string;
     escapeValue: (value: string) => string;
   }> {
@@ -1175,7 +1178,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     const escapeValue = useBash
       ? (v: string) => `'${v.replace(/'/g, "'\\''")}'`
       : (v: string) => this.escapeForTarget(v);
-    return { useBash, path, escapePath, escapeValue };
+    return { useBash, path, nativePath, escapePath, escapeValue };
   }
 
   /**
@@ -1200,8 +1203,8 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     }
   }
 
-  // Cache for detected HTTP client (curl or wget)
-  private httpClient: "curl" | "wget" | null = null;
+  // Cache for the detected HTTP client.
+  private httpClient: HttpClient | null = null;
   private snapCurlFallbackSelected = false;
 
   // Cache for detected curl capabilities (probed once per sandbox).
@@ -1240,20 +1243,32 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
   }
 
   /**
-   * Detect available HTTP client (curl or wget).
+   * Detect an available HTTP client for the target platform.
    * Alpine Linux uses wget by default, most other distros have curl.
-   * On Windows (cmd.exe), curl resolves to the real curl.exe bundled with Win10+.
+   * Windows falls back to PowerShell when curl.exe is unavailable.
    */
-  private async detectHttpClient(): Promise<"curl" | "wget"> {
+  private async detectHttpClient(): Promise<HttpClient> {
     if (this.httpClient) return this.httpClient;
 
-    // On Windows, curl.exe is bundled since Win10 build 17063 and there's no
-    // wget to fall back to. Skip detection since `command -v` is POSIX-only.
-    // If curl is missing on an older Windows Server, the download command
-    // itself will fail with a clear "curl is not recognized" error.
+    // Most supported Windows versions bundle curl.exe, but hardened or older
+    // installations can omit it. Probe with syntax matching the selected
+    // shell, then fall back to Windows PowerShell's HTTP client.
     if (this.isWindows()) {
-      this.httpClient = "curl";
-      return "curl";
+      const shell = await this.detectShell();
+      const curlCheck = await this.runSetupCommand(
+        shell === "bash" ? "command -v curl || true" : "where curl 2>nul",
+        { displayName: "" },
+      );
+      if (
+        curlCheck.exitCode === 0 &&
+        /curl(?:\.exe)?/i.test(curlCheck.stdout)
+      ) {
+        this.httpClient = "curl";
+        return "curl";
+      }
+
+      this.httpClient = "powershell";
+      return "powershell";
     }
 
     const curlCheck = await this.runSetupCommand("command -v curl || true", {
@@ -1304,6 +1319,20 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
 
     this.httpClient = "curl";
     return "curl";
+  }
+
+  private static encodePowerShellValue(value: string): string {
+    const encoded = Buffer.from(value, "utf8").toString("base64");
+    return `[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encoded}'))`;
+  }
+
+  private static buildEncodedPowerShellCommand(
+    script: string,
+    useBash: boolean,
+  ): string {
+    const executable = useBash ? "powershell.exe" : "powershell";
+    const encoded = Buffer.from(script, "utf16le").toString("base64");
+    return `${executable} -NoLogo -NoProfile -NonInteractive -EncodedCommand ${encoded}`;
   }
 
   private async statNativeFile(
@@ -1717,7 +1746,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       // emit POSIX syntax with MSYS-form paths. cmd.exe syntax like
       // `if not exist` breaks under bash and leaves the target dir missing,
       // causing curl to fail with the Windows "invalid filename syntax" error.
-      const { useBash, path, escapePath, escapeValue } =
+      const { useBash, path, nativePath, escapePath, escapeValue } =
         await this.shellContext(rawPath);
       const httpClient = await this.detectHttpClient();
       const dir = CentrifugoSandbox.parentDir(path);
@@ -1751,10 +1780,27 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           .filter(Boolean)
           .join(" ");
         downloadPart = `curl ${curlFlags} -o ${escapedPath} ${escapedUrl}`;
-      } else {
+      } else if (httpClient === "wget") {
         downloadPart = `wget -q --tries=3 --waitretry=1 -O ${escapedPath} ${escapedUrl}`;
+      } else {
+        const powerShellScript = [
+          "$ErrorActionPreference='Stop'",
+          "$ProgressPreference='SilentlyContinue'",
+          `$url=${CentrifugoSandbox.encodePowerShellValue(url)}`,
+          `$destination=${CentrifugoSandbox.encodePowerShellValue(nativePath)}`,
+          "$directory=[IO.Path]::GetDirectoryName($destination)",
+          "if ($directory) { [IO.Directory]::CreateDirectory($directory) | Out-Null }",
+          "Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $destination",
+        ].join("; ");
+        downloadPart = CentrifugoSandbox.buildEncodedPowerShellCommand(
+          powerShellScript,
+          useBash,
+        );
       }
-      const command = `${mkdirPart} ${downloadPart}`;
+      const command =
+        httpClient === "powershell"
+          ? downloadPart
+          : `${mkdirPart} ${downloadPart}`;
 
       // JS-level retry safety net on top of curl's --retry, for transient
       // network/TLS errors that can survive curl's own retry loop:
@@ -1769,7 +1815,9 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       const transientExitCodes =
         httpClient === "curl"
           ? new Set([7, 18, 23, 28, 35, 56, 92, 124])
-          : new Set([4, 124]);
+          : httpClient === "wget"
+            ? new Set([4, 124])
+            : new Set<number>();
       const MAX_ATTEMPTS = 3;
 
       let result: Awaited<ReturnType<typeof this.commands.run>> | null = null;
@@ -1842,7 +1890,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       uploadUrl: string,
       contentType: string,
     ): Promise<void> => {
-      const { path, escapePath, escapeValue } =
+      const { useBash, path, nativePath, escapePath, escapeValue } =
         await this.shellContext(rawPath);
       const httpClient = await this.detectHttpClient();
 
@@ -1879,10 +1927,25 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
               .join(" ")
           : "";
 
-      const command =
-        httpClient === "curl"
-          ? `curl ${curlUploadFlags} -X PUT -H ${escapedContentType} --data-binary @${escapedPath} ${escapedUrl}`
-          : `wget -q --method=PUT --header=${escapedContentType} --body-file=${escapedPath} -O - ${escapedUrl}`;
+      let command: string;
+      if (httpClient === "curl") {
+        command = `curl ${curlUploadFlags} -X PUT -H ${escapedContentType} --data-binary @${escapedPath} ${escapedUrl}`;
+      } else if (httpClient === "wget") {
+        command = `wget -q --method=PUT --header=${escapedContentType} --body-file=${escapedPath} -O - ${escapedUrl}`;
+      } else {
+        const powerShellScript = [
+          "$ErrorActionPreference='Stop'",
+          "$ProgressPreference='SilentlyContinue'",
+          `$url=${CentrifugoSandbox.encodePowerShellValue(uploadUrl)}`,
+          `$source=${CentrifugoSandbox.encodePowerShellValue(nativePath)}`,
+          `$contentType=${CentrifugoSandbox.encodePowerShellValue(contentType)}`,
+          "Invoke-WebRequest -UseBasicParsing -Method Put -Uri $url -InFile $source -ContentType $contentType",
+        ].join("; ");
+        command = CentrifugoSandbox.buildEncodedPowerShellCommand(
+          powerShellScript,
+          useBash,
+        );
+      }
 
       const result = await this.commands.run(command, {
         timeoutMs: 120000,

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1893,6 +1893,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           const safeStderr = redactTransferDetails(result.stderr, url, [
             rawPath,
             path,
+            nativePath,
           ]);
           throw new Error(
             `Failed to download file: ${safeStderr}\n` +

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1337,7 +1337,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       const { useBash, path, escapePath } = await this.shellContext(scriptPath);
       const executable = useBash ? "powershell.exe" : "powershell";
       return {
-        command: `${executable} -NoLogo -NoProfile -NonInteractive -File ${escapePath(path)}`,
+        command: `${executable} -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File ${escapePath(path)}`,
         cleanup: async () => {
           await this.files.remove(scriptPath);
         },
@@ -1972,7 +1972,11 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           displayName: `Uploading: ${fileName}`,
         });
         if (result.exitCode !== 0) {
-          throw new Error(`Failed to upload file: ${result.stderr}`);
+          const safeStderr = redactTransferDetails(result.stderr, uploadUrl, [
+            rawPath,
+            path,
+          ]);
+          throw new Error(`Failed to upload file: ${safeStderr}`);
         }
       } finally {
         await cleanupPowerShellScript?.().catch(() => undefined);


### PR DESCRIPTION
## Production evidence

The frozen production audit window was `2026-08-21T20:30:39Z` through `2026-08-22T20:30:39Z`.

Trigger.dev run `run_06g2lt7jfgegkhf9actr4ia5e1` failed on production worker `20260822.7` / deployment `m6q4gbhg`, 49 minutes after deployment. The representative trace showed URL attachment staging on a selected Windows desktop failing with:

```
'curl' is not recognized as an internal or external command
```

The exact top-level signature had no equivalent in the preceding seven days.

## Root cause

`CentrifugoSandbox.detectHttpClient()` assumed every Windows host provided `curl.exe`. Hardened or older Windows installations can omit it, so both download and presigned-upload URL transfer paths could generate an unavailable command.

## Change

- Probe for `curl` using the active Windows shell and fall back to non-interactive Windows PowerShell when absent.
- Stage bounded temporary `.ps1` files so signed URLs cannot exceed `cmd.exe` limits; use one native relay path for write/remove and its corresponding cmd/Git Bash execution path.
- Use process-scoped `-ExecutionPolicy Bypass`, clean staged scripts and rejected `.b64tmp` chunk writes, and preserve the original error when cleanup fails.
- Redact signed URLs plus raw, MSYS, and native Windows paths from download/upload failures.
- Distinguish legacy cmd.exe from POSIX sh/dash/zsh when OS metadata is absent.
- Preserve existing Linux, E2B, curl, wget, timeout, and retry behavior.

## Validation

- 104 focused Centrifugo/sandbox-file tests passed.
- TypeScript typecheck, changed-file ESLint, Prettier, and `git diff --check` passed.
- Final commit hook passed the full suite: 418 suites / 4,269 tests.
- GitHub Actions, Vercel Preview, Trigger.dev Preview, and CodeRabbit are green on `987fd75a`; every actionable review finding is fixed and every thread is resolved.
- Adversarial review covered both transfer directions, native/MSYS/cmd paths, aggregate command limits, partial writes, rejected operations, cleanup, redaction, retry behavior, and Vercel/Trigger deploy-skew compatibility.

## Manual verification

On a Windows desktop connection without `curl`:

1. Start an Agent run with a URL-backed attachment.
2. Confirm attachment staging completes through PowerShell and the Agent can access the staged file.
3. Generate/share a file through the presigned upload path and confirm it uploads successfully.
4. Confirm no raw signed URL or local path appears in console/error telemetry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file downloads and uploads on Windows when `curl.exe` is unavailable.
  * Added a PowerShell fallback for more reliable HTTP transfers.
  * Improved handling of Windows paths, URLs, and content types.
  * Added transfer-method-specific retry behavior.
  * Improved cleanup of temporary files after successful or failed transfers.
  * Prevented temporary files from remaining after file-write or upload failures.
  * Improved error messages by removing sensitive URLs and file paths.
  * Improved compatibility with POSIX and Git Bash shell environments.
  * Improved PowerShell transfer reliability when local script execution policies are restricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->