### PR TITLE
Split MicroVM base image from agent releases

### DIFF
--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/build-aws-microvm-release-manifest.ts"
       - "scripts/deploy-aws-microvm.mjs"
       - "scripts/package-aws-microvm.mjs"
+      - "scripts/lib/aws-microvm-build-diagnostics.cjs"
       - "scripts/lib/aws-microvm-container-image.cjs"
       - "scripts/smoke-aws-microvm.mjs"
       - "scripts/sync-trigger-microvm-release-env.ts"

--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -66,11 +66,13 @@ jobs:
         shell: bash
         run: |
           tree_id="$(git rev-parse HEAD:docker)"
+          echo "tree_id=${tree_id}" >> "$GITHUB_OUTPUT"
           echo "tag=microvm-base-${tree_id}" >> "$GITHUB_OUTPUT"
       - name: Reuse existing content-addressed base
         id: inspect
         env:
           BASE_TAG: ${{ steps.context.outputs.tag }}
+          EXPECTED_TREE_ID: ${{ steps.context.outputs.tree_id }}
           FORCE_REBUILD: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_base }}
         shell: bash
         run: |
@@ -84,6 +86,14 @@ jobs:
             digest="$(awk '$1 == "Digest:" { print $2; exit }' "$inspect_file")"
             if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
               echo "Unable to resolve an immutable digest for $image_ref"
+              exit 1
+            fi
+            image_json="$(docker buildx imagetools inspect "$image_ref" --format '{{json .Image}}')"
+            architecture="$(jq -r 'if .architecture then .architecture else .["linux/arm64"].architecture // empty end' <<< "$image_json")"
+            os="$(jq -r 'if .os then .os else .["linux/arm64"].os // empty end' <<< "$image_json")"
+            tree_id="$(jq -r 'if .config then .config.Labels["tech.hackerai.microvm-base-tree"] // empty else .["linux/arm64"].config.Labels["tech.hackerai.microvm-base-tree"] // empty end' <<< "$image_json")"
+            if [[ "$os/$architecture" != "linux/arm64" || "$tree_id" != "$EXPECTED_TREE_ID" ]]; then
+              echo "Refusing incompatible base tag: expected linux/arm64 tree $EXPECTED_TREE_ID, got $os/$architecture tree ${tree_id:-missing}"
               exit 1
             fi
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -103,6 +113,7 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            tech.hackerai.microvm-base-tree=${{ steps.context.outputs.tree_id }}
           cache-from: type=gha,scope=microvm-sandbox-base
           cache-to: type=gha,mode=max,scope=microvm-sandbox-base
           no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_base }}
@@ -112,6 +123,7 @@ jobs:
         env:
           EXISTING_DIGEST: ${{ steps.inspect.outputs.digest }}
           BUILT_DIGEST: ${{ steps.build.outputs.digest }}
+          EXPECTED_TREE_ID: ${{ steps.context.outputs.tree_id }}
         shell: bash
         run: |
           digest="${EXISTING_DIGEST:-$BUILT_DIGEST}"
@@ -119,13 +131,22 @@ jobs:
             echo "Missing valid sandbox base digest"
             exit 1
           fi
+          image_ref="${REGISTRY}/${IMAGE_NAME}@${digest}"
+          image_json="$(docker buildx imagetools inspect "$image_ref" --format '{{json .Image}}')"
+          architecture="$(jq -r 'if .architecture then .architecture else .["linux/arm64"].architecture // empty end' <<< "$image_json")"
+          os="$(jq -r 'if .os then .os else .["linux/arm64"].os // empty end' <<< "$image_json")"
+          tree_id="$(jq -r 'if .config then .config.Labels["tech.hackerai.microvm-base-tree"] // empty else .["linux/arm64"].config.Labels["tech.hackerai.microvm-base-tree"] // empty end' <<< "$image_json")"
+          if [[ "$os/$architecture" != "linux/arm64" || "$tree_id" != "$EXPECTED_TREE_ID" ]]; then
+            echo "Resolved base image does not match linux/arm64 tree $EXPECTED_TREE_ID"
+            exit 1
+          fi
           docker logout "$REGISTRY" >/dev/null 2>&1 || true
