### PR TITLE
Fix subagent runtime failures

### DIFF
--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -274,6 +274,28 @@ describe("s3Utils", () => {
       await expect(s3ObjectExists("workspace.tar.gz")).rejects.toBe(outage);
     });
 
+    it("reports the region and required permission for access-denied metadata reads", async () => {
+      const { S3Client } = await import("@aws-sdk/client-s3");
+      const accessDenied = {
+        name: "Unknown",
+        $metadata: { httpStatusCode: 403 },
+      };
+      const mockSend = jest.fn().mockRejectedValue(accessDenied);
+      (S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+        () => ({ send: mockSend }) as unknown as S3Client,
+      );
+      const { getS3ObjectMetadata } = await import("../s3Utils");
+
+      await expect(
+        getS3ObjectMetadata("workspace.tar.gz", {
+          region: "eu-west-1",
+          bucketName: "workspace-eu",
+        }),
+      ).rejects.toThrow(
+        "S3 metadata access denied in eu-west-1 (HTTP 403); verify s3:GetObject permission for the target key",
+      );
+    });
+
     it("returns S3's server-side modification time for regional selection", async () => {
       const { S3Client } = await import("@aws-sdk/client-s3");
       const lastModified = new Date("2026-08-24T04:00:00.000Z");

--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -286,13 +286,17 @@ describe("s3Utils", () => {
       );
       const { getS3ObjectMetadata } = await import("../s3Utils");
 
-      await expect(
-        getS3ObjectMetadata("workspace.tar.gz", {
-          region: "eu-west-1",
-          bucketName: "workspace-eu",
-        }),
-      ).rejects.toThrow(
+      const metadataPromise = getS3ObjectMetadata("workspace.tar.gz", {
+        region: "eu-west-1",
+        bucketName: "workspace-eu",
+      });
+
+      await expect(metadataPromise).rejects.toThrow(
         "S3 metadata access denied in eu-west-1 (HTTP 403); verify s3:GetObject permission for the target key",
+      );
+      await expect(metadataPromise).rejects.toHaveProperty(
+        "cause",
+        accessDenied,
       );
     });
 

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -192,6 +192,12 @@ export async function getS3ObjectMetadata(
     ) {
       return { exists: false };
     }
+    if (record?.$metadata?.httpStatusCode === 403) {
+      throw new Error(
+        `S3 metadata access denied in ${region} (HTTP 403); verify s3:GetObject permission for the target key`,
+        { cause: error },
+      );
+    }
     throw error;
   }
 }

