### PR TITLE
Prevent large chat code blocks from freezing

### DIFF
--- a/__mocks__/streamdown.tsx
+++ b/__mocks__/streamdown.tsx
@@ -1,8 +1,20 @@
 import React from "react";
 
+export const useIsCodeFenceIncomplete = () => false;
+
 // Simple mock for streamdown
-export const Streamdown = ({ children }: { children: string }) => {
-  return <div data-testid="streamdown">{children}</div>;
+export const Streamdown = ({
+  children,
+  isAnimating = false,
+}: {
+  children: string;
+  isAnimating?: boolean;
+}) => {
+  return (
+    <div data-animating={String(isAnimating)} data-testid="streamdown">
+      {children}
+    </div>
+  );
 };
 
 export default Streamdown;

--- a/app/components/CodeHighlight.tsx
+++ b/app/components/CodeHighlight.tsx
@@ -37,7 +37,6 @@ const CodeHighlightImpl = ({
   const codeContent = String(children);
 
   const [isWrapped, setIsWrapped] = useState(false);
-  const [forceHighlight, setForceHighlight] = useState(false);
   const isIncomplete = useIsCodeFenceIncomplete();
 
   const isInline: boolean | undefined = node
@@ -60,15 +59,11 @@ const CodeHighlightImpl = ({
     [codeContent, isIncomplete],
   );
   const shouldUsePlainText =
-    !isLanguageSupported ||
-    isLargeStreamingBlock ||
-    (isOversizedCompletedBlock && !forceHighlight);
-  const canForceHighlight =
-    isLanguageSupported && isOversizedCompletedBlock && !forceHighlight;
+    !isLanguageSupported || isLargeStreamingBlock || isOversizedCompletedBlock;
   const highlightMode = shouldUsePlainText
     ? isLargeStreamingBlock
       ? "plain-streaming"
-      : isOversizedCompletedBlock && !forceHighlight
+      : isOversizedCompletedBlock
         ? "plain-large"
         : "plain-unsupported"
     : "highlighted";
@@ -100,8 +95,6 @@ const CodeHighlightImpl = ({
           isWrapped={isWrapped}
           onToggleWrap={handleToggleWrap}
           variant="codeblock"
-          showHighlight={canForceHighlight}
-          onHighlight={() => setForceHighlight(true)}
         />
       </div>
 

--- a/app/components/CodeHighlight.tsx
+++ b/app/components/CodeHighlight.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from "react";
 import { memo, useState, useMemo } from "react";
 import ShikiHighlighter, { isInlineCode, type Element } from "react-shiki";
+import { useIsCodeFenceIncomplete } from "streamdown";
 import { CodeActionButtons } from "@/components/ui/code-action-buttons";
 import {
-  shouldUseShikiHighlighter,
+  isLanguageSupported as isShikiLanguageSupported,
   ShikiErrorBoundary,
 } from "@/lib/utils/shiki";
 
@@ -12,6 +13,18 @@ interface CodeHighlightProps {
   children?: ReactNode | undefined;
   node?: unknown;
 }
+
+export const MAX_STREAMING_HIGHLIGHT_CHARS = 20_000;
+export const MAX_HIGHLIGHT_CHARS = 100_000;
+export const MAX_HIGHLIGHT_LINES = 2_000;
+
+const exceedsLineLimit = (code: string, limit: number): boolean => {
+  let lines = 1;
+  for (let index = 0; index < code.length; index += 1) {
+    if (code.charCodeAt(index) === 10 && ++lines > limit) return true;
+  }
+  return false;
+};
 
 const CodeHighlightImpl = ({
   className,
@@ -24,22 +37,51 @@ const CodeHighlightImpl = ({
   const codeContent = String(children);
 
   const [isWrapped, setIsWrapped] = useState(false);
+  const [forceHighlight, setForceHighlight] = useState(false);
+  const isIncomplete = useIsCodeFenceIncomplete();
 
   const isInline: boolean | undefined = node
     ? isInlineCode(node as Element)
     : undefined;
 
-  // Check if language is supported by Shiki
-  const shouldUsePlainText = useMemo(() => {
-    return !shouldUseShikiHighlighter(language);
+  const isLanguageSupported = useMemo(() => {
+    return isShikiLanguageSupported(language);
   }, [language]);
+
+  // Avoid scanning every growing block for newlines. Character length gives us
+  // an O(1) streaming guard; the line limit is evaluated once the fence closes.
+  const isLargeStreamingBlock =
+    isIncomplete && codeContent.length > MAX_STREAMING_HIGHLIGHT_CHARS;
+  const isOversizedCompletedBlock = useMemo(
+    () =>
+      !isIncomplete &&
+      (codeContent.length > MAX_HIGHLIGHT_CHARS ||
+        exceedsLineLimit(codeContent, MAX_HIGHLIGHT_LINES)),
+    [codeContent, isIncomplete],
+  );
+  const shouldUsePlainText =
+    !isLanguageSupported ||
+    isLargeStreamingBlock ||
+    (isOversizedCompletedBlock && !forceHighlight);
+  const canForceHighlight =
+    isLanguageSupported && isOversizedCompletedBlock && !forceHighlight;
+  const highlightMode = shouldUsePlainText
+    ? isLargeStreamingBlock
+      ? "plain-streaming"
+      : isOversizedCompletedBlock && !forceHighlight
+        ? "plain-large"
+        : "plain-unsupported"
+    : "highlighted";
 
   const handleToggleWrap = () => {
     setIsWrapped(!isWrapped);
   };
 
   return !isInline ? (
-    <div className="shiki not-prose relative rounded-lg bg-card border border-border my-2 overflow-hidden">
+    <div
+      className="shiki not-prose relative rounded-lg bg-card border border-border my-2 overflow-hidden"
+      data-highlight-mode={highlightMode}
+    >
       {/* Menu bar */}
       <div className="flex items-center justify-between px-4 py-2 bg-muted border-b border-border">
         {/* Left side - Language */}
@@ -58,6 +100,8 @@ const CodeHighlightImpl = ({
           isWrapped={isWrapped}
           onToggleWrap={handleToggleWrap}
           variant="codeblock"
+          showHighlight={canForceHighlight}
+          onHighlight={() => setForceHighlight(true)}
         />
       </div>
 
@@ -91,6 +135,7 @@ const CodeHighlightImpl = ({
               language={language}
               theme="houston"
               delay={150}
+              engine="javascript"
               addDefaultStyles={false}
               showLanguage={false}
               className={`shiki not-prose relative bg-card text-sm font-[450] text-card-foreground [&_pre]:!bg-transparent [&_pre]:px-[1em] [&_pre]:py-[1em] [&_pre]:rounded-none [&_pre]:m-0 ${

--- a/app/components/MemoizedMarkdown.tsx
+++ b/app/components/MemoizedMarkdown.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Streamdown } from "streamdown";
+import { Streamdown, type Components } from "streamdown";
 import { CodeHighlight } from "./CodeHighlight";
 import { MarkdownTable } from "./MarkdownTable";
 import { isTauriEnvironment, revealFileInDir } from "@/app/hooks/useTauri";
@@ -17,53 +17,61 @@ function isLocalFilePath(href: string | undefined): boolean {
 
 interface MemoizedMarkdownProps {
   content: string;
+  isAnimating?: boolean;
 }
 
-export const MemoizedMarkdown = memo(({ content }: MemoizedMarkdownProps) => {
-  return (
-    <Streamdown
-      components={{
-        code: CodeHighlight,
-        table: MarkdownTable,
-        a({ children, href }) {
-          // Local file paths: clickable in Tauri, plain text on web
-          if (isLocalFilePath(href)) {
-            const decodedPath = decodeURIComponent(href!);
-            if (isTauriEnvironment()) {
-              return (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={() => revealFileInDir(decodedPath)}
-                      className="text-link hover:text-link/80 hover:underline transition-colors duration-200 cursor-pointer inline"
-                    >
-                      {children}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">{decodedPath}</TooltipContent>
-                </Tooltip>
-              );
-            }
-            // Web: render as plain text, not a navigable link
-            return <span className="text-muted-foreground">{children}</span>;
-          }
-          return (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-link hover:text-link/80 hover:underline transition-colors duration-200"
+const MarkdownLink: NonNullable<Components["a"]> = ({ children, href }) => {
+  // Local file paths: clickable in Tauri, plain text on web
+  if (isLocalFilePath(href)) {
+    const decodedPath = decodeURIComponent(href!);
+    if (isTauriEnvironment()) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => revealFileInDir(decodedPath)}
+              className="text-link hover:text-link/80 hover:underline transition-colors duration-200 cursor-pointer inline"
             >
               {children}
-            </a>
-          );
-        },
-      }}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">{decodedPath}</TooltipContent>
+        </Tooltip>
+      );
+    }
+    // Web: render as plain text, not a navigable link
+    return <span className="text-muted-foreground">{children}</span>;
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-link hover:text-link/80 hover:underline transition-colors duration-200"
     >
-      {content}
-    </Streamdown>
+      {children}
+    </a>
   );
-});
+};
+
+// Streamdown includes component identity in its per-block memoization check.
+// Keep this map stable so appending one block does not re-render completed
+// code blocks earlier in the same streaming response.
+const MARKDOWN_COMPONENTS: Components = {
+  code: CodeHighlight,
+  table: MarkdownTable,
+  a: MarkdownLink,
+};
+
+export const MemoizedMarkdown = memo(
+  ({ content, isAnimating = false }: MemoizedMarkdownProps) => {
+    return (
+      <Streamdown components={MARKDOWN_COMPONENTS} isAnimating={isAnimating}>
+        {content}
+      </Streamdown>
+    );
+  },
+);
 
 MemoizedMarkdown.displayName = "MemoizedMarkdown";

--- a/app/components/MessagePartHandler.tsx
+++ b/app/components/MessagePartHandler.tsx
@@ -220,7 +220,12 @@ export const MessagePartHandler = memo(function MessagePartHandler({
       }
 
       // For assistant messages, use memoized markdown rendering
-      return <MemoizedMarkdown content={text} />;
+      return (
+        <MemoizedMarkdown
+          content={text}
+          isAnimating={status === "streaming" && isLastMessage === true}
+        />
+      );
     }
 
     case "reasoning":

--- a/app/components/__tests__/CodeHighlight.test.tsx
+++ b/app/components/__tests__/CodeHighlight.test.tsx
@@ -1,17 +1,37 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
-import { CodeHighlight } from "../CodeHighlight";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  CodeHighlight,
+  MAX_HIGHLIGHT_CHARS,
+  MAX_HIGHLIGHT_LINES,
+  MAX_STREAMING_HIGHLIGHT_CHARS,
+} from "../CodeHighlight";
+
+let mockInlineCode = true;
+let mockCodeFenceIncomplete = false;
+let mockShikiRenderCount = 0;
 
 jest.mock("react-shiki", () => ({
   __esModule: true,
   default: ({ children }: { children?: React.ReactNode }) => {
     const React = require("react");
-    return React.createElement("div", null, children);
+    mockShikiRenderCount += 1;
+    return React.createElement("div", { "data-testid": "shiki" }, children);
   },
-  isInlineCode: () => true,
+  isInlineCode: () => mockInlineCode,
+}));
+
+jest.mock("streamdown", () => ({
+  useIsCodeFenceIncomplete: () => mockCodeFenceIncomplete,
 }));
 
 describe("CodeHighlight", () => {
+  beforeEach(() => {
+    mockInlineCode = true;
+    mockCodeFenceIncomplete = false;
+    mockShikiRenderCount = 0;
+  });
+
   it("wraps long inline code tokens instead of forcing horizontal scrolling", () => {
     render(
       <CodeHighlight node={{ type: "element", tagName: "code" } as any}>
@@ -24,5 +44,93 @@ describe("CodeHighlight", () => {
     expect(code).toHaveClass("whitespace-pre-wrap");
     expect(code).toHaveClass("break-words");
     expect(code).toHaveClass("[overflow-wrap:anywhere]");
+  });
+
+  it("keeps large incomplete code fences plain while they stream", () => {
+    mockInlineCode = false;
+    mockCodeFenceIncomplete = true;
+    const code = "x".repeat(MAX_STREAMING_HIGHLIGHT_CHARS + 1);
+
+    const { container } = render(
+      <CodeHighlight
+        className="language-js"
+        node={{ type: "element", tagName: "code" } as any}
+      >
+        {code}
+      </CodeHighlight>,
+    );
+
+    expect(
+      container.querySelector('[data-highlight-mode="plain-streaming"]'),
+    ).toBeInTheDocument();
+    expect(container.querySelector("pre > code")).toHaveTextContent(code);
+    expect(mockShikiRenderCount).toBe(0);
+  });
+
+  it("highlights a completed block after the streaming guard releases", () => {
+    mockInlineCode = false;
+    const code = "const answer = 42;";
+
+    const { container } = render(
+      <CodeHighlight
+        className="language-js"
+        node={{ type: "element", tagName: "code" } as any}
+      >
+        {code}
+      </CodeHighlight>,
+    );
+
+    expect(
+      container.querySelector('[data-highlight-mode="highlighted"]'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("shiki")).toHaveTextContent(code);
+  });
+
+  it("keeps oversized completed blocks plain until highlighting is requested", () => {
+    mockInlineCode = false;
+    const code = "x".repeat(MAX_HIGHLIGHT_CHARS + 1);
+
+    const { container } = render(
+      <CodeHighlight
+        className="language-js"
+        node={{ type: "element", tagName: "code" } as any}
+      >
+        {code}
+      </CodeHighlight>,
+    );
+
+    expect(
+      container.querySelector('[data-highlight-mode="plain-large"]'),
+    ).toBeInTheDocument();
+    expect(mockShikiRenderCount).toBe(0);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Enable syntax highlighting" }),
+    );
+
+    expect(
+      container.querySelector('[data-highlight-mode="highlighted"]'),
+    ).toBeInTheDocument();
+    expect(mockShikiRenderCount).toBe(1);
+  });
+
+  it("also bounds completed blocks with extremely many short lines", () => {
+    mockInlineCode = false;
+    const code = "x\n".repeat(MAX_HIGHLIGHT_LINES);
+
+    const { container } = render(
+      <CodeHighlight
+        className="language-js"
+        node={{ type: "element", tagName: "code" } as any}
+      >
+        {code}
+      </CodeHighlight>,
+    );
+
+    expect(code.length).toBeLessThan(MAX_HIGHLIGHT_CHARS);
+    expect(
+      container.querySelector('[data-highlight-mode="plain-large"]'),
+    ).toBeInTheDocument();
+    expect(mockShikiRenderCount).toBe(0);
   });
 });

--- a/app/components/__tests__/CodeHighlight.test.tsx
+++ b/app/components/__tests__/CodeHighlight.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import {
   CodeHighlight,
   MAX_HIGHLIGHT_CHARS,
@@ -86,7 +86,7 @@ describe("CodeHighlight", () => {
     expect(screen.getByTestId("shiki")).toHaveTextContent(code);
   });
 
-  it("keeps oversized completed blocks plain until highlighting is requested", () => {
+  it("keeps oversized completed blocks plain without a highlighting override", () => {
     mockInlineCode = false;
     const code = "x".repeat(MAX_HIGHLIGHT_CHARS + 1);
 
@@ -103,15 +103,9 @@ describe("CodeHighlight", () => {
       container.querySelector('[data-highlight-mode="plain-large"]'),
     ).toBeInTheDocument();
     expect(mockShikiRenderCount).toBe(0);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Enable syntax highlighting" }),
-    );
-
     expect(
-      container.querySelector('[data-highlight-mode="highlighted"]'),
-    ).toBeInTheDocument();
-    expect(mockShikiRenderCount).toBe(1);
+      screen.queryByRole("button", { name: "Enable syntax highlighting" }),
+    ).not.toBeInTheDocument();
   });
 
   it("also bounds completed blocks with extremely many short lines", () => {

--- a/app/components/__tests__/MemoizedMarkdown.test.tsx
+++ b/app/components/__tests__/MemoizedMarkdown.test.tsx
@@ -1,0 +1,70 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { MemoizedMarkdown } from "../MemoizedMarkdown";
+
+const mockComponentMaps: unknown[] = [];
+
+jest.mock("streamdown", () => ({
+  Streamdown: ({
+    children,
+    components,
+    isAnimating,
+  }: {
+    children: string;
+    components: unknown;
+    isAnimating: boolean;
+  }) => {
+    mockComponentMaps.push(components);
+    return (
+      <div data-animating={String(isAnimating)} data-testid="streamdown">
+        {children}
+      </div>
+    );
+  },
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  isTauriEnvironment: () => false,
+  revealFileInDir: jest.fn(),
+}));
+
+describe("MemoizedMarkdown", () => {
+  beforeEach(() => {
+    mockComponentMaps.length = 0;
+  });
+
+  it("keeps Streamdown component identities stable across content updates", () => {
+    const { rerender } = render(
+      <MemoizedMarkdown content="first block" isAnimating />,
+    );
+
+    rerender(
+      <MemoizedMarkdown content="first block\n\nnext block" isAnimating />,
+    );
+
+    expect(mockComponentMaps.length).toBeGreaterThanOrEqual(2);
+    expect(
+      mockComponentMaps.every(
+        (componentMap) => componentMap === mockComponentMaps[0],
+      ),
+    ).toBe(true);
+  });
+
+  it("forwards streaming state to Streamdown", () => {
+    const { rerender } = render(
+      <MemoizedMarkdown content="streaming" isAnimating />,
+    );
+
+    expect(screen.getByTestId("streamdown")).toHaveAttribute(
+      "data-animating",
+      "true",
+    );
+
+    rerender(<MemoizedMarkdown content="complete" isAnimating={false} />);
+
+    expect(screen.getByTestId("streamdown")).toHaveAttribute(
+      "data-animating",
+      "false",
+    );
+  });
+});

--- a/app/components/__tests__/MessagePartHandler.subagents.test.ts
+++ b/app/components/__tests__/MessagePartHandler.subagents.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, it } from "@jest/globals";
-import { areMessagePartHandlerPropsEqual } from "../MessagePartHandler";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  areMessagePartHandlerPropsEqual,
+  MessagePartHandler,
+} from "../MessagePartHandler";
+
+jest.mock("../MemoizedMarkdown", () => ({
+  MemoizedMarkdown: ({
+    content,
+    isAnimating,
+  }: {
+    content: string;
+    isAnimating: boolean;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-animating": String(isAnimating), "data-testid": "markdown" },
+      content,
+    ),
+}));
 
 const basePart = {
   type: "tool-create_agent",
@@ -36,5 +56,43 @@ describe("MessagePartHandler subagent memoization", () => {
 
     expect(areMessagePartHandlerPropsEqual(previous, next)).toBe(false);
     expect(areMessagePartHandlerPropsEqual(next, next)).toBe(true);
+  });
+
+  it("marks only the latest actively streaming assistant markdown as animating", () => {
+    const message = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "streaming code" }],
+    } as any;
+
+    const { rerender } = render(
+      React.createElement(MessagePartHandler, {
+        message,
+        part: message.parts[0],
+        partIndex: 0,
+        status: "streaming",
+        isLastMessage: true,
+      }),
+    );
+
+    expect(screen.getByTestId("markdown")).toHaveAttribute(
+      "data-animating",
+      "true",
+    );
+
+    rerender(
+      React.createElement(MessagePartHandler, {
+        message,
+        part: message.parts[0],
+        partIndex: 0,
+        status: "streaming",
+        isLastMessage: false,
+      }),
+    );
+
+    expect(screen.getByTestId("markdown")).toHaveAttribute(
+      "data-animating",
+      "false",
+    );
   });
 });

--- a/components/ui/code-action-buttons.tsx
+++ b/components/ui/code-action-buttons.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Download, Copy, Check, WrapText } from "lucide-react";
+import { Download, Copy, Check, WrapText, Braces } from "lucide-react";
 import {
   Tooltip,
   TooltipTrigger,
@@ -19,6 +19,8 @@ interface CodeActionButtonsProps {
   showDownload?: boolean;
   showCopy?: boolean;
   showWrap?: boolean;
+  showHighlight?: boolean;
+  onHighlight?: () => void;
 }
 
 export const CodeActionButtons: React.FC<CodeActionButtonsProps> = ({
@@ -31,6 +33,8 @@ export const CodeActionButtons: React.FC<CodeActionButtonsProps> = ({
   showDownload = true,
   showCopy = true,
   showWrap = true,
+  showHighlight = false,
+  onHighlight,
 }) => {
   const [copied, setCopied] = useState(false);
 
@@ -81,6 +85,24 @@ export const CodeActionButtons: React.FC<CodeActionButtonsProps> = ({
     <div
       className={`flex items-center ${variant === "sidebar" ? "gap-0.5" : "space-x-2"}`}
     >
+      {showHighlight && onHighlight && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onHighlight}
+              className={getButtonClasses()}
+              aria-label="Enable syntax highlighting"
+            >
+              <Braces size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Enable syntax highlighting (may be slow)
+          </TooltipContent>
+        </Tooltip>
+      )}
+
       {showDownload && (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/components/ui/code-action-buttons.tsx
+++ b/components/ui/code-action-buttons.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Download, Copy, Check, WrapText, Braces } from "lucide-react";
+import { Download, Copy, Check, WrapText } from "lucide-react";
 import {
   Tooltip,
   TooltipTrigger,
@@ -19,8 +19,6 @@ interface CodeActionButtonsProps {
   showDownload?: boolean;
   showCopy?: boolean;
   showWrap?: boolean;
-  showHighlight?: boolean;
-  onHighlight?: () => void;
 }
 
 export const CodeActionButtons: React.FC<CodeActionButtonsProps> = ({
@@ -33,8 +31,6 @@ export const CodeActionButtons: React.FC<CodeActionButtonsProps> = ({
   showDownload = true,
   showCopy = true,
   showWrap = true,
-  showHighlight = false,
-  onHighlight,
 }) => {
   const [copied, setCopied] = useState(false);
 
@@ -85,24 +81,6 @@ export const CodeActionButtons: React.FC<CodeActionButtonsProps> = ({
     <div
       className={`flex items-center ${variant === "sidebar" ? "gap-0.5" : "space-x-2"}`}
     >
-      {showHighlight && onHighlight && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={onHighlight}
-              className={getButtonClasses()}
-              aria-label="Enable syntax highlighting"
-            >
-              <Braces size={14} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            Enable syntax highlighting (may be slow)
-          </TooltipContent>
-        </Tooltip>
-      )}
-
       {showDownload && (
         <Tooltip>
           <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

- keep Streamdown component identities stable so completed markdown blocks remain memoized during streaming
- render large active code fences and oversized completed blocks as plain text to bound main-thread Shiki work
- keep the large-block safeguard automatic with no extra highlighting control or risky override
- use the JavaScript Shiki engine and cover streaming propagation, memoization, character guards, and line guards with regression tests

## Validation

- 424 Jest suites passed, 4,360 tests passed
- `pnpm run typecheck`
- `pnpm run lint` (zero errors; seven pre-existing unrelated warnings)
- Prettier and `git diff --check`
- local Playwright verification: oversized completed block rendered in `plain-large` mode with only Download, Enable text wrapping, and Copy; no highlighting override, browser console errors, or Next.js overlay

## Manual verification

1. Open a chat containing a normal fenced code block and confirm syntax highlighting still appears.
2. Stream a code fence beyond 20,000 characters and confirm it remains responsive and switches to plain rendering while incomplete.
3. Open a completed block over 100,000 characters or 2,000 lines and confirm it stays plain with Download, Wrap, and Copy available and no highlighting override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved streaming Markdown display with animation state applied only to the latest incoming assistant message.
  - Added safer handling for large or incomplete code blocks, displaying plain text when highlighting limits are exceeded.
  - Enhanced code highlighting support for completed blocks while preserving readable fallback behavior.
  - Improved link handling: local files reveal appropriately in the desktop app, while external links open securely in new tabs.

- **Bug Fixes**
  - Prevented unnecessary code highlighting and inconsistent rendering during streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->