### PR TITLE
Harden MicroVM workspace cleanup

### DIFF
--- a/app/api/delete-sandboxes/__tests__/route.test.ts
+++ b/app/api/delete-sandboxes/__tests__/route.test.ts
@@ -1,6 +1,10 @@
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { terminateCloudSandboxesForUser } from "@/lib/ai/tools/utils/cloud-sandbox";
-import { getActiveTriggerRunsForUser } from "@/lib/db/actions";
+import {
+  beginCloudSandboxDeletionForUser,
+  finishCloudSandboxDeletionForUser,
+  getActiveTriggerRunsForUser,
+} from "@/lib/db/actions";
 import { cancelSubagentsForUserDeletion } from "@/lib/db/subagents";
 import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
 import { POST } from "../route";
@@ -12,6 +16,8 @@ jest.mock("@/lib/ai/tools/utils/cloud-sandbox", () => ({
   terminateCloudSandboxesForUser: jest.fn(),
 }));
 jest.mock("@/lib/db/actions", () => ({
+  beginCloudSandboxDeletionForUser: jest.fn(),
+  finishCloudSandboxDeletionForUser: jest.fn(),
   getActiveTriggerRunsForUser: jest.fn(),
 }));
 jest.mock("@/lib/db/subagents", () => ({
@@ -31,6 +37,14 @@ const mockTerminateCloudSandboxesForUser =
 const mockGetActiveTriggerRunsForUser =
   getActiveTriggerRunsForUser as jest.MockedFunction<
     typeof getActiveTriggerRunsForUser
+  >;
+const mockBeginCloudSandboxDeletionForUser =
+  beginCloudSandboxDeletionForUser as jest.MockedFunction<
+    typeof beginCloudSandboxDeletionForUser
+  >;
+const mockFinishCloudSandboxDeletionForUser =
+  finishCloudSandboxDeletionForUser as jest.MockedFunction<
+    typeof finishCloudSandboxDeletionForUser
   >;
 const mockCancelSubagentsForUserDeletion =
   cancelSubagentsForUserDeletion as jest.MockedFunction<
@@ -73,6 +87,11 @@ describe("POST /api/delete-sandboxes", () => {
       userId: "user_123",
       subscription: "pro",
     } as never);
+    mockBeginCloudSandboxDeletionForUser.mockResolvedValue({
+      acquired: true,
+      operationId: "sandbox-deletion-operation",
+    });
+    mockFinishCloudSandboxDeletionForUser.mockResolvedValue(true);
     mockGetActiveTriggerRunsForUser.mockResolvedValue({
       runs: [
         {
@@ -111,6 +130,9 @@ describe("POST /api/delete-sandboxes", () => {
     expect(mockGetActiveTriggerRunsForUser).toHaveBeenCalledWith({
       userId: "user_123",
     });
+    expect(mockBeginCloudSandboxDeletionForUser).toHaveBeenCalledWith({
+      userId: "user_123",
+    });
     expect(mockCancelSubagentsForUserDeletion).toHaveBeenCalledWith(
       "user_123",
       "terminal-sandbox-deleted",
@@ -127,6 +149,13 @@ describe("POST /api/delete-sandboxes", () => {
       "terminal-sandbox-deleted",
     );
     expect(mockTerminateCloudSandboxesForUser).toHaveBeenCalledWith("user_123");
+    expect(mockFinishCloudSandboxDeletionForUser).toHaveBeenCalledWith({
+      userId: "user_123",
+      operationId: "sandbox-deletion-operation",
+    });
+    expect(
+      mockBeginCloudSandboxDeletionForUser.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockGetActiveTriggerRunsForUser.mock.invocationCallOrder[0]);
     expect(
       mockCloseAndCancelAgentResources.mock.invocationCallOrder[0],
     ).toBeLessThan(
@@ -149,6 +178,7 @@ describe("POST /api/delete-sandboxes", () => {
     });
     expect(mockCancelSubagentsForUserDeletion).not.toHaveBeenCalled();
     expect(mockTerminateCloudSandboxesForUser).not.toHaveBeenCalled();
+    expect(mockFinishCloudSandboxDeletionForUser).toHaveBeenCalledTimes(1);
   });
 
   it("stops before termination when validation cleanup is not bounded", async () => {
@@ -166,6 +196,23 @@ describe("POST /api/delete-sandboxes", () => {
     });
     expect(mockCloseAndCancelAgentResources).not.toHaveBeenCalled();
     expect(mockTerminateCloudSandboxesForUser).not.toHaveBeenCalled();
+    expect(mockFinishCloudSandboxDeletionForUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not overlap two sandbox deletion operations", async () => {
+    mockBeginCloudSandboxDeletionForUser.mockResolvedValueOnce({
+      acquired: false,
+    });
+
+    const response = await POST({} as any);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Sandbox deletion is already in progress",
+    });
+    expect(mockGetActiveTriggerRunsForUser).not.toHaveBeenCalled();
+    expect(mockTerminateCloudSandboxesForUser).not.toHaveBeenCalled();
+    expect(mockFinishCloudSandboxDeletionForUser).not.toHaveBeenCalled();
   });
 
   it("does not query or terminate sandboxes for free users", async () => {
@@ -177,6 +224,7 @@ describe("POST /api/delete-sandboxes", () => {
     const response = await POST({} as any);
 
     expect(response.status).toBe(403);
+    expect(mockBeginCloudSandboxDeletionForUser).not.toHaveBeenCalled();
     expect(mockGetActiveTriggerRunsForUser).not.toHaveBeenCalled();
     expect(mockTerminateCloudSandboxesForUser).not.toHaveBeenCalled();
   });

--- a/app/api/delete-sandboxes/route.ts
+++ b/app/api/delete-sandboxes/route.ts
@@ -1,7 +1,11 @@
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { NextRequest } from "next/server";
 import { terminateCloudSandboxesForUser } from "@/lib/ai/tools/utils/cloud-sandbox";
-import { getActiveTriggerRunsForUser } from "@/lib/db/actions";
+import {
+  beginCloudSandboxDeletionForUser,
+  finishCloudSandboxDeletionForUser,
+  getActiveTriggerRunsForUser,
+} from "@/lib/db/actions";
 import { cancelSubagentsForUserDeletion } from "@/lib/db/subagents";
 import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
 
@@ -9,6 +13,11 @@ export const maxDuration = 60;
 const SANDBOX_DELETION_REASON = "terminal-sandbox-deleted";
 
 export async function POST(req: NextRequest) {
+  let deletionFence: { userId: string; operationId: string } | undefined;
+  const requestId =
+    req.headers?.get("x-request-id") ??
+    req.headers?.get("x-vercel-id") ??
+    crypto.randomUUID();
   try {
     const { userId, subscription } = await getUserIDAndPro(req);
 
@@ -26,6 +35,15 @@ export async function POST(req: NextRequest) {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    const fence = await beginCloudSandboxDeletionForUser({ userId });
+    if (!fence.acquired) {
+      return new Response(
+        JSON.stringify({ error: "Sandbox deletion is already in progress" }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    deletionFence = { userId, operationId: fence.operationId };
 
     const activeAgentResources = await getActiveTriggerRunsForUser({ userId });
     if (activeAgentResources.hasMore) {
@@ -77,5 +95,25 @@ export async function POST(req: NextRequest) {
         headers: { "Content-Type": "application/json" },
       },
     );
+  } finally {
+    if (deletionFence) {
+      try {
+        await finishCloudSandboxDeletionForUser(deletionFence);
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            timestamp: new Date().toISOString(),
+            level: "error",
+            event: "cloud_sandbox_deletion_fence_release_failed",
+            request_id: requestId,
+            service: "delete-sandboxes-api",
+            environment:
+              process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+            user_id: deletionFence.userId,
+            error_name: error instanceof Error ? error.name : "UnknownError",
+          }),
+        );
+      }
+    }
   }
 }

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -222,6 +222,10 @@ status. Reject buckets whose status is `Enabled` or `Suspended`; S3 cannot retur
 those buckets to the never-versioned state. Before decommissioning a previously
 versioned bucket, use version-aware administrative cleanup to list and delete
 every object version and delete marker. A key-only delete is not sufficient.
+Before enabling the provider, run `pnpm s3:validate` with all three workspace
+bucket variables and an operator identity allowed to call
+`s3:GetBucketVersioning`. The runtime identity does not need that bucket-level
+permission.
 
 Optional controls:
 

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -217,10 +217,11 @@ inside the guest. Every regional metadata lookup must succeed before restore
 chooses an object, so an outage cannot be mistaken for an empty or older
 workspace.
 
-Workspace buckets must keep versioning disabled. If versioning was ever enabled,
-delete all historical versions before using the bucket for workspaces; deleting
-only the current deterministic key would otherwise leave old workspace contents
-behind.
+Workspace buckets must be never-versioned: `GetBucketVersioning` must return no
+status. Reject buckets whose status is `Enabled` or `Suspended`; S3 cannot return
+those buckets to the never-versioned state. Before decommissioning a previously
+versioned bucket, use version-aware administrative cleanup to list and delete
+every object version and delete marker. A key-only delete is not sufficient.
 
 Optional controls:
 

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -209,10 +209,18 @@ AWS_LAMBDA_MICROVM_WORKSPACE_BUCKET_EU_WEST_1=<private bucket in eu-west-1>
 The existing `AWS_S3_REGION` and `AWS_S3_BUCKET_NAME` continue to serve normal
 file attachments and are not changed by workspace routing. The S3 identity must
 have `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` for
-`users/*/microvm-workspace/v1/*` in each workspace bucket. S3 credentials are
-never placed inside the guest. Every regional metadata lookup must succeed
-before restore chooses an object, so an outage cannot be mistaken for an empty
-or older workspace.
+`users/*/microvm-workspace/v1/*` in each workspace bucket. It also needs
+`s3:ListBucket` on each workspace bucket, constrained with an `s3:prefix`
+condition to `users/*/microvm-workspace/v1/*`, so `HeadObject` can distinguish a
+new workspace from an authorization failure. S3 credentials are never placed
+inside the guest. Every regional metadata lookup must succeed before restore
+chooses an object, so an outage cannot be mistaken for an empty or older
+workspace.
+
+Workspace buckets must keep versioning disabled. If versioning was ever enabled,
+delete all historical versions before using the bucket for workspaces; deleting
+only the current deterministic key would otherwise leave old workspace contents
+behind.
 
 Optional controls:
 

--- a/convex/__tests__/localSandbox.cloudCleanup.test.ts
+++ b/convex/__tests__/localSandbox.cloudCleanup.test.ts
@@ -74,6 +74,125 @@ describe("cloud sandbox session cleanup", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  it("does not create a MicroVM session while sandbox deletion is active", async () => {
+    const query = jest.fn((table: string) => {
+      if (table === "user_deletion_fences") {
+        return {
+          withIndex: jest.fn(() => ({
+            first: jest.fn().mockResolvedValue(null),
+          })),
+        };
+      }
+      expect(table).toBe("cloud_sandbox_deletion_fences");
+      return {
+        withIndex: jest.fn(() => ({
+          unique: jest.fn().mockResolvedValue({
+            _id: "sandbox-fence-1",
+            expires_at: Date.now() + 60_000,
+          }),
+        })),
+      };
+    });
+    const insert = jest.fn();
+    const deleteRow = jest.fn();
+    const { beginCloudSession } = await import("../localSandbox");
+
+    await expect(
+      beginCloudSession.handler(
+        { db: { query, insert, delete: deleteRow } } as never,
+        {
+          serviceKey: "service-key",
+          userId: "user-1",
+          region: "us-east-1",
+          imageIdentifier: "image-1",
+        },
+      ),
+    ).rejects.toBeInstanceOf(Error);
+    expect(insert).not.toHaveBeenCalled();
+    expect(deleteRow).not.toHaveBeenCalled();
+  });
+
+  it("replaces an expired sandbox deletion lease", async () => {
+    const query = jest.fn(() => ({
+      withIndex: jest.fn(() => ({
+        unique: jest.fn().mockResolvedValue({
+          _id: "expired-fence",
+          expires_at: Date.now() - 1,
+        }),
+      })),
+    }));
+    const deleteRow = jest.fn();
+    const insert = jest.fn();
+    const { beginCloudSandboxDeletion } = await import("../localSandbox");
+
+    await expect(
+      beginCloudSandboxDeletion.handler(
+        { db: { query, delete: deleteRow, insert } } as never,
+        { serviceKey: "service-key", userId: "user-1" },
+      ),
+    ).resolves.toEqual({
+      acquired: true,
+      operationId: expect.any(String),
+    });
+    expect(deleteRow).toHaveBeenCalledWith("expired-fence");
+    expect(insert).toHaveBeenCalledWith(
+      "cloud_sandbox_deletion_fences",
+      expect.objectContaining({
+        user_id: "user-1",
+        operation_id: expect.any(String),
+        expires_at: expect.any(Number),
+      }),
+    );
+  });
+
+  it("does not overlap an active sandbox deletion lease", async () => {
+    const query = jest.fn(() => ({
+      withIndex: jest.fn(() => ({
+        unique: jest.fn().mockResolvedValue({
+          _id: "active-fence",
+          expires_at: Date.now() + 60_000,
+        }),
+      })),
+    }));
+    const deleteRow = jest.fn();
+    const insert = jest.fn();
+    const { beginCloudSandboxDeletion } = await import("../localSandbox");
+
+    await expect(
+      beginCloudSandboxDeletion.handler(
+        { db: { query, delete: deleteRow, insert } } as never,
+        { serviceKey: "service-key", userId: "user-1" },
+      ),
+    ).resolves.toEqual({ acquired: false });
+    expect(deleteRow).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("does not release another sandbox deletion operation's lease", async () => {
+    const query = jest.fn(() => ({
+      withIndex: jest.fn(() => ({
+        unique: jest.fn().mockResolvedValue({
+          _id: "newer-fence",
+          operation_id: "newer-operation",
+        }),
+      })),
+    }));
+    const deleteRow = jest.fn();
+    const { finishCloudSandboxDeletion } = await import("../localSandbox");
+
+    await expect(
+      finishCloudSandboxDeletion.handler(
+        { db: { query, delete: deleteRow } } as never,
+        {
+          serviceKey: "service-key",
+          userId: "user-1",
+          operationId: "older-operation",
+        },
+      ),
+    ).resolves.toBe(false);
+    expect(deleteRow).not.toHaveBeenCalled();
+  });
+
   it("keeps a healthy active session pinned across region and image changes", async () => {
     const now = Date.now();
     const active = {
@@ -99,6 +218,13 @@ describe("cloud sandbox session cleanup", () => {
         return {
           withIndex: jest.fn(() => ({
             first: jest.fn().mockResolvedValue(null),
+          })),
+        };
+      }
+      if (table === "cloud_sandbox_deletion_fences") {
+        return {
+          withIndex: jest.fn(() => ({
+            unique: jest.fn().mockResolvedValue(null),
           })),
         };
       }
@@ -169,6 +295,13 @@ describe("cloud sandbox session cleanup", () => {
         return {
           withIndex: jest.fn(() => ({
             first: jest.fn().mockResolvedValue(null),
+          })),
+        };
+      }
+      if (table === "cloud_sandbox_deletion_fences") {
+        return {
+          withIndex: jest.fn(() => ({
+            unique: jest.fn().mockResolvedValue(null),
           })),
         };
       }

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -65,6 +65,7 @@ async function hashCloudBootstrapToken(token: string): Promise<string> {
 const CLOUD_SESSION_PROVIDER = "aws-lambda-microvm" as const;
 const CLOUD_SESSION_TOKEN_TTL_MS = 9 * 60 * 60 * 1000;
 const CLOUD_SESSION_STARTING_STALE_MS = 2 * 60 * 1000;
+const CLOUD_SANDBOX_DELETION_FENCE_TTL_MS = 2 * 60 * 1000;
 const RELAY_READY_CLIENT_VERSION = "aws-lambda-microvm-relay-ready-v1";
 
 const cloudSessionStatus = v.union(
@@ -604,6 +605,63 @@ export const disconnect = mutation({
 // AWS LAMBDA MICROVM CLOUD CONNECTIONS
 // ============================================================================
 
+export const beginCloudSandboxDeletion = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      acquired: v.literal(true),
+      operationId: v.string(),
+    }),
+    v.object({ acquired: v.literal(false) }),
+  ),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("cloud_sandbox_deletion_fences")
+      .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+      .unique();
+
+    if (existing && existing.expires_at > now) {
+      return { acquired: false as const };
+    }
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+
+    const operationId = crypto.randomUUID();
+    await ctx.db.insert("cloud_sandbox_deletion_fences", {
+      user_id: args.userId,
+      operation_id: operationId,
+      started_at: now,
+      expires_at: now + CLOUD_SANDBOX_DELETION_FENCE_TTL_MS,
+    });
+    return { acquired: true as const, operationId };
+  },
+});
+
+export const finishCloudSandboxDeletion = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    operationId: v.string(),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const existing = await ctx.db
+      .query("cloud_sandbox_deletion_fences")
+      .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+      .unique();
+    if (!existing || existing.operation_id !== args.operationId) return false;
+    await ctx.db.delete(existing._id);
+    return true;
+  },
+});
+
 export const beginCloudSession = mutation({
   args: {
     serviceKey: v.string(),
@@ -634,6 +692,19 @@ export const beginCloudSession = mutation({
       });
     }
     const now = Date.now();
+    const sandboxDeletionFence = await ctx.db
+      .query("cloud_sandbox_deletion_fences")
+      .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+      .unique();
+    if (sandboxDeletionFence && sandboxDeletionFence.expires_at > now) {
+      throw new ConvexError({
+        code: "SANDBOX_DELETION_IN_PROGRESS",
+        message: "Sandbox deletion is in progress",
+      });
+    }
+    if (sandboxDeletionFence) {
+      await ctx.db.delete(sandboxDeletionFence._id);
+    }
     const [active, starting, running] = await Promise.all([
       ctx.db
         .query("cloud_sandbox_sessions")

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -703,6 +703,16 @@ export default defineSchema({
     started_at: v.number(),
   }).index("by_user_id", ["user_id"]),
 
+  // Short-lived lease held while Data Controls stops a user's sandboxes and
+  // deletes their durable workspace. This closes the acquisition/deletion
+  // race without permanently fencing the account when a request is interrupted.
+  cloud_sandbox_deletion_fences: defineTable({
+    user_id: v.string(),
+    operation_id: v.string(),
+    started_at: v.number(),
+    expires_at: v.number(),
+  }).index("by_user_id", ["user_id"]),
+
   user_suspensions: defineTable({
     user_id: v.string(),
     status: v.union(v.literal("active"), v.literal("resolved")),

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -1168,7 +1168,8 @@ describe("AWS Lambda MicroVM development logging", () => {
       .mockRejectedValueOnce(
         Object.assign(new Error("denied"), { name: "AccessDeniedException" }),
       )
-      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
+      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } })
+      .mockResolvedValueOnce({ state: "TERMINATED" });
     mockMutation.mockResolvedValue(true);
     const warnSpy = jest.spyOn(console, "warn").mockImplementation();
     const infoSpy = jest.spyOn(console, "info").mockImplementation();
@@ -1177,7 +1178,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       terminateAwsLambdaMicrovmForUser("user-delete"),
     ).rejects.toThrow("Failed to terminate 1 AWS Lambda MicroVM session");
 
-    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(mockSend).toHaveBeenCalledTimes(3);
     expect(mockMutation.mock.calls).toEqual(
       expect.arrayContaining([
         expect.arrayContaining([
@@ -1212,7 +1213,9 @@ describe("AWS Lambda MicroVM development logging", () => {
         microvmId: "microvm-attached-late",
       })
       .mockResolvedValueOnce(true);
-    mockSend.mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
+    mockSend
+      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } })
+      .mockResolvedValueOnce({ state: "TERMINATED" });
     const infoSpy = jest.spyOn(console, "info").mockImplementation();
 
     await expect(
@@ -1229,6 +1232,39 @@ describe("AWS Lambda MicroVM development logging", () => {
       }),
     );
     infoSpy.mockRestore();
+  });
+
+  it("keeps workspace deletion blocked until AWS termination is confirmed", async () => {
+    jest.useFakeTimers();
+    mockQuery.mockResolvedValueOnce([
+      {
+        sessionId: "session-termination-pending",
+        status: "running",
+        microvmId: "microvm-termination-pending",
+        region: "us-east-1",
+      },
+    ]);
+    mockSend
+      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } })
+      .mockResolvedValue({ state: "TERMINATING" });
+    mockMutation.mockResolvedValue(true);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    const pending = expect(
+      terminateAwsLambdaMicrovmForUser("user-termination-pending"),
+    ).rejects.toThrow("Failed to terminate 1 AWS Lambda MicroVM session");
+    await jest.advanceTimersByTimeAsync(1_000);
+    await pending;
+
+    expect(mockMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user-termination-pending",
+        sessionId: "session-termination-pending",
+        failureCode: "termination_confirmation_required",
+      }),
+    );
+    warnSpy.mockRestore();
   });
 
   it("suspends a running reusable MicroVM when the Agent becomes idle", async () => {
@@ -1325,24 +1361,33 @@ describe("AWS Lambda MicroVM development logging", () => {
       },
     ]);
     mockSnapshotWorkspace.mockRejectedValueOnce(new Error("S3 unavailable"));
-    mockSend
-      .mockResolvedValueOnce({
-        state: "RUNNING",
-        endpoint: "microvm-unsaved.example.test",
-      })
-      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
+    mockSend.mockResolvedValueOnce({
+      state: "RUNNING",
+      endpoint: "microvm-unsaved.example.test",
+    });
     const warnSpy = jest.spyOn(console, "warn").mockImplementation();
 
     await expect(
       suspendAwsLambdaMicrovmsForUser("user-unsaved"),
     ).rejects.toThrow("Failed to stop 1 AWS Lambda MicroVM session");
-    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(mockSend).toHaveBeenCalledTimes(1);
     expect(
       mockMutation.mock.calls.some(
         ([, args]) =>
           args.sessionId === "session-unsaved" && args.state === "SUSPENDING",
       ),
-    ).toBe(true);
+    ).toBe(false);
+    const retainedEvent = warnSpy.mock.calls
+      .map(([payload]) => JSON.parse(payload as string))
+      .find(
+        (payload) =>
+          payload.event === "cloud_sandbox_unsaved_workspace_retained",
+      );
+    expect(retainedEvent).toMatchObject({
+      user_id: "user-unsaved",
+      session_id: "session-unsaved",
+      reason: "snapshot_failed",
+    });
 
     warnSpy.mockRestore();
   });

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -1267,6 +1267,51 @@ describe("AWS Lambda MicroVM development logging", () => {
     warnSpy.mockRestore();
   });
 
+  it("aborts a stalled termination status request within the deadline", async () => {
+    jest.useFakeTimers();
+    mockQuery.mockResolvedValueOnce([
+      {
+        sessionId: "session-termination-stalled",
+        status: "running",
+        microvmId: "microvm-termination-stalled",
+        region: "us-east-1",
+      },
+    ]);
+    mockSend
+      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } })
+      .mockImplementationOnce(
+        (_command: unknown, options?: { abortSignal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options?.abortSignal?.addEventListener("abort", () => {
+              reject(
+                Object.assign(new Error("aborted"), { name: "AbortError" }),
+              );
+            });
+          }),
+      );
+    mockMutation.mockResolvedValue(true);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    const pending = expect(
+      terminateAwsLambdaMicrovmForUser("user-termination-stalled"),
+    ).rejects.toThrow("Failed to terminate 1 AWS Lambda MicroVM session");
+    await jest.advanceTimersByTimeAsync(1_000);
+    await pending;
+
+    expect(mockSend.mock.calls[1][1]).toEqual({
+      abortSignal: expect.objectContaining({ aborted: true }),
+    });
+    expect(mockMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user-termination-stalled",
+        sessionId: "session-termination-stalled",
+        failureCode: "termination_confirmation_required",
+      }),
+    );
+    warnSpy.mockRestore();
+  });
+
   it("suspends a running reusable MicroVM when the Agent becomes idle", async () => {
     mockQuery.mockResolvedValueOnce([
       {

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-workspace.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-workspace.test.ts
@@ -108,7 +108,10 @@ describe("AWS Lambda MicroVM durable workspace", () => {
     const command = buildWorkspaceSnapshotCommand("https://s3.example/upload");
     const result = spawnSync(
       "bash",
-      ["-c", `tar() { return 1; }; curl() { printf uploaded; }; ${command}`],
+      [
+        "-c",
+        `flock() { return 0; }; tar() { return 1; }; curl() { printf uploaded; }; ${command}`,
+      ],
       { encoding: "utf8" },
     );
 
@@ -120,7 +123,10 @@ describe("AWS Lambda MicroVM durable workspace", () => {
     const command = buildWorkspaceSnapshotCommand("https://s3.example/upload");
     const result = spawnSync(
       "bash",
-      ["-c", `tar() { return 2; }; curl() { printf uploaded; }; ${command}`],
+      [
+        "-c",
+        `flock() { return 0; }; tar() { return 2; }; curl() { printf uploaded; }; ${command}`,
+      ],
       { encoding: "utf8" },
     );
 

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -38,6 +38,8 @@ const DEFAULT_MIN_REMAINING_SECONDS = 2 * 60 * 60 + 5 * 60;
 const DIRECT_IDLE_SECONDS = 5 * 60;
 const DIRECT_SUSPENDED_SECONDS = 30 * 60;
 const SESSION_READY_TIMEOUT_MS = 90_000;
+const USER_DELETION_TERMINATION_CONFIRM_TIMEOUT_MS =
+  process.env.NODE_ENV === "test" ? 1_000 : 15_000;
 const RETRYABLE_TRANSPORT_ERROR_CODES = new Set([
   "EAI_AGAIN",
   "ENOTFOUND",
@@ -680,6 +682,39 @@ async function terminateMicrovm(
       ...errorLogFields(error),
     });
     return "failed";
+  }
+}
+
+async function confirmMicrovmTerminated(
+  microvmId: string,
+  region: string,
+): Promise<void> {
+  const deadline = Date.now() + USER_DELETION_TERMINATION_CONFIRM_TIMEOUT_MS;
+  let delayMs = 250;
+  let lastState = "unknown";
+
+  while (true) {
+    try {
+      const response = await getClient(region).send(
+        new GetMicrovmCommand({ microvmIdentifier: microvmId }),
+      );
+      lastState = response.state ?? "unknown";
+      if (response.state === "TERMINATED") return;
+    } catch (error) {
+      if (isAwsNotFound(error)) return;
+      throw error;
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error(
+        `AWS MicroVM termination was not confirmed; last state was ${lastState}`,
+      );
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(delayMs, remainingMs)),
+    );
+    delayMs = Math.min(Math.round(delayMs * 1.5), 1_000);
   }
 }
 
@@ -1784,6 +1819,20 @@ export async function terminateAwsLambdaMicrovmForUser(
 
       const outcome = await terminateMicrovm(microvmId, session.region);
       if (outcome === "terminated") {
+        // TerminateMicrovm acknowledges the request before AWS necessarily
+        // stops the guest. Confirm the terminal state before the caller is
+        // allowed to delete the workspace object that guest can checkpoint.
+        try {
+          await confirmMicrovmTerminated(microvmId, session.region);
+        } catch (error) {
+          await markCleanupPending(
+            userId,
+            session.sessionId,
+            { serviceKey },
+            "termination_confirmation_required",
+          );
+          throw error;
+        }
         await markEnded(
           userId,
           session.sessionId,
@@ -2036,30 +2085,16 @@ export async function suspendAwsLambdaMicrovmsForUser(
         ...errorLogFields(error),
       });
       if (!workspaceSaved) {
-        // Never destroy the only remaining copy of a user's project. Make one
-        // best-effort suspend attempt to contain cost, then leave the MicroVM
-        // for the platform duration backstop if both operations failed.
-        try {
-          await getClient(session.region).send(
-            new SuspendMicrovmCommand({ microvmIdentifier: microvmId }),
-          );
-          await recordCloudMicrovmState(
-            userId,
-            session.sessionId,
-            microvmId,
-            serviceKey,
-            "SUSPENDING",
-          );
-        } catch (suspendError) {
-          log("error", "cloud_sandbox_unsaved_workspace_retained", {
-            user_id: userId,
-            session_id: session.sessionId,
-            microvm_id: microvmId,
-            region: session.region,
-            reason: "snapshot_and_suspend_failed",
-            ...errorLogFields(suspendError),
-          });
-        }
+        // Suspending would put the only live copy on AWS's 30-minute automatic
+        // termination path. Keep the session reusable and leave its existing
+        // two-minute checkpoint loop running so transient S3 failures can heal.
+        log("warn", "cloud_sandbox_unsaved_workspace_retained", {
+          user_id: userId,
+          session_id: session.sessionId,
+          microvm_id: microvmId,
+          region: session.region,
+          reason: "snapshot_failed",
+        });
         failures.push(error);
         continue;
       }

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -692,25 +692,36 @@ async function confirmMicrovmTerminated(
   const deadline = Date.now() + USER_DELETION_TERMINATION_CONFIRM_TIMEOUT_MS;
   let delayMs = 250;
   let lastState = "unknown";
+  const timeoutError = () =>
+    new Error(
+      `AWS MicroVM termination was not confirmed; last state was ${lastState}`,
+    );
 
   while (true) {
+    const requestBudgetMs = deadline - Date.now();
+    if (requestBudgetMs <= 0) throw timeoutError();
+    const abortController = new AbortController();
+    const abortTimeout = setTimeout(
+      () => abortController.abort(),
+      requestBudgetMs,
+    );
     try {
       const response = await getClient(region).send(
         new GetMicrovmCommand({ microvmIdentifier: microvmId }),
+        { abortSignal: abortController.signal },
       );
       lastState = response.state ?? "unknown";
       if (response.state === "TERMINATED") return;
     } catch (error) {
       if (isAwsNotFound(error)) return;
+      if (abortController.signal.aborted) throw timeoutError();
       throw error;
+    } finally {
+      clearTimeout(abortTimeout);
     }
 
     const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      throw new Error(
-        `AWS MicroVM termination was not confirmed; last state was ${lastState}`,
-      );
-    }
+    if (remainingMs <= 0) throw timeoutError();
     await new Promise((resolve) =>
       setTimeout(resolve, Math.min(delayMs, remainingMs)),
     );

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -816,6 +816,42 @@ export async function getActiveTriggerRunsForUser({
   }
 }
 
+export async function beginCloudSandboxDeletionForUser({
+  userId,
+}: {
+  userId: string;
+}) {
+  try {
+    return await getConvexClient().mutation(
+      api.localSandbox.beginCloudSandboxDeletion,
+      { serviceKey, userId },
+    );
+  } catch (error) {
+    throw databaseError("localSandbox.beginCloudSandboxDeletion", error, {
+      user_id: userId,
+    });
+  }
+}
+
+export async function finishCloudSandboxDeletionForUser({
+  userId,
+  operationId,
+}: {
+  userId: string;
+  operationId: string;
+}) {
+  try {
+    return await getConvexClient().mutation(
+      api.localSandbox.finishCloudSandboxDeletion,
+      { serviceKey, userId, operationId },
+    );
+  } catch (error) {
+    throw databaseError("localSandbox.finishCloudSandboxDeletion", error, {
+      user_id: userId,
+    });
+  }
+}
+
 export async function fenceAndGetActiveAgentResourcesForUser({
   userId,
 }: {

--- a/scripts/__tests__/validate-s3-security.test.ts
+++ b/scripts/__tests__/validate-s3-security.test.ts
@@ -1,0 +1,101 @@
+import { validateWorkspaceBucketVersioning } from "../validate-s3-security";
+
+const WORKSPACE_BUCKET_ENV_NAMES = [
+  "AWS_LAMBDA_MICROVM_WORKSPACE_BUCKET_US_EAST_1",
+  "AWS_LAMBDA_MICROVM_WORKSPACE_BUCKET_US_WEST_2",
+  "AWS_LAMBDA_MICROVM_WORKSPACE_BUCKET_EU_WEST_1",
+] as const;
+
+describe("MicroVM workspace bucket versioning validation", () => {
+  const originalProvider = process.env.CLOUD_SANDBOX_PROVIDER;
+  const originalBuckets = Object.fromEntries(
+    WORKSPACE_BUCKET_ENV_NAMES.map((name) => [name, process.env[name]]),
+  );
+
+  beforeEach(() => {
+    delete process.env.CLOUD_SANDBOX_PROVIDER;
+    for (const name of WORKSPACE_BUCKET_ENV_NAMES) delete process.env[name];
+  });
+
+  afterAll(() => {
+    if (originalProvider === undefined) {
+      delete process.env.CLOUD_SANDBOX_PROVIDER;
+    } else {
+      process.env.CLOUD_SANDBOX_PROVIDER = originalProvider;
+    }
+    for (const name of WORKSPACE_BUCKET_ENV_NAMES) {
+      const value = originalBuckets[name];
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  it("warns without failing when the MicroVM provider is not configured", async () => {
+    const readVersioning = jest.fn();
+
+    await expect(
+      validateWorkspaceBucketVersioning(readVersioning),
+    ).resolves.toEqual(
+      expect.objectContaining({ passed: true, warning: expect.any(String) }),
+    );
+    expect(readVersioning).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a selected provider has incomplete bucket configuration", async () => {
+    process.env.CLOUD_SANDBOX_PROVIDER = "aws-lambda-microvm";
+    process.env[WORKSPACE_BUCKET_ENV_NAMES[0]] = "workspace-east";
+    const readVersioning = jest.fn();
+
+    const result = await validateWorkspaceBucketVersioning(readVersioning);
+
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain(WORKSPACE_BUCKET_ENV_NAMES[1]);
+    expect(result.message).toContain(WORKSPACE_BUCKET_ENV_NAMES[2]);
+    expect(readVersioning).not.toHaveBeenCalled();
+  });
+
+  it.each(["Enabled", "Suspended"])(
+    "rejects a workspace bucket whose versioning status is %s",
+    async (status) => {
+      for (const [index, name] of WORKSPACE_BUCKET_ENV_NAMES.entries()) {
+        process.env[name] = `workspace-${index}`;
+      }
+      const readVersioning = jest.fn(async (region: string) =>
+        region === "us-west-2" ? status : undefined,
+      );
+
+      const result = await validateWorkspaceBucketVersioning(readVersioning);
+
+      expect(result.passed).toBe(false);
+      expect(result.message).toContain(`us-west-2 (${status})`);
+      expect(readVersioning).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it("accepts only never-versioned workspace buckets", async () => {
+    for (const [index, name] of WORKSPACE_BUCKET_ENV_NAMES.entries()) {
+      process.env[name] = `workspace-${index}`;
+    }
+    const readVersioning = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      validateWorkspaceBucketVersioning(readVersioning),
+    ).resolves.toEqual(expect.objectContaining({ passed: true }));
+    expect(readVersioning).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails closed when versioning status cannot be verified", async () => {
+    for (const [index, name] of WORKSPACE_BUCKET_ENV_NAMES.entries()) {
+      process.env[name] = `workspace-${index}`;
+    }
+    const readVersioning = jest
+      .fn()
+      .mockRejectedValue(new Error("AccessDenied"));
+
+    const result = await validateWorkspaceBucketVersioning(readVersioning);
+
+    expect(result).toEqual(
+      expect.objectContaining({ passed: false, message: expect.any(String) }),
+    );
+  });
+});

--- a/scripts/validate-s3-security.ts
+++ b/scripts/validate-s3-security.ts
@@ -455,7 +455,7 @@ function validateIamPermissions(): ValidationResult {
     message:
       "Please manually verify IAM permissions follow least privilege principle:",
     warning:
-      'Required permissions: s3:PutObject, s3:GetObject, s3:DeleteObject on "arn:aws:s3:::YOUR_BUCKET/*". No wildcard permissions.',
+      'Attachments require s3:PutObject, s3:GetObject, and s3:DeleteObject on "arn:aws:s3:::YOUR_BUCKET/*". MicroVM workspace buckets additionally require bucket-level s3:ListBucket constrained by s3:prefix to "users/*/microvm-workspace/v1/*", and versioning must remain disabled. No wildcard permissions.',
   };
 }
 

--- a/scripts/validate-s3-security.ts
+++ b/scripts/validate-s3-security.ts
@@ -25,13 +25,14 @@ import {
   GetBucketEncryptionCommand,
   GetPublicAccessBlockCommand,
   GetBucketCorsCommand,
+  GetBucketVersioningCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 // Load environment variables
 dotenv.config({ path: ".env.local" });
 
-interface ValidationResult {
+export interface ValidationResult {
   name: string;
   passed: boolean;
   message: string;
@@ -39,6 +40,18 @@ interface ValidationResult {
 }
 
 const results: ValidationResult[] = [];
+
+const WORKSPACE_BUCKET_ENV_BY_REGION = {
+  "us-east-1": "AWS_LAMBDA_MICROVM_WORKSPACE_BUCKET_US_EAST_1",
+  "us-west-2": "AWS_LAMBDA_MICROVM_WORKSPACE_BUCKET_US_WEST_2",
+  "eu-west-1": "AWS_LAMBDA_MICROVM_WORKSPACE_BUCKET_EU_WEST_1",
+} as const;
+
+type WorkspaceRegion = keyof typeof WORKSPACE_BUCKET_ENV_BY_REGION;
+type ReadWorkspaceBucketVersioning = (
+  region: WorkspaceRegion,
+  bucketName: string,
+) => Promise<string | undefined>;
 
 /**
  * Log validation result with colored output
@@ -460,6 +473,94 @@ function validateIamPermissions(): ValidationResult {
 }
 
 /**
+ * Test 9: Reject workspace buckets that are or were versioned.
+ *
+ * This is intentionally an operator-time check. The runtime identity remains
+ * limited to object access plus prefix-scoped ListBucket and does not need
+ * bucket-configuration permissions on every user deletion.
+ */
+export async function validateWorkspaceBucketVersioning(
+  readVersioning?: ReadWorkspaceBucketVersioning,
+): Promise<ValidationResult> {
+  const configured = Object.entries(WORKSPACE_BUCKET_ENV_BY_REGION).filter(
+    ([, envName]) => Boolean(process.env[envName]),
+  );
+  const workspaceProviderSelected =
+    process.env.CLOUD_SANDBOX_PROVIDER === "aws-lambda-microvm";
+
+  if (configured.length === 0 && !workspaceProviderSelected) {
+    return {
+      name: "MicroVM Workspace Bucket Versioning",
+      passed: true,
+      message: "MicroVM workspace buckets are not configured; check skipped.",
+      warning:
+        "Run this validation with all workspace bucket environment variables before enabling the AWS Lambda MicroVM provider.",
+    };
+  }
+
+  const missing = Object.values(WORKSPACE_BUCKET_ENV_BY_REGION).filter(
+    (envName) => !process.env[envName],
+  );
+  if (missing.length > 0) {
+    return {
+      name: "MicroVM Workspace Bucket Versioning",
+      passed: false,
+      message: `Missing workspace bucket environment variables: ${missing.join(", ")}`,
+    };
+  }
+
+  const getVersioning =
+    readVersioning ??
+    (async (region: WorkspaceRegion, bucketName: string) => {
+      const client = new S3Client({
+        region,
+        credentials: {
+          accessKeyId: process.env.AWS_S3_ACCESS_KEY_ID!,
+          secretAccessKey: process.env.AWS_S3_SECRET_ACCESS_KEY!,
+        },
+      });
+      const response = await client.send(
+        new GetBucketVersioningCommand({ Bucket: bucketName }),
+      );
+      return response.Status;
+    });
+
+  const invalidRegions: string[] = [];
+  try {
+    for (const [region, envName] of Object.entries(
+      WORKSPACE_BUCKET_ENV_BY_REGION,
+    ) as Array<[WorkspaceRegion, string]>) {
+      const status = await getVersioning(region, process.env[envName]!);
+      if (status !== undefined) invalidRegions.push(`${region} (${status})`);
+    }
+  } catch (error) {
+    return {
+      name: "MicroVM Workspace Bucket Versioning",
+      passed: false,
+      message:
+        "Failed to verify that every MicroVM workspace bucket is never-versioned: " +
+        (error instanceof Error ? error.message : "Unknown error"),
+    };
+  }
+
+  if (invalidRegions.length > 0) {
+    return {
+      name: "MicroVM Workspace Bucket Versioning",
+      passed: false,
+      message: `Workspace buckets must be never-versioned; rejected regions: ${invalidRegions.join(", ")}`,
+      warning:
+        "Use version-aware administrative cleanup to delete every historical object version and delete marker before decommissioning a previously versioned bucket.",
+    };
+  }
+
+  return {
+    name: "MicroVM Workspace Bucket Versioning",
+    passed: true,
+    message: "All configured MicroVM workspace buckets are never-versioned.",
+  };
+}
+
+/**
  * Main validation function
  */
 async function main() {
@@ -525,6 +626,11 @@ async function main() {
   results.push(iamResult);
   logResult(iamResult);
 
+  // Test 9: Workspace buckets must never have had versioning enabled
+  const workspaceVersioningResult = await validateWorkspaceBucketVersioning();
+  results.push(workspaceVersioningResult);
+  logResult(workspaceVersioningResult);
+
   // Summary
   console.log("=".repeat(60));
   console.log("Validation Summary");
@@ -557,8 +663,10 @@ async function main() {
   }
 }
 
-// Run validation
-main().catch((error) => {
-  console.error("Fatal error during validation:", error);
-  process.exit(1);
-});
+// Run validation only when invoked as a script; tests import the focused checks.
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("Fatal error during validation:", error);
+    process.exit(1);
+  });
+}

--- a/scripts/validate-s3-security.ts
+++ b/scripts/validate-s3-security.ts
@@ -455,7 +455,7 @@ function validateIamPermissions(): ValidationResult {
     message:
       "Please manually verify IAM permissions follow least privilege principle:",
     warning:
-      'Attachments require s3:PutObject, s3:GetObject, and s3:DeleteObject on "arn:aws:s3:::YOUR_BUCKET/*". MicroVM workspace buckets additionally require bucket-level s3:ListBucket constrained by s3:prefix to "users/*/microvm-workspace/v1/*", and versioning must remain disabled. No wildcard permissions.',
+      'Attachments require s3:PutObject, s3:GetObject, and s3:DeleteObject on "arn:aws:s3:::YOUR_BUCKET/*". MicroVM workspace buckets additionally require bucket-level s3:ListBucket constrained by s3:prefix to "users/*/microvm-workspace/v1/*" and must be never-versioned (GetBucketVersioning returns no status); reject Enabled or Suspended buckets. Before decommissioning a previously versioned bucket, list and delete every object version and delete marker with version-aware admin tooling. No wildcard permissions.',
   };
 }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2303,8 +2303,9 @@ const finishCloudSandboxLifecycleForParentRun = async ({
       });
     }
   } catch (error) {
-    // AWS suspension already attempts termination as a cost-safety fallback.
-    // Preserve the Agent result while surfacing any double failure for retry.
+    // Wind-down retains an unsaved VM so its checkpoint loop can retry. Once a
+    // snapshot exists, a failed suspend can still terminate as a cost backstop.
+    // Preserve the Agent result while surfacing the cleanup failure.
     triggerLogger.error("[agent-long] shared sandbox wind-down failed", {
       event: "agent_cloud_sandbox_wind_down_failed",
       user_id: userId,


### PR DESCRIPTION
## Summary

- retain an unsaved MicroVM after a final snapshot failure so its existing checkpoint loop can retry instead of explicitly entering the 30-minute suspended-termination path
- hold a short-lived, operation-owned Convex lease while Data Controls cancels runs, terminates sandboxes, and deletes workspace objects, preventing concurrent sandbox acquisition
- confirm AWS reports the MicroVM terminal (or absent) before cleanup is allowed to delete its deterministic S3 workspace object
- document the prefix-scoped ListBucket permission required for missing-key HeadObject behavior and require workspace bucket versioning to remain disabled
- make the durable-workspace shell harness portable on macOS by stubbing Linux-only flock in the test itself

## Why

The initial persistence rollout saved on graceful wind-down, but two failure paths could still lose or recreate state:

1. A failed final S3 snapshot explicitly suspended the only live copy even though AWS automatically terminates suspended VMs after 30 minutes.
2. Delete Sandboxes could race a new Agent acquisition, and cleanup treated acceptance of TerminateMicrovm as proof that the guest had stopped before deleting S3.

This patch keeps normal successful Agent startup and wind-down unchanged. The new polling occurs only during explicit deletion, and the Convex fence check shares the existing beginCloudSession transaction rather than adding another startup round trip.

## Validation

- full pre-commit suite: 422 suites, 4,343 tests passed
- `corepack pnpm typecheck`
- targeted ESLint and Prettier checks for all changed files
- focused lifecycle tests for active/expired/owner-tokened deletion leases, concurrent deletion, confirmed AWS termination, snapshot failure retention, and delete ordering

## Manual verification

1. In a non-production deployment, start an AWS MicroVM Agent and create a marker file. End the last run and confirm the regional workspace object is updated before the VM suspends.
2. Temporarily deny workspace PutObject, end a run, and confirm the VM is retained without an explicit SuspendMicrovm call. Restore permission and confirm the existing guest checkpoint updates S3.
3. Use Data Controls > Delete sandboxes while an Agent is active. Confirm new acquisition is rejected during cleanup, AWS reaches TERMINATED/NotFound before S3 deletion, and all three regional deterministic objects are absent afterward.

## AWS operational change

- Updated both Preview and Production S3 runtime IAM policies.
- Added `s3:ListBucket` for all regional MicroVM workspace buckets, constrained by `s3:prefix` to `users/*/microvm-workspace/v1/*`.
- Verified all workspace buckets have S3 Versioning disabled.
- Retained the existing object-level `GetObject`, `PutObject`, and `DeleteObject` permissions.
- No credentials, bucket names, account identifiers, or user data were changed or recorded.

## Review note

An independent security pass found no cross-user workspace access path or presigned-URL secret logging. Broader archive byte/file-count/expansion quotas remain a separate protocol-hardening concern and are intentionally not bundled into this lifecycle fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping sandbox deletion requests and improved handling when deletion is already in progress.
  * Sandbox sessions can no longer start while deletion is active.
  * Deletions now wait for cloud resources to fully terminate before ending sessions.
  * Preserved reusable environments when workspace snapshots fail, helping prevent data loss.
  * Improved cleanup of previously versioned workspace storage, including old object versions and delete markers.
* **Documentation**
  * Clarified sandbox cleanup retries, termination safeguards, and workspace storage requirements.
  * Added guidance for validating workspace storage configuration before activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->