### PR TITLE
Fix terminal output persistence across sandboxes

### DIFF
--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -166,6 +166,20 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     session_id: sessionId,
     log_budget: context.ptyParserLogBudget,
   });
+  const buildTerminalOutputPersistenceTelemetry = () => ({
+    service: context.triggerRunId
+      ? ("agent-long" as const)
+      : ("chat-handler" as const),
+    environment:
+      process.env.TRIGGER_ENV ??
+      process.env.VERCEL_ENV ??
+      process.env.NODE_ENV ??
+      "unknown",
+    requestId: context.triggerRunId ?? process.env.VERCEL_REQUEST_ID ?? null,
+    triggerRunId: context.triggerRunId ?? null,
+    chatId: context.chatId,
+    userId: context.userID,
+  });
   const logSandboxReadinessRecovery = (args: {
     level: "info" | "warn" | "error";
     outcome: "started" | "reconnected" | "failed" | "skipped_unavailable";
@@ -1299,6 +1313,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                       sandbox: sandboxInstance,
                       terminalWriter: createTerminalWriter,
                       scopeId: chatId,
+                      telemetry: buildTerminalOutputPersistenceTelemetry(),
                     });
                     if (saveMsg) {
                       outputWithSaveInfo = saveMsg + "\n" + outputWithSaveInfo;
@@ -1364,6 +1379,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                         sandbox: sandboxInstance,
                         terminalWriter: createTerminalWriter,
                         scopeId: chatId,
+                        telemetry: buildTerminalOutputPersistenceTelemetry(),
                       });
                       if (saveMsg) {
                         outputWithSaveInfo =

--- a/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
+++ b/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it, jest } from "@jest/globals";
+import { phLogger } from "@/lib/posthog/server";
 import {
+  classifyTerminalOutputPersistenceFailure,
   MAX_SAVED_TERMINAL_OUTPUT_FILES,
   saveFullOutputToFile,
 } from "../terminal-output-saver";
