### PR TITLE
Make PM user research PostHog-only

### DIFF
--- a/.agents/skills/hackerai-user-research/SKILL.md
+++ b/.agents/skills/hackerai-user-research/SKILL.md
@@ -56,7 +56,7 @@ Use the current task schema as the authority. A typical run is:
 ```json
 {
   "question": "What kinds of users are our highest-spending customers, what recurring work do they use HackerAI for, and why do they pay?",
-  "cohortLabel": "Top 10 users by PostHog-recorded lifetime paid spend",
+  "cohortLabel": "PostHog top-spender research cohort",
   "userIds": ["internal-user-id-1", "internal-user-id-2", "internal-user-id-3"],
   "maxChatsPerUser": 12
 }

--- a/.agents/skills/hackerai-user-research/SKILL.md
+++ b/.agents/skills/hackerai-user-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hackerai-user-research
-description: Run privacy-safe HackerAI customer research from an authorized PM question and a product-data cohort. Use for requests to understand user types, recurring jobs, workflows, friction, value drivers, reasons to pay, or customer avatars from actual HackerAI messages, including top-spender research. Also use when a PM asks how to run, repeat, or interpret the `pm-user-research` Trigger task. Do not use for support investigations, decisions about one person's eligibility or risk, or exporting raw customer content.
+description: Run privacy-safe HackerAI customer research from an authorized PM question and a PostHog cohort. Use for requests to understand user types, recurring jobs, workflows, friction, value drivers, reasons to pay, or customer avatars from actual HackerAI messages, including top-spender research. Also use when a PM asks how to run, repeat, or interpret the `pm-user-research` Trigger task. Do not use for support investigations, decisions about one person's eligibility or risk, or exporting raw customer content.
 ---
 
 # HackerAI User Research
@@ -15,13 +15,17 @@ Read [references/privacy-policy.md](references/privacy-policy.md) and
 ## Workflow
 
 1. Extract the research question, cohort rule, exclusions, requested output, and
-   privacy constraints from the authorized PM's request. A Linear issue may be
-   supplied for optional tracking, but it is not an authorization control and
-   must not be required to run research.
-2. Select the cohort in PostHog. Use Stripe-synced revenue in PostHog when its
-   freshness and account mapping are sufficient. Check Stripe directly only for
-   unmatched customers, refunds/disputes, payer-versus-user ambiguity, or other
-   reconciliation gaps. Never use Google Drive.
+   privacy constraints from the authorized PM's request. Possession of the
+   scoped PM gateway key establishes access to this workflow; do not ask for a
+   separate per-run approval or inspect a Linear issue's state or comments for
+   authorization. A Linear issue may be supplied only as optional tracking
+   metadata.
+2. Select the cohort entirely in PostHog. For spend-ranked research, use the
+   available Stripe-synced revenue properties in PostHog without opening Stripe
+   or requiring Stripe access. If PostHog cannot prove an exact accounting
+   adjustment or payer mapping, use the best available PostHog cohort and state
+   that limitation in the aggregate report instead of blocking the run. Never
+   use Google Drive.
 3. Resolve each cohort member to the internal user ID used by Convex. Exclude
    internal/test/fraud accounts and deduplicate payer or organization
    relationships before triggering analysis. Stop unless 3-20 unique internal
@@ -52,17 +56,18 @@ Use the current task schema as the authority. A typical run is:
 ```json
 {
   "question": "What kinds of users are our highest-spending customers, what recurring work do they use HackerAI for, and why do they pay?",
-  "cohortLabel": "Top 10 users by reconciled lifetime net paid spend",
+  "cohortLabel": "Top 10 users by PostHog-recorded lifetime paid spend",
   "userIds": ["internal-user-id-1", "internal-user-id-2", "internal-user-id-3"],
   "maxChatsPerUser": 12
 }
 ```
 
 `linearIssueId` may be added as an optional tracking reference, for example
-`"linearIssueId": "HAC-65"`. The issue's presence or state does not authorize
-or block a run.
+`"linearIssueId": "HAC-65"`. Do not read the issue or its comments to look for
+approval; its presence, state, and prior cohort notes never authorize or block a
+run.
 
-Do not place email addresses, Stripe customer IDs, or message content in the
+Do not place email addresses, billing customer IDs, or message content in the
 payload. `userIds` must be the internal Convex/WorkOS user IDs.
 
 ## Quality checks

--- a/.agents/skills/hackerai-user-research/references/pm-runbook.md
+++ b/.agents/skills/hackerai-user-research/references/pm-runbook.md
@@ -2,25 +2,32 @@
 
 ## 1. Prepare the cohort
 
-Start from a specific research request made by an authorized PM. The request
-must define the question, cohort rule, exclusions, and intended aggregate
-output. A Linear issue may be included for optional tracking, but its presence
-or state is not an authorization control. For spend-ranked research, use
-PostHog's Stripe-synced lifetime net paid amount when available and current.
-Exclude refunds/disputes, internal and test users, fraud, duplicates, and
-unmatched customers. Open Stripe only to resolve discrepancies or payer/account
-ownership. Produce internal Convex/WorkOS user IDs, not emails or Stripe IDs.
+Start from a specific research request made by an authorized PM using the scoped
+PM gateway. The request must define the question, cohort rule, exclusions, and
+intended aggregate output. The gateway key establishes access to the workflow;
+do not request separate per-run approval or inspect Linear state or comments for
+authorization. A Linear issue may be included only for optional tracking.
+
+Select the cohort entirely in PostHog. For spend-ranked research, use PostHog's
+available Stripe-synced lifetime paid amount and account mapping. Exclude
+internal and test users, known fraud or abuse, duplicates, and unmatched
+customers using data available in PostHog. Do not open Stripe or require Stripe
+access. If PostHog does not establish an exact refund, dispute, payer, or account
+adjustment, use the best supported PostHog ranking and record the limitation in
+the aggregate report. Produce internal Convex/WorkOS user IDs, not emails or
+billing customer IDs.
 
 ## 2. Run through Codex
 
 Ask Codex:
 
-> Use $hackerai-user-research. Select the reconciled top-spender cohort, run the
+> Use $hackerai-user-research. Select the PostHog top-spender cohort, run the
 > analysis, wait for it, and give me the aggregate findings with coverage,
 > confidence, unknowns, and recommended experiments.
 
-Codex should use the skill's `scripts/run-research.mjs` gateway runner and wait
-for completion. The PM's Codex environment must contain the scoped
+Codex should proceed from the authorized PM's request without checking for
+another approval. It should use the skill's `scripts/run-research.mjs` gateway
+runner and wait for completion. The PM's Codex environment must contain the scoped
 `HACKERAI_PM_USER_RESEARCH_KEY`; it must not contain Trigger or Convex service
 keys. The runner always calls the production gateway at
 `https://hackerai.co/api/internal/user-research`; no Preview URL or Preview PM