--- a/lib/ai/subagents/__tests__/runtime-contracts.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-contracts.test.ts
@@ -171,6 +171,11 @@ describe("security validation subagent runtime contracts", () => {
     expect(child).toContain("getSubagentProviderRetryDecision");
     expect(child).toContain("canRecoverMissingSubagentResult");
     expect(child).toContain("getSubagentResultRecoveryRetryDecision");
+    expect(child).toContain("getSubagentExplorationStepLimit");
+    expect(child).toContain("shouldStartSubagentResultRecovery");
+    expect(child).toContain(
+      'event: "subagent_structured_result_recovery_started"',
+    );
     expect(child).toContain('"structured_result_recovery_exhausted"');
     expect(child).toContain('"resultRecoveryRetryCount"');
     expect(child).toContain('event: "subagent_recovery_exhausted"');

--- a/lib/ai/subagents/__tests__/runtime-recovery.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-recovery.test.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from "@jest/globals";
 import {
   buildMissingSubagentResultRecoveryMessage,
   canRecoverMissingSubagentResult,
+  getSubagentExplorationStepLimit,
   getSubagentProviderRetryDecision,
   getSubagentRecoveryErrorDiagnostics,
   getSubagentResultRecoveryRetryDecision,
   isRecoverableProviderCategory,
   isTransientProviderCategory,
   pipeSubagentUiMessageStream,
+  shouldStartSubagentResultRecovery,
+  SUBAGENT_RESULT_RECOVERY_STEP_RESERVE,
 } from "../runtime-recovery";
 
 describe("subagent runtime recovery", () => {
@@ -99,6 +102,26 @@ describe("subagent runtime recovery", () => {
     expect(buildMissingSubagentResultRecoveryMessage()).toContain(
       "confirmed result must include at least one reproduction step and one evidence reference",
     );
+  });
+
+  it("reserves the final steps for structured-result recovery", () => {
+    expect(SUBAGENT_RESULT_RECOVERY_STEP_RESERVE).toBe(2);
+    expect(getSubagentExplorationStepLimit(50)).toBe(48);
+    expect(getSubagentExplorationStepLimit(2)).toBe(1);
+    expect(
+      shouldStartSubagentResultRecovery(0, {
+        aborted: false,
+        spendCapExceeded: false,
+        remainingSteps: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldStartSubagentResultRecovery(1, {
+        aborted: false,
+        spendCapExceeded: false,
+        remainingSteps: 2,
+      }),
+    ).toBe(false);
   });
 
   it("retries a failed structured-result recovery exactly once", () => {

--- a/lib/ai/subagents/__tests__/runtime-recovery.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-recovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@jest/globals";
 import {
   buildMissingSubagentResultRecoveryMessage,
   canRecoverMissingSubagentResult,
+  canStartSubagentResultRecoveryGeneration,
   getSubagentExplorationStepLimit,
   getSubagentProviderRetryDecision,
   getSubagentRecoveryErrorDiagnostics,
@@ -146,6 +147,12 @@ describe("subagent runtime recovery", () => {
       getSubagentResultRecoveryRetryDecision(outputFailure, 1, healthyRuntime)
         .shouldRetry,
     ).toBe(false);
+  });
+
+  it("bounds every structured-result generation, including deferred submissions", () => {
+    expect(canStartSubagentResultRecoveryGeneration(0)).toBe(true);
+    expect(canStartSubagentResultRecoveryGeneration(1)).toBe(true);
+    expect(canStartSubagentResultRecoveryGeneration(2)).toBe(false);
   });
 
   it("does not retry structured-result recovery after cancellation, spend, or step exhaustion", () => {

--- a/lib/ai/subagents/__tests__/sandbox-identity.test.ts
+++ b/lib/ai/subagents/__tests__/sandbox-identity.test.ts
@@ -25,6 +25,9 @@ describe("subagent sandbox identity", () => {
       assertSubagentSandboxIdentity(aws, "aws:relay-1"),
     ).not.toThrow();
     expect(() =>
+      assertSubagentSandboxIdentity(aws, "aws:replaced-relay"),
+    ).not.toThrow();
+    expect(() =>
       assertSubagentSandboxIdentity(aws, "connection:relay-1"),
     ).not.toThrow();
     expect(() => assertSubagentSandboxIdentity(local, "aws:relay-1")).toThrow(

--- a/lib/ai/subagents/runtime-recovery.ts
+++ b/lib/ai/subagents/runtime-recovery.ts
@@ -54,6 +54,13 @@ export type SubagentResultRecoveryRetryDecision =
 export const SUBAGENT_RESULT_RECOVERY_STEP_RESERVE =
   1 + SUBAGENT_MAX_RESULT_RECOVERY_FAILURE_RETRIES;
 
+// Count every structured-output generation, including generations that defer
+// because a parent update arrived. This prevents deferrals from bypassing the
+// same bounded recovery budget used for provider and schema failures.
+export const canStartSubagentResultRecoveryGeneration = (
+  generationAttemptsUsed: number,
+): boolean => generationAttemptsUsed < SUBAGENT_RESULT_RECOVERY_STEP_RESERVE;
+
 export const getSubagentExplorationStepLimit = (
   remainingSteps: number,
 ): number =>

--- a/lib/ai/subagents/runtime-recovery.ts
+++ b/lib/ai/subagents/runtime-recovery.ts
@@ -48,6 +48,32 @@ export type SubagentResultRecoveryRetryDecision =
     delayMs: number;
   };
 
+// Keep enough of the global step budget for one structured-output attempt and
+// its single bounded retry. Without this reserve, an exploratory generation can
+// consume all 50 steps and make the existing result-recovery path unreachable.
+export const SUBAGENT_RESULT_RECOVERY_STEP_RESERVE =
+  1 + SUBAGENT_MAX_RESULT_RECOVERY_FAILURE_RETRIES;
+
+export const getSubagentExplorationStepLimit = (
+  remainingSteps: number,
+): number =>
+  Math.max(1, remainingSteps - SUBAGENT_RESULT_RECOVERY_STEP_RESERVE);
+
+export const shouldStartSubagentResultRecovery = (
+  recoveriesUsed: number,
+  options: {
+    aborted: boolean;
+    spendCapExceeded: boolean;
+    remainingSteps: number;
+  },
+): boolean =>
+  options.remainingSteps <= SUBAGENT_RESULT_RECOVERY_STEP_RESERVE &&
+  canRecoverMissingSubagentResult(recoveriesUsed, {
+    aborted: options.aborted,
+    spendCapExceeded: options.spendCapExceeded,
+    hasStepsRemaining: options.remainingSteps > 0,
+  });
+
 const ALLOWED_RECOVERY_ERROR_NAMES = new Set([
   "AI_APICallError",
   "AI_JSONParseError",

--- a/lib/ai/subagents/sandbox-identity.ts
+++ b/lib/ai/subagents/sandbox-identity.ts
@@ -38,6 +38,16 @@ export const assertSubagentSandboxIdentity = (
 ): void => {
   if (!expectedIdentity) return;
   const actualIdentity = getSubagentSandboxIdentity(sandbox);
+  // AWS MicroVMs are a user-scoped cloud workspace. The physical VM can be
+  // replaced while the parent run is active, and the workspace is restored
+  // onto the single active VM recorded for that user. Keep provider isolation,
+  // but do not reject a child solely because the physical MicroVM rotated.
+  if (
+    expectedIdentity.startsWith("aws:") &&
+    actualIdentity.startsWith("aws:")
+  ) {
+    return;
+  }
   const legacyAwsIdentity = actualIdentity.startsWith("aws:")
     ? `connection:${actualIdentity.slice("aws:".length)}`
     : undefined;

--- a/lib/ai/tools/subagent-tools.ts
+++ b/lib/ai/tools/subagent-tools.ts
@@ -1,4 +1,8 @@
-import { idempotencyKeys, wait } from "@trigger.dev/sdk";
+import {
+  idempotencyKeys,
+  logger as triggerLogger,
+  wait,
+} from "@trigger.dev/sdk";
 import { tool, type UIMessageStreamWriter } from "ai";
 
 import type { ToolContext } from "@/types";
@@ -24,6 +28,7 @@ import {
 } from "@/lib/ai/subagents/fingerprint";
 import { getSubagentSandboxIdentity } from "@/lib/ai/subagents/sandbox-identity";
 import { SUBAGENT_TEXT_MODEL } from "@/lib/ai/subagents/model-routing";
+import { getSubagentRecoveryErrorDiagnostics } from "@/lib/ai/subagents/runtime-recovery";
 import { getSandboxWithFallbackGuard } from "@/lib/ai/tools/utils/sandbox-fallback";
 import {
   claimNextTerminalSubagentForParent,
@@ -163,10 +168,27 @@ export const createCreateAgentTool = (
       const { sandbox } = await getSandboxWithFallbackGuard({
         sandboxManager: context.sandboxManager,
       }).catch((error) => {
+        const diagnostics = getSubagentRecoveryErrorDiagnostics(error);
         captureCreateFailure(
           "sandbox_acquisition",
           "sandbox_acquisition_error",
         );
+        triggerLogger.error("[subagent] sandbox acquisition failed", {
+          event: "subagent_sandbox_acquisition_failed",
+          service: "hackerai-subagent",
+          environment:
+            process.env.TRIGGER_ENV ?? process.env.NODE_ENV ?? "unknown",
+          user_id: context.userID,
+          parent_trigger_run_id: parentTriggerRunId,
+          parent_tool_call_id: execution.toolCallId,
+          profile,
+          failure_stage: "sandbox_acquisition",
+          error_category: diagnostics.category,
+          error_name: diagnostics.errorName,
+          error_code: diagnostics.errorCode,
+          status_code: diagnostics.statusCode,
+          duration_ms: Date.now() - createStartedAt,
+        });
         throw error;
       });
       const sandboxIdentity = getSubagentSandboxIdentity(sandbox);

--- a/lib/analytics/__tests__/subagents.test.ts
+++ b/lib/analytics/__tests__/subagents.test.ts
@@ -57,6 +57,8 @@ describe("subagent lifecycle analytics", () => {
       undelivered_count: undefined,
       target_count: undefined,
       result_available: undefined,
+      result_recovery_count: undefined,
+      result_submission_count: undefined,
       environment: expect.any(String),
       service_version: expect.any(String),
     });

--- a/lib/analytics/subagents.ts
+++ b/lib/analytics/subagents.ts
@@ -36,6 +36,8 @@ type SubagentLifecycleEvent = BaseSubagentEvent & {
   undeliveredCount?: number;
   targetCount?: number;
   resultAvailable?: boolean;
+  resultRecoveryCount?: number;
+  resultSubmissionCount?: number;
 };
 
 const boundedCategory = (value: string | undefined): string | undefined =>
@@ -105,6 +107,8 @@ export const captureSubagentLifecycleEvent = (
     undelivered_count: fields.undeliveredCount,
     target_count: fields.targetCount,
     result_available: fields.resultAvailable,
+    result_recovery_count: fields.resultRecoveryCount,
+    result_submission_count: fields.resultSubmissionCount,
     environment: runtimeEnvironment(),
     service_version: serviceVersion(),
   });

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -40,11 +40,13 @@ import {
 import {
   buildMissingSubagentResultRecoveryMessage,
   canRecoverMissingSubagentResult,
+  getSubagentExplorationStepLimit,
   getSubagentProviderRetryDecision,
   getSubagentRecoveryErrorDiagnostics,
   getSubagentResultRecoveryRetryDecision,
   isTransientProviderCategory,
   pipeSubagentUiMessageStream,
+  shouldStartSubagentResultRecovery,
   type SubagentRecoveryErrorDiagnostics,
 } from "@/lib/ai/subagents/runtime-recovery";
 import { getSubagentProfileDefinition } from "@/lib/ai/subagents/profiles";
@@ -198,6 +200,8 @@ const captureCompletion = (
   costDollars: number,
   stepCount: number,
   durationMs: number,
+  resultRecoveryCount: number,
+  resultSubmissionCount: number,
 ) => {
   const base = {
     userId: row.user_id,
@@ -214,6 +218,8 @@ const captureCompletion = (
     durationMs,
     stepCount,
     costDollars,
+    resultRecoveryCount,
+    resultSubmissionCount,
   };
   captureSubagentLifecycleEvent("subagent_completed", {
     ...base,
@@ -466,6 +472,8 @@ export const subagentTask = task({
     let providerRetriesUsed = 0;
     let resultRecoveriesUsed = 0;
     let resultRecoveryRetriesUsed = 0;
+    let resultSubmissionAttempts = 0;
+    let generationAttempt = 0;
     let lastRecoveryErrorDiagnostics:
       SubagentRecoveryErrorDiagnostics | undefined;
     let deferredForParentUpdate = false;
@@ -616,6 +624,7 @@ export const subagentTask = task({
           try {
             const acceptResult = async (input: unknown) => {
               runtimeStage = "result_validation";
+              resultSubmissionAttempts += 1;
               const parsed = profile.finalResultTool.schema.parse(input);
               if (
                 Buffer.byteLength(JSON.stringify(parsed), "utf8") >
@@ -722,9 +731,10 @@ export const subagentTask = task({
               unguardedTools,
               assertRuntimeAuthorized,
             );
-            runtimeStage = "sandbox_setup";
+            runtimeStage = "sandbox_acquisition";
             await assertRuntimeAuthorized();
             const sandbox = await ensureSandbox();
+            runtimeStage = "sandbox_identity_validation";
             assertSubagentSandboxIdentity(sandbox, row.sandbox_identity);
 
             const provider = createTrackedProvider();
@@ -768,7 +778,54 @@ export const subagentTask = task({
               { role: "user", content: prompt },
             ];
             const parentUpdates = new Map<string, ModelMessage>();
-            let generationAttempt = 0;
+            const beginStructuredResultRecovery = async (
+              reason: "missing_result" | "reserved_step_budget",
+            ): Promise<boolean> => {
+              const remainingSteps = SUBAGENT_MAX_STEPS - stepCount;
+              const canRecover = canRecoverMissingSubagentResult(
+                resultRecoveriesUsed,
+                {
+                  aborted: activeAbort.signal.aborted,
+                  spendCapExceeded,
+                  hasStepsRemaining: remainingSteps > 0,
+                },
+              );
+              if (!canRecover) return false;
+
+              resultRecoveriesUsed += 1;
+              conversationMessages.push({
+                role: "user",
+                content: buildMissingSubagentResultRecoveryMessage(
+                  profile.finalResultTool.name,
+                ),
+              });
+              await recordSubagentRecovery({
+                subagentId: row.subagent_id,
+                triggerRunId: ctx.run.id,
+                kind: "result_recovery",
+              }).catch(() => false);
+              metadata.set("resultRecoveryCount", resultRecoveriesUsed);
+              triggerLogger.warn(
+                "[subagent] structured result recovery started",
+                {
+                  event: "subagent_structured_result_recovery_started",
+                  service: "hackerai-subagent",
+                  environment:
+                    process.env.TRIGGER_ENV ??
+                    process.env.NODE_ENV ??
+                    "unknown",
+                  user_id: row.user_id,
+                  subagent_id: row.subagent_id,
+                  parent_trigger_run_id: row.parent_trigger_run_id,
+                  trigger_run_id: ctx.run.id,
+                  recovery_reason: reason,
+                  result_recovery_count: resultRecoveriesUsed,
+                  step_count: stepCount,
+                  remaining_step_count: remainingSteps,
+                },
+              );
+              return true;
+            };
 
             while (
               !resultValue &&
@@ -776,12 +833,25 @@ export const subagentTask = task({
               !activeAbort.signal.aborted
             ) {
               runtimeStage = "generation";
+              let remainingSteps = SUBAGENT_MAX_STEPS - stepCount;
+              if (
+                shouldStartSubagentResultRecovery(resultRecoveriesUsed, {
+                  aborted: activeAbort.signal.aborted,
+                  spendCapExceeded,
+                  remainingSteps,
+                })
+              ) {
+                await beginStructuredResultRecovery("reserved_step_budget");
+                remainingSteps = SUBAGENT_MAX_STEPS - stepCount;
+              }
+              const structuredResultRecovery = resultRecoveriesUsed > 0;
+              const attemptStepLimit = structuredResultRecovery
+                ? remainingSteps
+                : getSubagentExplorationStepLimit(remainingSteps);
               generationAttempt += 1;
               let attemptError: unknown;
               let attemptResponseModel: string | undefined;
               let attemptUiMessages: UIMessage[] = [];
-              const remainingSteps = SUBAGENT_MAX_STEPS - stepCount;
-              const structuredResultRecovery = resultRecoveriesUsed > 0;
               const generation = streamText({
                 model: getGuardedLanguageModel(
                   activeModelName,
@@ -799,7 +869,7 @@ export const subagentTask = task({
                   : undefined,
                 stopWhen: [
                   hasToolCall(profile.finalResultTool.name),
-                  stepCountIs(remainingSteps),
+                  stepCountIs(attemptStepLimit),
                 ],
                 maxOutputTokens: profile.maxOutputTokens,
                 abortSignal: activeAbort.signal,
@@ -1162,34 +1232,19 @@ export const subagentTask = task({
                 continue;
               }
 
-              const canRecover = canRecoverMissingSubagentResult(
-                resultRecoveriesUsed,
-                {
-                  aborted: activeAbort.signal.aborted,
-                  spendCapExceeded,
-                  hasStepsRemaining: stepCount < SUBAGENT_MAX_STEPS,
-                },
-              );
-              if (!canRecover) break;
-
-              resultRecoveriesUsed += 1;
-              conversationMessages.push({
-                role: "user",
-                content: buildMissingSubagentResultRecoveryMessage(
-                  profile.finalResultTool.name,
-                ),
-              });
-              await recordSubagentRecovery({
-                subagentId: row.subagent_id,
-                triggerRunId: ctx.run.id,
-                kind: "result_recovery",
-              }).catch(() => false);
-              metadata.set("resultRecoveryCount", resultRecoveriesUsed);
+              if (!(await beginStructuredResultRecovery("missing_result"))) {
+                break;
+              }
             }
           } catch (error) {
             runtimeFailure = error;
             runtimeFailureStage = runtimeStage;
-            runtimeFailureCode ??= "runtime_error";
+            runtimeFailureCode ??=
+              runtimeStage === "sandbox_acquisition"
+                ? "sandbox_acquisition_failed"
+                : runtimeStage === "sandbox_identity_validation"
+                  ? "sandbox_identity_changed"
+                  : "runtime_error";
             throw error;
           }
         },
@@ -1297,8 +1352,13 @@ export const subagentTask = task({
           stepCount,
           costDollars,
           errorCategory: terminalFailure.code,
-          runtimeErrorCategory: runtimeDiagnostics?.category,
+          runtimeErrorCategory:
+            runtimeDiagnostics?.category === "unknown"
+              ? undefined
+              : runtimeDiagnostics?.category,
           failureStage: terminalFailureStage,
+          resultRecoveryCount: resultRecoveriesUsed,
+          resultSubmissionCount: resultSubmissionAttempts,
         });
         if (runtimeDiagnostics) {
           triggerLogger.error("[subagent] bounded recovery exhausted", {
@@ -1318,6 +1378,26 @@ export const subagentTask = task({
             provider_retry_count: providerRetriesUsed,
             result_recovery_count: resultRecoveriesUsed,
             result_recovery_retry_count: resultRecoveryRetriesUsed,
+            result_submission_count: resultSubmissionAttempts,
+          });
+        }
+        if (terminalFailure.code === "structured_result_missing") {
+          triggerLogger.error("[subagent] structured result missing", {
+            event: "subagent_structured_result_missing",
+            service: "hackerai-subagent",
+            environment:
+              process.env.TRIGGER_ENV ?? process.env.NODE_ENV ?? "unknown",
+            user_id: row.user_id,
+            subagent_id: row.subagent_id,
+            parent_trigger_run_id: row.parent_trigger_run_id,
+            trigger_run_id: ctx.run.id,
+            model: activeModelName,
+            step_count: stepCount,
+            generation_attempt_count: generationAttempt,
+            result_recovery_count: resultRecoveriesUsed,
+            result_recovery_retry_count: resultRecoveryRetriesUsed,
+            result_submission_count: resultSubmissionAttempts,
+            deadline_reminder_sent: deadlineReminderSent,
           });
         }
         metadata
@@ -1371,6 +1451,8 @@ export const subagentTask = task({
         costDollars,
         stepCount,
         Date.now() - startedAt,
+        resultRecoveriesUsed,
+        resultSubmissionAttempts,
       );
       return { subagentId: row.subagent_id, status: "completed" };
     } catch (error) {
@@ -1437,6 +1519,8 @@ export const subagentTask = task({
               ? undefined
               : outerRuntimeDiagnostics.category,
           failureStage: runtimeStage,
+          resultRecoveryCount: resultRecoveriesUsed,
+          resultSubmissionCount: resultSubmissionAttempts,
         });
       } else {
         const persistedOutput = await loadPersistedTerminalOutput(
@@ -1461,6 +1545,9 @@ export const subagentTask = task({
         error_name: outerRuntimeDiagnostics.errorName,
         error_code: outerRuntimeDiagnostics.errorCode,
         status_code: outerRuntimeDiagnostics.statusCode,
+        result_recovery_count: resultRecoveriesUsed,
+        result_recovery_retry_count: resultRecoveryRetriesUsed,
+        result_submission_count: resultSubmissionAttempts,
       });
       metadata
         .set("status", terminalFailure.status)

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -40,6 +40,7 @@ import {
 import {
   buildMissingSubagentResultRecoveryMessage,
   canRecoverMissingSubagentResult,
+  canStartSubagentResultRecoveryGeneration,
   getSubagentExplorationStepLimit,
   getSubagentProviderRetryDecision,
   getSubagentRecoveryErrorDiagnostics,
@@ -471,6 +472,7 @@ export const subagentTask = task({
     let deadlineReminderSent = false;
     let providerRetriesUsed = 0;
     let resultRecoveriesUsed = 0;
+    let resultRecoveryGenerationAttempts = 0;
     let resultRecoveryRetriesUsed = 0;
     let resultSubmissionAttempts = 0;
     let generationAttempt = 0;
@@ -845,6 +847,41 @@ export const subagentTask = task({
                 remainingSteps = SUBAGENT_MAX_STEPS - stepCount;
               }
               const structuredResultRecovery = resultRecoveriesUsed > 0;
+              if (structuredResultRecovery) {
+                if (
+                  !canStartSubagentResultRecoveryGeneration(
+                    resultRecoveryGenerationAttempts,
+                  )
+                ) {
+                  triggerLogger.error(
+                    "[subagent] structured result generation budget exhausted",
+                    {
+                      event:
+                        "subagent_structured_result_generation_budget_exhausted",
+                      service: "hackerai-subagent",
+                      environment:
+                        process.env.TRIGGER_ENV ??
+                        process.env.NODE_ENV ??
+                        "unknown",
+                      subagent_id: row.subagent_id,
+                      parent_trigger_run_id: row.parent_trigger_run_id,
+                      trigger_run_id: ctx.run.id,
+                      result_recovery_generation_count:
+                        resultRecoveryGenerationAttempts,
+                      result_recovery_retry_count: resultRecoveryRetriesUsed,
+                      result_submission_count: resultSubmissionAttempts,
+                      deferred_for_parent_update: deferredForParentUpdate,
+                      step_count: stepCount,
+                    },
+                  );
+                  break;
+                }
+                resultRecoveryGenerationAttempts += 1;
+                metadata.set(
+                  "resultRecoveryGenerationCount",
+                  resultRecoveryGenerationAttempts,
+                );
+              }
               const attemptStepLimit = structuredResultRecovery
                 ? remainingSteps
                 : getSubagentExplorationStepLimit(remainingSteps);
@@ -1377,6 +1414,7 @@ export const subagentTask = task({
             status_code: runtimeDiagnostics.statusCode,
             provider_retry_count: providerRetriesUsed,
             result_recovery_count: resultRecoveriesUsed,
+            result_recovery_generation_count: resultRecoveryGenerationAttempts,
             result_recovery_retry_count: resultRecoveryRetriesUsed,
             result_submission_count: resultSubmissionAttempts,
           });
@@ -1395,6 +1433,7 @@ export const subagentTask = task({
             step_count: stepCount,
             generation_attempt_count: generationAttempt,
             result_recovery_count: resultRecoveriesUsed,
+            result_recovery_generation_count: resultRecoveryGenerationAttempts,
             result_recovery_retry_count: resultRecoveryRetriesUsed,
             result_submission_count: resultSubmissionAttempts,
             deadline_reminder_sent: deadlineReminderSent,
@@ -1546,6 +1585,7 @@ export const subagentTask = task({
         error_code: outerRuntimeDiagnostics.errorCode,
         status_code: outerRuntimeDiagnostics.statusCode,
         result_recovery_count: resultRecoveriesUsed,
+        result_recovery_generation_count: resultRecoveryGenerationAttempts,
         result_recovery_retry_count: resultRecoveryRetriesUsed,
         result_submission_count: resultSubmissionAttempts,
       });


### PR DESCRIPTION
## Summary

- accept AWS MicroVM rotation as the same user-scoped workspace while preserving provider isolation
- reserve the final two subagent steps for structured-result recovery instead of exhausting all 50 exploratory steps
- add bounded recovery/submission telemetry and sandbox-acquisition diagnostics
- surface regional S3 metadata permission failures instead of opaque `UnknownError` output

## Root causes

- physical AWS MicroVM replacement changed the encoded sandbox identity even though the logical user workspace stayed the same
- exploratory generation could consume the full global step budget, leaving the existing structured-result recovery path unreachable
- the durable-workspace Trigger worker was deployed before its Convex functions and production environment were deployed
- the production S3 principal still lacks regional workspace-prefix permissions

## Validation

- `pnpm typecheck`
- focused Jest: 5 suites, 53 tests
- focused ESLint for all changed files
- `git diff --check origin/main...HEAD`
- Convex production deploy completed with no deleted indexes
- Trigger production worker `20260824.17` deployed and promoted

## Manual verification

1. Grant `arn:aws:iam::630609837323:user/vercel-convex-s3-user` `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on `users/*/microvm-workspace/v1/*` in all three regional artifact buckets.
2. Grant prefix-scoped `s3:ListBucket` on each bucket so a missing workspace returns 404 instead of 403.
3. Start an AWS Cloud Agent run for a user without an archive and confirm sandbox acquisition succeeds.
4. Rotate the physical MicroVM, delegate a subagent, and confirm the child accepts the replacement workspace.
5. Run a subagent that reaches its exploration limit and confirm structured-result recovery starts before step 50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud storage access-denied errors with clearer region, permission, and status details.
  * Improved AI task recovery when structured results are missing or generation attempts fail.
  * Improved sandbox handling to support valid cloud VM rotation without false identity errors.
* **Reliability**
  * Added safeguards for step limits and bounded recovery attempts to help tasks complete predictably.
  * Added clearer failure diagnostics for sandbox setup and result submission issues.
* **Analytics**
  * Added tracking for result submissions and recovery attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->