@@ -13,12 +15,20 @@ const CHAT_KEY = createHash("sha256")
 
 const createSandbox = ({
   sandboxKind,
+  cloudProvider,
+  nativeFileRelay = false,
+  statSizeBytes,
   listedFiles = [],
 }: {
   sandboxKind?: "centrifugo";
+  cloudProvider?: "aws-lambda-microvm";
+  nativeFileRelay?: boolean;
+  statSizeBytes?: number;
   listedFiles?: Array<{ name: string }>;
 } = {}) => ({
   ...(sandboxKind ? { sandboxKind } : {}),
+  ...(cloudProvider ? { getCloudProvider: () => cloudProvider } : {}),
+  ...(sandboxKind ? { supportsNativeFileRelay: () => nativeFileRelay } : {}),
   commands: {
     run: jest.fn(async () => ({
       stdout: "",
@@ -27,6 +37,9 @@ const createSandbox = ({
     })),
   },
   files: {
+    ...(statSizeBytes !== undefined
+      ? { stat: jest.fn(async () => ({ sizeBytes: statSizeBytes })) }
+      : {}),
     write: jest.fn(async () => undefined),
     list: jest.fn(async () => listedFiles),
     remove: jest.fn(async () => undefined),
@@ -69,6 +82,149 @@ describe("saveFullOutputToFile", () => {
       new RegExp(`^/tmp/terminal_full_output/chat-${CHAT_KEY}/`),
     );
     jest.useRealTimers();
+  });
+
+  it("stores AWS Lambda MicroVM output under the direct mutation root", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const sandbox = createSandbox({
+      sandboxKind: "centrifugo",
+      cloudProvider: "aws-lambda-microvm",
+    });
+
+    const savedPath = await saveFullOutputToFile(
+      sandbox as any,
+      "full output",
+      CHAT_ID,
+    );
+
+    expect(savedPath).toBe(
+      `/home/user/terminal_full_output/chat-${CHAT_KEY}/2026-07-16_15-30-45_123Z.txt`,
+    );
+    expect(sandbox.commands.run).toHaveBeenCalledWith(
+      `mkdir -p /home/user/terminal_full_output/chat-${CHAT_KEY}`,
+      { timeoutMs: 5000 },
+    );
+    jest.useRealTimers();
+  });
+
+  it("retries one transient desktop relay failure and records recovery", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const sandbox = createSandbox({
+      sandboxKind: "centrifugo",
+      nativeFileRelay: true,
+    });
+    sandbox.files.write
+      .mockRejectedValueOnce(new Error("Load failed"))
+      .mockResolvedValueOnce(undefined);
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});
+
+    const savePromise = saveFullOutputToFile(
+      sandbox as any,
+      "full output",
+      CHAT_ID,
+      {
+        service: "agent-long",
+        environment: "prod",
+        requestId: "run-1",
+        triggerRunId: "run-1",
+        chatId: CHAT_ID,
+      },
+    );
+    await jest.advanceTimersByTimeAsync(250);
+
+    await expect(savePromise).resolves.toContain(
+      `/tmp/terminal_full_output/chat-${CHAT_KEY}/`,
+    );
+    expect(sandbox.files.write).toHaveBeenCalledTimes(2);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"result":"recovered"'),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"failure_category":"transport"'),
+    );
+    expect(eventSpy).toHaveBeenCalledWith(
+      "terminal_output_persistence_failure",
+      expect.objectContaining({
+        provider: "desktop",
+        attempt_count: 2,
+        result: "recovered",
+        failure_category: "transport",
+        retry_decision: "retried",
+      }),
+    );
+
+    infoSpy.mockRestore();
+    eventSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("does not repeat a completed desktop relay timeout", async () => {
+    const sandbox = createSandbox({
+      sandboxKind: "centrifugo",
+      nativeFileRelay: true,
+    });
+    sandbox.files.write.mockRejectedValueOnce(
+      new Error(
+        "Desktop file request timed out after 120000ms path=/private/user/evidence.txt",
+      ),
+    );
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});
+
+    await expect(
+      saveFullOutputToFile(sandbox as any, "private command output", CHAT_ID, {
+        service: "chat-handler",
+        environment: "production",
+        requestId: "request-1",
+        chatId: CHAT_ID,
+      }),
+    ).resolves.toBeNull();
+
+    expect(sandbox.files.write).toHaveBeenCalledTimes(1);
+    const payload = String(warnSpy.mock.calls[0]?.[0]);
+    expect(payload).toContain('"failure_category":"timeout"');
+    expect(payload).toContain('"retry_decision":"skipped_timeout"');
+    expect(payload).not.toContain("private command output");
+    expect(payload).not.toContain("/private/user/evidence.txt");
+    expect(eventSpy).toHaveBeenCalledWith(
+      "terminal_output_persistence_failure",
+      expect.objectContaining({
+        provider: "desktop",
+        attempt_count: 1,
+        result: "failed",
+        failure_category: "timeout",
+        retry_decision: "skipped_timeout",
+      }),
+    );
+
+    warnSpy.mockRestore();
+    eventSpy.mockRestore();
+  });
+
+  it("accepts a completed desktop write whose timeout only lost the ack", async () => {
+    const output = "full output";
+    const sandbox = createSandbox({
+      sandboxKind: "centrifugo",
+      nativeFileRelay: true,
+      statSizeBytes: Buffer.byteLength(output),
+    });
+    sandbox.files.write.mockRejectedValueOnce(
+      new Error("Desktop file request timed out after 120000ms"),
+    );
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+
+    await expect(
+      saveFullOutputToFile(sandbox as any, output, CHAT_ID),
+    ).resolves.toContain(`/tmp/terminal_full_output/chat-${CHAT_KEY}/`);
+
+    expect(sandbox.files.write).toHaveBeenCalledTimes(1);
+    expect((sandbox.files as any).stat).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"retry_decision":"verified_after_timeout"'),
+    );
+
+    infoSpy.mockRestore();
   });
 
   it("uses an unscoped directory when no chat identifier is available", async () => {
@@ -134,11 +290,30 @@ describe("saveFullOutputToFile", () => {
       `/home/user/terminal_full_output/chat-${CHAT_KEY}/`,
     );
     expect(warnSpy).toHaveBeenCalledWith(
-      "[Terminal Command] Failed to prune old saved terminal output:",
-      expect.any(Error),
+      expect.stringContaining(
+        '"event":"terminal_output_retention_prune_failed"',
+      ),
     );
 
     warnSpy.mockRestore();
     jest.useRealTimers();
+  });
+});
+
+describe("classifyTerminalOutputPersistenceFailure", () => {
+  it.each([
+    ["Desktop file request timed out after 120000ms", "timeout"],
+    ["Load failed", "transport"],
+    [
+      "Local sandbox connection is not subscribed to the file relay",
+      "relay_unavailable",
+    ],
+    ["Direct file mutation path is outside its allowed root", "permission"],
+    ["ENOSPC: no space left on device", "filesystem"],
+    ["opaque failure", "unknown"],
+  ])("classifies %s as %s", (message, category) => {
+    expect(classifyTerminalOutputPersistenceFailure(new Error(message))).toBe(
+      category,
+    );
   });
 });