@@ -33,6 +40,9 @@ and zero-data-retention routing required.
 The request JSON is temporary restricted data because it contains internal user
 IDs. Create it outside the repository with mode 600, pass its path to the
 runner, then remove it. Never commit it or copy it into Linear.
+
+The scoped gateway key authenticates the PM runner to the restricted production
+endpoint. It is not a per-run approval and does not require a Linear issue.
 
 ## 3. Interpret the result
 

--- a/.agents/skills/hackerai-user-research/references/privacy-policy.md
+++ b/.agents/skills/hackerai-user-research/references/privacy-policy.md
@@ -1,8 +1,9 @@
 # Customer research privacy policy
 
 Use customer messages only for a specific internal research purpose requested by
-an authorized PM. The request must define the cohort and intended output. A
-Linear issue is optional tracking metadata, not an authorization control.
+an authorized PM using the scoped PM gateway. The request must define the cohort
+and intended output. Do not require a separate per-run approval record or check
+Linear status or comments. A Linear issue is optional tracking metadata only.
 
 ## Allowed
 

--- a/app/api/internal/user-research/__tests__/route.test.ts
+++ b/app/api/internal/user-research/__tests__/route.test.ts
@@ -43,7 +43,7 @@ const originalHash = process.env.PM_USER_RESEARCH_RUNNER_KEY_SHA256;
 
 const validPayload = {
   question: "What recurring work creates the most customer value?",
-  cohortLabel: "Approved production research cohort",
+  cohortLabel: "PostHog top-spender research cohort",
   userIds: ["user-1", "user-2", "user-3"],
   maxChatsPerUser: 12,
 };