-          if ! docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}@${digest}" >/dev/null; then
+          if ! docker buildx imagetools inspect "$image_ref" >/dev/null; then
             echo "Sandbox base image must allow anonymous GHCR pulls"
             exit 1
           fi
-          echo "image=${REGISTRY}/${IMAGE_NAME}@${digest}" >> "$GITHUB_OUTPUT"
-          echo "Using ${REGISTRY}/${IMAGE_NAME}@${digest}"
+          echo "image=${image_ref}" >> "$GITHUB_OUTPUT"
+          echo "Using ${image_ref}"
 
   prepare:
     name: Build release artifact

--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -118,6 +118,11 @@ jobs:
             echo "Missing valid sandbox base digest"
             exit 1
           fi
+          docker logout "$REGISTRY" >/dev/null 2>&1 || true
+          if ! docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}@${digest}" >/dev/null; then
+            echo "Sandbox base image must allow anonymous GHCR pulls"
+            exit 1
+          fi
           echo "image=${REGISTRY}/${IMAGE_NAME}@${digest}" >> "$GITHUB_OUTPUT"
           echo "Using ${REGISTRY}/${IMAGE_NAME}@${digest}"
 

--- a/.github/workflows/aws-lambda-microvm-release.yml
+++ b/.github/workflows/aws-lambda-microvm-release.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/build-aws-microvm-release-manifest.ts"
       - "scripts/deploy-aws-microvm.mjs"
       - "scripts/package-aws-microvm.mjs"
+      - "scripts/lib/aws-microvm-container-image.cjs"
       - "scripts/smoke-aws-microvm.mjs"
       - "scripts/sync-trigger-microvm-release-env.ts"
       - "scripts/lib/aws-microvm-release-manifest.ts"
@@ -21,14 +22,108 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
   workflow_dispatch:
+    inputs:
+      rebuild_base:
+        description: "Rebuild the Kali/tool base even when docker/ is unchanged"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: aws-lambda-microvm-production
   cancel-in-progress: false
 
 jobs:
+  base:
+    name: Resolve immutable sandbox base
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+      reused: ${{ steps.inspect.outputs.exists }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/hackerai-sandbox
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Calculate base image tag
+        id: context
+        shell: bash
+        run: |
+          tree_id="$(git rev-parse HEAD:docker)"
+          echo "tag=microvm-base-${tree_id}" >> "$GITHUB_OUTPUT"
+      - name: Reuse existing content-addressed base
+        id: inspect
+        env:
+          BASE_TAG: ${{ steps.context.outputs.tag }}
+          FORCE_REBUILD: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_base }}
+        shell: bash
+        run: |
+          if [[ "$FORCE_REBUILD" == "true" ]]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          image_ref="${REGISTRY}/${IMAGE_NAME}:${BASE_TAG}"
+          inspect_file="${RUNNER_TEMP}/microvm-base-inspect.txt"
+          if docker buildx imagetools inspect "$image_ref" > "$inspect_file" 2>/dev/null; then
+            digest="$(awk '$1 == "Digest:" { print $2; exit }' "$inspect_file")"
+            if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "Unable to resolve an immutable digest for $image_ref"
+              exit 1
+            fi
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build and publish changed sandbox base
+        id: build
+        if: steps.inspect.outputs.exists != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=microvm-sandbox-base
+          cache-to: type=gha,mode=max,scope=microvm-sandbox-base
+          no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_base }}
+          platforms: linux/arm64
+      - name: Resolve exact base image digest
+        id: resolve
+        env:
+          EXISTING_DIGEST: ${{ steps.inspect.outputs.digest }}
+          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
+        run: |
+          digest="${EXISTING_DIGEST:-$BUILT_DIGEST}"
+          if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Missing valid sandbox base digest"
+            exit 1
+          fi
+          echo "image=${REGISTRY}/${IMAGE_NAME}@${digest}" >> "$GITHUB_OUTPUT"
+          echo "Using ${REGISTRY}/${IMAGE_NAME}@${digest}"
+
   prepare:
     name: Build release artifact
+    needs: base
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: aws-lambda-microvm-production
@@ -36,6 +131,7 @@ jobs:
       contents: read
     env:
       CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+      AWS_LAMBDA_MICROVM_CONTAINER_BASE_IMAGE: ${{ needs.base.outputs.image }}
     steps:
       - name: Validate shared release configuration
         shell: bash