--- a/lib/ai/tools/utils/terminal-output-saver.ts
+++ b/lib/ai/tools/utils/terminal-output-saver.ts
@@ -1,16 +1,146 @@
 import { createHash } from "node:crypto";
 import type { AnySandbox } from "@/types";
 import type { createTerminalHandler } from "@/lib/utils/terminal-executor";
+import { phLogger } from "@/lib/posthog/server";
 import { FULL_OUTPUT_SAVED_MESSAGE } from "@/lib/token-utils";
-import { asCommonSandbox, isE2BSandbox } from "./sandbox-types";
+import {
+  asCommonSandbox,
+  isAwsLambdaMicrovmSandbox,
+  isCentrifugoSandbox,
+  isE2BSandbox,
+} from "./sandbox-types";
 
 export const MAX_SAVED_TERMINAL_OUTPUT_FILES = 10;
+const DESKTOP_RELAY_RETRY_DELAY_MS = 250;
+
+type TerminalOutputPersistenceProvider =
+  "e2b" | "aws-lambda-microvm" | "desktop" | "centrifugo";
+type TerminalOutputPersistenceFailureCategory =
+  | "timeout"
+  | "transport"
+  | "relay_unavailable"
+  | "permission"
+  | "filesystem"
+  | "unknown";
+
+export type TerminalOutputPersistenceTelemetry = {
+  service: "agent-long" | "chat-handler";
+  environment: string;
+  requestId?: string | null;
+  triggerRunId?: string | null;
+  chatId?: string;
+  userId?: string;
+};
+
+const getPersistenceProvider = (
+  sandbox: AnySandbox,
+): TerminalOutputPersistenceProvider => {
+  if (isCentrifugoSandbox(sandbox)) {
+    if (
+      typeof sandbox.getCloudProvider === "function" &&
+      sandbox.getCloudProvider() === "aws-lambda-microvm"
+    ) {
+      return "aws-lambda-microvm";
+    }
+    if (
+      typeof sandbox.supportsNativeFileRelay === "function" &&
+      sandbox.supportsNativeFileRelay()
+    ) {
+      return "desktop";
+    }
+    return "centrifugo";
+  }
+  return "e2b";
+};
+
+export const classifyTerminalOutputPersistenceFailure = (
+  error: unknown,
+): TerminalOutputPersistenceFailureCategory => {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  if (/timed?\s*out|timeout/.test(message)) return "timeout";
+  if (
+    /not subscribed|relay is not available|reconnect the desktop app/.test(
+      message,
+    )
+  ) {
+    return "relay_unavailable";
+  }
+  if (
+    /load failed|failed to publish|subscription error|network|disconnected|connection (?:closed|reset)|econnreset/.test(
+      message,
+    )
+  ) {
+    return "transport";
+  }
+  if (
+    /outside its allowed root|permission denied|access denied|eacces|eperm/.test(
+      message,
+    )
+  ) {
+    return "permission";
+  }
+  if (
+    /no space left|enospc|read-only file system|enoent|not a directory/.test(
+      message,
+    )
+  ) {
+    return "filesystem";
+  }
+  return "unknown";
+};
+
+const canRetryDesktopRelayFailure = (
+  provider: TerminalOutputPersistenceProvider,
+  category: TerminalOutputPersistenceFailureCategory,
+): boolean =>
+  provider === "desktop" &&
+  (category === "transport" || category === "relay_unavailable");
+
+const emitPersistenceFailure = (args: {
+  provider: TerminalOutputPersistenceProvider;
+  attemptCount: number;
+  result: "recovered" | "failed";
+  failureCategory: TerminalOutputPersistenceFailureCategory;
+  retryDecision:
+    "retried" | "verified_after_timeout" | "skipped_timeout" | "not_retryable";
+  telemetry?: TerminalOutputPersistenceTelemetry;
+}): void => {
+  const fields = {
+    provider: args.provider,
+    attempt_count: args.attemptCount,
+    result: args.result,
+    failure_category: args.failureCategory,
+    retry_decision: args.retryDecision,
+    service: args.telemetry?.service ?? "unknown",
+    environment: args.telemetry?.environment ?? "unknown",
+    request_id: args.telemetry?.requestId ?? null,
+    trace_id: args.telemetry?.triggerRunId ?? null,
+    trigger_run_id: args.telemetry?.triggerRunId ?? null,
+    chat_id: args.telemetry?.chatId ?? null,
+    user_id: args.telemetry?.userId ?? null,
+  };
+
+  const payload = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level: args.result === "recovered" ? "info" : "warn",
+    event: "terminal_output_persistence_failure",
+    ...fields,
+  });
+  if (args.result === "recovered") console.info(payload);
+  else console.warn(payload);
+
+  phLogger.event("terminal_output_persistence_failure", {
+    ...(args.telemetry?.userId && { userId: args.telemetry.userId }),
+    ...fields,
+  });
+};
 
 /** Builds a stable, non-identifying output directory for one chat scope. */
 const getOutputDirectory = (sandbox: AnySandbox, scopeId?: string): string => {
-  const baseDirectory = isE2BSandbox(sandbox)
-    ? "/home/user/terminal_full_output"
-    : "/tmp/terminal_full_output";
+  const baseDirectory =
+    isE2BSandbox(sandbox) || isAwsLambdaMicrovmSandbox(sandbox)
+      ? "/home/user/terminal_full_output"
+      : "/tmp/terminal_full_output";
   const scopeKey = scopeId
     ? createHash("sha256").update(scopeId).digest("hex").slice(0, 16)
     : "unscoped";
@@ -40,27 +170,29 @@ const pruneOldSavedOutputs = async (
 
 /**
  * Save full terminal output to a file in the sandbox when it exceeds token limits.
- * E2B (cloud) saves under ~/terminal_full_output/, local Docker saves under
- * /tmp/terminal_full_output/. Each chat gets an isolated retained directory.
+ * E2B and AWS Lambda MicroVMs save under ~/terminal_full_output/. Desktop and
+ * other Centrifugo sandboxes save under /tmp/terminal_full_output/. Each chat
+ * gets an isolated retained directory.
  * Returns the file path if saved, or null if saving failed.
  */
 export async function saveFullOutputToFile(
   sandbox: AnySandbox,
   fullOutput: string,
   scopeId?: string,
+  telemetry?: TerminalOutputPersistenceTelemetry,
 ): Promise<string | null> {
-  try {
-    const now = new Date();
-    const timestamp = now
-      .toISOString()
-      .replace(/[T]/g, "_")
-      .replace(/[:]/g, "-")
-      .replace(/\./, "_");
-    // e.g. 2026-02-17_16-54-34_442Z
+  const provider = getPersistenceProvider(sandbox);
+  const now = new Date();
+  const timestamp = now
+    .toISOString()
+    .replace(/[T]/g, "_")
+    .replace(/[:]/g, "-")
+    .replace(/\./, "_");
+  // e.g. 2026-02-17_16-54-34_442Z
 
-    const dir = getOutputDirectory(sandbox, scopeId);
-    const filePath = `${dir}/${timestamp}.txt`;
-
+  const dir = getOutputDirectory(sandbox, scopeId);
+  const filePath = `${dir}/${timestamp}.txt`;
+  const save = async (): Promise<string> => {
     await sandbox.commands.run(`mkdir -p ${dir}`, {
       timeoutMs: 5000,
     });
@@ -70,15 +202,101 @@ export async function saveFullOutputToFile(
       await pruneOldSavedOutputs(sandbox, dir);
     } catch (err) {
       console.warn(
-        "[Terminal Command] Failed to prune old saved terminal output:",
-        err,
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: "warn",
+          event: "terminal_output_retention_prune_failed",
+          service: telemetry?.service ?? "unknown",
+          environment: telemetry?.environment ?? "unknown",
+          request_id: telemetry?.requestId ?? null,
+          trace_id: telemetry?.triggerRunId ?? null,
+          provider,
+          failure_category: classifyTerminalOutputPersistenceFailure(err),
+        }),
       );
     }
 
     return filePath;
-  } catch (err) {
-    console.warn("[Terminal Command] Failed to save full output to file:", err);
-    return null;
+  };
+
+  let attemptCount = 1;
+  try {
+    return await save();
+  } catch (firstError) {
+    const firstCategory = classifyTerminalOutputPersistenceFailure(firstError);
+    if (provider === "desktop" && firstCategory === "timeout") {
+      const stat = (
+        sandbox.files as unknown as {
+          stat?: (path: string) => Promise<{ sizeBytes?: number }>;
+        }
+      ).stat;
+      if (stat) {
+        try {
+          const metadata = await stat(filePath);
+          if (metadata.sizeBytes === Buffer.byteLength(fullOutput, "utf8")) {
+            emitPersistenceFailure({
+              provider,
+              attemptCount,
+              result: "recovered",
+              failureCategory: firstCategory,
+              retryDecision: "verified_after_timeout",
+              telemetry,
+            });
+            return filePath;
+          }
+        } catch {
+          // A bounded metadata probe is only a fallback for a lost write ack.
+        }
+        emitPersistenceFailure({
+          provider,
+          attemptCount,
+          result: "failed",
+          failureCategory: firstCategory,
+          retryDecision: "verified_after_timeout",
+          telemetry,
+        });
+        return null;
+      }
+    }
+    if (!canRetryDesktopRelayFailure(provider, firstCategory)) {
+      emitPersistenceFailure({
+        provider,
+        attemptCount,
+        result: "failed",
+        failureCategory: firstCategory,
+        retryDecision:
+          firstCategory === "timeout" ? "skipped_timeout" : "not_retryable",
+        telemetry,
+      });
+      return null;
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, DESKTOP_RELAY_RETRY_DELAY_MS),
+    );
+    attemptCount += 1;
+    try {
+      const savedPath = await save();
+      emitPersistenceFailure({
+        provider,
+        attemptCount,
+        result: "recovered",
+        failureCategory: firstCategory,
+        retryDecision: "retried",
+        telemetry,
+      });
+      return savedPath;
+    } catch (retryError) {
+      emitPersistenceFailure({
+        provider,
+        attemptCount,
+        result: "failed",
+        failureCategory: classifyTerminalOutputPersistenceFailure(retryError),
+        retryDecision: "retried",
+        telemetry,
+      });
+      return null;
+    }
   }
 }
 