@@ -80,7 +80,7 @@ const validResult = {
     followUpExperiments: [
       {
         hypothesis: "Verified practitioners value faster activation.",
-        test: "Run an approved verified-practitioner cohort.",
+        test: "Run a verified-practitioner cohort.",
         successMetric: "Activation and repeat Agent usage",
       },
     ],

--- a/docs/internal/user-research.md
+++ b/docs/internal/user-research.md
@@ -6,7 +6,8 @@ called through the repo-owned Codex skill `$hackerai-user-research`.
 ## What it does
 
 1. Accepts an authorized PM's research question and 3-20 internal user IDs
-   selected from PostHog/Stripe/account evidence. A Linear issue is optional
+   selected entirely from PostHog. The scoped PM gateway key establishes access;
+   no separate per-run approval record is required. A Linear issue is optional
    tracking metadata and does not authorize or block a run.
 2. Uses service-keyed Convex queries to sample up to 20 chats across each user's
    observed date range.
@@ -66,8 +67,14 @@ runner uses the fixed production URL, so Preview needs no PM gateway URL or key.
 ## PM invocation
 
 Invoke `$hackerai-user-research` in Codex with the research question and cohort
-criteria. A Linear issue may be supplied only when tracking is useful. The skill
-uses PostHog for cohort selection and the scoped gateway runner to start and
-wait for `pm-user-research`. PostHog's Stripe sync can be the normal spend
-source; direct Stripe access is only necessary for reconciliation gaps. Do not
-add PMs to the Trigger organization or give them Trigger/Convex credentials.
+criteria. Codex must not ask for a separate per-run approval or inspect Linear
+state or comments before running it. A Linear issue may be supplied only when
+tracking is useful. The skill uses PostHog exclusively for cohort selection and
+the scoped gateway runner to start and wait for `pm-user-research`. Spend-ranked
+cohorts use the available Stripe-synced properties in PostHog; PMs do not need
+direct Stripe access. If the available PostHog data has accounting or mapping
+limitations, label them in the aggregate output instead of blocking the run. Do
+not add PMs to the Trigger organization or give them Trigger/Convex credentials.
+
+`HACKERAI_PM_USER_RESEARCH_KEY` authenticates the scoped runner; it is not a
+per-run approval mechanism and is unrelated to Linear.

--- a/lib/research/__tests__/user-research.test.ts
+++ b/lib/research/__tests__/user-research.test.ts
@@ -44,7 +44,7 @@ describe("user research privacy controls", () => {
   it("accepts a bounded request without a Linear reference", () => {
     const request = {
       question: "What recurring work creates the most customer value?",
-      cohortLabel: "Approved production research cohort",
+      cohortLabel: "PostHog top-spender research cohort",
       userIds: ["user-1", "user-2", "user-3"],
       maxChatsPerUser: 12,
     };
@@ -221,7 +221,7 @@ ${"QUJD".repeat(16)}
   it("keeps every profile in a valid bounded cohort payload", () => {
     const prompt = buildCohortPrompt({
       question: "Which recurring user types and jobs appear?",
-      cohortLabel: "Reconciled paid cohort",
+      cohortLabel: "PostHog paid cohort",
       profiles: Array.from({ length: 20 }, (_, index) => ({
         pseudonym: `U${String(index + 1).padStart(2, "0")}`,
         profile: {


### PR DESCRIPTION
## Summary
- make Production PostHog the only cohort-selection source for PM user research
- remove separate per-run and Linear approval checks from the skill contract
- treat missing accounting or payer reconciliation as a disclosed limitation instead of a blocker
- preserve the scoped PM gateway key as the production access boundary
- align HAC-65 and its historical workflow comments with the new contract

## Testing
- skill quick validator
- Prettier check for all changed files
- targeted user-research gateway and privacy tests (22 passed)
- PM runner proxy tests (2 passed)
- commit hooks: typecheck and complete Jest suite (424 suites, 4372 tests passed)

## Manual verification
- In an authorized PM Codex environment with HACKERAI_PM_USER_RESEARCH_KEY, invoke the user-research skill for HAC-65.
- Confirm Codex selects the cohort entirely in Production PostHog and does not request Stripe access or separate Linear approval.
- If PostHog lacks exact refund, dispute, or payer mapping evidence, confirm the run proceeds and reports that limitation in the aggregate output.

## Deployment
No Vercel or Trigger deployment is required. The production gateway already accepts bounded runs without a Linear approval; merging updates the repo-owned Codex skill and documentation.

Linear: HAC-65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Updates**
  - Cohort selection now uses PostHog exclusively, including Stripe-synced lifetime paid spend.
  - Research requests must use the authorized PM gateway and define the cohort and intended output.
  - Linear tracking and separate per-run approval checks are optional.
  - Runs can proceed despite accounting or identity-mapping limitations, which are recorded clearly.

- **Documentation**
  - Updated guidance and examples to reflect the streamlined PostHog-based research process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->