### PR TITLE
Reorder chats when users send messages

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -160,6 +160,70 @@ describe("saveMessage — is_hidden handling", () => {
       "messages",
       expect.objectContaining({ is_hidden: true }),
     );
+    expect(mockCtx.db.patch).not.toHaveBeenCalledWith(
+      "chat-doc-1",
+      expect.objectContaining({ update_time: expect.any(Number) }),
+    );
+  });
+
+  it("bumps chat activity when a visible user message is inserted", async () => {
+    setupExistingMessage(null);
+
+    const { saveMessage } = await import("../messages");
+
+    await saveMessage.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      id: "msg-visible-user",
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      role: "user" as const,
+      parts: [{ type: "text", text: "move this chat to the top" }],
+    });
+
+    const insertedMessage = mockCtx.db.insert.mock.calls[0]?.[1];
+    expect(mockCtx.db.patch).toHaveBeenCalledWith("chat-doc-1", {
+      update_time: insertedMessage.update_time,
+    });
+  });
+
+  it("does not bump chat activity for assistant message inserts", async () => {
+    setupExistingMessage(null);
+
+    const { saveMessage } = await import("../messages");
+
+    await saveMessage.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      id: "msg-visible-assistant",
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      role: "assistant" as const,
+      parts: [{ type: "text", text: "response" }],
+    });
+
+    expect(mockCtx.db.patch).not.toHaveBeenCalledWith(
+      "chat-doc-1",
+      expect.objectContaining({ update_time: expect.any(Number) }),
+    );
+  });
+
+  it("does not bump chat activity when an existing user message is retried", async () => {
+    setupExistingMessage(makeMessage());
+
+    const { saveMessage } = await import("../messages");
+
+    await saveMessage.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      id: "msg-1",
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      role: "user" as const,
+      parts: [{ type: "text", text: "hello" }],
+    });
+
+    expect(mockCtx.db.patch).not.toHaveBeenCalledWith(
+      "chat-doc-1",
+      expect.objectContaining({ update_time: expect.any(Number) }),
+    );
   });
 
   it("stores the Trigger run ID on an inserted assistant message", async () => {
@@ -426,6 +490,9 @@ describe("saveMessage — is_hidden handling", () => {
 
     expect(mockCtx.db.patch).toHaveBeenCalledWith("chat-doc-1", {
       canceled_at: undefined,
+    });
+    expect(mockCtx.db.patch).toHaveBeenCalledWith("chat-doc-1", {
+      update_time: expect.any(Number),
     });
     expect(mockCtx.db.insert).toHaveBeenCalledWith(
       "messages",

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -765,8 +765,8 @@ export const saveChat = mutation({
  * toggles them in the UI, before sending. Client-callable, ownership-checked.
  *
  * Intentionally does NOT bump `update_time` (would reorder the sidebar) or
- * touch stream state — those side effects belong to `updateChat`, which only
- * the backend should call at end-of-stream.
+ * touch stream state. A visible user-message insert records new activity in
+ * `messages.saveMessage`; end-of-stream chat fields are handled by `updateChat`.
  */
 export const updateChatPreferences = mutation({
   args: {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -494,7 +494,7 @@ async function ensureChatWritableForMessageInsert(
   chatId: string,
   userId: string,
   role: "user" | "assistant" | "system",
-): Promise<void> {
+): Promise<Doc<"chats">> {
   const chat = await loadOwnedChat(ctx, chatId, userId);
 
   if (chat.canceled_at !== undefined) {
@@ -502,7 +502,7 @@ async function ensureChatWritableForMessageInsert(
       await ctx.db.patch(chat._id, {
         canceled_at: undefined,
       });
-      return;
+      return chat;
     }
 
     throw new ConvexError({
@@ -510,6 +510,8 @@ async function ensureChatWritableForMessageInsert(
       message: "This chat is no longer accepting new messages",
     });
   }
+
+  return chat;
 }
 
 /**
@@ -542,6 +544,7 @@ export const saveMessage = mutation({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
     let failureStage = "start";
+    let chatForInsert: Doc<"chats"> | null = null;
 
     try {
       const ensureOwnedFiles = async (
@@ -695,7 +698,7 @@ export const saveMessage = mutation({
         }
 
         failureStage = "verify_chat_writable_for_insert";
-        await ensureChatWritableForMessageInsert(
+        chatForInsert = await ensureChatWritableForMessageInsert(
           ctx,
           args.chatId,
           args.userId,
@@ -712,6 +715,7 @@ export const saveMessage = mutation({
       failureStage = "extract_content";
       const content = extractTextFromParts(partsForSave);
 
+      const now = Date.now();
       const messageDocumentBase = {
         id: args.id,
         chat_id: args.chatId,
@@ -719,7 +723,7 @@ export const saveMessage = mutation({
         role: args.role,
         parts: partsForSave,
         file_ids: fileIdsForSave,
-        update_time: Date.now(),
+        update_time: now,
         model: args.model,
         mode: args.mode,
         generation_started_at: args.generationStartedAt,
@@ -800,6 +804,15 @@ export const saveMessage = mutation({
         ...messageDocumentBase,
         content: indexedContent?.content,
       });
+
+      // Move the chat to the top of the sidebar as soon as the user submits a
+      // visible message. Existing-message retries return above, so they do not
+      // create artificial activity. Hidden user messages are automatic Agent
+      // continuations rather than new user activity.
+      if (args.role === "user" && args.isHidden !== true && chatForInsert) {
+        failureStage = "update_chat_activity";
+        await ctx.db.patch(chatForInsert._id, { update_time: now });
+      }
 
       // Mark attached files as linked so purge won't remove them.
       // Batch-read in parallel, skip no-op patches when already attached.


### PR DESCRIPTION
## Summary
- bump a chat's activity timestamp when a visible user message is inserted
- move the active chat to the top of the reactive sidebar before generation finishes
- avoid reordering for assistant messages, hidden Agent continuations, and idempotent retries

## Validation
- `pnpm exec jest --runInBand convex/__tests__/messages.hidden.test.ts convex/__tests__/messages.shared.test.ts lib/db/__tests__/actions-save-message.test.ts convex/__tests__/chats.getUserChats.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint convex/messages.ts convex/__tests__/messages.hidden.test.ts`
- `pnpm exec prettier --check convex/messages.ts convex/chats.ts convex/__tests__/messages.hidden.test.ts`
- `pnpm run check:local-dependencies`

Automated validation is sufficient because this is a backend-only reactive ordering change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat activity timestamps now update when a new visible user message is added.
  - Hidden messages, assistant messages, and retried messages no longer incorrectly update chat activity.
  - New messages that clear a cancellation state now correctly refresh chat activity.

- **Documentation**
  - Clarified when message insertion and end-of-stream updates affect chat activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->