### PR TITLE
Limit session replay to English locales

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -224,17 +224,20 @@ describe("PostHogProvider", () => {
     });
     mockLoadPostHogClient.mockResolvedValue(posthog);
 
-    render(
-      <PostHogProvider>
-        <div>child</div>
-      </PostHogProvider>,
-    );
+    try {
+      render(
+        <PostHogProvider>
+          <div>child</div>
+        </PostHogProvider>,
+      );
 
-    await waitFor(() =>
-      expect(posthog.startSessionRecording).toHaveBeenCalledTimes(1),
-    );
-    expect(posthog.stopSessionRecording).not.toHaveBeenCalled();
-    languageSpy.mockRestore();
+      await waitFor(() =>
+        expect(posthog.startSessionRecording).toHaveBeenCalledTimes(1),
+      );
+      expect(posthog.stopSessionRecording).not.toHaveBeenCalled();
+    } finally {
+      languageSpy.mockRestore();
+    }
   });
 
   it("clears the queued analytics identity when the user signs out", () => {

--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -156,7 +156,7 @@ describe("PostHogProvider", () => {
     expect(posthog.stopSessionRecording).not.toHaveBeenCalled();
   });
 
-  it.each(["fr-FR", "es_ES", "invalid locale"])(
+  it.each(["fr-FR", "es_ES", "invalid locale", "   "])(
     "does not record a paid user's %s session",
     async (locale) => {
       const posthog = {

--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -66,6 +66,7 @@ describe("PostHogProvider", () => {
         email: "user@example.com",
         firstName: "Test",
         lastName: "User",
+        locale: "en-US",
       },
     });
   });
@@ -151,6 +152,89 @@ describe("PostHogProvider", () => {
       $current_url: "https://hackerai.co/auth-error",
       $referrer: "https://idp.example/callback",
     });
+    expect(posthog.startSessionRecording).toHaveBeenCalledTimes(1);
+    expect(posthog.stopSessionRecording).not.toHaveBeenCalled();
+  });
+
+  it.each(["fr-FR", "es_ES", "invalid locale"])(
+    "does not record a paid user's %s session",
+    async (locale) => {
+      const posthog = {
+        __loaded: false,
+        init: jest.fn(),
+        set_config: jest.fn(),
+        opt_in_capturing: jest.fn(),
+        has_opted_out_capturing: jest.fn(() => false),
+        identify: jest.fn(),
+        sessionRecordingStarted: jest.fn(() => false),
+        startSessionRecording: jest.fn(),
+        stopSessionRecording: jest.fn(),
+        reset: jest.fn(),
+        opt_out_capturing: jest.fn(),
+      };
+      mockUseAuth.mockReturnValue({
+        user: {
+          id: "user-123",
+          email: "user@example.com",
+          firstName: "Test",
+          lastName: "User",
+          locale,
+        },
+      });
+      mockLoadPostHogClient.mockResolvedValue(posthog);
+
+      render(
+        <PostHogProvider>
+          <div>child</div>
+        </PostHogProvider>,
+      );
+
+      await waitFor(() =>
+        expect(posthog.stopSessionRecording).toHaveBeenCalledTimes(1),
+      );
+      expect(posthog.startSessionRecording).not.toHaveBeenCalled();
+    },
+  );
+
+  it("falls back to the primary browser locale when account locale is missing", async () => {
+    const languageSpy = jest
+      .spyOn(window.navigator, "language", "get")
+      .mockReturnValue("en-CA");
+    const posthog = {
+      __loaded: false,
+      init: jest.fn(),
+      set_config: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      has_opted_out_capturing: jest.fn(() => false),
+      identify: jest.fn(),
+      sessionRecordingStarted: jest.fn(() => false),
+      startSessionRecording: jest.fn(),
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "user-123",
+        email: "user@example.com",
+        firstName: "Test",
+        lastName: "User",
+        locale: null,
+      },
+    });
+    mockLoadPostHogClient.mockResolvedValue(posthog);
+
+    render(
+      <PostHogProvider>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    await waitFor(() =>
+      expect(posthog.startSessionRecording).toHaveBeenCalledTimes(1),
+    );
+    expect(posthog.stopSessionRecording).not.toHaveBeenCalled();
+    languageSpy.mockRestore();
   });
 
   it("clears the queued analytics identity when the user signs out", () => {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -169,7 +169,8 @@ export function PostHogProvider({
 
         confirmAuthenticatedAnalyticsUserId(userId!);
 
-        const replayLocale = userLocale?.trim() || window.navigator.language;
+        const replayLocale =
+          userLocale == null ? window.navigator.language : userLocale;
         const shouldRecordSession =
           subscription !== "free" && isEnglishLocale(replayLocale);
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -26,6 +26,17 @@ import {
 
 let lastIdentifiedSignature: string | null = null;
 
+function isEnglishLocale(locale: string | null | undefined) {
+  const normalizedLocale = locale?.trim().replaceAll("_", "-");
+  if (!normalizedLocale) return false;
+
+  try {
+    return new Intl.Locale(normalizedLocale).language === "en";
+  } catch {
+    return false;
+  }
+}
+
 export function PostHogProvider({
   children,
   firstTouchAttribution = null,
@@ -39,6 +50,7 @@ export function PostHogProvider({
   const userEmail = user?.email;
   const userFirstName = user?.firstName;
   const userLastName = user?.lastName;
+  const userLocale = user?.locale;
 
   useEffect(() => {
     const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
@@ -157,7 +169,11 @@ export function PostHogProvider({
 
         confirmAuthenticatedAnalyticsUserId(userId!);
 
-        if (subscription !== "free") {
+        const replayLocale = userLocale?.trim() || window.navigator.language;
+        const shouldRecordSession =
+          subscription !== "free" && isEnglishLocale(replayLocale);
+
+        if (shouldRecordSession) {
           if (!posthog.sessionRecordingStarted()) {
             posthog.startSessionRecording();
           }
@@ -178,6 +194,7 @@ export function PostHogProvider({
     userFirstName,
     userId,
     userLastName,
+    userLocale,
   ]);
 
   return children;


### PR DESCRIPTION
## Summary
- record PostHog session replays only for paid users whose account locale resolves to English
- fall back to the primary browser locale only when the account locale is missing
- fail closed for non-English, malformed, or whitespace-only locales and stop any active recording
- cover English, non-English, malformed, whitespace-only, underscore-delimited, and browser-fallback behavior

## Validation
- `corepack pnpm exec jest --runInBand app/__tests__/providers.test.tsx`
- `corepack pnpm exec jest --runInBand` (418 suites, 4,280 tests)
- `corepack pnpm typecheck`
- `corepack pnpm lint` (0 errors; 7 pre-existing warnings)
- `corepack pnpm exec prettier --check app/providers.tsx app/__tests__/providers.test.tsx`
- `corepack pnpm run check:local-dependencies`
- `git diff --check`

## Manual verification
1. Sign in with a paid English-locale account and confirm a new replay appears in PostHog.
2. Sign in with a paid non-English-locale account and confirm no replay is created.
3. Sign in with a free English-locale account and confirm no replay is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Session recordings now start for paid users with English locales.
  * Session recordings are stopped for paid users with non-English or invalid locales, including blank values.
  * When no account locale is available, the browser’s primary language is used as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->