### PR TITLE
Fix live chat recovery regressions

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -828,7 +828,6 @@ export const ChatInput = ({
         <input
           ref={fileInputRef}
           type="file"
-          accept="*"
           multiple
           className="hidden"
           aria-label="Upload files"

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -191,6 +191,22 @@ describe("ChatInput - Integration Tests", () => {
   });
 
   describe("Ask Mode Integration", () => {
+    it("leaves the unrestricted file picker accept list unset", () => {
+      render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+          />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByLabelText("Upload files")).not.toHaveAttribute(
+        "accept",
+      );
+    });
+
     it("renders Ask mode by default without the logged-out mode selector", () => {
       render(
         <TestWrapper>

--- a/app/components/__tests__/chat-transition-contract.test.ts
+++ b/app/components/__tests__/chat-transition-contract.test.ts
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+
+const chatSource = fs.readFileSync(
+  path.resolve(__dirname, "../chat.tsx"),
+  "utf8",
+);
+
+describe("chat route transition rendering", () => {
+  it("resets route-owned messages before paint", () => {
+    expect(chatSource).toMatch(
+      /Sync local chat state from URL[\s\S]*useLayoutEffect\(\(\) => \{[\s\S]*setChatId\(routeChatId\)/,
+    );
+    expect(chatSource).toMatch(
+      /messagesChatIdRef[\s\S]*useLayoutEffect\(\(\) => \{[\s\S]*setMessages\(serverMessages\)/,
+    );
+  });
+
+  it("shows an explicit loading state instead of hiding stale messages", () => {
+    expect(chatSource).toContain('data-testid="chat-timeline-loading"');
+    expect(chatSource).toContain("Loading task…");
+    expect(chatSource).toMatch(/<Messages\s+key=\{chatId\}/);
+    expect(chatSource).not.toMatch(
+      /isInitialExistingChatLoad\s*\?\s*"opacity-0"/,
+    );
+  });
+});

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -114,9 +114,7 @@ import { HackingSuggestions } from "./HackingSuggestions";
 const AGENT_LONG_SILENT_COMPLETION_POLL_DELAY_MS = 5_000;
 const AGENT_LONG_SILENT_COMPLETION_POLL_INTERVAL_MS = 5_000;
 const AGENT_LONG_ACTIVE_COMPLETION_POLL_INTERVAL_MS = 15_000;
-const AGENT_LONG_SILENT_COMPLETION_QUIET_MS = 3_000;
-const AGENT_LONG_ACTIVE_COMPLETION_QUIET_MS = 10_000;
-const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 6_000;
+const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 2_000;
 type MessagePaginationStatus =
   "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
 
@@ -1220,7 +1218,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       agentLongHasVisibleProgressRef.current = false;
       agentLongMessageFingerprintRef.current =
         getAgentLongMessageProgressFingerprint(messagesRef.current);
-      agentLongLastMessageChangeAtRef.current = Date.now();
     }
     if (
       shouldUseAgentLongForCurrentChat &&
@@ -1298,7 +1295,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const agentLongMessageFingerprint =
     getAgentLongMessageProgressFingerprint(messages);
   const agentLongMessageFingerprintRef = useRef(agentLongMessageFingerprint);
-  const agentLongLastMessageChangeAtRef = useRef(Date.now());
 
   useEffect(() => {
     if (
@@ -1307,7 +1303,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       return;
     }
     agentLongMessageFingerprintRef.current = agentLongMessageFingerprint;
-    agentLongLastMessageChangeAtRef.current = Date.now();
     agentLongHasVisibleProgressRef.current = true;
   }, [agentLongMessageFingerprint]);
 
@@ -1371,15 +1366,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     };
 
     const checkRunCompletion = async () => {
-      const quietMs = agentLongHasVisibleProgressRef.current
-        ? AGENT_LONG_ACTIVE_COMPLETION_QUIET_MS
-        : AGENT_LONG_SILENT_COMPLETION_QUIET_MS;
-      if (
-        isCompletionCheckInFlight ||
-        Date.now() - agentLongLastMessageChangeAtRef.current < quietMs
-      ) {
-        return;
-      }
+      if (isCompletionCheckInFlight) return;
 
       const runId =
         agentLongRunId ??

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1317,9 +1317,13 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // the app's authenticated resume endpoint so the first message in a new
   // chat can leave "Working..." even before chatData is subscribed.
   useEffect(() => {
+    const trackedAgentLongRunId =
+      agentLongRunId ??
+      agentLongRunCorrelationRef.current?.runId ??
+      activeTriggerRunRef.current;
     if (
       (status !== "streaming" && status !== "submitted") ||
-      !shouldUseAgentLongForCurrentChat
+      (!shouldUseAgentLongForCurrentChat && !trackedAgentLongRunId)
     ) {
       return;
     }
@@ -1333,7 +1337,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     const finishLocally = () => {
       if (stopped || activeChatIdRef.current !== chatId) return;
       stopped = true;
-      stop();
+      stopRef.current();
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
@@ -1375,7 +1379,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       if (isCompletionCheckInFlight) return;
 
       const runId =
-        agentLongRunId ??
+        trackedAgentLongRunId ??
         agentLongRunCorrelationRef.current?.runId ??
         activeTriggerRunRef.current;
       if (!runId) return;
@@ -1440,7 +1444,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     saveAgentLongPartialSnapshot,
     shouldUseAgentLongForCurrentChat,
     status,
-    stop,
   ]);
 
   // Ref bridge: StreamEffects exposes resetAutoContinueCount here

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -115,6 +115,7 @@ const AGENT_LONG_SILENT_COMPLETION_POLL_DELAY_MS = 5_000;
 const AGENT_LONG_SILENT_COMPLETION_POLL_INTERVAL_MS = 5_000;
 const AGENT_LONG_ACTIVE_COMPLETION_POLL_INTERVAL_MS = 15_000;
 const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 2_000;
+const AGENT_LONG_COMPLETION_REQUEST_TIMEOUT_MS = 8_000;
 type MessagePaginationStatus =
   "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
 
@@ -726,6 +727,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   } | null>(null);
   const [agentLongRunId, setAgentLongRunId] = useState<string | null>(null);
   const agentLongHasVisibleProgressRef = useRef(false);
+  const agentLongRunFallbackAllowedRef = useRef(true);
+  const agentLongSubmissionGenerationRef = useRef(0);
 
   useLayoutEffect(() => {
     activeChatIdRef.current = chatId;
@@ -772,15 +775,24 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           // Reset the previous run before starting the request. Doing this in
           // the passive `submitted` effect can race with onRunStarted and
           // erase the new run metadata before completion reconciliation sees it.
+          const submissionGeneration =
+            ++agentLongSubmissionGenerationRef.current;
           agentLongRunCorrelationRef.current = null;
+          agentLongRunFallbackAllowedRef.current = false;
           setAgentLongRunId(null);
           agentLongHasVisibleProgressRef.current = false;
-          agentLongMessageFingerprintRef.current =
-            getAgentLongMessageProgressFingerprint(messagesRef.current);
+          agentLongMessageFingerprintRef.current = {
+            chatId: activeChatIdRef.current,
+            fingerprint: getAgentLongMessageProgressFingerprint(
+              messagesRef.current,
+            ),
+          };
           return fetchAgentLongStream(init, (run) => {
             if (
-              run.chatId !== undefined &&
-              run.chatId !== activeChatIdRef.current
+              submissionGeneration !==
+                agentLongSubmissionGenerationRef.current ||
+              (run.chatId !== undefined &&
+                run.chatId !== activeChatIdRef.current)
             ) {
               return;
             }
@@ -792,6 +804,12 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
               };
             }
           });
+        }
+        if (init?.method !== "GET") {
+          agentLongSubmissionGenerationRef.current += 1;
+          agentLongRunCorrelationRef.current = null;
+          agentLongRunFallbackAllowedRef.current = false;
+          setAgentLongRunId(null);
         }
         // Reconnect for legacy "agent-long" chats normalised to "agent" mode
         // on load — route based on the URL (not on ref state) to be resilient
@@ -1036,6 +1054,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         return;
       }
       browserStreamFinishedRef.current = true;
+      agentLongRunCorrelationRef.current = null;
+      agentLongRunFallbackAllowedRef.current = false;
+      setAgentLongRunId(null);
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
@@ -1056,6 +1077,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         return;
       }
       browserStreamFinishedRef.current = true;
+      agentLongRunCorrelationRef.current = null;
+      agentLongRunFallbackAllowedRef.current = false;
+      setAgentLongRunId(null);
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
@@ -1222,8 +1246,12 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   useEffect(() => {
     if (status === "submitted") {
       agentLongHasVisibleProgressRef.current = false;
-      agentLongMessageFingerprintRef.current =
-        getAgentLongMessageProgressFingerprint(messagesRef.current);
+      agentLongMessageFingerprintRef.current = {
+        chatId,
+        fingerprint: getAgentLongMessageProgressFingerprint(
+          messagesRef.current,
+        ),
+      };
     }
     if (
       shouldUseAgentLongForCurrentChat &&
@@ -1231,7 +1259,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     ) {
       browserStreamFinishedRef.current = false;
     }
-  }, [shouldUseAgentLongForCurrentChat, status]);
+  }, [chatId, shouldUseAgentLongForCurrentChat, status]);
 
   useEffect(() => {
     const isAgentLongDoubleCloseNoise = (message: unknown) =>
@@ -1284,7 +1312,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   }, []);
 
   useEffect(() => {
+    agentLongSubmissionGenerationRef.current += 1;
     agentLongRunCorrelationRef.current = null;
+    agentLongRunFallbackAllowedRef.current = true;
     setAgentLongRunId(null);
     agentLongHasVisibleProgressRef.current = false;
     setDataStream([]);
@@ -1300,17 +1330,31 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   const agentLongMessageFingerprint =
     getAgentLongMessageProgressFingerprint(messages);
-  const agentLongMessageFingerprintRef = useRef(agentLongMessageFingerprint);
+  const agentLongMessageFingerprintRef = useRef({
+    chatId,
+    fingerprint: agentLongMessageFingerprint,
+  });
 
   useEffect(() => {
+    if (agentLongMessageFingerprintRef.current.chatId !== chatId) {
+      agentLongMessageFingerprintRef.current = {
+        chatId,
+        fingerprint: agentLongMessageFingerprint,
+      };
+      return;
+    }
     if (
-      agentLongMessageFingerprintRef.current === agentLongMessageFingerprint
+      agentLongMessageFingerprintRef.current.fingerprint ===
+      agentLongMessageFingerprint
     ) {
       return;
     }
-    agentLongMessageFingerprintRef.current = agentLongMessageFingerprint;
+    agentLongMessageFingerprintRef.current = {
+      chatId,
+      fingerprint: agentLongMessageFingerprint,
+    };
     agentLongHasVisibleProgressRef.current = true;
-  }, [agentLongMessageFingerprint]);
+  }, [agentLongMessageFingerprint, chatId]);
 
   // Trigger.dev can finish and persist an Agent answer even if the realtime
   // UI stream never delivers a terminal chunk to useChat. Reconcile against
@@ -1320,7 +1364,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     const trackedAgentLongRunId =
       agentLongRunId ??
       agentLongRunCorrelationRef.current?.runId ??
-      activeTriggerRunRef.current;
+      (agentLongRunFallbackAllowedRef.current
+        ? activeTriggerRunRef.current
+        : null);
     if (
       (status !== "streaming" && status !== "submitted") ||
       (!shouldUseAgentLongForCurrentChat && !trackedAgentLongRunId)
@@ -1337,6 +1383,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     const finishLocally = () => {
       if (stopped || activeChatIdRef.current !== chatId) return;
       stopped = true;
+      agentLongRunCorrelationRef.current = null;
+      agentLongRunFallbackAllowedRef.current = false;
+      setAgentLongRunId(null);
       stopRef.current();
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
@@ -1381,16 +1430,27 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       const runId =
         trackedAgentLongRunId ??
         agentLongRunCorrelationRef.current?.runId ??
-        activeTriggerRunRef.current;
+        (agentLongRunFallbackAllowedRef.current
+          ? activeTriggerRunRef.current
+          : null);
       if (!runId) return;
 
       isCompletionCheckInFlight = true;
+      const requestAbortController = new AbortController();
+      const abortRequest = () => requestAbortController.abort();
+      abortController.signal.addEventListener("abort", abortRequest, {
+        once: true,
+      });
+      const requestTimeout = setTimeout(
+        abortRequest,
+        AGENT_LONG_COMPLETION_REQUEST_TIMEOUT_MS,
+      );
       try {
         const response = await fetch(AGENT_STATUS_ENDPOINT, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ chatId, runId }),
-          signal: abortController.signal,
+          signal: requestAbortController.signal,
         });
         if (response.status === 404) {
           scheduleFinishLocally();
@@ -1408,6 +1468,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           // the visible error state.
         }
       } finally {
+        clearTimeout(requestTimeout);
+        abortController.signal.removeEventListener("abort", abortRequest);
         isCompletionCheckInFlight = false;
       }
     };

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -769,6 +769,14 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
               init,
             );
           }
+          // Reset the previous run before starting the request. Doing this in
+          // the passive `submitted` effect can race with onRunStarted and
+          // erase the new run metadata before completion reconciliation sees it.
+          agentLongRunCorrelationRef.current = null;
+          setAgentLongRunId(null);
+          agentLongHasVisibleProgressRef.current = false;
+          agentLongMessageFingerprintRef.current =
+            getAgentLongMessageProgressFingerprint(messagesRef.current);
           return fetchAgentLongStream(init, (run) => {
             if (
               run.chatId !== undefined &&
@@ -1213,8 +1221,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   useEffect(() => {
     if (status === "submitted") {
-      agentLongRunCorrelationRef.current = null;
-      setAgentLongRunId(null);
       agentLongHasVisibleProgressRef.current = false;
       agentLongMessageFingerprintRef.current =
         getAgentLongMessageProgressFingerprint(messagesRef.current);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -111,9 +111,11 @@ import { finalizeNewChatRoute } from "./chat-route";
 
 import { HackingSuggestions } from "./HackingSuggestions";
 
-const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 15_000;
-const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 15_000;
-const AGENT_LONG_COMPLETION_QUIET_MS = 10_000;
+const AGENT_LONG_SILENT_COMPLETION_POLL_DELAY_MS = 5_000;
+const AGENT_LONG_SILENT_COMPLETION_POLL_INTERVAL_MS = 5_000;
+const AGENT_LONG_ACTIVE_COMPLETION_POLL_INTERVAL_MS = 15_000;
+const AGENT_LONG_SILENT_COMPLETION_QUIET_MS = 3_000;
+const AGENT_LONG_ACTIVE_COMPLETION_QUIET_MS = 10_000;
 const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 6_000;
 type MessagePaginationStatus =
   "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
@@ -642,7 +644,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const lastRunFinishedAt = chatDataForCurrentChat?.last_run_finished_at;
 
   // Sync local chat state from URL (single source of truth)
-  useEffect(() => {
+  useLayoutEffect(() => {
     setStreamedTitle(null);
     lastAppliedTodoOutputRef.current = null;
     if (routeChatId) {
@@ -724,6 +726,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     runId: string;
     token: string;
   } | null>(null);
+  const [agentLongRunId, setAgentLongRunId] = useState<string | null>(null);
+  const agentLongHasVisibleProgressRef = useRef(false);
 
   useLayoutEffect(() => {
     activeChatIdRef.current = chatId;
@@ -767,7 +771,21 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
               init,
             );
           }
-          return fetchAgentLongStream(init);
+          return fetchAgentLongStream(init, (run) => {
+            if (
+              run.chatId !== undefined &&
+              run.chatId !== activeChatIdRef.current
+            ) {
+              return;
+            }
+            setAgentLongRunId(run.runId);
+            if (run.runCorrelationToken) {
+              agentLongRunCorrelationRef.current = {
+                runId: run.runId,
+                token: run.runCorrelationToken,
+              };
+            }
+          });
         }
         // Reconnect for legacy "agent-long" chats normalised to "agent" mode
         // on load — route based on the URL (not on ref state) to be resilient
@@ -887,9 +905,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
             runId: correlationData.runId,
             token: correlationData.token,
           };
+          setAgentLongRunId(correlationData.runId);
         }
         return;
       }
+      agentLongHasVisibleProgressRef.current = true;
       setDataStream((ds) => [...ds, { ...dataPart, __chatId: chatId }]);
       switch (dataPart.type) {
         case "data-agent-approval-session": {
@@ -1081,6 +1101,15 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   setMessagesRef.current = setMessages;
   messagesRef.current = messages;
 
+  const messagesChatIdRef = useRef(chatId);
+  useLayoutEffect(() => {
+    if (messagesChatIdRef.current === chatId) return;
+    messagesChatIdRef.current = chatId;
+    messagesRef.current = serverMessages;
+    setMessages(serverMessages);
+    setTempChatFileDetails(new Map());
+  }, [chatId, serverMessages, setMessages]);
+
   useEffect(() => {
     const shouldApplyOutput =
       status === "streaming" || status === "submitted" || !shouldFetchMessages;
@@ -1187,6 +1216,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   useEffect(() => {
     if (status === "submitted") {
       agentLongRunCorrelationRef.current = null;
+      setAgentLongRunId(null);
+      agentLongHasVisibleProgressRef.current = false;
+      agentLongMessageFingerprintRef.current =
+        getAgentLongMessageProgressFingerprint(messagesRef.current);
+      agentLongLastMessageChangeAtRef.current = Date.now();
     }
     if (
       shouldUseAgentLongForCurrentChat &&
@@ -1248,6 +1282,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   useEffect(() => {
     agentLongRunCorrelationRef.current = null;
+    setAgentLongRunId(null);
+    agentLongHasVisibleProgressRef.current = false;
     setDataStream([]);
     setIsAutoResuming(false);
     dispatchStreaming({ type: "RESET_ON_CHAT_CHANGE" });
@@ -1272,6 +1308,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     }
     agentLongMessageFingerprintRef.current = agentLongMessageFingerprint;
     agentLongLastMessageChangeAtRef.current = Date.now();
+    agentLongHasVisibleProgressRef.current = true;
   }, [agentLongMessageFingerprint]);
 
   // Trigger.dev can finish and persist an Agent answer even if the realtime
@@ -1279,12 +1316,15 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // the app's authenticated resume endpoint so the first message in a new
   // chat can leave "Working..." even before chatData is subscribed.
   useEffect(() => {
-    if (status !== "streaming" || !shouldUseAgentLongForCurrentChat) {
+    if (
+      (status !== "streaming" && status !== "submitted") ||
+      !shouldUseAgentLongForCurrentChat
+    ) {
       return;
     }
 
     let stopped = false;
-    let pollInterval: ReturnType<typeof setInterval> | undefined;
+    let pollTimeout: ReturnType<typeof setTimeout> | undefined;
     let finishTimeout: ReturnType<typeof setTimeout> | undefined;
     let isCompletionCheckInFlight = false;
     const abortController = new AbortController();
@@ -1316,6 +1356,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       // The transport also polls the status endpoint and can deliver a
       // synthetic finish after a terminal status. Give it a brief chance to
       // close normally before falling back to stop(), which aborts the stream.
+      const stopGraceMs = agentLongHasVisibleProgressRef.current
+        ? AGENT_LONG_COMPLETION_STOP_GRACE_MS
+        : 0;
       finishTimeout = setTimeout(() => {
         finishTimeout = undefined;
         if (
@@ -1324,19 +1367,22 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         ) {
           finishLocally();
         }
-      }, AGENT_LONG_COMPLETION_STOP_GRACE_MS);
+      }, stopGraceMs);
     };
 
     const checkRunCompletion = async () => {
+      const quietMs = agentLongHasVisibleProgressRef.current
+        ? AGENT_LONG_ACTIVE_COMPLETION_QUIET_MS
+        : AGENT_LONG_SILENT_COMPLETION_QUIET_MS;
       if (
         isCompletionCheckInFlight ||
-        Date.now() - agentLongLastMessageChangeAtRef.current <
-          AGENT_LONG_COMPLETION_QUIET_MS
+        Date.now() - agentLongLastMessageChangeAtRef.current < quietMs
       ) {
         return;
       }
 
       const runId =
+        agentLongRunId ??
         agentLongRunCorrelationRef.current?.runId ??
         activeTriggerRunRef.current;
       if (!runId) return;
@@ -1369,26 +1415,32 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
     };
 
-    const pollDelay = setTimeout(() => {
-      void checkRunCompletion();
-      pollInterval = setInterval(() => {
-        void checkRunCompletion();
-      }, AGENT_LONG_COMPLETION_POLL_INTERVAL_MS);
-    }, AGENT_LONG_COMPLETION_POLL_DELAY_MS);
+    const scheduleCompletionCheck = (delayMs: number) => {
+      pollTimeout = setTimeout(async () => {
+        await checkRunCompletion();
+        if (stopped) return;
+        scheduleCompletionCheck(
+          agentLongHasVisibleProgressRef.current
+            ? AGENT_LONG_ACTIVE_COMPLETION_POLL_INTERVAL_MS
+            : AGENT_LONG_SILENT_COMPLETION_POLL_INTERVAL_MS,
+        );
+      }, delayMs);
+    };
+    scheduleCompletionCheck(AGENT_LONG_SILENT_COMPLETION_POLL_DELAY_MS);
 
     return () => {
       stopped = true;
       abortController.abort();
-      clearTimeout(pollDelay);
+      if (pollTimeout !== undefined) {
+        clearTimeout(pollTimeout);
+      }
       if (finishTimeout !== undefined) {
         clearTimeout(finishTimeout);
-      }
-      if (pollInterval !== undefined) {
-        clearInterval(pollInterval);
       }
     };
   }, [
     activeTriggerRunRef,
+    agentLongRunId,
     chatId,
     isExistingChatRef,
     setIsAutoResuming,
@@ -1866,7 +1918,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     [branchChatMutation, initializeChat, router],
   );
 
-  const hasMessages = messages.length > 0;
+  const isRouteTransitioning =
+    routeChatId !== undefined && routeChatId !== chatId;
+  const hasMessages = !isRouteTransitioning && messages.length > 0;
   const showChatLayout = hasMessages || isExistingChat;
   const { isInitialExistingChatLoad, isChatNotFound } =
     getExistingChatLoadState({
@@ -1979,44 +2033,53 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                 </div>
               ) : showChatLayout ? (
                 <div
-                  className={`flex min-h-0 flex-1 transition-opacity duration-150 motion-reduce:transition-none ${
-                    isInitialExistingChatLoad ? "opacity-0" : "opacity-100"
-                  }`}
-                  aria-busy={isInitialExistingChatLoad}
+                  className="flex min-h-0 flex-1"
+                  aria-busy={isInitialExistingChatLoad || isRouteTransitioning}
                   data-testid="chat-timeline-shell"
                 >
-                  <Messages
-                    chatId={chatId}
-                    scrollRef={scrollRef}
-                    contentRef={contentRef}
-                    messages={messages}
-                    setMessages={setMessages}
-                    onRegenerate={handleRegenerate}
-                    onRetry={handleRetry}
-                    onContinue={handleContinue}
-                    onReconnect={resumeStream}
-                    onEditMessage={handleEditMessage}
-                    onBranchMessage={handleBranchMessage}
-                    status={status}
-                    error={error || null}
-                    paginationStatus={paginatedMessages.status}
-                    loadMore={paginatedMessages.loadMore}
-                    isMobile={isMobile}
-                    tempChatFileDetails={tempChatFileDetails}
-                    finishReason={chatDataForCurrentChat?.finish_reason}
-                    agentRunSpendCapWarning={agentRunSpendCapWarning}
-                    uploadStatus={uploadStatus}
-                    summarizationStatus={summarizationStatus}
-                    mode={
-                      chatMode ??
-                      (chatDataForCurrentChat as any)?.default_model_slug
-                    }
-                    chatTitle={chatTitle}
-                    branchedFromChatId={branchedFromChatId}
-                    branchedFromChatTitle={branchedFromChatTitle}
-                    anchorMessageId={timelineAnchorMessageId}
-                    contentInsetEndAdjustment={composerOverlayHeight}
-                  />
+                  {isInitialExistingChatLoad || isRouteTransitioning ? (
+                    <div
+                      className="flex min-h-0 flex-1 items-center justify-center text-sm text-muted-foreground"
+                      role="status"
+                      data-testid="chat-timeline-loading"
+                    >
+                      Loading task…
+                    </div>
+                  ) : (
+                    <Messages
+                      key={chatId}
+                      chatId={chatId}
+                      scrollRef={scrollRef}
+                      contentRef={contentRef}
+                      messages={messages}
+                      setMessages={setMessages}
+                      onRegenerate={handleRegenerate}
+                      onRetry={handleRetry}
+                      onContinue={handleContinue}
+                      onReconnect={resumeStream}
+                      onEditMessage={handleEditMessage}
+                      onBranchMessage={handleBranchMessage}
+                      status={status}
+                      error={error || null}
+                      paginationStatus={paginatedMessages.status}
+                      loadMore={paginatedMessages.loadMore}
+                      isMobile={isMobile}
+                      tempChatFileDetails={tempChatFileDetails}
+                      finishReason={chatDataForCurrentChat?.finish_reason}
+                      agentRunSpendCapWarning={agentRunSpendCapWarning}
+                      uploadStatus={uploadStatus}
+                      summarizationStatus={summarizationStatus}
+                      mode={
+                        chatMode ??
+                        (chatDataForCurrentChat as any)?.default_model_slug
+                      }
+                      chatTitle={chatTitle}
+                      branchedFromChatId={branchedFromChatId}
+                      branchedFromChatTitle={branchedFromChatTitle}
+                      anchorMessageId={timelineAnchorMessageId}
+                      contentInsetEndAdjustment={composerOverlayHeight}
+                    />
+                  )}
                 </div>
               ) : (
                 <div className="flex-1 flex flex-col min-h-0">

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -485,6 +485,11 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(reconciliationSrc).toMatch(/isCompletionCheckInFlight/);
     expect(reconciliationSrc).toMatch(/response\.status\s*===\s*404/);
     expect(reconciliationSrc).toMatch(/payload\.terminal\s*===\s*true/);
+    expect(statusSrc).toMatch(/active_trigger_run_id\s*!==\s*runId/);
+    expect(statusSrc).toMatch(/status:\s*"DETACHED",\s*terminal:\s*true/);
+    expect(transportSrc).toMatch(
+      /status\s*===\s*"COMPLETED"\s*\|\|\s*status\s*===\s*"DETACHED"/,
+    );
     expect(reconciliationSrc).not.toMatch(/AGENT_RESUME_ENDPOINT/);
     expect(reconciliationSrc).toMatch(/scheduleFinishLocally\(\)/);
     expect(reconciliationSrc).toMatch(/finishLocally\(\)/);

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -475,6 +475,10 @@ describe("agent-long chat UI — completion reconciliation", () => {
       /status\s*!==\s*"streaming"\s*&&\s*status\s*!==\s*"submitted"/,
     );
     expect(reconciliationSrc).toMatch(/agentLongRunId\s*\?\?/);
+    expect(reconciliationSrc).toMatch(/trackedAgentLongRunId/);
+    expect(reconciliationSrc).toMatch(
+      /!shouldUseAgentLongForCurrentChat\s*&&\s*!trackedAgentLongRunId/,
+    );
     expect(reconciliationSrc).not.toMatch(/agentLongLastMessageChangeAtRef/);
     expect(reconciliationSrc).toMatch(/AGENT_STATUS_ENDPOINT/);
     expect(reconciliationSrc).toMatch(/method:\s*"POST"/);
@@ -492,7 +496,8 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(
       /getLatestAgentLongAssistantMessageForPartialSave/,
     );
-    expect(chatComponentSrc).toMatch(/stop\(\)/);
+    expect(reconciliationSrc).toMatch(/stopRef\.current\(\)/);
+    expect(reconciliationSrc).not.toMatch(/^\s+stop,$/m);
     const submittedEffectStart = chatComponentSrc.indexOf(
       'if (status === "submitted")',
     );

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -493,6 +493,24 @@ describe("agent-long chat UI — completion reconciliation", () => {
       /getLatestAgentLongAssistantMessageForPartialSave/,
     );
     expect(chatComponentSrc).toMatch(/stop\(\)/);
+    const submittedEffectStart = chatComponentSrc.indexOf(
+      'if (status === "submitted")',
+    );
+    const submittedEffectEnd = chatComponentSrc.indexOf(
+      "if (\n      shouldUseAgentLongForCurrentChat",
+      submittedEffectStart,
+    );
+    const submittedEffectSrc = chatComponentSrc.slice(
+      submittedEffectStart,
+      submittedEffectEnd,
+    );
+    expect(submittedEffectSrc).not.toMatch(/setAgentLongRunId\(null\)/);
+    expect(submittedEffectSrc).not.toMatch(
+      /agentLongRunCorrelationRef\.current\s*=\s*null/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /agentLongRunCorrelationRef\.current\s*=\s*null;[\s\S]*setAgentLongRunId\(null\);[\s\S]*return fetchAgentLongStream/,
+    );
     expect(chatComponentSrc).toMatch(
       /const finishLocally = \(\) => \{[\s\S]*finalizeNewChatRoute/,
     );

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -471,6 +471,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(
       /AGENT_LONG_ACTIVE_COMPLETION_POLL_INTERVAL_MS\s*=\s*15_000/,
     );
+    expect(chatComponentSrc).toMatch(
+      /AGENT_LONG_COMPLETION_REQUEST_TIMEOUT_MS\s*=\s*8_000/,
+    );
     expect(reconciliationSrc).toMatch(
       /status\s*!==\s*"streaming"\s*&&\s*status\s*!==\s*"submitted"/,
     );
@@ -483,6 +486,11 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(reconciliationSrc).toMatch(/AGENT_STATUS_ENDPOINT/);
     expect(reconciliationSrc).toMatch(/method:\s*"POST"/);
     expect(reconciliationSrc).toMatch(/isCompletionCheckInFlight/);
+    expect(reconciliationSrc).toMatch(/requestAbortController/);
+    expect(reconciliationSrc).toMatch(
+      /setTimeout\([\s\S]*AGENT_LONG_COMPLETION_REQUEST_TIMEOUT_MS/,
+    );
+    expect(reconciliationSrc).toMatch(/clearTimeout\(requestTimeout\)/);
     expect(reconciliationSrc).toMatch(/response\.status\s*===\s*404/);
     expect(reconciliationSrc).toMatch(/payload\.terminal\s*===\s*true/);
     expect(statusSrc).toMatch(/active_trigger_run_id\s*!==\s*runId/);
@@ -503,6 +511,24 @@ describe("agent-long chat UI — completion reconciliation", () => {
     );
     expect(reconciliationSrc).toMatch(/stopRef\.current\(\)/);
     expect(reconciliationSrc).not.toMatch(/^\s+stop,$/m);
+    expect(reconciliationSrc).toMatch(
+      /agentLongRunFallbackAllowedRef\.current\s*\?\s*activeTriggerRunRef\.current\s*:\s*null/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /agentLongRunFallbackAllowedRef\.current\s*=\s*false;[\s\S]*return fetchAgentLongStream/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /submissionGeneration\s*=\s*\+\+agentLongSubmissionGenerationRef\.current/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /submissionGeneration\s*!==\s*agentLongSubmissionGenerationRef\.current/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /if \(init\?\.method !== "GET"\) \{[\s\S]*agentLongRunCorrelationRef\.current = null;[\s\S]*agentLongRunFallbackAllowedRef\.current = false;[\s\S]*setAgentLongRunId\(null\)/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /agentLongMessageFingerprintRef\.current\.chatId !== chatId/,
+    );
     const submittedEffectStart = chatComponentSrc.indexOf(
       'if (status === "submitted")',
     );

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -465,8 +465,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(reconciliationSrc).toMatch(
       /AGENT_LONG_SILENT_COMPLETION_POLL_DELAY_MS/,
     );
-    expect(reconciliationSrc).toMatch(/AGENT_LONG_SILENT_COMPLETION_QUIET_MS/);
-    expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_STOP_GRACE_MS/);
+    expect(chatComponentSrc).toMatch(
+      /AGENT_LONG_COMPLETION_STOP_GRACE_MS\s*=\s*2_000/,
+    );
     expect(chatComponentSrc).toMatch(
       /AGENT_LONG_ACTIVE_COMPLETION_POLL_INTERVAL_MS\s*=\s*15_000/,
     );
@@ -474,6 +475,7 @@ describe("agent-long chat UI — completion reconciliation", () => {
       /status\s*!==\s*"streaming"\s*&&\s*status\s*!==\s*"submitted"/,
     );
     expect(reconciliationSrc).toMatch(/agentLongRunId\s*\?\?/);
+    expect(reconciliationSrc).not.toMatch(/agentLongLastMessageChangeAtRef/);
     expect(reconciliationSrc).toMatch(/AGENT_STATUS_ENDPOINT/);
     expect(reconciliationSrc).toMatch(/method:\s*"POST"/);
     expect(reconciliationSrc).toMatch(/isCompletionCheckInFlight/);

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -462,12 +462,18 @@ describe("agent-long chat UI — completion reconciliation", () => {
       reconciliationEnd,
     );
 
-    expect(reconciliationSrc).toMatch(/AGENT_LONG_COMPLETION_POLL_DELAY_MS/);
-    expect(reconciliationSrc).toMatch(/AGENT_LONG_COMPLETION_QUIET_MS/);
+    expect(reconciliationSrc).toMatch(
+      /AGENT_LONG_SILENT_COMPLETION_POLL_DELAY_MS/,
+    );
+    expect(reconciliationSrc).toMatch(/AGENT_LONG_SILENT_COMPLETION_QUIET_MS/);
     expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_STOP_GRACE_MS/);
     expect(chatComponentSrc).toMatch(
-      /AGENT_LONG_COMPLETION_POLL_INTERVAL_MS\s*=\s*15_000/,
+      /AGENT_LONG_ACTIVE_COMPLETION_POLL_INTERVAL_MS\s*=\s*15_000/,
     );
+    expect(reconciliationSrc).toMatch(
+      /status\s*!==\s*"streaming"\s*&&\s*status\s*!==\s*"submitted"/,
+    );
+    expect(reconciliationSrc).toMatch(/agentLongRunId\s*\?\?/);
     expect(reconciliationSrc).toMatch(/AGENT_STATUS_ENDPOINT/);
     expect(reconciliationSrc).toMatch(/method:\s*"POST"/);
     expect(reconciliationSrc).toMatch(/isCompletionCheckInFlight/);
@@ -491,6 +497,15 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(/setIsExistingChat\(true\)/);
     expect(statusSrc).toMatch(
       /NextResponse\.json\(\{ status: run\.status, terminal \}\)/,
+    );
+  });
+
+  test("captures the Trigger run before realtime data reaches useChat", () => {
+    expect(transportSrc).toMatch(
+      /onRunStarted\?\.\(\{[\s\S]*runId:\s*handle\.runId/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /fetchAgentLongStream\(init,\s*\(run\)\s*=>\s*\{[\s\S]*setAgentLongRunId\(run\.runId\)/,
     );
   });
 

--- a/lib/api/__tests__/agent-status-route.test.ts
+++ b/lib/api/__tests__/agent-status-route.test.ts
@@ -66,6 +66,11 @@ describe("agent status route", () => {
 
   it("reports a nonterminal run without touching persisted lifecycle state", async () => {
     const { createAgentStatusPost } = await import("../agent-status-route");
+    mockGetChatById.mockResolvedValue({
+      id: "chat-1",
+      user_id: "user-1",
+      active_trigger_run_id: "run-1",
+    } as never);
     mockRunsRetrieve.mockResolvedValue({
       status: "EXECUTING",
       metadata: { chatId: "chat-1", userId: "user-1" },
@@ -80,7 +85,28 @@ describe("agent status route", () => {
       status: "EXECUTING",
       terminal: false,
     });
-    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockGetChatById).toHaveBeenCalledWith({ id: "chat-1" });
+    expect(mockSetActiveTriggerRun).not.toHaveBeenCalled();
+  });
+
+  it("treats a persisted run detached during cleanup as UI-terminal", async () => {
+    const { createAgentStatusPost } = await import("../agent-status-route");
+    mockGetChatById.mockResolvedValue({
+      id: "chat-1",
+      user_id: "user-1",
+      active_trigger_run_id: null,
+    } as never);
+
+    const response = await createAgentStatusPost({ endpoint: "/api/agent" })(
+      requestFor("chat-1", "run-1"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "DETACHED",
+      terminal: true,
+    });
+    expect(mockRunsRetrieve).not.toHaveBeenCalled();
     expect(mockSetActiveTriggerRun).not.toHaveBeenCalled();
   });
 
@@ -117,5 +143,21 @@ describe("agent status route", () => {
       expectedRunId: "run-1",
       clearApprovalPending: true,
     });
+  });
+
+  it("does not reveal status for a chat owned by another user", async () => {
+    const { createAgentStatusPost } = await import("../agent-status-route");
+    mockGetChatById.mockResolvedValue({
+      id: "chat-1",
+      user_id: "user-2",
+      active_trigger_run_id: "run-1",
+    } as never);
+
+    const response = await createAgentStatusPost({ endpoint: "/api/agent" })(
+      requestFor("chat-1", "run-1"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockRunsRetrieve).not.toHaveBeenCalled();
   });
 });

--- a/lib/api/agent-status-route.ts
+++ b/lib/api/agent-status-route.ts
@@ -107,6 +107,22 @@ export const createAgentStatusPost =
       const authContext = await getUserIDAndPro(req);
       userId = authContext.userId;
 
+      const chat = await getChatById({ id: chatId });
+      if (!chat) {
+        return new NextResponse("Chat not found", { status: 404 });
+      }
+      if (chat.user_id !== userId) {
+        return new NextResponse("Forbidden", { status: 403 });
+      }
+
+      // The Agent task clears this association as soon as its user-visible
+      // answer is persisted, before post-run cleanup finishes in Trigger.dev.
+      // Treat that detached state as UI-terminal so the browser does not keep
+      // showing Stop while only backend cleanup remains.
+      if (chat.active_trigger_run_id !== runId) {
+        return NextResponse.json({ status: "DETACHED", terminal: true });
+      }
+
       const run = (await runs.retrieve(runId)) as TriggerRunStatus;
       if (!runBelongsToChatOwner(run, { chatId, userId })) {
         return new NextResponse("Forbidden", { status: 403 });

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -41,6 +41,12 @@ type RunHandle = {
   approvalSessionPublicAccessToken?: string;
 };
 
+export type AgentLongRunStarted = {
+  chatId?: string;
+  runId: string;
+  runCorrelationToken?: string;
+};
+
 const getAgentResumeUrl = (chatId: string | undefined): string | undefined =>
   chatId
     ? `${AGENT_RESUME_ENDPOINT}?chatId=${encodeURIComponent(chatId)}`
@@ -743,6 +749,7 @@ const buildSSEResponseFromRun = (
 
 export const fetchAgentLongStream = async (
   init: RequestInit | undefined,
+  onRunStarted?: (run: AgentLongRunStarted) => void,
 ): Promise<Response> => {
   const chatId = getChatIdFromRequestInit(init);
   const linkedAbort = createLinkedAbortController(init?.signal ?? undefined);
@@ -758,6 +765,11 @@ export const fetchAgentLongStream = async (
     if (!startResponse.ok) return startResponse;
 
     const handle: RunHandle = await startResponse.json();
+    onRunStarted?.({
+      chatId: handle.chatId ?? chatId,
+      runId: handle.runId,
+      runCorrelationToken: handle.runCorrelationToken,
+    });
     return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
       chatId,
       resumeUrl: getAgentResumeUrl(chatId),

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -419,7 +419,7 @@ const buildSSEResponseFromRun = (
         };
 
         const handleRunStatus = (status: string | undefined) => {
-          if (status === "COMPLETED") {
+          if (status === "COMPLETED" || status === "DETACHED") {
             startCompletedRunDrainTimer();
             return;
           }

--- a/lib/utils/__tests__/message-processor.test.ts
+++ b/lib/utils/__tests__/message-processor.test.ts
@@ -9,6 +9,7 @@ describe("normalizeMessages", () => {
       { action: "exec", command: "sleep 60", brief: "Running check" },
     ],
     ["tool-run_terminal_cmd", { command: "sleep 60" }],
+    ["tool-interact_terminal_session", { command: "\u0003" }],
   ])("marks an interrupted %s invocation as stopped", (type, input) => {
     const messages = [
       {
@@ -36,12 +37,14 @@ describe("normalizeMessages", () => {
 
     const result = normalizeMessages(messages);
     const terminalPart = result.messages[1].parts[0] as {
+      type: string;
       state: string;
       errorText?: string;
       output?: { output?: string; result?: { stdout?: string } };
     };
 
     expect(result.hasChanges).toBe(true);
+    expect(terminalPart.type).toBe(type);
     expect(terminalPart.state).toBe("output-error");
     expect(terminalPart.errorText).toBe(ABORTED_TOOL_ERROR_TEXT);
     expect(

--- a/lib/utils/__tests__/message-processor.test.ts
+++ b/lib/utils/__tests__/message-processor.test.ts
@@ -1,0 +1,52 @@
+import { normalizeMessages } from "../message-processor";
+import { ABORTED_TOOL_ERROR_TEXT } from "@/lib/chat/tool-abort-utils";
+import type { ChatMessage } from "@/types/chat";
+
+describe("normalizeMessages", () => {
+  it.each([
+    [
+      "tool-shell",
+      { action: "exec", command: "sleep 60", brief: "Running check" },
+    ],
+    ["tool-run_terminal_cmd", { command: "sleep 60" }],
+  ])("marks an interrupted %s invocation as stopped", (type, input) => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Run a harmless long command" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type,
+            toolCallId: "tool-1",
+            state: "input-available",
+            input,
+          },
+          {
+            type: "data-terminal",
+            data: { toolCallId: "tool-1", terminal: "partial output\n" },
+          },
+        ],
+      },
+    ] as unknown as ChatMessage[];
+
+    const result = normalizeMessages(messages);
+    const terminalPart = result.messages[1].parts[0] as {
+      state: string;
+      errorText?: string;
+      output?: { output?: string; result?: { stdout?: string } };
+    };
+
+    expect(result.hasChanges).toBe(true);
+    expect(terminalPart.state).toBe("output-error");
+    expect(terminalPart.errorText).toBe(ABORTED_TOOL_ERROR_TEXT);
+    expect(
+      terminalPart.output?.output ?? terminalPart.output?.result?.stdout,
+    ).toBe("partial output\n");
+    expect(result.messages[1].parts).toHaveLength(1);
+  });
+});

--- a/lib/utils/message-processor.ts
+++ b/lib/utils/message-processor.ts
@@ -1,5 +1,6 @@
 import type { UIToolInvocation } from "ai";
 import { ChatMessage } from "@/types/chat";
+import { ABORTED_TOOL_ERROR_TEXT } from "@/lib/chat/tool-abort-utils";
 
 /**
  * Checks if a part is a completed reasoning block with redacted text.
@@ -39,6 +40,7 @@ interface BaseToolPart {
   input?: any;
   output?: any;
   result?: any; // legacy
+  errorText?: string;
 }
 
 // Specific interface for terminal tools that have special data handling
@@ -221,12 +223,11 @@ const transformTerminalToolPart = (
     return {
       type: "tool-shell",
       toolCallId: terminalPart.toolCallId,
-      state: "output-available",
+      state: "output-error",
       input: terminalPart.input,
+      errorText: ABORTED_TOOL_ERROR_TEXT,
       output: {
-        output:
-          stdout ||
-          (stdout.length === 0 ? "Command was stopped/aborted by user" : ""),
+        output: stdout,
       },
     };
   }
@@ -234,14 +235,14 @@ const transformTerminalToolPart = (
   return {
     type: "tool-run_terminal_cmd",
     toolCallId: terminalPart.toolCallId,
-    state: "output-available",
+    state: "output-error",
     input: terminalPart.input,
+    errorText: ABORTED_TOOL_ERROR_TEXT,
     output: {
       result: {
         exitCode: 130, // Standard exit code for SIGINT (interrupted)
         stdout: stdout,
-        stderr:
-          stdout.length === 0 ? "Command was stopped/aborted by user" : "",
+        stderr: "",
       },
     },
   };

--- a/lib/utils/message-processor.ts
+++ b/lib/utils/message-processor.ts
@@ -233,7 +233,7 @@ const transformTerminalToolPart = (
   }
 
   return {
-    type: "tool-run_terminal_cmd",
+    type: terminalPart.type,
     toolCallId: terminalPart.toolCallId,
     state: "output-error",
     input: terminalPart.input,


### PR DESCRIPTION
## Summary

- capture each Trigger Agent run ID immediately, scope recovery to that submission, and reconcile submitted, streaming, completed, and detached runs
- reset route-owned messages before paint and show an explicit loading state instead of retaining a stale timeline during chat switches
- preserve interrupted terminal tools as stopped errors with partial output and the original terminal tool type
- remove the invalid unrestricted upload `accept="*"` token

## Why these started

- the August 14 polling reduction only reconciled after `useChat` reached streaming, so a missed first realtime chunk could leave the UI submitted forever
- Agent persistence clears `active_trigger_run_id` after the user-visible answer is saved but before Trigger post-run cleanup finishes; status-only polling therefore kept Stop visible during cleanup
- the August 9 composer-preservation transition retained the old Messages tree behind opacity during route changes
- the stop normalizer treated incomplete terminal tools as successful results and could change an interactive-terminal part into a command part
- `accept="*"` is not valid HTML accept syntax; current Chrome/macOS behavior exposed the latent picker incompatibility

## Validation

- 420 Jest suites passed (4,284 tests)
- `pnpm typecheck` passed
- changed-file ESLint passed with only three pre-existing `chat.tsx` hook warnings
- worktree dependency guard passed
- targeted regressions cover Agent run correlation, submitted and detached recovery, stale-run submission isolation, route transitions, interrupted terminal persistence, and unrestricted uploads

## Vercel preview verification

Tested `https://hackerai-qlh87546a-hackerai.vercel.app` with actual Google Chrome and Computer Use.

- Agent prompt returned `DETACHED_FIXED_OK` in about 9.7 seconds; the answer remained visible and the Stop/Thinking state returned to idle by about 16.7 seconds
- switching between three existing QA chats showed only the selected chat's messages, with correct URLs and no stale-answer leakage
- reload preserved the completed Agent answer and stayed idle
- the native upload picker opened for synthetic Markdown and PNG fixtures and the page DOM now exposes an unrestricted file input; however, the macOS picker kept Open disabled under Computer Use, so end-to-end upload completion remains acceptance-blocked
- live terminal cancellation remains blocked because two preview Agent attempts failed during AWS Lambda MicroVM sandbox creation with `provider_error`, before any command started

No production deployment or production data mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Chat transitions now reset state cleanly, show an explicit loading indicator, and prevent stale messages from appearing.
  - Long-running agent responses now update more reliably, including submitted, streaming, completed, and detached runs.
  - Interrupted shell and terminal commands now display a clear error state while preserving partial output.
  - File uploads continue to support unrestricted file selection without unnecessary picker restrictions.
  - Chat status checks now better handle missing or unauthorized chats.

- **Tests**
  - Added coverage for chat transitions, completion handling, interrupted commands, status checks, and file-upload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