--- a/.github/workflows/docker-sandbox.yml
+++ b/.github/workflows/docker-sandbox.yml
@@ -40,6 +40,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Reject reserved MicroVM base tags
+        env:
+          REQUESTED_TAG: ${{ inputs.tag || 'latest' }}
+        shell: bash
+        run: |
+          if [[ "$REQUESTED_TAG" == microvm-base-* ]]; then
+            echo "Tags beginning with microvm-base- are reserved for the AWS release workflow"
+            exit 1
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -68,6 +68,7 @@ Set one region's CloudFormation outputs and region, then run:
 export AWS_LAMBDA_MICROVM_ARTIFACT_BUCKET='<ArtifactBucketName>'
 export AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN='<BuildRoleArn>'
 export AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN='<ExecutionRoleArn>'
+export AWS_LAMBDA_MICROVM_CONTAINER_BASE_IMAGE='ghcr.io/hackerai-tech/hackerai-sandbox@sha256:<digest>'
 export AWS_REGION=us-east-1
 pnpm aws:microvm:deploy
 ```
@@ -87,9 +88,14 @@ failure rejects image validation rather than publishing an incompletely primed
 image; structured hook logs include per-step duration without bootstrap data.
 
 If the image build fails, inspect the CloudWatch log group shown by the Lambda
-MicroVM image. The HackerAI image currently uses Kali's public ARM64 container
-base, while the Lambda-managed MicroVM base is selected separately by the
-deployment script.
+MicroVM image. The heavyweight Kali and security-tool layer is built by GitHub
+Actions on a native ARM64 runner only when the `docker/` tree changes, published
+to GHCR, and pinned by digest in the small Lambda build artifact. The GHCR
+package must remain public so AWS's image builder can pull it without a registry
+credential. The Lambda-managed MicroVM base is selected separately by the
+deployment script. Failed releases also list the per-architecture image build
+states and reasons in the structured GitHub Actions log, even when the parent
+image version omits its reason.
 
 ## 3. Deploy the backend schema first
 
@@ -186,15 +192,24 @@ WebSocket subprotocol during the AWS-authenticated upgrade.
 ## Automated image promotion
 
 `.github/workflows/aws-lambda-microvm-release.yml` publishes a new image only
-when MicroVM image inputs change on `main`, or when it is run manually. It does
-not float production to AWS's implicit latest version. Instead it waits for the
-exact versions in all three regions, launches a short-lived VM in each region,
-executes a real command through every authenticated WebSocket, and confirms
-termination. Only after every matrix leg succeeds does it build one release
-manifest, upload and read back that exact manifest in Trigger.dev production,
-and deploy the pinned worker. A partial regional build can never become the
-active release. Vercel remains unchanged and older AWS image versions remain
-available for rollback.
+when MicroVM image inputs change on `main`, or when it is run manually. It first
+derives a content-addressed tag from the `docker/` tree. An existing tag is
+reused; a missing tag builds the heavyweight ARM64 sandbox once on a native ARM
+runner and publishes it to GHCR. Every regional Lambda artifact then contains
+only the agent layer and uses the exact resolved base digest. Normal agent-only
+changes therefore avoid rebuilding Kali and the security toolchain. The
+workflow does not float production to AWS's or GHCR's implicit latest version.
+Use the manual `rebuild_base` input for an intentional toolchain refresh when
+`docker/` is unchanged; that bypasses the registry and layer caches, publishes a
+new digest behind the tree tag, and promotes only the newly resolved digest.
+
+It then waits for the exact versions in all three regions, launches a
+short-lived VM in each region, executes a real command through every
+authenticated WebSocket, and confirms termination. Only after every matrix leg
+succeeds does it build one release manifest, upload and read back that exact
+manifest in Trigger.dev production, and deploy the pinned worker. A partial
+regional build can never become the active release. Vercel remains unchanged
+and older AWS image versions remain available for rollback.
 
 `AWS_LAMBDA_MICROVM_ENABLED_REGIONS` in the protected GitHub production
 environment is the durable placement kill switch. Keep `us-east-1` present and

--- a/scripts/__tests__/aws-microvm-build-diagnostics.test.js
+++ b/scripts/__tests__/aws-microvm-build-diagnostics.test.js
@@ -1,0 +1,52 @@
+const {
+  listMicrovmBuildDiagnostics,
+} = require("../lib/aws-microvm-build-diagnostics.cjs");
+
+describe("AWS Lambda MicroVM build diagnostics", () => {
+  test("follows pagination to find a failed ARM64 build reason", async () => {
+    const listPage = jest
+      .fn()
+      .mockResolvedValueOnce({
+        items: [
+          {
+            buildId: "successful-build",
+            buildState: "SUCCESSFUL",
+            architecture: "ARM_64",
+            stateReason: "not the failure",
+          },
+        ],
+        nextToken: "page-2",
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            buildId: "failed-build",
+            buildState: "FAILED",
+            architecture: "ARM_64",
+            stateReason: "container build timed out",
+          },
+        ],
+      });
+
+    const result = await listMicrovmBuildDiagnostics({
+      imageIdentifier: "image-arn",
+      imageVersion: "12.0",
+      listPage,
+    });
+
+    expect(listPage).toHaveBeenNthCalledWith(1, {
+      imageIdentifier: "image-arn",
+      imageVersion: "12.0",
+      maxResults: 25,
+      nextToken: undefined,
+    });
+    expect(listPage).toHaveBeenNthCalledWith(2, {
+      imageIdentifier: "image-arn",
+      imageVersion: "12.0",
+      maxResults: 25,
+      nextToken: "page-2",
+    });
+    expect(result.stateReason).toBe("container build timed out");
+    expect(result.builds).toHaveLength(2);
+  });
+});

--- a/scripts/__tests__/aws-microvm-container-image.test.js
+++ b/scripts/__tests__/aws-microvm-container-image.test.js
@@ -18,6 +18,7 @@ describe("AWS Lambda MicroVM container base image", () => {
     "",
     "ghcr.io/hackerai-tech/hackerai-sandbox:latest",
     "ghcr.io/hackerai-tech/hackerai-sandbox@sha256:short",
+    `ghcr.io/hackerai-tech//hackerai-sandbox@sha256:${digest}`,
     `ghcr.io/hackerai-tech/hackerai-sandbox@sha256:${digest}\nRUN id`,
   ])("rejects a mutable or invalid image reference: %p", (value) => {
     expect(() => resolveContainerBaseImage(value)).toThrow(

--- a/scripts/__tests__/aws-microvm-container-image.test.js
+++ b/scripts/__tests__/aws-microvm-container-image.test.js
@@ -1,0 +1,27 @@
+const {
+  resolveContainerBaseImage,
+} = require("../lib/aws-microvm-container-image.cjs");
+
+const digest = "0123456789abcdef".repeat(4);
+
+describe("AWS Lambda MicroVM container base image", () => {
+  test("accepts and trims an immutable registry digest", () => {
+    expect(
+      resolveContainerBaseImage(
+        `  ghcr.io/hackerai-tech/hackerai-sandbox@sha256:${digest}  `,
+      ),
+    ).toBe(`ghcr.io/hackerai-tech/hackerai-sandbox@sha256:${digest}`);
+  });
+
+  test.each([
+    undefined,
+    "",
+    "ghcr.io/hackerai-tech/hackerai-sandbox:latest",
+    "ghcr.io/hackerai-tech/hackerai-sandbox@sha256:short",
+    `ghcr.io/hackerai-tech/hackerai-sandbox@sha256:${digest}\nRUN id`,
+  ])("rejects a mutable or invalid image reference: %p", (value) => {
+    expect(() => resolveContainerBaseImage(value)).toThrow(
+      "must be an immutable container image digest",
+    );
+  });
+});

--- a/scripts/__tests__/aws-microvm-container-image.test.js
+++ b/scripts/__tests__/aws-microvm-container-image.test.js
@@ -18,6 +18,8 @@ describe("AWS Lambda MicroVM container base image", () => {
     "",
     "ghcr.io/hackerai-tech/hackerai-sandbox:latest",
     "ghcr.io/hackerai-tech/hackerai-sandbox@sha256:short",
+    `ghcr..io/hackerai-tech/hackerai-sandbox@sha256:${digest}`,
+    `-ghcr.io/hackerai-tech/hackerai-sandbox@sha256:${digest}`,
     `ghcr.io/hackerai-tech//hackerai-sandbox@sha256:${digest}`,
     `ghcr.io/hackerai-tech/hackerai-sandbox@sha256:${digest}\nRUN id`,
   ])("rejects a mutable or invalid image reference: %p", (value) => {

--- a/scripts/deploy-aws-microvm.mjs
+++ b/scripts/deploy-aws-microvm.mjs
@@ -10,6 +10,9 @@ import {
   UpdateMicrovmImageCommand,
 } from "@aws-sdk/client-lambda-microvms";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import buildDiagnostics from "./lib/aws-microvm-build-diagnostics.cjs";
+
+const { listMicrovmBuildDiagnostics } = buildDiagnostics;
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const artifactPath = resolve(
@@ -87,26 +90,12 @@ const lambda = new LambdaMicrovmsClient({ region, maxAttempts: 4 });
 
 async function resolveBuildFailure(imageIdentifier, imageVersion) {
   try {
-    const response = await lambda.send(
-      new ListMicrovmImageBuildsCommand({
-        imageIdentifier,
-        imageVersion,
-        maxResults: 25,
-      }),
-    );
-    const builds = (response.items || []).map((build) => ({
-      build_id: build.buildId,
-      build_state: build.buildState,
-      architecture: build.architecture,
-      state_reason: build.stateReason?.trim() || null,
-    }));
-    const stateReason = builds.find(
-      (build) =>
-        build.build_state === "FAILED" &&
-        build.architecture === "ARM_64" &&
-        build.state_reason,
-    )?.state_reason;
-    return { builds, stateReason: stateReason || null };
+    return await listMicrovmBuildDiagnostics({
+      imageIdentifier,
+      imageVersion,
+      listPage: (input) =>
+        lambda.send(new ListMicrovmImageBuildsCommand(input)),
+    });
   } catch (error) {
     releaseLog("warn", "aws_microvm_image_build_diagnostics_failed", {
       region,

--- a/scripts/deploy-aws-microvm.mjs
+++ b/scripts/deploy-aws-microvm.mjs
@@ -5,6 +5,7 @@ import {
   CreateMicrovmImageCommand,
   GetMicrovmImageVersionCommand,
   LambdaMicrovmsClient,
+  ListMicrovmImageBuildsCommand,
   paginateListMicrovmImages,
   UpdateMicrovmImageCommand,
 } from "@aws-sdk/client-lambda-microvms";
@@ -83,6 +84,38 @@ await new S3Client({ region }).send(
 );
 
 const lambda = new LambdaMicrovmsClient({ region, maxAttempts: 4 });
+
+async function resolveBuildFailure(imageIdentifier, imageVersion) {
+  try {
+    const response = await lambda.send(
+      new ListMicrovmImageBuildsCommand({
+        imageIdentifier,
+        imageVersion,
+        maxResults: 25,
+      }),
+    );
+    const builds = (response.items || []).map((build) => ({
+      build_id: build.buildId,
+      build_state: build.buildState,
+      architecture: build.architecture,
+      state_reason: build.stateReason?.trim() || null,
+    }));
+    const stateReason = builds.find(
+      (build) => build.state_reason,
+    )?.state_reason;
+    return { builds, stateReason: stateReason || null };
+  } catch (error) {
+    releaseLog("warn", "aws_microvm_image_build_diagnostics_failed", {
+      region,
+      image_identifier: imageIdentifier,
+      image_version: imageVersion,
+      error_name: error?.name || "Error",
+      error_message: error?.message || String(error),
+    });
+    return { builds: [], stateReason: null };
+  }
+}
+
 const common = {
   baseImageArn,
   buildRoleArn,
@@ -229,7 +262,12 @@ publish: for (let attempt = 1; attempt <= publishAttempts; attempt += 1) {
       break publish;
     }
     if (version.state === "FAILED") {
-      const stateReason = version.stateReason?.trim() || null;
+      const buildFailure = await resolveBuildFailure(
+        imageIdentifier,
+        imageVersion,
+      );
+      const stateReason =
+        version.stateReason?.trim() || buildFailure.stateReason || null;
       const retrying = stateReason === null && attempt < publishAttempts;
       const delegatingRetry =
         stateReason === null && !retrying && Boolean(retrySignalFile);
@@ -245,6 +283,7 @@ publish: for (let attempt = 1; attempt <= publishAttempts; attempt += 1) {
           state: version.state,
           status: version.status,
           state_reason: stateReason,
+          builds: buildFailure.builds,
           retry_scheduled: retrying || delegatingRetry,
           retry_delegated: delegatingRetry,
         },

--- a/scripts/deploy-aws-microvm.mjs
+++ b/scripts/deploy-aws-microvm.mjs
@@ -101,7 +101,10 @@ async function resolveBuildFailure(imageIdentifier, imageVersion) {
       state_reason: build.stateReason?.trim() || null,
     }));
     const stateReason = builds.find(
-      (build) => build.state_reason,
+      (build) =>
+        build.build_state === "FAILED" &&
+        build.architecture === "ARM_64" &&
+        build.state_reason,
     )?.state_reason;
     return { builds, stateReason: stateReason || null };
   } catch (error) {

--- a/scripts/lib/aws-microvm-build-diagnostics.cjs
+++ b/scripts/lib/aws-microvm-build-diagnostics.cjs
@@ -1,0 +1,36 @@
+async function listMicrovmBuildDiagnostics({
+  imageIdentifier,
+  imageVersion,
+  listPage,
+}) {
+  const builds = [];
+  let nextToken;
+
+  do {
+    const response = await listPage({
+      imageIdentifier,
+      imageVersion,
+      maxResults: 25,
+      nextToken,
+    });
+    builds.push(
+      ...(response.items || []).map((build) => ({
+        build_id: build.buildId,
+        build_state: build.buildState,
+        architecture: build.architecture,
+        state_reason: build.stateReason?.trim() || null,
+      })),
+    );
+    nextToken = response.nextToken;
+  } while (nextToken);
+
+  const stateReason = builds.find(
+    (build) =>
+      build.build_state === "FAILED" &&
+      build.architecture === "ARM_64" &&
+      build.state_reason,
+  )?.state_reason;
+  return { builds, stateReason: stateReason || null };
+}
+
+module.exports = { listMicrovmBuildDiagnostics };

--- a/scripts/lib/aws-microvm-container-image.cjs
+++ b/scripts/lib/aws-microvm-container-image.cjs
@@ -1,5 +1,7 @@
-const CONTAINER_IMAGE_DIGEST_PATTERN =
-  /^(?:[a-z0-9.-]+(?::[0-9]+)?\/)?[a-z0-9._/-]+@sha256:[a-f0-9]{64}$/;
+const REPOSITORY_COMPONENT = "[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*";
+const CONTAINER_IMAGE_DIGEST_PATTERN = new RegExp(
+  `^(?:[a-z0-9.-]+(?::[0-9]+)?/)?${REPOSITORY_COMPONENT}(?:/${REPOSITORY_COMPONENT})*@sha256:[a-f0-9]{64}$`,
+);
 
 function resolveContainerBaseImage(value) {
   const image = value?.trim();

--- a/scripts/lib/aws-microvm-container-image.cjs
+++ b/scripts/lib/aws-microvm-container-image.cjs
@@ -1,0 +1,14 @@
+const CONTAINER_IMAGE_DIGEST_PATTERN =
+  /^(?:[a-z0-9.-]+(?::[0-9]+)?\/)?[a-z0-9._/-]+@sha256:[a-f0-9]{64}$/;
+
+function resolveContainerBaseImage(value) {
+  const image = value?.trim();
+  if (!image || !CONTAINER_IMAGE_DIGEST_PATTERN.test(image)) {
+    throw new Error(
+      "AWS_LAMBDA_MICROVM_CONTAINER_BASE_IMAGE must be an immutable container image digest (for example, ghcr.io/hackerai-tech/hackerai-sandbox@sha256:...)",
+    );
+  }
+  return image;
+}
+
+module.exports = { resolveContainerBaseImage };

--- a/scripts/lib/aws-microvm-container-image.cjs
+++ b/scripts/lib/aws-microvm-container-image.cjs
@@ -1,6 +1,8 @@
 const REPOSITORY_COMPONENT = "[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*";
+const REGISTRY_LABEL = "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?";
+const REGISTRY_HOST = `${REGISTRY_LABEL}(?:\\.${REGISTRY_LABEL})*(?::[0-9]+)?`;
 const CONTAINER_IMAGE_DIGEST_PATTERN = new RegExp(
-  `^(?:[a-z0-9.-]+(?::[0-9]+)?/)?${REPOSITORY_COMPONENT}(?:/${REPOSITORY_COMPONENT})*@sha256:[a-f0-9]{64}$`,
+  `^(?:${REGISTRY_HOST}/)?${REPOSITORY_COMPONENT}(?:/${REPOSITORY_COMPONENT})*@sha256:[a-f0-9]{64}$`,
 );
 
 function resolveContainerBaseImage(value) {

--- a/scripts/package-aws-microvm.mjs
+++ b/scripts/package-aws-microvm.mjs
@@ -2,13 +2,14 @@ import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import JSZip from "jszip";
+import containerImage from "./lib/aws-microvm-container-image.cjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outputDir = join(root, ".artifacts", "aws-lambda-microvm");
 const outputPath = join(outputDir, "hackerai-lambda-microvm.zip");
-const baseDockerfile = await readFile(
-  join(root, "docker", "Dockerfile"),
-  "utf8",
+const { resolveContainerBaseImage } = containerImage;
+const containerBaseImage = resolveContainerBaseImage(
+  process.env.AWS_LAMBDA_MICROVM_CONTAINER_BASE_IMAGE,
 );
 const localPackage = JSON.parse(
   await readFile(join(root, "packages", "local", "package.json"), "utf8"),
@@ -19,7 +20,7 @@ const localPackage = JSON.parse(
 // retaining optional node-pty for managed-cloud PTY support.
 delete localPackage.scripts;
 
-const dockerfile = `${baseDockerfile.trim()}
+const dockerfile = `FROM ${containerBaseImage}
 
 # Lambda MicroVM egress exposes an AWS link-local resolver that ProjectDiscovery
 # tools do not discover automatically. Keep explicit user resolver flags intact.


### PR DESCRIPTION
## Summary
- build the heavyweight ARM64 Kali/tool base on a native GitHub ARM runner only when the Docker tree changes (or when explicitly forced)
- package normal AWS Lambda MicroVM releases as a 68 KB thin agent layer pinned to the exact GHCR base digest
- surface per-architecture AWS image-build reasons when the parent image version returns no failure reason
- validate that only immutable digest references can enter the generated Dockerfile

## Why
AWS has recently failed every regional build after roughly 31 minutes while rebuilding an unchanged, unpinned Kali/tool Dockerfile. The release artifact mixed the slow mutable toolchain build with the frequently changing agent. This splits those lifecycles: Docker changes produce one reusable base; agent changes produce only the small layer AWS needs to assemble.

## Required rollout setting
Before merging, change the existing `ghcr.io/hackerai-tech/hackerai-sandbox` package from private to public. AWS image preparation has no GHCR credential input and must pull the digest anonymously. The package is built solely from the repository's public `docker/` context and receives no build secrets.

## Validation
- `pnpm typecheck`
- `pnpm jest scripts/__tests__/aws-microvm-container-image.test.js --runInBand` (6 tests passed)
- full pre-commit suite: 4,272/4,275 tests passed; the three unrelated failures passed immediately when rerun in isolation (37/37)
- Prettier check for every changed file
- workflow YAML parsed successfully
- packaged the thin artifact with a test digest and verified it is 68 KB, starts from that exact digest, and contains no heavy `apt-get` layer

## Manual verification
After GHCR visibility is public, merge or dispatch the workflow and confirm:
1. `Resolve immutable sandbox base` builds the ARM64 base once on `ubuntu-24.04-arm`.
2. The three AWS regional builds complete and smoke-test before promotion.
3. A second dispatch without `rebuild_base` reuses the existing base digest.
4. A dispatch with `rebuild_base=true` intentionally performs a no-cache toolchain refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated ARM64 base-image reuse and rebuild support for Lambda MicroVM releases.
  - Added an option to manually force base-image rebuilds.
  - Builds now use immutable, digest-pinned container images.

- **Bug Fixes**
  - Improved validation for container image references.
  - Enhanced failed-build reporting with paginated diagnostic details.
  - Prevented reserved base-image tags from being manually published.

- **Documentation**
  - Updated manual build and release guidance for pinned images, rebuilds, and image diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->