@@ -95,15 +313,21 @@ export async function saveTruncatedOutput(opts: {
   sandbox: AnySandbox;
   terminalWriter: (output: string) => Promise<void>;
   scopeId?: string;
+  telemetry?: TerminalOutputPersistenceTelemetry;
 }): Promise<string> {
-  const { handler, sandbox, terminalWriter, scopeId } = opts;
+  const { handler, sandbox, terminalWriter, scopeId, telemetry } = opts;
 
   if (!handler.wasTruncated()) {
     return "";
   }
 
   const fullOutput = handler.getFullOutput();
-  const savedPath = await saveFullOutputToFile(sandbox, fullOutput, scopeId);
+  const savedPath = await saveFullOutputToFile(
+    sandbox,
+    fullOutput,
+    scopeId,
+    telemetry,
+  );
 
   if (!savedPath) {
     return "";

--- a/lib/ai/tools/utils/terminal-output-saver.ts
+++ b/lib/ai/tools/utils/terminal-output-saver.ts
@@ -35,13 +35,8 @@ export type TerminalOutputPersistenceTelemetry = {
 const getPersistenceProvider = (
   sandbox: AnySandbox,
 ): TerminalOutputPersistenceProvider => {
+  if (isAwsLambdaMicrovmSandbox(sandbox)) return "aws-lambda-microvm";
   if (isCentrifugoSandbox(sandbox)) {
-    if (
-      typeof sandbox.getCloudProvider === "function" &&
-      sandbox.getCloudProvider() === "aws-lambda-microvm"
-    ) {
-      return "aws-lambda-microvm";
-    }
     if (
       typeof sandbox.supportsNativeFileRelay === "function" &&
       sandbox.supportsNativeFileRelay()


### PR DESCRIPTION
## Summary

- save terminal output for `aws-lambda-microvm` Centrifugo sandboxes under `/home/user/terminal_full_output`, the direct-mutation root allowed by that provider
- retry only immediate transient desktop relay failures once after 250 ms; never repeat a completed 120-second timeout
- use a bounded metadata probe after a desktop timeout to recognize a completed write whose acknowledgement was lost
- emit a privacy-safe `terminal_output_persistence_failure` event with bounded provider, attempt, result, failure-category, and retry-decision fields
- pass request/run/chat/user correlation fields from both terminal-output persistence call sites without logging command output, prompts, targets, paths, evidence, or raw errors
- add regression coverage for AWS Lambda MicroVM routing, transient relay recovery, timeout behavior, lost-ack recovery, privacy, and bounded classification

## Root cause

`terminal-output-saver.ts` treated every Centrifugo sandbox as a local/desktop sandbox and wrote under `/tmp`. AWS Lambda MicroVM direct file mutation only permits `/home/user`, so large terminal outputs deterministically failed with `Direct file mutation path is outside its allowed root`.

Desktop relay writes also had no bounded recovery path. Immediate transport errors such as `Load failed` returned `null`, while a completed 120-second timeout could not distinguish a failed write from a lost acknowledgement.

## Production IAM repair (out of band)

Updated customer-managed policy `arn:aws:iam::630609837323:policy/S3Access_HackerAI_ProdBucket`, attached to `arn:aws:iam::630609837323:user/vercel-convex-s3-user`. Version 6 is now the default.

Added only:

- `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on:
  - `arn:aws:s3:::hackerai-lambda-microvm-artifactbucket-dg0uomrstdzm/users/*/microvm-workspace/v1/*`
  - `arn:aws:s3:::hackerai-lambda-microvm-artifactbucket-qxwmdyaof45d/users/*/microvm-workspace/v1/*`
  - `arn:aws:s3:::hackerai-lambda-microvm-artifactbucket-qgwooqsfzict/users/*/microvm-workspace/v1/*`
- `s3:ListBucket` on those three exact bucket ARNs, constrained by `StringLike` `s3:prefix = users/*/microvm-workspace/v1/*`

The live Convex production deployment remains unchanged. Disposable lifecycle probes passed in all three configured regions: initial absence, presigned PUT, HEAD/byte-length check, presigned GET, exact marker equality, DELETE 204, post-delete 404, and cleanup confirmation.

## Validation

- `pnpm jest lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts --runInBand` — 2 suites, 58 tests passed
- `pnpm exec eslint lib/ai/tools/utils/terminal-output-saver.ts lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts lib/ai/tools/run-terminal-cmd.ts`
- `pnpm exec prettier --check lib/ai/tools/utils/terminal-output-saver.ts lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts lib/ai/tools/run-terminal-cmd.ts`
- `pnpm typecheck`
- pre-commit full suite — 424 suites, 4,370 tests passed

## Rollback

- Code: revert commits `0f47a07f` and `bf623ff1` in reverse order (or revert the merged PR).
- IAM: set policy version 4 as default. Version 5 contains the superseded, inactive bucket set and must not be selected. Re-run all three disposable lifecycle probes after any IAM rollback.
- No feature-flag change was made; the production subagents rollout remains at 50%.

## Manual verification after merge/deployment

1. Run an AWS Lambda MicroVM Agent command that exceeds the terminal truncation limit. Confirm the full output is written under `/home/user/terminal_full_output/chat-<hash>/` and no allowed-root warning appears.
2. Exercise a desktop sandbox with one injected immediate relay transport failure. Confirm one retry occurs and `terminal_output_persistence_failure` records `provider=desktop`, `attempt_count=2`, `result=recovered`, and a bounded category, without user content.
3. Exercise a completed desktop relay timeout. Confirm there is no second write; at most one bounded metadata probe occurs.
4. Re-audit production Trigger warnings and the new persistence event after deployment. Confirm the previous `/tmp` allowed-root warning is absent for AWS Lambda MicroVM runs.
5. Controlled physical restore test remains intentionally blocked until an exact production AuthKit user ID is explicitly designated as internal/test. For that identity only: write a unique `/home/user` marker, checkpoint and confirm the S3 object, replace the physical MicroVM while retaining the logical user workspace, reacquire it, verify the physical ID changed and marker restored exactly, then remove the marker and test snapshot/VM.

No customer workspace was touched or replaced during verification.
