### PR TITLE
Merge Ask mode continuation responses

### DIFF
--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -377,11 +377,11 @@ export const Messages = ({
 
   // Compute the branch boundary: last message that originated from another chat
   const branchBoundaryIndex = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].sourceMessageId) return i;
+    for (let i = visibleMessages.length - 1; i >= 0; i--) {
+      if (visibleMessages[i].sourceMessageId) return i;
     }
     return -1;
-  }, [messages]);
+  }, [visibleMessages]);
 
   const [expandedAgentMessageIds, setExpandedAgentMessageIds] = useState<
     ReadonlySet<string>

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -29,6 +29,7 @@ import { FileUrlCacheProvider } from "../contexts/FileUrlCacheContext";
 import {
   findLastAssistantMessageIndex,
   findLastUserMessageIndex,
+  mergeAskContinuationMessages,
 } from "@/lib/utils/message-utils";
 import type { ChatStatus, ChatMessage } from "@/types";
 import type { FileDetails } from "@/types/file";
@@ -309,10 +310,11 @@ export const Messages = ({
   // Prefetch and cache image URLs for better performance
   const { getCachedUrl, setCachedUrl } = useFileUrlCache(messages);
 
-  // Filter out auto-continue messages for rendering
+  // Keep Ask-mode continuation generations in one visible assistant response.
+  // The underlying messages remain separate for persistence and usage tracking.
   const visibleMessages = useMemo(
-    () => messages.filter((msg) => !msg.metadata?.isAutoContinue),
-    [messages],
+    () => mergeAskContinuationMessages(messages, mode),
+    [messages, mode],
   );
 
   // Memoize expensive calculations

--- a/app/components/__tests__/Messages.edit.test.tsx
+++ b/app/components/__tests__/Messages.edit.test.tsx
@@ -23,7 +23,11 @@ jest.mock("../MessageItem", () => ({
     onStartEdit: (messageId: string) => void;
     status: string;
   }) => (
-    <div data-testid={`message-${message.id}`} data-status={status}>
+    <div
+      data-testid={`message-${message.id}`}
+      data-status={status}
+      data-parts={JSON.stringify(message.parts)}
+    >
       {isEditing ? (
         <div data-testid="message-editor">Editing {message.id}</div>
       ) : canEdit ? (
@@ -165,6 +169,66 @@ describe("Messages virtualized row invalidation", () => {
   beforeEach(() => {
     mockLegendListScrollToIndex.mockReset();
     mockLegendListScrollToIndex.mockResolvedValue(undefined);
+  });
+
+  it("renders Ask continuation segments as one combined assistant row", () => {
+    const continuationMessages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Write code" }],
+        metadata: { mode: "ask" },
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "```ts\nconst a = 1;\n" }],
+        metadata: { mode: "ask" },
+      },
+      {
+        id: "continue-1",
+        role: "user",
+        parts: [{ type: "text", text: "Continue" }],
+        metadata: { mode: "ask", isAutoContinue: true },
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "const b = 2;\n```" }],
+        metadata: { mode: "ask" },
+      },
+    ] as ChatMessage[];
+
+    render(
+      <DataStreamProvider>
+        <Messages
+          chatId="chat-continue"
+          messages={continuationMessages}
+          setMessages={jest.fn()}
+          onRegenerate={jest.fn()}
+          onRetry={jest.fn()}
+          onEditMessage={jest.fn()}
+          status="ready"
+          error={null}
+          scrollRef={createRef<HTMLElement>()}
+          contentRef={createRef<HTMLElement>()}
+          isMobile
+          mode="ask"
+        />
+      </DataStreamProvider>,
+    );
+
+    expect(screen.queryByTestId("message-assistant-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("message-continue-1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("message-assistant-2")).toHaveAttribute(
+      "data-parts",
+      JSON.stringify([
+        {
+          type: "text",
+          text: "```ts\nconst a = 1;\nconst b = 2;\n```",
+        },
+      ]),
+    );
   });
   it("invalidates the virtualized row when editing starts", () => {
     render(

--- a/app/components/__tests__/Messages.edit.test.tsx
+++ b/app/components/__tests__/Messages.edit.test.tsx
@@ -11,13 +11,17 @@ import { mockLegendListScrollToIndex } from "../../../__mocks__/@legendapp/list-
 
 jest.mock("../MessageItem", () => ({
   MessageItem: ({
+    branchBoundaryIndex,
     canEdit,
+    index,
     isEditing,
     message,
     onStartEdit,
     status,
   }: {
+    branchBoundaryIndex?: number;
     canEdit: boolean;
+    index: number;
     isEditing: boolean;
     message: ChatMessage;
     onStartEdit: (messageId: string) => void;
@@ -25,6 +29,7 @@ jest.mock("../MessageItem", () => ({
   }) => (
     <div
       data-testid={`message-${message.id}`}
+      data-is-branch-boundary={index === branchBoundaryIndex}
       data-status={status}
       data-parts={JSON.stringify(message.parts)}
     >
@@ -228,6 +233,60 @@ describe("Messages virtualized row invalidation", () => {
           text: "```ts\nconst a = 1;\nconst b = 2;\n```",
         },
       ]),
+    );
+  });
+
+  it("aligns a merged Ask continuation branch boundary with the visible row", () => {
+    const continuationMessages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Write code" }],
+        metadata: { mode: "ask" },
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "first" }],
+        metadata: { mode: "ask" },
+      },
+      {
+        id: "continue-1",
+        role: "user",
+        parts: [{ type: "text", text: "Continue" }],
+        metadata: { mode: "ask", isAutoContinue: true },
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        sourceMessageId: "source-assistant-2",
+        parts: [{ type: "text", text: " second" }],
+        metadata: { mode: "ask" },
+      },
+    ] as ChatMessage[];
+
+    render(
+      <DataStreamProvider>
+        <Messages
+          chatId="chat-branched-continuation"
+          messages={continuationMessages}
+          setMessages={jest.fn()}
+          onRegenerate={jest.fn()}
+          onRetry={jest.fn()}
+          onEditMessage={jest.fn()}
+          status="ready"
+          error={null}
+          scrollRef={createRef<HTMLElement>()}
+          contentRef={createRef<HTMLElement>()}
+          isMobile
+          mode="ask"
+        />
+      </DataStreamProvider>,
+    );
+
+    expect(screen.getByTestId("message-assistant-2")).toHaveAttribute(
+      "data-is-branch-boundary",
+      "true",
     );
   });
   it("invalidates the virtualized row when editing starts", () => {

--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { jest } from "@jest/globals";
 import type { ChatMessage, SelectedModel } from "@/types";
+import { ASK_CONTINUE_PROMPT } from "@/app/hooks/useAutoContinue";
 
 const mockRegenerate = jest.fn();
 const mockSendMessage = jest.fn();
@@ -145,7 +146,10 @@ describe("useChatHandlers regenerate model", () => {
     });
 
     expect(mockSendMessage).toHaveBeenCalledWith(
-      expect.any(Object),
+      {
+        text: ASK_CONTINUE_PROMPT,
+        metadata: { isAutoContinue: true },
+      },
       expect.objectContaining({
         body: expect.objectContaining({ selectedModel: "hackerai-max" }),
       }),

--- a/app/hooks/useAutoContinue.ts
+++ b/app/hooks/useAutoContinue.ts
@@ -12,6 +12,8 @@ import { useLatestRef } from "./useLatestRef";
 export const MAX_AUTO_CONTINUES = 5;
 export const AUTO_CONTINUE_PROMPT =
   "Continue from the latest saved progress. Do not restart the original task or repeat completed work.";
+export const ASK_CONTINUE_PROMPT =
+  "Continue exactly where the previous response stopped. Do not repeat any previous text. If it stopped inside a code block, continue inside that same code block without opening a new one.";
 const AUTO_CONTINUE_SETTLE_DELAY_MS = 250;
 
 export interface UseAutoContinueParams {

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -24,7 +24,10 @@ import { toast } from "sonner";
 import { removeTodosBySourceMessages } from "@/lib/utils/todo-utils";
 import { useDataStreamDispatch } from "@/app/components/DataStreamProvider";
 import { getOnlineStatusSnapshot } from "@/app/hooks/useOnlineStatus";
-import { AUTO_CONTINUE_PROMPT } from "@/app/hooks/useAutoContinue";
+import {
+  ASK_CONTINUE_PROMPT,
+  AUTO_CONTINUE_PROMPT,
+} from "@/app/hooks/useAutoContinue";
 import { normalizeMessages } from "@/lib/utils/message-processor";
 import {
   getAutoContinueChainAssistantIds,
@@ -886,10 +889,14 @@ export const useChatHandlers = ({
     hasManuallyStoppedRef.current = false;
     const continuationSelectedModel =
       selectedModelOverride ?? requestSelectedModelRef.current;
+    const continuationPrompt =
+      chatModeRef.current === "ask"
+        ? ASK_CONTINUE_PROMPT
+        : AUTO_CONTINUE_PROMPT;
     runChatAction("continue response", () =>
       sendMessage(
         {
-          text: AUTO_CONTINUE_PROMPT,
+          text: continuationPrompt,
           metadata: { isAutoContinue: true },
         },
         {

--- a/lib/utils/__tests__/message-utils.test.ts
+++ b/lib/utils/__tests__/message-utils.test.ts
@@ -3,7 +3,10 @@ import {
   findLastUserMessageIndex,
   getAutoContinueChainAssistantIds,
   getMessagesUpToLastRealUser,
+  joinContinuationText,
+  mergeAskContinuationMessages,
 } from "../message-utils";
+import type { ChatMessage } from "@/types";
 
 const msg = (
   id: string,
@@ -19,6 +22,143 @@ const msg = (
 });
 
 describe("message-utils", () => {
+  describe("joinContinuationText", () => {
+    it("continues an open code fence as one downloadable code block", () => {
+      expect(
+        joinContinuationText(
+          "```ts\nconst first = 1;\n",
+          "const second = 2;\n```",
+        ),
+      ).toBe("```ts\nconst first = 1;\nconst second = 2;\n```");
+    });
+
+    it("removes a redundant opening fence from an in-progress code block", () => {
+      expect(
+        joinContinuationText(
+          "```python\nprint('first')\n",
+          "```python\nprint('second')\n```",
+        ),
+      ).toBe("```python\nprint('first')\nprint('second')\n```");
+    });
+
+    it("deduplicates a substantial exact overlap", () => {
+      expect(
+        joinContinuationText(
+          "The generated value is abcdefghijklmnopqrstuvwxyz",
+          "abcdefghijklmnopqrstuvwxyz\nand then it finishes.",
+        ),
+      ).toBe(
+        "The generated value is abcdefghijklmnopqrstuvwxyz\nand then it finishes.",
+      );
+    });
+  });
+
+  describe("mergeAskContinuationMessages", () => {
+    const askMessage = (
+      id: string,
+      role: "user" | "assistant",
+      text: string,
+      isAutoContinue = false,
+    ) =>
+      ({
+        id,
+        role,
+        parts: [{ type: "text", text }],
+        metadata: {
+          mode: "ask",
+          ...(isAutoContinue ? { isAutoContinue: true } : {}),
+        },
+      }) as ChatMessage;
+
+    it("renders a live Ask continuation as one assistant response", () => {
+      const visible = mergeAskContinuationMessages([
+        askMessage("user-1", "user", "Write code"),
+        askMessage("assistant-1", "assistant", "```ts\nconst a = 1;\n"),
+        askMessage("continue-1", "user", "Continue", true),
+        askMessage("assistant-2", "assistant", "const b = 2;\n```"),
+      ]);
+
+      expect(visible).toHaveLength(2);
+      expect(visible[1]).toMatchObject({
+        id: "assistant-2",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "```ts\nconst a = 1;\nconst b = 2;\n```",
+          },
+        ],
+      });
+    });
+
+    it("merges restored consecutive Ask assistant segments", () => {
+      const visible = mergeAskContinuationMessages([
+        askMessage("user-1", "user", "Write code"),
+        askMessage("assistant-1", "assistant", "first"),
+        askMessage("assistant-2", "assistant", " second"),
+      ]);
+
+      expect(visible.map((message) => message.id)).toEqual([
+        "user-1",
+        "assistant-2",
+      ]);
+      expect(visible[1].parts).toEqual([
+        { type: "text", text: "first second" },
+      ]);
+    });
+
+    it("does not merge Ask responses separated by a real user message", () => {
+      const visible = mergeAskContinuationMessages([
+        askMessage("user-1", "user", "First question"),
+        askMessage("assistant-1", "assistant", "First answer"),
+        askMessage("user-2", "user", "Second question"),
+        askMessage("assistant-2", "assistant", "Second answer"),
+      ]);
+
+      expect(visible).toHaveLength(4);
+    });
+
+    it("leaves Agent continuation messages separate", () => {
+      const messages = [
+        {
+          ...askMessage("assistant-1", "assistant", "first"),
+          metadata: { mode: "agent" as const },
+        },
+        {
+          ...askMessage("assistant-2", "assistant", "second"),
+          metadata: { mode: "agent" as const },
+        },
+      ];
+
+      expect(mergeAskContinuationMessages(messages)).toEqual(messages);
+    });
+
+    it("places continuation reasoning before the combined final text", () => {
+      const first = askMessage(
+        "assistant-1",
+        "assistant",
+        "```ts\nconst a = 1;\n",
+      );
+      const continuation = {
+        ...askMessage("assistant-2", "assistant", "const b = 2;\n```"),
+        parts: [
+          { type: "reasoning", text: "Continue the function" },
+          { type: "text", text: "const b = 2;\n```" },
+        ],
+      } as ChatMessage;
+
+      expect(
+        mergeAskContinuationMessages([first, continuation])[0].parts,
+      ).toEqual([
+        { type: "reasoning", text: "Continue the function" },
+        {
+          type: "text",
+          text: "```ts\nconst a = 1;\nconst b = 2;\n```",
+        },
+      ]);
+    });
+  });
+
   describe("findLastUserMessageIndex", () => {
     it("returns the latest user-authored message before an assistant response", () => {
       expect(

--- a/lib/utils/__tests__/message-utils.test.ts
+++ b/lib/utils/__tests__/message-utils.test.ts
@@ -41,6 +41,15 @@ describe("message-utils", () => {
       ).toBe("```python\nprint('first')\nprint('second')\n```");
     });
 
+    it("preserves a bare fence that closes the in-progress code block", () => {
+      expect(
+        joinContinuationText(
+          "```python\nprint('done')\n",
+          "```\n\nThe script is complete.",
+        ),
+      ).toBe("```python\nprint('done')\n```\n\nThe script is complete.");
+    });
+
     it("deduplicates a substantial exact overlap", () => {
       expect(
         joinContinuationText(
@@ -156,6 +165,32 @@ describe("message-utils", () => {
           text: "```ts\nconst a = 1;\nconst b = 2;\n```",
         },
       ]);
+    });
+
+    it("combines timing metadata across Ask continuation segments", () => {
+      const first = {
+        ...askMessage("assistant-1", "assistant", "first"),
+        metadata: {
+          mode: "ask" as const,
+          generationStartedAt: 1_000,
+          generationTimeMs: 2_000,
+        },
+      };
+      const continuation = {
+        ...askMessage("assistant-2", "assistant", " second"),
+        metadata: {
+          mode: "ask" as const,
+          generationStartedAt: 5_000,
+          generationTimeMs: 3_000,
+        },
+      };
+
+      expect(
+        mergeAskContinuationMessages([first, continuation])[0].metadata,
+      ).toMatchObject({
+        generationStartedAt: 1_000,
+        generationTimeMs: 5_000,
+      });
     });
   });
 

--- a/lib/utils/message-utils.ts
+++ b/lib/utils/message-utils.ts
@@ -2,6 +2,8 @@
  * Utility functions for processing message parts
  */
 
+import type { ChatMessage, ChatMode } from "@/types";
+
 export interface MessagePart {
   type: string;
   text?: string;
@@ -27,6 +29,181 @@ export const hasTextContent = (parts: MessagePart[]): boolean => {
       part.type === "step-start" ||
       part.type.startsWith("tool-"),
   );
+};
+
+const MIN_CONTINUATION_OVERLAP_CHARS = 24;
+
+const isTextPart = (
+  part: ChatMessage["parts"][number],
+): part is ChatMessage["parts"][number] & { type: "text"; text: string } =>
+  part.type === "text" && typeof (part as { text?: unknown }).text === "string";
+
+const isInsideMarkdownFence = (text: string): boolean => {
+  const fences = text.match(/^[\t ]*```/gm);
+  return (fences?.length ?? 0) % 2 === 1;
+};
+
+const stripRedundantOpeningFence = (
+  previousText: string,
+  continuationText: string,
+): string => {
+  if (!isInsideMarkdownFence(previousText)) return continuationText;
+
+  return continuationText.replace(/^\s*```[^\n\r]*\r?\n/, "");
+};
+
+const findExactSuffixPrefixOverlap = (
+  previousText: string,
+  continuationText: string,
+): number => {
+  if (
+    previousText.length < MIN_CONTINUATION_OVERLAP_CHARS ||
+    continuationText.length < MIN_CONTINUATION_OVERLAP_CHARS
+  ) {
+    return 0;
+  }
+
+  // KMP prefix table over `continuation + sentinel + previous` finds the
+  // longest continuation prefix that is also a suffix of the previous text in
+  // linear time. Use -1 as an out-of-band sentinel for UTF-16 code units.
+  const previousSuffix = previousText.slice(-continuationText.length);
+  const sequenceLength = continuationText.length + 1 + previousSuffix.length;
+  const prefixLengths = new Uint32Array(sequenceLength);
+  const codeUnitAt = (index: number): number => {
+    if (index < continuationText.length) {
+      return continuationText.charCodeAt(index);
+    }
+    if (index === continuationText.length) return -1;
+    return previousSuffix.charCodeAt(index - continuationText.length - 1);
+  };
+
+  for (let index = 1; index < sequenceLength; index++) {
+    let prefixLength = prefixLengths[index - 1];
+    const codeUnit = codeUnitAt(index);
+    while (prefixLength > 0 && codeUnit !== codeUnitAt(prefixLength)) {
+      prefixLength = prefixLengths[prefixLength - 1];
+    }
+    if (codeUnit === codeUnitAt(prefixLength)) prefixLength += 1;
+    prefixLengths[index] = prefixLength;
+  }
+
+  const overlap = prefixLengths[sequenceLength - 1];
+  return overlap >= MIN_CONTINUATION_OVERLAP_CHARS ? overlap : 0;
+};
+
+/**
+ * Joins a separately generated continuation to the previous text without
+ * introducing a second Markdown/code block. Providers occasionally repeat the
+ * tail of the first generation, so remove only a substantial exact overlap.
+ */
+export const joinContinuationText = (
+  previousText: string,
+  continuationText: string,
+): string => {
+  const strippedContinuation = stripRedundantOpeningFence(
+    previousText,
+    continuationText,
+  );
+  const overlap = findExactSuffixPrefixOverlap(
+    previousText,
+    strippedContinuation,
+  );
+
+  return previousText + strippedContinuation.slice(overlap);
+};
+
+const mergeContinuationParts = (
+  previousParts: ChatMessage["parts"],
+  continuationParts: ChatMessage["parts"],
+): ChatMessage["parts"] => {
+  const previousTextIndex = previousParts.findLastIndex(isTextPart);
+  const continuationTextIndex = continuationParts.findIndex(isTextPart);
+
+  if (previousTextIndex === -1 || continuationTextIndex === -1) {
+    return [...previousParts, ...continuationParts];
+  }
+
+  const previousTextPart = previousParts[previousTextIndex];
+  const continuationTextPart = continuationParts[continuationTextIndex];
+  if (!isTextPart(previousTextPart) || !isTextPart(continuationTextPart)) {
+    return [...previousParts, ...continuationParts];
+  }
+
+  return [
+    ...previousParts.slice(0, previousTextIndex),
+    ...continuationParts.slice(0, continuationTextIndex),
+    {
+      ...continuationTextPart,
+      text: joinContinuationText(
+        previousTextPart.text,
+        continuationTextPart.text,
+      ),
+    },
+    ...previousParts.slice(previousTextIndex + 1),
+    ...continuationParts.slice(continuationTextIndex + 1),
+  ];
+};
+
+const getMessageMode = (
+  message: ChatMessage,
+  fallbackMode?: ChatMode,
+): ChatMode | undefined => message.metadata?.mode ?? fallbackMode;
+
+/**
+ * Projects stored generation segments into the user-visible conversation.
+ * Ask-mode continuations remain separate records for usage, retry, and audit,
+ * but render as one logical assistant response. Hidden continuation prompts are
+ * removed here as before. Consecutive Ask assistant rows cover restored chats,
+ * where Convex intentionally omits the hidden prompt from query results.
+ */
+export const mergeAskContinuationMessages = (
+  messages: ChatMessage[],
+  fallbackMode?: ChatMode,
+): ChatMessage[] => {
+  const visibleMessages: ChatMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role === "user" && message.metadata?.isAutoContinue) {
+      continue;
+    }
+
+    const previousMessage = visibleMessages.at(-1);
+    const isAskContinuation =
+      message.role === "assistant" &&
+      previousMessage?.role === "assistant" &&
+      getMessageMode(message, fallbackMode) === "ask" &&
+      getMessageMode(previousMessage, fallbackMode) === "ask";
+
+    if (isAskContinuation && previousMessage) {
+      visibleMessages[visibleMessages.length - 1] = {
+        ...previousMessage,
+        ...message,
+        createdAt: previousMessage.createdAt ?? message.createdAt,
+        sourceMessageId:
+          message.sourceMessageId ?? previousMessage.sourceMessageId,
+        parts: mergeContinuationParts(previousMessage.parts, message.parts),
+        metadata: {
+          ...previousMessage.metadata,
+          ...message.metadata,
+          createdAt:
+            previousMessage.metadata?.createdAt ?? message.metadata?.createdAt,
+          feedbackType:
+            message.metadata?.feedbackType ??
+            previousMessage.metadata?.feedbackType,
+        },
+        ...((previousMessage.fileDetails || message.fileDetails) && {
+          fileDetails: [
+            ...(previousMessage.fileDetails ?? []),
+            ...(message.fileDetails ?? []),
+          ],
+        }),
+      };
+    } else {
+      visibleMessages.push(message);
+    }
+  }
+
+  return visibleMessages;
 };
 
 /**

--- a/lib/utils/message-utils.ts
+++ b/lib/utils/message-utils.ts
@@ -49,7 +49,12 @@ const stripRedundantOpeningFence = (
 ): string => {
   if (!isInsideMarkdownFence(previousText)) return continuationText;
 
-  return continuationText.replace(/^\s*```[^\n\r]*\r?\n/, "");
+  // A bare fence closes the block left open by the previous segment. Only
+  // remove a repeated opening fence when it carries an info string.
+  return continuationText.replace(
+    /^[\t ]*```[\t ]*[^\s`][^\n\r]*\r?\n/,
+    "",
+  );
 };
 
 const findExactSuffixPrefixOverlap = (
@@ -187,6 +192,15 @@ export const mergeAskContinuationMessages = (
           ...message.metadata,
           createdAt:
             previousMessage.metadata?.createdAt ?? message.metadata?.createdAt,
+          generationStartedAt:
+            previousMessage.metadata?.generationStartedAt ??
+            message.metadata?.generationStartedAt,
+          generationTimeMs:
+            previousMessage.metadata?.generationTimeMs === undefined &&
+            message.metadata?.generationTimeMs === undefined
+              ? undefined
+              : (previousMessage.metadata?.generationTimeMs ?? 0) +
+                (message.metadata?.generationTimeMs ?? 0),
           feedbackType:
             message.metadata?.feedbackType ??
             previousMessage.metadata?.feedbackType,


### PR DESCRIPTION
## Summary
- render Ask-mode continuation generations as one logical assistant response while retaining separate internal records for persistence, usage, and retry
- join continuation text across truncated Markdown fences, remove redundant opening fences, and deduplicate substantial exact overlap
- use an Ask-specific continuation prompt that resumes inside an open code block without repeating prior text
- keep Agent-mode continuation rendering unchanged

## Validation
- `pnpm exec jest lib/utils/__tests__/message-utils.test.ts app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx app/components/__tests__/Messages.edit.test.tsx --runInBand` (52 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --runInBand` (421 suites, 4,310 tests)
- `git diff --check`

## Manual verification
1. In Ask mode, request code long enough to hit the output limit.
2. Click Continue.
3. Confirm the continuation appears in the existing assistant response, with no visible continuation prompt or second assistant row.
4. Download the completed code block and confirm it contains both the original and continued code.
5. Repeat in Agent mode and confirm its existing multi-message behavior is unchanged.

The local authenticated route could not be visually exercised because the VPS Next dev process exited while compiling `/`; the focused Messages integration test verifies the one-row combined-parts contract, and visual verification will be retried against the Vercel preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ask-mode responses now continue seamlessly across multiple generations.
  * Continued text, including fenced code blocks, is combined into a single assistant response.
  * Redundant continuation prompts and duplicated text are hidden from the conversation view.
  * Message details, attached files, and generation timing are preserved when responses are merged.
  * Conversation branches now align correctly with the visible merged response.

* **Bug Fixes**
  * Improved continuation behavior to prevent repeated content and broken code formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->