### PR TITLE
fix(security): avoid regex backtracking in browser usage detection

### DIFF
--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -737,6 +737,19 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     expect(detectAgentBrowserUsage("agent-browser-next open")).toBeNull();
   });
 
+  test("detectAgentBrowserUsage handles adversarial assignment text in linear time", () => {
+    const adversarialCommand = `&A=${'"" A='.repeat(20_000)}`;
+
+    expect(detectAgentBrowserUsage(adversarialCommand)).toBeNull();
+  });
+
+  test("detectAgentBrowserUsage ignores command separators inside quotes", () => {
+    expect(detectAgentBrowserUsage('echo "&& agent-browser open"')).toBeNull();
+    expect(
+      detectAgentBrowserUsage("printf '; agent-browser click'"),
+    ).toBeNull();
+  });
+
   test("injects the idle timeout only for cloud agent-browser commands", async () => {
     const e2b = {
       jupyterUrl: "http://fake",

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -750,6 +750,57 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     ).toBeNull();
   });
 
+  test("detectAgentBrowserUsage handles shell redirections", () => {
+    expect(
+      detectAgentBrowserUsage(
+        "agent-browser>/tmp/browser.log open 2>/tmp/errors",
+      ),
+    ).toEqual({
+      invocationCount: 1,
+      primaryAction: "open",
+      actions: ["open"],
+      usedViaNpx: false,
+    });
+    expect(
+      detectAgentBrowserUsage(
+        "2>/tmp/errors npx -y agent-browser@0.26.0 snapshot",
+      ),
+    ).toEqual({
+      invocationCount: 1,
+      primaryAction: "snapshot",
+      actions: ["snapshot"],
+      usedViaNpx: true,
+    });
+    expect(
+      detectAgentBrowserUsage("agent-browser >> /tmp/browser.log click 2>&1"),
+    ).toEqual({
+      invocationCount: 1,
+      primaryAction: "click",
+      actions: ["click"],
+      usedViaNpx: false,
+    });
+    expect(
+      detectAgentBrowserUsage('agent-browser >"/tmp/browser log" open'),
+    ).toMatchObject({ primaryAction: "open" });
+    expect(
+      detectAgentBrowserUsage('echo "agent-browser>/tmp/output open"'),
+    ).toBeNull();
+    expect(
+      detectAgentBrowserUsage("echo agent-browser\\>/tmp/output open"),
+    ).toBeNull();
+  });
+
+  test("detectAgentBrowserUsage removes shell line continuations", () => {
+    const continuedCommand = "agent-browser \\" + "\nopen";
+
+    expect(detectAgentBrowserUsage(continuedCommand)).toEqual({
+      invocationCount: 1,
+      primaryAction: "open",
+      actions: ["open"],
+      usedViaNpx: false,
+    });
+  });
+
   test("injects the idle timeout only for cloud agent-browser commands", async () => {
     const e2b = {
       jupyterUrl: "http://fake",

--- a/lib/ai/tools/utils/agent-browser-usage.ts
+++ b/lib/ai/tools/utils/agent-browser-usage.ts
@@ -3,8 +3,115 @@ import { phLogger } from "@/lib/posthog/server";
 import { isCentrifugoSandbox, isE2BSandbox } from "./sandbox-types";
 import { AGENT_BROWSER_IDLE_TIMEOUT_MS } from "./agent-browser-runtime";
 
-const AGENT_BROWSER_INVOCATION_RE =
-  /(?:^|[;&|()]\s*)(?:(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s;&|()]+)\s+)*)?(?:npx\s+(?:--yes\s+|-y\s+)?)?agent-browser(?:@[^\s;&|()]+)?(?=$|\s|[;&|()])(?:\s+([^\s;&|()]+))?/g;
+const SHELL_COMMAND_SEPARATORS = new Set([";", "&", "|", "(", ")", "\n", "\r"]);
+const SHELL_WHITESPACE_RE = /\s/;
+const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+const AGENT_BROWSER_COMMAND_RE = /^agent-browser(?:@[^\s;&|()]+)?$/;
+
+function splitShellCommands(command: string): string[] {
+  const commands: string[] = [];
+  let start = 0;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < command.length; index++) {
+    const character = command[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (SHELL_COMMAND_SEPARATORS.has(character)) {
+      commands.push(command.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  commands.push(command.slice(start));
+  return commands;
+}
+
+function splitShellWords(command: string): string[] {
+  const words: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  let hasContent = false;
+
+  const pushCurrent = () => {
+    if (!hasContent) return;
+    words.push(current);
+    current = "";
+    hasContent = false;
+  };
+
+  for (const character of command) {
+    if (escaped) {
+      current += character;
+      hasContent = true;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      hasContent = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      else current += character;
+      hasContent = true;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      hasContent = true;
+      continue;
+    }
+    if (SHELL_WHITESPACE_RE.test(character)) {
+      pushCurrent();
+      continue;
+    }
+    current += character;
+    hasContent = true;
+  }
+
+  if (escaped) current += "\\";
+  pushCurrent();
+  return words;
+}
+
+function parseAgentBrowserInvocation(command: string): {
+  action?: string;
+  usedViaNpx: boolean;
+} | null {
+  const words = splitShellWords(command);
+  let index = 0;
+
+  if (words[index] === "env") index++;
+  while (ENV_ASSIGNMENT_RE.test(words[index] ?? "")) index++;
+
+  let usedViaNpx = false;
+  if (words[index] === "npx") {
+    usedViaNpx = true;
+    index++;
+    if (words[index] === "--yes" || words[index] === "-y") index++;
+  }
+
+  if (!AGENT_BROWSER_COMMAND_RE.test(words[index] ?? "")) return null;
+  return { action: words[index + 1], usedViaNpx };
+}
 
 const KNOWN_AGENT_BROWSER_ACTIONS = new Set([
   "open",
@@ -72,22 +179,12 @@ export function detectAgentBrowserUsage(
   let invocationCount = 0;
   let usedViaNpx = false;
 
-  AGENT_BROWSER_INVOCATION_RE.lastIndex = 0;
-  for (
-    let match = AGENT_BROWSER_INVOCATION_RE.exec(command);
-    match !== null;
-    match = AGENT_BROWSER_INVOCATION_RE.exec(command)
-  ) {
+  for (const shellCommand of splitShellCommands(command)) {
+    const invocation = parseAgentBrowserInvocation(shellCommand);
+    if (!invocation) continue;
     invocationCount++;
-    const matchedCommand = match[0] ?? "";
-    if (
-      /\bnpx\s+(?:--yes\s+|-y\s+)?agent-browser(?:@[^\s;&|()]+)?(?=$|\s|[;&|()])/.test(
-        matchedCommand,
-      )
-    ) {
-      usedViaNpx = true;
-    }
-    const action = normalizeAgentBrowserAction(match[1]);
+    usedViaNpx ||= invocation.usedViaNpx;
+    const action = normalizeAgentBrowserAction(invocation.action);
     if (!actions.includes(action)) actions.push(action);
   }
 

--- a/lib/ai/tools/utils/agent-browser-usage.ts
+++ b/lib/ai/tools/utils/agent-browser-usage.ts
@@ -13,6 +13,7 @@ function splitShellCommands(command: string): string[] {
   let start = 0;
   let quote: "'" | '"' | null = null;
   let escaped = false;
+  let redirectionOperatorOpen = false;
 
   for (let index = 0; index < command.length; index++) {
     const character = command[index];
@@ -32,6 +33,21 @@ function splitShellCommands(command: string): string[] {
       quote = character;
       continue;
     }
+    if (redirectionOperatorOpen) {
+      if (
+        character === ">" ||
+        character === "<" ||
+        character === "&" ||
+        character === "|"
+      ) {
+        continue;
+      }
+      redirectionOperatorOpen = false;
+    }
+    if (character === ">" || character === "<") {
+      redirectionOperatorOpen = true;
+      continue;
+    }
     if (SHELL_COMMAND_SEPARATORS.has(character)) {
       commands.push(command.slice(start, index));
       start = index + 1;
@@ -48,6 +64,9 @@ function splitShellWords(command: string): string[] {
   let quote: "'" | '"' | null = null;
   let escaped = false;
   let hasContent = false;
+  let skippingRedirectionTarget = false;
+  let redirectionTargetStarted = false;
+  let redirectionOperatorOpen = false;
 
   const pushCurrent = () => {
     if (!hasContent) return;
@@ -58,25 +77,64 @@ function splitShellWords(command: string): string[] {
 
   for (const character of command) {
     if (escaped) {
-      current += character;
-      hasContent = true;
       escaped = false;
+      if (character === "\n") continue;
+      if (skippingRedirectionTarget) redirectionTargetStarted = true;
+      else {
+        current += character;
+        hasContent = true;
+      }
       continue;
     }
     if (character === "\\" && quote !== "'") {
       escaped = true;
-      hasContent = true;
       continue;
     }
     if (quote) {
       if (character === quote) quote = null;
-      else current += character;
-      hasContent = true;
+      else if (!skippingRedirectionTarget) current += character;
+      if (skippingRedirectionTarget) redirectionTargetStarted = true;
+      else hasContent = true;
       continue;
     }
     if (character === "'" || character === '"') {
       quote = character;
-      hasContent = true;
+      if (skippingRedirectionTarget) redirectionTargetStarted = true;
+      else hasContent = true;
+      continue;
+    }
+    if (skippingRedirectionTarget) {
+      if (redirectionOperatorOpen) {
+        if (
+          character === ">" ||
+          character === "<" ||
+          character === "&" ||
+          character === "|"
+        ) {
+          continue;
+        }
+        redirectionOperatorOpen = false;
+      }
+      if (SHELL_WHITESPACE_RE.test(character)) {
+        if (redirectionTargetStarted) {
+          skippingRedirectionTarget = false;
+          redirectionTargetStarted = false;
+        }
+      } else {
+        redirectionTargetStarted = true;
+      }
+      continue;
+    }
+    if (character === ">" || character === "<") {
+      if (/^\d+$/.test(current)) {
+        current = "";
+        hasContent = false;
+      } else {
+        pushCurrent();
+      }
+      skippingRedirectionTarget = true;
+      redirectionTargetStarted = false;
+      redirectionOperatorOpen = true;
       continue;
     }
     if (SHELL_WHITESPACE_RE.test(character)) {
@@ -87,7 +145,10 @@ function splitShellWords(command: string): string[] {
     hasContent = true;
   }
 
-  if (escaped) current += "\\";
+  if (escaped) {
+    current += "\\";
+    hasContent = true;
+  }
   pushCurrent();
   return words;
 }


### PR DESCRIPTION
## Summary
- replace the potentially exponential agent-browser invocation regex with a linear shell command/word scanner
- preserve environment-prefix, npx, version, and action detection behavior
- add regression coverage for CodeQL’s adversarial assignment pattern and quoted separators

## Security
Closes the path reported by CodeQL alert #1 (`js/redos`). Untrusted terminal command text is now scanned in linear time without executing or interpreting it.

## Verification
- `corepack pnpm exec jest lib/ai/tools/__tests__/run-terminal-cmd.test.ts --runInBand`
- `corepack pnpm exec eslint lib/ai/tools/utils/agent-browser-usage.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts`
- `corepack pnpm run typecheck`
- pre-commit full suite: 418 suites / 4,270 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of agent-browser commands in complex shell input.
  - Correctly handles quoted strings, escaped characters, command separators, shell redirections, line continuations, environment assignments, optional confirmation flags, and versioned commands.
  - Prevents false positives from command-like text embedded in larger assignments or quoted content.

- **Tests**
  - Added regression coverage for adversarial inputs, quoted separators, redirections, escaped redirections, and shell line continuations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->