### PR TITLE
Reduce AWS MicroVM persistence and NAT costs

### DIFF
--- a/__mocks__/@aws-sdk/client-s3.ts
+++ b/__mocks__/@aws-sdk/client-s3.ts
@@ -8,6 +8,10 @@ export const PutObjectCommand = jest.fn().mockImplementation((params: any) => ({
   params,
 }));
 
+export const CopyObjectCommand = jest
+  .fn()
+  .mockImplementation((params: any) => ({ params }));
+
 export class GetObjectCommand {
   constructor(params: any) {}
 }

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -10,9 +10,11 @@ The integration is ARM64-only because Lambda MicroVMs currently support
 Graviton only. The image grants `ALL` guest OS capabilities so tools that need
 raw sockets can run inside the VM. The AWS-managed authenticated endpoint uses
 `ALL_INGRESS`; it is not an unauthenticated public listener. Outbound internet
-access uses a regional VPC connector whose private subnet routes through a NAT
-Gateway and retained Elastic IP. Replacing a MicroVM therefore does not change
-the public source IPv4 address observed by an authorized target.
+access uses a regional VPC connector whose private subnet routes arbitrary
+internet traffic through a NAT Gateway and retained Elastic IP. Same-region S3
+traffic uses the private route table's S3 gateway endpoint instead, avoiding
+NAT processing without changing the public source IPv4 address observed by an
+authorized target.
 
 ## 1. Provision AWS prerequisites
 
@@ -56,6 +58,12 @@ Each regional stack output includes `EgressNetworkConnectorArn` and
 deletion cannot silently release the address. If the stack is intentionally
 removed, clean up the retained address separately only after every customer has
 been notified and migrated.
+
+Each stack also associates a no-hourly-charge S3 gateway endpoint with the
+MicroVM private route table. Updating only `cloudformation.yaml` intentionally
+does not trigger the costly image-release workflow. Apply the stack update in
+all three regions with the commands above after reviewing the CloudFormation
+change set; no image rebuild is required.
 
 Availability tradeoff: each region intentionally uses one NAT Gateway and one
 Elastic IP in one Availability Zone. This keeps the published allowlist to one
@@ -184,12 +192,17 @@ After the last active parent run or subagent finishes, the guest archives
 `/home/user` and uploads it to one private, user-scoped `workspace.tar.gz`
 object in the workspace bucket matching the MicroVM's AWS region before
 suspending the VM. A fresh replacement checks all three regional objects and
-restores the newest one, using S3's server-side `LastModified` timestamps,
-before any Agent tool can use the new VM. Near-lifetime replacement also
-snapshots before terminating the old VM. While a VM is running, a guest-side
-checkpoint process refreshes the object in that VM's region every two minutes
-using a scoped eight-hour upload URL. This bounds data loss if Trigger.dev
-reaches its hard task cutoff before normal Agent cleanup can run.
+selects the newest one using S3's server-side `LastModified` timestamps. If it
+came from another region, S3 copies it into the replacement VM's regional
+bucket before the guest downloads it, so restore traffic can use the local
+gateway endpoint instead of NAT. Near-lifetime replacement also snapshots
+before terminating the old VM. While a VM is running, a guest-side checkpoint
+process fingerprints the workspace before archiving. Changed workspaces
+checkpoint every five minutes; an unchanged workspace skips compression and
+upload and backs off to ten minutes. Normal Agent completion and near-lifetime
+replacement still force a full snapshot. This bounds data loss if Trigger.dev
+reaches its hard task cutoff before normal Agent cleanup can run without
+repeatedly uploading an unchanged archive.
 
 The archive keeps source files, dotfiles, and Git state, but excludes
 rebuildable `node_modules`, pnpm/npm caches, and the general home cache. The S3
@@ -215,7 +228,8 @@ condition to `users/*/microvm-workspace/v1/*`, so `HeadObject` can distinguish a
 new workspace from an authorization failure. S3 credentials are never placed
 inside the guest. Every regional metadata lookup must succeed before restore
 chooses an object, so an outage cannot be mistaken for an empty or older
-workspace.
+workspace. Cross-region `CopyObject` uses the same source `s3:GetObject` and
+destination `s3:PutObject` permissions; there is no separate S3 copy action.
 
 Workspace buckets must be never-versioned: `GetBucketVersioning` must return no
 status. Reject buckets whose status is `Enabled` or `Suspended`; S3 cannot return
@@ -250,7 +264,14 @@ Optional controls:
   workspace snapshot succeeds. If both snapshot and suspend fail, the VM is
   retained until the maximum-duration backstop rather than deleting the only
   project copy. Replacement cleanup and Data Controls termination remain
-  additional safety boundaries.
+  additional safety boundaries. The ten-minute reconciliation task also checks
+  physically running sessions for confirmed orphaning. It only initiates the
+  same snapshot-backed suspend after 15 minutes without a connection heartbeat
+  and after Convex confirms that the user has neither an active parent run nor
+  an active subagent. Reconciliation runs are serialized and clean up at most
+  one confirmed orphan per sweep so long snapshots cannot overlap. Missing
+  ownership evidence fails closed and leaves the VM for the platform lifecycle
+  backstop.
 
 Never expose these variables with a `NEXT_PUBLIC_` prefix. AWS endpoint tokens
 are generated on demand by the Trigger.dev runtime, restricted to port 9000,

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -195,7 +195,9 @@ suspending the VM. A fresh replacement checks all three regional objects and
 selects the newest one using S3's server-side `LastModified` timestamps. If it
 came from another region, S3 copies it into the replacement VM's regional
 bucket before the guest downloads it, so restore traffic can use the local
-gateway endpoint instead of NAT. Near-lifetime replacement also snapshots
+gateway endpoint instead of NAT. The copy is conditional on the destination
+object version observed during selection, so a concurrent local checkpoint wins
+instead of being overwritten by an older restore. Near-lifetime replacement also snapshots
 before terminating the old VM. While a VM is running, a guest-side checkpoint
 process fingerprints the workspace before archiving. Changed workspaces
 checkpoint every five minutes; an unchanged workspace skips compression and
@@ -269,9 +271,11 @@ Optional controls:
   same snapshot-backed suspend after 15 minutes without a connection heartbeat
   and after Convex confirms that the user has neither an active parent run nor
   an active subagent. Reconciliation runs are serialized and clean up at most
-  one confirmed orphan per sweep so long snapshots cannot overlap. Missing
-  ownership evidence fails closed and leaves the VM for the platform lifecycle
-  backstop.
+  one confirmed orphan per sweep so long snapshots cannot overlap; queued runs
+  expire after ten minutes instead of accumulating. Ownership is checked again
+  after the forced snapshot and immediately before suspension; reconnecting
+  during the snapshot keeps the VM running. Missing ownership evidence fails
+  closed and leaves the VM for the platform lifecycle backstop.
 
 Never expose these variables with a `NEXT_PUBLIC_` prefix. AWS endpoint tokens
 are generated on demand by the Trigger.dev runtime, restricted to port 9000,

--- a/aws-lambda-microvm/cloudformation.yaml
+++ b/aws-lambda-microvm/cloudformation.yaml
@@ -139,6 +139,23 @@ Resources:
       NatGatewayId: !Ref EgressNatGateway
       RouteTableId: !Ref EgressPrivateRouteTable
 
+  # Keep same-region workspace checkpoint traffic off the metered NAT path.
+  # S3 bucket policies and IAM still authorize requests; the default endpoint
+  # policy avoids blocking legitimate public or customer-provided S3 URLs.
+  EgressS3GatewayEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.s3"
+      VpcEndpointType: Gateway
+      VpcId: !Ref EgressVpc
+      RouteTableIds:
+        - !Ref EgressPrivateRouteTable
+      Tags:
+        - Key: Name
+          Value: !Sub "hackerai-microvm-s3-${AWS::Region}"
+        - Key: application
+          Value: hackerai
+
   EgressPrivateRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:

--- a/convex/__tests__/localSandbox.cloudCleanup.test.ts
+++ b/convex/__tests__/localSandbox.cloudCleanup.test.ts
@@ -487,6 +487,92 @@ describe("cloud sandbox session cleanup", () => {
     );
   });
 
+  it("allows orphan cleanup only after activity and all owners are stale", async () => {
+    const staleAt = Date.now() - 30 * 60 * 1_000;
+    const query = jest.fn((table: string) => ({
+      withIndex: jest.fn(() => ({
+        unique: jest.fn().mockResolvedValue(
+          table === "cloud_sandbox_sessions"
+            ? {
+                user_id: "user-orphan",
+                session_id: "session-orphan",
+                microvm_id: "microvm-orphan",
+                status: "active",
+                created_at: staleAt,
+                last_connected_at: staleAt,
+                connection_id: "connection-orphan",
+              }
+            : table === "local_sandbox_connections"
+              ? { last_heartbeat: staleAt }
+              : null,
+        ),
+        first: jest.fn().mockResolvedValue(null),
+      })),
+    }));
+    const { getCloudSessionOrphanCleanupEligibility } =
+      await import("../localSandbox");
+
+    await expect(
+      getCloudSessionOrphanCleanupEligibility.handler(
+        { db: { query } } as never,
+        {
+          serviceKey: "service-key",
+          userId: "user-orphan",
+          sessionId: "session-orphan",
+          microvmId: "microvm-orphan",
+          staleBeforeMs: Date.now() - 15 * 60 * 1_000,
+        },
+      ),
+    ).resolves.toEqual({
+      eligible: true,
+      reason: "eligible",
+      lastActivityAt: staleAt,
+    });
+    expect(query).toHaveBeenCalledWith("chats");
+    expect(query).toHaveBeenCalledWith("subagent_runs");
+  });
+
+  it("protects a stale session that still has an active parent run", async () => {
+    const staleAt = Date.now() - 30 * 60 * 1_000;
+    const query = jest.fn((table: string) => ({
+      withIndex: jest.fn(() => ({
+        unique: jest.fn().mockResolvedValue(
+          table === "cloud_sandbox_sessions"
+            ? {
+                user_id: "user-owned",
+                session_id: "session-owned",
+                microvm_id: "microvm-owned",
+                status: "active",
+                created_at: staleAt,
+              }
+            : null,
+        ),
+        first: jest
+          .fn()
+          .mockResolvedValue(table === "chats" ? { _id: "chat-1" } : null),
+      })),
+    }));
+    const { getCloudSessionOrphanCleanupEligibility } =
+      await import("../localSandbox");
+
+    await expect(
+      getCloudSessionOrphanCleanupEligibility.handler(
+        { db: { query } } as never,
+        {
+          serviceKey: "service-key",
+          userId: "user-owned",
+          sessionId: "session-owned",
+          microvmId: "microvm-owned",
+          staleBeforeMs: Date.now() - 15 * 60 * 1_000,
+        },
+      ),
+    ).resolves.toEqual({
+      eligible: false,
+      reason: "active_parent_run",
+      lastActivityAt: staleAt,
+    });
+  });
+
   it("records failed regional failover timing when the replacement ends", async () => {
     const failoverStartedAt = Date.now() - 25;
     const patch = jest.fn().mockResolvedValue(undefined);

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -50,6 +50,10 @@ describe("s3Actions", () => {
       limit: 400,
       reset: Date.now() + 5 * 60 * 60 * 1000,
     });
+    const { copyS3Object } = await import("../s3Utils");
+    (
+      copyS3Object as jest.MockedFunction<typeof copyS3Object>
+    ).mockResolvedValue({ copied: true });
 
     // Setup environment variables
     process.env.AWS_S3_ACCESS_KEY_ID = "test-access-key";
@@ -95,9 +99,21 @@ describe("s3Actions", () => {
       const { copyS3Object, getS3ObjectMetadata, generateS3DownloadUrl } =
         await import("../s3Utils");
       (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 100 })
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 300 })
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 200 });
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 100,
+          eTag: '"east-100"',
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 300,
+          eTag: '"west-300"',
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 200,
+          eTag: '"eu-200"',
+        });
       (
         generateS3DownloadUrl as jest.MockedFunction<
           typeof generateS3DownloadUrl
@@ -118,6 +134,7 @@ describe("s3Actions", () => {
         "users/user_123/microvm-workspace/v1/workspace.tar.gz",
         { region: "us-west-2", bucketName: "workspace-west" },
         { region: "us-east-1", bucketName: "workspace-east" },
+        { ifMatch: '"east-100"' },
       );
       expect(generateS3DownloadUrl).toHaveBeenCalledWith(
         "users/user_123/microvm-workspace/v1/workspace.tar.gz",
@@ -129,9 +146,21 @@ describe("s3Actions", () => {
       const { getS3ObjectMetadata, generateS3DownloadUrl } =
         await import("../s3Utils");
       (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 300 })
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 100 })
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 300 });
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 300,
+          eTag: '"east-300"',
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 100,
+          eTag: '"west-100"',
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 300,
+          eTag: '"eu-300"',
+        });
       (
         generateS3DownloadUrl as jest.MockedFunction<
           typeof generateS3DownloadUrl
@@ -178,7 +207,11 @@ describe("s3Actions", () => {
         await import("../s3Utils");
       const regionalOutage = new Error("regional S3 unavailable");
       (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 100 })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 100,
+          eTag: '"east-100"',
+        })
         .mockRejectedValueOnce(regionalOutage)
         .mockResolvedValueOnce({ exists: false });
       const { getMicrovmWorkspaceDownloadUrlAction } =
@@ -198,8 +231,16 @@ describe("s3Actions", () => {
       const { copyS3Object, getS3ObjectMetadata, generateS3DownloadUrl } =
         await import("../s3Utils");
       (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 100 })
-        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 300 })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 100,
+          eTag: '"east-100"',
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 300,
+          eTag: '"west-300"',
+        })
         .mockResolvedValueOnce({ exists: false });
       const copyFailure = new Error("cross-region copy failed");
       (
@@ -216,6 +257,74 @@ describe("s3Actions", () => {
         }),
       ).rejects.toBe(copyFailure);
       expect(generateS3DownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it("does not overwrite a checkpoint that changes during restore localization", async () => {
+      const { copyS3Object, getS3ObjectMetadata, generateS3DownloadUrl } =
+        await import("../s3Utils");
+      (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 100,
+          eTag: '"east-100"',
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 300,
+          eTag: '"west-300"',
+        })
+        .mockResolvedValueOnce({ exists: false });
+      (
+        copyS3Object as jest.MockedFunction<typeof copyS3Object>
+      ).mockResolvedValue({ copied: false });
+      (
+        generateS3DownloadUrl as jest.MockedFunction<
+          typeof generateS3DownloadUrl
+        >
+      ).mockResolvedValue("https://s3.example/current-local-checkpoint");
+      const { getMicrovmWorkspaceDownloadUrlAction } =
+        await import("../s3Actions");
+
+      await expect(
+        getMicrovmWorkspaceDownloadUrlAction.handler({} as any, {
+          serviceKey: "service-key",
+          userId: "user_123",
+          region: "us-east-1",
+        }),
+      ).resolves.toBe("https://s3.example/current-local-checkpoint");
+      expect(copyS3Object).toHaveBeenCalledWith(
+        "users/user_123/microvm-workspace/v1/workspace.tar.gz",
+        { region: "us-west-2", bucketName: "workspace-west" },
+        { region: "us-east-1", bucketName: "workspace-east" },
+        { ifMatch: '"east-100"' },
+      );
+    });
+
+    it("fails closed when a destination ETag is unavailable for a conditional copy", async () => {
+      const { copyS3Object, getS3ObjectMetadata } = await import("../s3Utils");
+      (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 100,
+          eTag: null,
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          lastModifiedMs: 300,
+          eTag: '"west-300"',
+        })
+        .mockResolvedValueOnce({ exists: false });
+      const { getMicrovmWorkspaceDownloadUrlAction } =
+        await import("../s3Actions");
+
+      await expect(
+        getMicrovmWorkspaceDownloadUrlAction.handler({} as any, {
+          serviceKey: "service-key",
+          userId: "user_123",
+          region: "us-east-1",
+        }),
+      ).rejects.toThrow("S3 workspace metadata in us-east-1 is missing ETag");
+      expect(copyS3Object).not.toHaveBeenCalled();
     });
 
     it("fails closed when a regional bucket is not configured", async () => {

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -92,7 +92,7 @@ describe("s3Actions", () => {
     });
 
     it("restores the newest snapshot across all workspace regions", async () => {
-      const { getS3ObjectMetadata, generateS3DownloadUrl } =
+      const { copyS3Object, getS3ObjectMetadata, generateS3DownloadUrl } =
         await import("../s3Utils");
       (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
         .mockResolvedValueOnce({ exists: true, lastModifiedMs: 100 })
@@ -114,9 +114,14 @@ describe("s3Actions", () => {
         }),
       ).resolves.toBe("https://s3.example/download");
       expect(getS3ObjectMetadata).toHaveBeenCalledTimes(3);
-      expect(generateS3DownloadUrl).toHaveBeenCalledWith(
+      expect(copyS3Object).toHaveBeenCalledWith(
         "users/user_123/microvm-workspace/v1/workspace.tar.gz",
         { region: "us-west-2", bucketName: "workspace-west" },
+        { region: "us-east-1", bucketName: "workspace-east" },
+      );
+      expect(generateS3DownloadUrl).toHaveBeenCalledWith(
+        "users/user_123/microvm-workspace/v1/workspace.tar.gz",
+        { region: "us-east-1", bucketName: "workspace-east" },
       );
     });
 
@@ -141,6 +146,8 @@ describe("s3Actions", () => {
         region: "eu-west-1",
       });
 
+      const { copyS3Object } = await import("../s3Utils");
+      expect(copyS3Object).not.toHaveBeenCalled();
       expect(generateS3DownloadUrl).toHaveBeenCalledWith(
         "users/user_123/microvm-workspace/v1/workspace.tar.gz",
         { region: "eu-west-1", bucketName: "workspace-eu" },
@@ -184,6 +191,30 @@ describe("s3Actions", () => {
           region: "us-east-1",
         }),
       ).rejects.toBe(regionalOutage);
+      expect(generateS3DownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when a cross-region restore cannot be localized", async () => {
+      const { copyS3Object, getS3ObjectMetadata, generateS3DownloadUrl } =
+        await import("../s3Utils");
+      (getS3ObjectMetadata as jest.MockedFunction<typeof getS3ObjectMetadata>)
+        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 100 })
+        .mockResolvedValueOnce({ exists: true, lastModifiedMs: 300 })
+        .mockResolvedValueOnce({ exists: false });
+      const copyFailure = new Error("cross-region copy failed");
+      (
+        copyS3Object as jest.MockedFunction<typeof copyS3Object>
+      ).mockRejectedValue(copyFailure);
+      const { getMicrovmWorkspaceDownloadUrlAction } =
+        await import("../s3Actions");
+
+      await expect(
+        getMicrovmWorkspaceDownloadUrlAction.handler({} as any, {
+          serviceKey: "service-key",
+          userId: "user_123",
+          region: "us-east-1",
+        }),
+      ).rejects.toBe(copyFailure);
       expect(generateS3DownloadUrl).not.toHaveBeenCalled();
     });
 

--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -305,7 +305,7 @@ describe("s3Utils", () => {
       const lastModified = new Date("2026-08-24T04:00:00.000Z");
       const mockSend = jest
         .fn()
-        .mockResolvedValue({ LastModified: lastModified });
+        .mockResolvedValue({ LastModified: lastModified, ETag: '"etag-42"' });
       (S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
         () => ({ send: mockSend }) as unknown as S3Client,
       );
@@ -319,6 +319,7 @@ describe("s3Utils", () => {
       ).resolves.toEqual({
         exists: true,
         lastModifiedMs: lastModified.getTime(),
+        eTag: '"etag-42"',
       });
     });
   });
@@ -333,11 +334,14 @@ describe("s3Utils", () => {
       );
       const { copyS3Object } = await import("../s3Utils");
 
-      await copyS3Object(
-        "users/user%2F123/microvm-workspace/v1/workspace.tar.gz",
-        { region: "us-west-2", bucketName: "workspace-west" },
-        { region: "eu-west-1", bucketName: "workspace-eu" },
-      );
+      await expect(
+        copyS3Object(
+          "users/user%2F123/microvm-workspace/v1/workspace.tar.gz",
+          { region: "us-west-2", bucketName: "workspace-west" },
+          { region: "eu-west-1", bucketName: "workspace-eu" },
+          { ifMatch: '"destination-etag"' },
+        ),
+      ).resolves.toEqual({ copied: true });
 
       expect(S3Client).toHaveBeenCalledWith(
         expect.objectContaining({ region: "eu-west-1" }),
@@ -347,8 +351,34 @@ describe("s3Utils", () => {
         Key: "users/user%2F123/microvm-workspace/v1/workspace.tar.gz",
         CopySource:
           "workspace-west/users/user%252F123/microvm-workspace/v1/workspace.tar.gz",
+        IfMatch: '"destination-etag"',
       });
       expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves a concurrently updated destination checkpoint", async () => {
+      const { S3Client, CopyObjectCommand } =
+        await import("@aws-sdk/client-s3");
+      const mockSend = jest.fn().mockRejectedValue({
+        name: "PreconditionFailed",
+        $metadata: { httpStatusCode: 412 },
+      });
+      (S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+        () => ({ send: mockSend }) as unknown as S3Client,
+      );
+      const { copyS3Object } = await import("../s3Utils");
+
+      await expect(
+        copyS3Object(
+          "workspace.tar.gz",
+          { region: "us-west-2", bucketName: "workspace-west" },
+          { region: "us-east-1", bucketName: "workspace-east" },
+          { ifNoneMatch: "*" },
+        ),
+      ).resolves.toEqual({ copied: false });
+      expect(CopyObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ IfNoneMatch: "*" }),
+      );
     });
   });
 });

--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -380,5 +380,27 @@ describe("s3Utils", () => {
         expect.objectContaining({ IfNoneMatch: "*" }),
       );
     });
+
+    it("propagates a conditional conflict when the destination may be absent", async () => {
+      const { S3Client } = await import("@aws-sdk/client-s3");
+      const conflict = {
+        name: "ConditionalRequestConflict",
+        $metadata: { httpStatusCode: 409 },
+      };
+      const mockSend = jest.fn().mockRejectedValue(conflict);
+      (S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+        () => ({ send: mockSend }) as unknown as S3Client,
+      );
+      const { copyS3Object } = await import("../s3Utils");
+
+      await expect(
+        copyS3Object(
+          "workspace.tar.gz",
+          { region: "us-west-2", bucketName: "workspace-west" },
+          { region: "us-east-1", bucketName: "workspace-east" },
+          { ifNoneMatch: "*" },
+        ),
+      ).rejects.toBe(conflict);
+    });
   });
 });

--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -322,4 +322,33 @@ describe("s3Utils", () => {
       });
     });
   });
+
+  describe("copyS3Object", () => {
+    it("copies a workspace into the destination region server-side", async () => {
+      const { S3Client, CopyObjectCommand } =
+        await import("@aws-sdk/client-s3");
+      const mockSend = jest.fn().mockResolvedValue({});
+      (S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+        () => ({ send: mockSend }) as unknown as S3Client,
+      );
+      const { copyS3Object } = await import("../s3Utils");
+
+      await copyS3Object(
+        "users/user%2F123/microvm-workspace/v1/workspace.tar.gz",
+        { region: "us-west-2", bucketName: "workspace-west" },
+        { region: "eu-west-1", bucketName: "workspace-eu" },
+      );
+
+      expect(S3Client).toHaveBeenCalledWith(
+        expect.objectContaining({ region: "eu-west-1" }),
+      );
+      expect(CopyObjectCommand).toHaveBeenCalledWith({
+        Bucket: "workspace-eu",
+        Key: "users/user%2F123/microvm-workspace/v1/workspace.tar.gz",
+        CopySource:
+          "workspace-west/users/user%252F123/microvm-workspace/v1/workspace.tar.gz",
+      });
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -67,6 +67,7 @@ const CLOUD_SESSION_TOKEN_TTL_MS = 9 * 60 * 60 * 1000;
 const CLOUD_SESSION_STARTING_STALE_MS = 2 * 60 * 1000;
 const CLOUD_SANDBOX_DELETION_FENCE_TTL_MS = 2 * 60 * 1000;
 const RELAY_READY_CLIENT_VERSION = "aws-lambda-microvm-relay-ready-v1";
+const ACTIVE_SUBAGENT_STATUSES = ["queued", "running", "finalizing"] as const;
 
 const cloudSessionStatus = v.union(
   v.literal("starting"),
@@ -108,6 +109,7 @@ const cloudSessionForBackend = v.object({
   createdAt: v.number(),
   updatedAt: v.number(),
   bootstrapExpiresAt: v.number(),
+  lastConnectedAt: v.optional(v.number()),
   relayReadyAt: v.optional(v.number()),
   awsState: v.optional(cloudMicrovmState),
   awsStateCheckedAt: v.optional(v.number()),
@@ -147,6 +149,7 @@ function serializeCloudSession(session: {
   created_at: number;
   updated_at: number;
   bootstrap_expires_at: number;
+  last_connected_at?: number;
   relay_ready_at?: number;
   aws_state?:
     | "PENDING"
@@ -179,6 +182,7 @@ function serializeCloudSession(session: {
     createdAt: session.created_at,
     updatedAt: session.updated_at,
     bootstrapExpiresAt: session.bootstrap_expires_at,
+    lastConnectedAt: session.last_connected_at,
     relayReadyAt: session.relay_ready_at,
     awsState: session.aws_state,
     awsStateCheckedAt: session.aws_state_checked_at,
@@ -925,6 +929,99 @@ export const listCloudSessionsForReconciliation = query({
         userId: session.user_id,
         session: serializeCloudSession(session),
       }));
+  },
+});
+
+export const getCloudSessionOrphanCleanupEligibility = query({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    sessionId: v.string(),
+    microvmId: v.string(),
+    staleBeforeMs: v.number(),
+  },
+  returns: v.object({
+    eligible: v.boolean(),
+    reason: v.union(
+      v.literal("eligible"),
+      v.literal("session_not_owned"),
+      v.literal("session_not_active"),
+      v.literal("recent_activity"),
+      v.literal("active_parent_run"),
+      v.literal("active_subagent"),
+    ),
+    lastActivityAt: v.optional(v.number()),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const session = await ctx.db
+      .query("cloud_sandbox_sessions")
+      .withIndex("by_session_id", (q) => q.eq("session_id", args.sessionId))
+      .unique();
+    if (
+      !session ||
+      session.user_id !== args.userId ||
+      session.microvm_id !== args.microvmId
+    ) {
+      return { eligible: false, reason: "session_not_owned" as const };
+    }
+    if (session.status !== "active" && session.status !== "running") {
+      return { eligible: false, reason: "session_not_active" as const };
+    }
+
+    const connection = session.connection_id
+      ? await ctx.db
+          .query("local_sandbox_connections")
+          .withIndex("by_connection_id", (q) =>
+            q.eq("connection_id", session.connection_id!),
+          )
+          .unique()
+      : null;
+    const lastActivityAt = Math.max(
+      session.created_at,
+      session.last_connected_at ?? 0,
+      session.relay_ready_at ?? 0,
+      connection?.last_heartbeat ?? 0,
+    );
+    if (lastActivityAt >= args.staleBeforeMs) {
+      return {
+        eligible: false,
+        reason: "recent_activity" as const,
+        lastActivityAt,
+      };
+    }
+
+    const activeParentRun = await ctx.db
+      .query("chats")
+      .withIndex("by_user_and_active_trigger_run", (q) =>
+        q.eq("user_id", args.userId).gt("active_trigger_run_id", ""),
+      )
+      .first();
+    if (activeParentRun) {
+      return {
+        eligible: false,
+        reason: "active_parent_run" as const,
+        lastActivityAt,
+      };
+    }
+
+    for (const status of ACTIVE_SUBAGENT_STATUSES) {
+      const activeSubagent = await ctx.db
+        .query("subagent_runs")
+        .withIndex("by_user_and_status", (q) =>
+          q.eq("user_id", args.userId).eq("status", status),
+        )
+        .first();
+      if (activeSubagent) {
+        return {
+          eligible: false,
+          reason: "active_subagent" as const,
+          lastActivityAt,
+        };
+      }
+    }
+
+    return { eligible: true, reason: "eligible" as const, lastActivityAt };
   },
 });
 

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -932,6 +932,7 @@ export const listCloudSessionsForReconciliation = query({
   },
 });
 
+/** Fail-closed ownership and activity gate for scheduled orphan cleanup. */
 export const getCloudSessionOrphanCleanupEligibility = query({
   args: {
     serviceKey: v.string(),

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -3,6 +3,7 @@
 import { action } from "./_generated/server";
 import { v, ConvexError, type VLiteral } from "convex/values";
 import {
+  copyS3Object,
   deleteS3Object,
   generateS3DownloadUrl,
   generateS3UploadUrl,
@@ -153,7 +154,17 @@ export const getMicrovmWorkspaceDownloadUrlAction = action({
       }
       return selected;
     });
-    return generateS3DownloadUrl(s3Key, latest.target);
+    const restoreTarget = getMicrovmWorkspaceS3Target(args.region);
+    if (latest.sourceRegion !== args.region) {
+      await copyS3Object(s3Key, latest.target, restoreTarget);
+      convexLogger.info("microvm_workspace_copied_to_restore_region", {
+        service: "microvm_workspace",
+        environment: process.env.CONVEX_CLOUD_URL ? "cloud" : "unknown",
+        source_region: latest.sourceRegion,
+        destination_region: args.region,
+      });
+    }
+    return generateS3DownloadUrl(s3Key, restoreTarget);
   },
 });
 

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -136,6 +136,7 @@ export const getMicrovmWorkspaceDownloadUrlAction = action({
           sourceRegion,
           target,
           lastModifiedMs: metadata.lastModifiedMs,
+          eTag: metadata.eTag,
         };
       }),
     );
@@ -156,12 +157,26 @@ export const getMicrovmWorkspaceDownloadUrlAction = action({
     });
     const restoreTarget = getMicrovmWorkspaceS3Target(args.region);
     if (latest.sourceRegion !== args.region) {
-      await copyS3Object(s3Key, latest.target, restoreTarget);
-      convexLogger.info("microvm_workspace_copied_to_restore_region", {
+      const destination = candidates.find(
+        (candidate) => candidate?.sourceRegion === args.region,
+      );
+      if (destination && !destination.eTag) {
+        throw new Error(
+          `S3 workspace metadata in ${args.region} is missing ETag`,
+        );
+      }
+      const result = await copyS3Object(
+        s3Key,
+        latest.target,
+        restoreTarget,
+        destination ? { ifMatch: destination.eTag! } : { ifNoneMatch: "*" },
+      );
+      convexLogger.info("microvm_workspace_restore_localized", {
         service: "microvm_workspace",
         environment: process.env.CONVEX_CLOUD_URL ? "cloud" : "unknown",
         source_region: latest.sourceRegion,
         destination_region: args.region,
+        outcome: result.copied ? "copied" : "destination_changed",
       });
     }
     return generateS3DownloadUrl(s3Key, restoreTarget);

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -4,6 +4,7 @@ import {
   GetObjectCommand,
   DeleteObjectCommand,
   HeadObjectCommand,
+  CopyObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { v4 as uuidv4 } from "uuid";
@@ -200,6 +201,26 @@ export async function getS3ObjectMetadata(
     }
     throw error;
   }
+}
+
+/**
+ * Copy a trusted object into another regional bucket. The copy runs inside S3,
+ * so a MicroVM never has to download a cross-region workspace through NAT.
+ */
+export async function copyS3Object(
+  s3Key: string,
+  source: S3ObjectTarget,
+  destination: S3ObjectTarget,
+): Promise<void> {
+  const s3Client = getS3Client(destination.region);
+  const encodedKey = s3Key.split("/").map(encodeURIComponent).join("/");
+  await s3Client.send(
+    new CopyObjectCommand({
+      Bucket: destination.bucketName,
+      Key: s3Key,
+      CopySource: `${source.bucketName}/${encodedKey}`,
+    }),
+  );
 }
 
 /** Return whether an S3 object exists without treating a missing key as an error. */

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -160,9 +160,10 @@ export async function generateS3DownloadUrl(
 }
 
 export type S3ObjectMetadata =
-  { exists: false } | { exists: true; lastModifiedMs: number | null };
+  | { exists: false }
+  | { exists: true; lastModifiedMs: number | null; eTag: string | null };
 
-/** Read object presence and its S3-authoritative modification time. */
+/** Read object presence plus its S3-authoritative modification time and ETag. */
 export async function getS3ObjectMetadata(
   s3Key: string,
   target?: S3ObjectTarget,
@@ -177,6 +178,7 @@ export async function getS3ObjectMetadata(
     return {
       exists: true,
       lastModifiedMs: result.LastModified?.getTime() ?? null,
+      eTag: result.ETag ?? null,
     };
   } catch (error) {
     const record =
@@ -206,21 +208,40 @@ export async function getS3ObjectMetadata(
 /**
  * Copy a trusted object into another regional bucket. The copy runs inside S3,
  * so a MicroVM never has to download a cross-region workspace through NAT.
+ * The destination precondition keeps a concurrent checkpoint from being
+ * overwritten by the restore copy.
  */
 export async function copyS3Object(
   s3Key: string,
   source: S3ObjectTarget,
   destination: S3ObjectTarget,
-): Promise<void> {
+  destinationCondition: { ifMatch: string } | { ifNoneMatch: "*" },
+): Promise<{ copied: boolean }> {
   const s3Client = getS3Client(destination.region);
   const encodedKey = s3Key.split("/").map(encodeURIComponent).join("/");
-  await s3Client.send(
-    new CopyObjectCommand({
-      Bucket: destination.bucketName,
-      Key: s3Key,
-      CopySource: `${source.bucketName}/${encodedKey}`,
-    }),
-  );
+  try {
+    await s3Client.send(
+      new CopyObjectCommand({
+        Bucket: destination.bucketName,
+        Key: s3Key,
+        CopySource: `${source.bucketName}/${encodedKey}`,
+        ...(destinationCondition && "ifMatch" in destinationCondition
+          ? { IfMatch: destinationCondition.ifMatch }
+          : { IfNoneMatch: "*" }),
+      }),
+    );
+    return { copied: true };
+  } catch (error) {
+    const statusCode =
+      error && typeof error === "object"
+        ? (error as { $metadata?: { httpStatusCode?: unknown } }).$metadata
+            ?.httpStatusCode
+        : undefined;
+    if (statusCode === 409 || statusCode === 412) {
+      return { copied: false };
+    }
+    throw error;
+  }
 }
 
 /** Return whether an S3 object exists without treating a missing key as an error. */

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -237,7 +237,7 @@ export async function copyS3Object(
         ? (error as { $metadata?: { httpStatusCode?: unknown } }).$metadata
             ?.httpStatusCode
         : undefined;
-    if (statusCode === 409 || statusCode === 412) {
+    if (statusCode === 412) {
       return { copied: false };
     }
     throw error;

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -496,6 +496,11 @@ describe("AWS Lambda MicroVM development logging", () => {
       suspended: 1,
       terminal: 1,
       failures: 0,
+      orphanCleanupChecked: 0,
+      orphanCleanupEligible: 0,
+      orphanCleanupSuspended: 0,
+      orphanCleanupTerminated: 0,
+      orphanCleanupFailures: 0,
     });
     expect(mockMutation.mock.calls).toEqual(
       expect.arrayContaining([
@@ -516,6 +521,66 @@ describe("AWS Lambda MicroVM development logging", () => {
         ]),
       ]),
     );
+    infoSpy.mockRestore();
+  });
+
+  it("snapshot-suspends a stale running MicroVM with no active owner", async () => {
+    const staleAt = Date.now() - 30 * 60 * 1_000;
+    const session = {
+      sessionId: "session-orphan",
+      status: "active" as const,
+      microvmId: "microvm-orphan",
+      region: "us-east-1",
+      imageIdentifier: process.env.AWS_LAMBDA_MICROVM_IMAGE_ID,
+      imageVersion: "6.0",
+      createdAt: staleAt,
+      updatedAt: staleAt,
+      lastConnectedAt: staleAt,
+      bootstrapExpiresAt: Date.now() + 60_000,
+    };
+    mockQuery
+      .mockResolvedValueOnce([{ userId: "user-orphan", session }])
+      .mockResolvedValueOnce({
+        eligible: true,
+        reason: "eligible",
+        lastActivityAt: staleAt,
+      })
+      .mockResolvedValueOnce([session]);
+    mockSend
+      .mockResolvedValueOnce({
+        state: "RUNNING",
+        endpoint: "microvm-orphan.example.test",
+      })
+      .mockResolvedValueOnce({
+        state: "RUNNING",
+        endpoint: "microvm-orphan.example.test",
+      })
+      .mockResolvedValueOnce({
+        state: "SUSPENDING",
+        $metadata: { requestId: "suspend-orphan", httpStatusCode: 200 },
+      });
+    mockMutation.mockResolvedValue(true);
+    const infoSpy = jest.spyOn(console, "info").mockImplementation();
+
+    await expect(reconcileAwsLambdaMicrovmSessions()).resolves.toEqual({
+      checked: 1,
+      running: 1,
+      suspended: 0,
+      terminal: 0,
+      failures: 0,
+      orphanCleanupChecked: 1,
+      orphanCleanupEligible: 1,
+      orphanCleanupSuspended: 1,
+      orphanCleanupTerminated: 0,
+      orphanCleanupFailures: 0,
+    });
+    expect(mockSnapshotWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-orphan",
+        region: "us-east-1",
+      }),
+    );
+    expect(mockSend.mock.calls).toHaveLength(3);
     infoSpy.mockRestore();
   });
 

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -500,6 +500,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       orphanCleanupEligible: 0,
       orphanCleanupSuspended: 0,
       orphanCleanupTerminated: 0,
+      orphanCleanupProtected: 0,
       orphanCleanupFailures: 0,
     });
     expect(mockMutation.mock.calls).toEqual(
@@ -545,7 +546,12 @@ describe("AWS Lambda MicroVM development logging", () => {
         reason: "eligible",
         lastActivityAt: staleAt,
       })
-      .mockResolvedValueOnce([session]);
+      .mockResolvedValueOnce([session])
+      .mockResolvedValueOnce({
+        eligible: true,
+        reason: "eligible",
+        lastActivityAt: staleAt,
+      });
     mockSend
       .mockResolvedValueOnce({
         state: "RUNNING",
@@ -572,6 +578,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       orphanCleanupEligible: 1,
       orphanCleanupSuspended: 1,
       orphanCleanupTerminated: 0,
+      orphanCleanupProtected: 0,
       orphanCleanupFailures: 0,
     });
     expect(mockSnapshotWorkspace).toHaveBeenCalledWith(
@@ -581,6 +588,72 @@ describe("AWS Lambda MicroVM development logging", () => {
       }),
     );
     expect(mockSend.mock.calls).toHaveLength(3);
+    infoSpy.mockRestore();
+  });
+
+  it("keeps a stale MicroVM running when an owner reconnects during its snapshot", async () => {
+    const staleAt = Date.now() - 30 * 60 * 1_000;
+    const session = {
+      sessionId: "session-reactivated",
+      status: "active" as const,
+      microvmId: "microvm-reactivated",
+      region: "us-east-1",
+      imageIdentifier: process.env.AWS_LAMBDA_MICROVM_IMAGE_ID,
+      imageVersion: "6.0",
+      createdAt: staleAt,
+      updatedAt: staleAt,
+      lastConnectedAt: staleAt,
+      bootstrapExpiresAt: Date.now() + 60_000,
+    };
+    mockQuery
+      .mockResolvedValueOnce([{ userId: "user-reactivated", session }])
+      .mockResolvedValueOnce({
+        eligible: true,
+        reason: "eligible",
+        lastActivityAt: staleAt,
+      })
+      .mockResolvedValueOnce([session])
+      .mockResolvedValueOnce({
+        eligible: false,
+        reason: "active_parent_run",
+        lastActivityAt: Date.now(),
+      });
+    mockSend
+      .mockResolvedValueOnce({
+        state: "RUNNING",
+        endpoint: "microvm-reactivated.example.test",
+      })
+      .mockResolvedValueOnce({
+        state: "RUNNING",
+        endpoint: "microvm-reactivated.example.test",
+      });
+    mockMutation.mockResolvedValue(true);
+    const infoSpy = jest.spyOn(console, "info").mockImplementation();
+
+    await expect(reconcileAwsLambdaMicrovmSessions()).resolves.toEqual({
+      checked: 1,
+      running: 1,
+      suspended: 0,
+      terminal: 0,
+      failures: 0,
+      orphanCleanupChecked: 1,
+      orphanCleanupEligible: 1,
+      orphanCleanupSuspended: 0,
+      orphanCleanupTerminated: 0,
+      orphanCleanupProtected: 1,
+      orphanCleanupFailures: 0,
+    });
+    expect(mockSnapshotWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(
+      infoSpy.mock.calls
+        .map(([payload]) => JSON.parse(payload as string))
+        .find(
+          (payload) =>
+            payload.event === "cloud_sandbox_orphan_cleanup_skipped" &&
+            payload.phase === "post_snapshot",
+        ),
+    ).toMatchObject({ reason: "active_parent_run" });
     infoSpy.mockRestore();
   });
 
@@ -1404,6 +1477,7 @@ describe("AWS Lambda MicroVM development logging", () => {
         terminated: 0,
         alreadyGone: 0,
         workspacesSaved: 1,
+        ownershipProtected: 0,
       },
     );
 
@@ -1454,6 +1528,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       terminated: 0,
       alreadyGone: 0,
       workspacesSaved: 1,
+      ownershipProtected: 0,
     });
 
     expect(mockSnapshotWorkspace).toHaveBeenCalledTimes(1);
@@ -1534,6 +1609,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       terminated: 1,
       alreadyGone: 0,
       workspacesSaved: 1,
+      ownershipProtected: 0,
     });
     expect(mockSend).toHaveBeenCalledTimes(3);
     expect(mockMutation).toHaveBeenCalledWith(

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -1624,6 +1624,66 @@ describe("AWS Lambda MicroVM development logging", () => {
     warnSpy.mockRestore();
   });
 
+  it("keeps an orphan MicroVM running when its owner reconnects before fallback termination", async () => {
+    const session = {
+      sessionId: "session-fallback-reactivated",
+      status: "running" as const,
+      microvmId: "microvm-fallback-reactivated",
+      region: "us-east-1",
+    };
+    mockQuery
+      .mockResolvedValueOnce([session])
+      .mockResolvedValueOnce({
+        eligible: true,
+        reason: "eligible",
+        lastActivityAt: Date.now() - 30 * 60 * 1_000,
+      })
+      .mockResolvedValueOnce({
+        eligible: false,
+        reason: "active_parent_run",
+        lastActivityAt: Date.now(),
+      });
+    mockSend
+      .mockResolvedValueOnce({
+        state: "RUNNING",
+        endpoint: "microvm-fallback-reactivated.example.test",
+      })
+      .mockRejectedValueOnce(new Error("suspend failed"));
+    const infoSpy = jest.spyOn(console, "info").mockImplementation();
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    await expect(
+      suspendAwsLambdaMicrovmsForUser("user-fallback-reactivated", {
+        sessionId: session.sessionId,
+        orphanCleanup: {
+          microvmId: session.microvmId,
+          staleBeforeMs: Date.now() - 15 * 60 * 1_000,
+        },
+      }),
+    ).resolves.toEqual({
+      total: 1,
+      suspended: 0,
+      alreadySuspended: 0,
+      terminated: 0,
+      alreadyGone: 0,
+      workspacesSaved: 1,
+      ownershipProtected: 1,
+    });
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(
+      infoSpy.mock.calls
+        .map(([payload]) => JSON.parse(payload as string))
+        .find(
+          (payload) =>
+            payload.event === "cloud_sandbox_orphan_cleanup_skipped" &&
+            payload.phase === "pre_termination",
+        ),
+    ).toMatchObject({ reason: "active_parent_run" });
+
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
   it("keeps a session retryable when suspend and termination both fail", async () => {
     mockQuery.mockResolvedValueOnce([
       {

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-workspace.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-workspace.test.ts
@@ -68,7 +68,12 @@ describe("AWS Lambda MicroVM durable workspace", () => {
       region: "us-west-2",
     });
     const checkpointCommand = run.mock.calls[1][0] as string;
-    expect(checkpointCommand).toContain("sleep 120");
+    expect(checkpointCommand).toContain("interval=300");
+    expect(checkpointCommand).toContain('sleep "$interval"');
+    expect(checkpointCommand).toContain("checkpoint.fingerprint");
+    expect(checkpointCommand.indexOf('mv "$fingerprint_tmp"')).toBeLessThan(
+      checkpointCommand.indexOf("nohup /bin/bash"),
+    );
     expect(checkpointCommand).toContain("nohup /bin/bash");
     expect(checkpointCommand).toContain("exec 8>&-");
   });
@@ -184,9 +189,24 @@ describe("AWS Lambda MicroVM durable workspace", () => {
 
   it("keeps fatal checkpoint tar errors from reaching the upload", () => {
     const script = buildWorkspaceCheckpointScript();
+    expect(script).not.toContain("if (");
     expect(script).toContain("tar_status=0");
     expect(script).toContain("tar_status=$?");
     expect(script).toContain('[ "$tar_status" -le 1 ]');
+  });
+
+  it("skips unchanged checkpoints and backs off quiet workspaces", () => {
+    const script = buildWorkspaceCheckpointScript();
+
+    expect(script).toContain("workspace_fingerprint()");
+    expect(script).toContain("sha256sum");
+    expect(script).toContain("-name node_modules");
+    expect(script).toContain("exit 10");
+    expect(script).toContain('checkpoint_status="$?"');
+    expect(script).toContain("interval=600");
+    expect(script.indexOf('--upload-file "$archive"')).toBeLessThan(
+      script.indexOf('mv "$fingerprint_tmp" "$fingerprint_file"'),
+    );
   });
 
   it("bounds detached checkpoint work below the final snapshot lock wait", () => {
@@ -194,7 +214,10 @@ describe("AWS Lambda MicroVM durable workspace", () => {
 
     expect(script).toContain("timeout --signal=TERM --kill-after=5s 45s tar");
     expect(script).toContain("timeout --signal=TERM --kill-after=5s 50s curl");
+    expect(script).toContain(
+      "timeout --signal=TERM --kill-after=2s 10s /bin/bash -c",
+    );
     expect(script).toContain("--connect-timeout 15 --max-time 50");
-    expect(45 + 5 + 50 + 5).toBeLessThan(120);
+    expect(10 + 2 + 45 + 5 + 50 + 5).toBeLessThan(120);
   });
 });

--- a/lib/ai/tools/utils/aws-lambda-microvm-workspace.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm-workspace.ts
@@ -14,7 +14,11 @@ const WORKSPACE_CHECKPOINT_SCRIPT = "/tmp/.hackerai-workspace-v1-checkpoint.sh";
 const WORKSPACE_CHECKPOINT_PID = "/tmp/.hackerai-workspace-v1-checkpoint.pid";
 const WORKSPACE_CHECKPOINT_START_LOCK =
   "/tmp/.hackerai-workspace-v1-checkpoint-start.lock";
-const WORKSPACE_CHECKPOINT_INTERVAL_SECONDS = 2 * 60;
+const WORKSPACE_CHECKPOINT_FINGERPRINT =
+  "/tmp/.hackerai-workspace-v1-checkpoint.fingerprint";
+const WORKSPACE_ACTIVE_CHECKPOINT_INTERVAL_SECONDS = 5 * 60;
+const WORKSPACE_QUIET_CHECKPOINT_INTERVAL_SECONDS = 10 * 60;
+const WORKSPACE_CHECKPOINT_FINGERPRINT_TIMEOUT_SECONDS = 10;
 const WORKSPACE_CHECKPOINT_TAR_TIMEOUT_SECONDS = 45;
 const WORKSPACE_CHECKPOINT_UPLOAD_TIMEOUT_SECONDS = 50;
 const WORKSPACE_CHECKPOINT_CONNECT_TIMEOUT_SECONDS = 15;
@@ -37,6 +41,27 @@ type WorkspaceSandbox = {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function workspaceFingerprintCommand(): string {
+  return [
+    `(cd ${shellQuote(WORKSPACE_ROOT)} && find . \\`,
+    "  \\( -path './.cache' -o -path './.npm/_cacache' -o -path './.local/share/pnpm/store' -o -name node_modules \\) -prune -o " +
+      "\\",
+    "  -printf '%P\\0%y\\0%s\\0%T@\\0%l\\0' | LC_ALL=C sort -z | sha256sum | cut -d' ' -f1)",
+  ].join("\n");
+}
+
+function boundedWorkspaceFingerprintCommand(): string {
+  return [
+    "timeout",
+    "--signal=TERM",
+    "--kill-after=2s",
+    `${WORKSPACE_CHECKPOINT_FINGERPRINT_TIMEOUT_SECONDS}s`,
+    "/bin/bash",
+    "-c",
+    shellQuote(`set -euo pipefail; ${workspaceFingerprintCommand()}`),
+  ].join(" ");
 }
 
 function transferError(
@@ -118,19 +143,37 @@ export function buildWorkspaceSnapshotCommand(uploadUrl: string) {
 export function buildWorkspaceCheckpointScript() {
   return [
     "#!/bin/bash",
+    `interval=${WORKSPACE_ACTIVE_CHECKPOINT_INTERVAL_SECONDS}`,
+    "workspace_fingerprint() {",
+    `  ${boundedWorkspaceFingerprintCommand()}`,
+    "}",
     "while true; do",
-    `  sleep ${WORKSPACE_CHECKPOINT_INTERVAL_SECONDS}`,
+    '  sleep "$interval"',
     "  (",
     "    set -eu",
-    "    flock -n 9 || exit 0",
+    "    flock -n 9 || exit 11",
+    '    fingerprint="$(workspace_fingerprint)"',
+    `    fingerprint_file=${shellQuote(WORKSPACE_CHECKPOINT_FINGERPRINT)}`,
+    '    if [ -r "$fingerprint_file" ] && [ "$(cat "$fingerprint_file")" = "$fingerprint" ]; then exit 10; fi',
     '    archive="$(mktemp /tmp/hackerai-workspace.XXXXXX.tar.gz)"',
-    "    trap 'rm -f \"$archive\"' EXIT",
+    '    fingerprint_tmp="${fingerprint_file}.$$"',
+    '    trap \'rm -f "$archive" "$fingerprint_tmp"\' EXIT',
     "    tar_status=0",
     `    timeout --signal=TERM --kill-after=5s ${WORKSPACE_CHECKPOINT_TAR_TIMEOUT_SECONDS}s tar --create --gzip --file="$archive" --directory=${shellQuote(WORKSPACE_ROOT)} --warning=no-file-changed --exclude='./.cache' --exclude='./.npm/_cacache' --exclude='./.local/share/pnpm/store' --exclude='*/node_modules' . || tar_status=$?`,
     '    [ "$tar_status" -le 1 ]',
     `    upload_url="$(cat ${shellQuote(WORKSPACE_UPLOAD_URL_FILE)})"`,
     `    timeout --signal=TERM --kill-after=5s ${WORKSPACE_CHECKPOINT_UPLOAD_TIMEOUT_SECONDS}s curl --fail --silent --show-error --connect-timeout ${WORKSPACE_CHECKPOINT_CONNECT_TIMEOUT_SECONDS} --max-time ${WORKSPACE_CHECKPOINT_UPLOAD_TIMEOUT_SECONDS} --retry 3 --retry-all-errors --request PUT --upload-file "$archive" "$upload_url"`,
-    `  ) 9>${shellQuote(WORKSPACE_SNAPSHOT_LOCK)} || true`,
+    '    printf \'%s\\n\' "$fingerprint" > "$fingerprint_tmp"',
+    '    mv "$fingerprint_tmp" "$fingerprint_file"',
+    `  ) 9>${shellQuote(WORKSPACE_SNAPSHOT_LOCK)}`,
+    '  checkpoint_status="$?"',
+    '  if [ "$checkpoint_status" -eq 0 ]; then',
+    `    interval=${WORKSPACE_ACTIVE_CHECKPOINT_INTERVAL_SECONDS}`,
+    '  elif [ "$checkpoint_status" -eq 10 ]; then',
+    `    interval=${WORKSPACE_QUIET_CHECKPOINT_INTERVAL_SECONDS}`,
+    "  else",
+    `    interval=${WORKSPACE_ACTIVE_CHECKPOINT_INTERVAL_SECONDS}`,
+    "  fi",
     "done",
   ].join("\n");
 }
@@ -143,9 +186,15 @@ export function buildWorkspaceCheckpointCommand(uploadUrl: string) {
     `url_file=${shellQuote(WORKSPACE_UPLOAD_URL_FILE)}`,
     `script=${shellQuote(WORKSPACE_CHECKPOINT_SCRIPT)}`,
     `pid_file=${shellQuote(WORKSPACE_CHECKPOINT_PID)}`,
+    `fingerprint_file=${shellQuote(WORKSPACE_CHECKPOINT_FINGERPRINT)}`,
     'url_tmp="${url_file}.$$"',
     `printf '%s' ${shellQuote(uploadUrl)} > "$url_tmp"`,
     'mv "$url_tmp" "$url_file"',
+    `if [ ! -r "$fingerprint_file" ] && fingerprint="$(${boundedWorkspaceFingerprintCommand()})"; then`,
+    '  fingerprint_tmp="${fingerprint_file}.$$"',
+    '  printf \'%s\\n\' "$fingerprint" > "$fingerprint_tmp"',
+    '  mv "$fingerprint_tmp" "$fingerprint_file"',
+    "fi",
     'if [ ! -x "$script" ]; then',
     '  script_tmp="${script}.$$"',
     `  printf '%s\n' ${shellQuote(checkpointScript)} > "$script_tmp"`,

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -125,6 +125,7 @@ export type AwsLambdaMicrovmReconciliationSummary = {
   orphanCleanupEligible: number;
   orphanCleanupSuspended: number;
   orphanCleanupTerminated: number;
+  orphanCleanupProtected: number;
   orphanCleanupFailures: number;
 };
 
@@ -144,6 +145,7 @@ export type AwsLambdaMicrovmSuspensionSummary = {
   terminated: number;
   alreadyGone: number;
   workspacesSaved: number;
+  ownershipProtected: number;
 };
 
 type AwsLambdaMicrovmConfig = {
@@ -668,6 +670,20 @@ async function recordCloudMicrovmState(
       },
     ),
   );
+}
+
+/** Read the authoritative Convex ownership gate immediately before cleanup. */
+async function getCloudSessionOrphanCleanupEligibility(args: {
+  serviceKey: string;
+  userId: string;
+  sessionId: string;
+  microvmId: string;
+  staleBeforeMs: number;
+}): Promise<CloudSessionOrphanCleanupEligibility> {
+  return (await getConvexClient().query(
+    api.localSandbox.getCloudSessionOrphanCleanupEligibility,
+    args,
+  )) as CloudSessionOrphanCleanupEligibility;
 }
 
 function asAwsMicrovmState(value: unknown): AwsMicrovmState | undefined {
@@ -1932,7 +1948,10 @@ export async function terminateAwsLambdaMicrovmForUser(
  */
 export async function suspendAwsLambdaMicrovmsForUser(
   userId: string,
-  options: { sessionId?: string } = {},
+  options: {
+    sessionId?: string;
+    orphanCleanup?: { microvmId: string; staleBeforeMs: number };
+  } = {},
 ): Promise<AwsLambdaMicrovmSuspensionSummary> {
   const serviceKey = required("CONVEX_SERVICE_ROLE_KEY");
   const activeSessions = (await getConvexClient().query(
@@ -1954,6 +1973,7 @@ export async function suspendAwsLambdaMicrovmsForUser(
     terminated: 0,
     alreadyGone: 0,
     workspacesSaved: 0,
+    ownershipProtected: 0,
   };
   const failures: unknown[] = [];
 
@@ -2070,6 +2090,42 @@ export async function suspendAwsLambdaMicrovmsForUser(
         region: session.region,
         duration_ms: Math.round(performance.now() - startedAt),
       });
+
+      if (options.orphanCleanup) {
+        let eligibility: CloudSessionOrphanCleanupEligibility;
+        try {
+          eligibility = await getCloudSessionOrphanCleanupEligibility({
+            serviceKey,
+            userId,
+            sessionId: session.sessionId,
+            microvmId: options.orphanCleanup.microvmId,
+            staleBeforeMs: options.orphanCleanup.staleBeforeMs,
+          });
+        } catch (error) {
+          failures.push(error);
+          log("warn", "cloud_sandbox_orphan_cleanup_recheck_failed", {
+            user_id: userId,
+            session_id: session.sessionId,
+            microvm_id: microvmId,
+            region: session.region,
+            failure_code: failureCode(error),
+            ...errorLogFields(error),
+          });
+          continue;
+        }
+        if (!eligibility.eligible) {
+          summary.ownershipProtected++;
+          log("info", "cloud_sandbox_orphan_cleanup_skipped", {
+            user_id: userId,
+            session_id: session.sessionId,
+            microvm_id: microvmId,
+            region: session.region,
+            reason: eligibility.reason,
+            phase: "post_snapshot",
+          });
+          continue;
+        }
+      }
 
       const response = await getClient(session.region).send(
         new SuspendMicrovmCommand({ microvmIdentifier: microvmId }),
@@ -2211,6 +2267,7 @@ export async function reconcileAwsLambdaMicrovmSessions(
     orphanCleanupEligible: 0,
     orphanCleanupSuspended: 0,
     orphanCleanupTerminated: 0,
+    orphanCleanupProtected: 0,
     orphanCleanupFailures: 0,
   };
   const errors: unknown[] = [];
@@ -2292,16 +2349,14 @@ export async function reconcileAwsLambdaMicrovmSessions(
   for (const { userId, session } of runningCandidates.values()) {
     if (!session.microvmId) continue;
     try {
-      const eligibility = (await getConvexClient().query(
-        api.localSandbox.getCloudSessionOrphanCleanupEligibility,
-        {
-          serviceKey,
-          userId,
-          sessionId: session.sessionId,
-          microvmId: session.microvmId,
-          staleBeforeMs: Date.now() - CONFIRMED_ORPHAN_STALE_MS,
-        },
-      )) as CloudSessionOrphanCleanupEligibility;
+      const staleBeforeMs = Date.now() - CONFIRMED_ORPHAN_STALE_MS;
+      const eligibility = await getCloudSessionOrphanCleanupEligibility({
+        serviceKey,
+        userId,
+        sessionId: session.sessionId,
+        microvmId: session.microvmId,
+        staleBeforeMs,
+      });
       summary.orphanCleanupChecked++;
       if (!eligibility.eligible) {
         log("debug", "cloud_sandbox_orphan_cleanup_skipped", {
@@ -2322,11 +2377,13 @@ export async function reconcileAwsLambdaMicrovmSessions(
       orphanCleanupBudget--;
       const stopped = await suspendAwsLambdaMicrovmsForUser(userId, {
         sessionId: session.sessionId,
+        orphanCleanup: { microvmId: session.microvmId, staleBeforeMs },
       });
       summary.orphanCleanupSuspended +=
         stopped.suspended + stopped.alreadySuspended;
       summary.orphanCleanupTerminated +=
         stopped.terminated + stopped.alreadyGone;
+      summary.orphanCleanupProtected += stopped.ownershipProtected;
       log("info", "cloud_sandbox_confirmed_orphan_cleanup_completed", {
         user_id: userId,
         session_id: session.sessionId,
@@ -2339,6 +2396,7 @@ export async function reconcileAwsLambdaMicrovmSessions(
         sessions_total: stopped.total,
         sessions_suspended: stopped.suspended + stopped.alreadySuspended,
         sessions_terminated: stopped.terminated + stopped.alreadyGone,
+        sessions_ownership_protected: stopped.ownershipProtected,
         workspaces_saved: stopped.workspacesSaved,
       });
     } catch (error) {

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -37,6 +37,8 @@ const DEFAULT_MAX_DURATION_SECONDS = 8 * 60 * 60;
 const DEFAULT_MIN_REMAINING_SECONDS = 2 * 60 * 60 + 5 * 60;
 const DIRECT_IDLE_SECONDS = 5 * 60;
 const DIRECT_SUSPENDED_SECONDS = 30 * 60;
+const CONFIRMED_ORPHAN_STALE_MS = 15 * 60 * 1_000;
+const CONFIRMED_ORPHAN_CLEANUP_LIMIT = 1;
 const SESSION_READY_TIMEOUT_MS = 90_000;
 const USER_DELETION_TERMINATION_CONFIRM_TIMEOUT_MS =
   process.env.NODE_ENV === "test" ? 1_000 : 15_000;
@@ -81,6 +83,7 @@ type CloudSession = {
   createdAt: number;
   updatedAt: number;
   bootstrapExpiresAt: number;
+  lastConnectedAt?: number;
   relayReadyAt?: number;
   awsState?: AwsMicrovmState;
   awsStateCheckedAt?: number;
@@ -100,12 +103,29 @@ type CloudSessionReconciliationCandidate = {
   session: CloudSession;
 };
 
+type CloudSessionOrphanCleanupEligibility = {
+  eligible: boolean;
+  reason:
+    | "eligible"
+    | "session_not_owned"
+    | "session_not_active"
+    | "recent_activity"
+    | "active_parent_run"
+    | "active_subagent";
+  lastActivityAt?: number;
+};
+
 export type AwsLambdaMicrovmReconciliationSummary = {
   checked: number;
   running: number;
   suspended: number;
   terminal: number;
   failures: number;
+  orphanCleanupChecked: number;
+  orphanCleanupEligible: number;
+  orphanCleanupSuspended: number;
+  orphanCleanupTerminated: number;
+  orphanCleanupFailures: number;
 };
 
 type CloudSessionCleanupCandidate = {
@@ -1912,15 +1932,21 @@ export async function terminateAwsLambdaMicrovmForUser(
  */
 export async function suspendAwsLambdaMicrovmsForUser(
   userId: string,
+  options: { sessionId?: string } = {},
 ): Promise<AwsLambdaMicrovmSuspensionSummary> {
   const serviceKey = required("CONVEX_SERVICE_ROLE_KEY");
-  const sessions = (await getConvexClient().query(
+  const activeSessions = (await getConvexClient().query(
     api.localSandbox.listActiveCloudSessionsForBackend,
     {
       serviceKey,
       userId,
     },
   )) as CloudSession[];
+  const sessions = options.sessionId
+    ? activeSessions.filter(
+        (session) => session.sessionId === options.sessionId,
+      )
+    : activeSessions;
   const summary: AwsLambdaMicrovmSuspensionSummary = {
     total: sessions.length,
     suspended: 0,
@@ -2181,8 +2207,18 @@ export async function reconcileAwsLambdaMicrovmSessions(
     suspended: 0,
     terminal: 0,
     failures: 0,
+    orphanCleanupChecked: 0,
+    orphanCleanupEligible: 0,
+    orphanCleanupSuspended: 0,
+    orphanCleanupTerminated: 0,
+    orphanCleanupFailures: 0,
   };
   const errors: unknown[] = [];
+  const runningCandidates = new Map<
+    string,
+    CloudSessionReconciliationCandidate
+  >();
+  let orphanCleanupBudget = CONFIRMED_ORPHAN_CLEANUP_LIMIT;
 
   for (let offset = 0; offset < candidates.length; offset += 10) {
     const batch = candidates.slice(offset, offset + 10);
@@ -2212,8 +2248,12 @@ export async function reconcileAwsLambdaMicrovmSessions(
               : undefined,
           );
           summary.checked++;
-          if (state === "RUNNING" || state === "PENDING") summary.running++;
-          else if (state === "SUSPENDED" || state === "SUSPENDING") {
+          if (state === "RUNNING" || state === "PENDING") {
+            summary.running++;
+            if (state === "RUNNING" && !runningCandidates.has(userId)) {
+              runningCandidates.set(userId, { userId, session });
+            }
+          } else if (state === "SUSPENDED" || state === "SUSPENDING") {
             summary.suspended++;
           } else summary.terminal++;
         } catch (error) {
@@ -2247,6 +2287,73 @@ export async function reconcileAwsLambdaMicrovmSessions(
         }
       }),
     );
+  }
+
+  for (const { userId, session } of runningCandidates.values()) {
+    if (!session.microvmId) continue;
+    try {
+      const eligibility = (await getConvexClient().query(
+        api.localSandbox.getCloudSessionOrphanCleanupEligibility,
+        {
+          serviceKey,
+          userId,
+          sessionId: session.sessionId,
+          microvmId: session.microvmId,
+          staleBeforeMs: Date.now() - CONFIRMED_ORPHAN_STALE_MS,
+        },
+      )) as CloudSessionOrphanCleanupEligibility;
+      summary.orphanCleanupChecked++;
+      if (!eligibility.eligible) {
+        log("debug", "cloud_sandbox_orphan_cleanup_skipped", {
+          user_id: userId,
+          session_id: session.sessionId,
+          microvm_id: session.microvmId,
+          region: session.region,
+          reason: eligibility.reason,
+          last_activity_age_ms:
+            eligibility.lastActivityAt === undefined
+              ? null
+              : Math.max(0, Date.now() - eligibility.lastActivityAt),
+        });
+        continue;
+      }
+
+      summary.orphanCleanupEligible++;
+      orphanCleanupBudget--;
+      const stopped = await suspendAwsLambdaMicrovmsForUser(userId, {
+        sessionId: session.sessionId,
+      });
+      summary.orphanCleanupSuspended +=
+        stopped.suspended + stopped.alreadySuspended;
+      summary.orphanCleanupTerminated +=
+        stopped.terminated + stopped.alreadyGone;
+      log("info", "cloud_sandbox_confirmed_orphan_cleanup_completed", {
+        user_id: userId,
+        session_id: session.sessionId,
+        microvm_id: session.microvmId,
+        region: session.region,
+        last_activity_age_ms:
+          eligibility.lastActivityAt === undefined
+            ? null
+            : Math.max(0, Date.now() - eligibility.lastActivityAt),
+        sessions_total: stopped.total,
+        sessions_suspended: stopped.suspended + stopped.alreadySuspended,
+        sessions_terminated: stopped.terminated + stopped.alreadyGone,
+        workspaces_saved: stopped.workspacesSaved,
+      });
+    } catch (error) {
+      summary.orphanCleanupFailures++;
+      errors.push(error);
+      log("warn", "cloud_sandbox_confirmed_orphan_cleanup_failed", {
+        user_id: userId,
+        session_id: session.sessionId,
+        microvm_id: session.microvmId,
+        region: session.region,
+        failure_code: failureCode(error),
+        ...errorLogFields(error),
+      });
+    }
+    if (orphanCleanupBudget <= 0) break;
   }
 
   log("info", "cloud_sandbox_state_reconciliation_completed", summary);

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -2191,6 +2191,42 @@ export async function suspendAwsLambdaMicrovmsForUser(
         failures.push(error);
         continue;
       }
+      if (options.orphanCleanup) {
+        let eligibility: CloudSessionOrphanCleanupEligibility;
+        try {
+          eligibility = await getCloudSessionOrphanCleanupEligibility({
+            serviceKey,
+            userId,
+            sessionId: session.sessionId,
+            microvmId: options.orphanCleanup.microvmId,
+            staleBeforeMs: options.orphanCleanup.staleBeforeMs,
+          });
+        } catch (recheckError) {
+          failures.push(recheckError);
+          log("warn", "cloud_sandbox_orphan_cleanup_recheck_failed", {
+            user_id: userId,
+            session_id: session.sessionId,
+            microvm_id: microvmId,
+            region: session.region,
+            phase: "pre_termination",
+            failure_code: failureCode(recheckError),
+            ...errorLogFields(recheckError),
+          });
+          continue;
+        }
+        if (!eligibility.eligible) {
+          summary.ownershipProtected++;
+          log("info", "cloud_sandbox_orphan_cleanup_skipped", {
+            user_id: userId,
+            session_id: session.sessionId,
+            microvm_id: microvmId,
+            region: session.region,
+            reason: eligibility.reason,
+            phase: "pre_termination",
+          });
+          continue;
+        }
+      }
       const terminationOutcome = await terminateMicrovm(
         microvmId,
         session.region,

--- a/lib/ai/tools/utils/cloud-sandbox.ts
+++ b/lib/ai/tools/utils/cloud-sandbox.ts
@@ -25,6 +25,7 @@ export type CloudSandboxSuspensionSummary = {
   terminated: number;
   alreadyGone: number;
   workspacesSaved: number;
+  ownershipProtected: number;
 };
 
 export async function ensureCloudSandboxConnection(options: {
@@ -172,6 +173,7 @@ export async function suspendCloudSandboxesForUser(
       terminated: 0,
       alreadyGone: 0,
       workspacesSaved: 0,
+      ownershipProtected: 0,
     };
   }
 

--- a/scripts/__tests__/aws-microvm-cloudformation.test.ts
+++ b/scripts/__tests__/aws-microvm-cloudformation.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("AWS Lambda MicroVM network prerequisites", () => {
+  const template = readFileSync(
+    join(process.cwd(), "aws-lambda-microvm/cloudformation.yaml"),
+    "utf8",
+  );
+
+  it("routes regional S3 traffic through a free gateway endpoint", () => {
+    expect(template).toMatch(
+      /EgressS3GatewayEndpoint:\s+Type: AWS::EC2::VPCEndpoint/,
+    );
+    expect(template).toMatch(
+      /ServiceName: !Sub "com\.amazonaws\.\$\{AWS::Region\}\.s3"/,
+    );
+    expect(template).toMatch(/VpcEndpointType: Gateway/);
+    expect(template).toMatch(/RouteTableIds:\s+- !Ref EgressPrivateRouteTable/);
+  });
+});

--- a/trigger/microvm-session-reconciliation.ts
+++ b/trigger/microvm-session-reconciliation.ts
@@ -8,6 +8,10 @@ import { reconcileAwsLambdaMicrovmSessions } from "@/lib/ai/tools/utils/aws-lamb
 export const reconcileAwsLambdaMicrovmSessionState = schedules.task({
   id: "reconcile-aws-lambda-microvm-session-state",
   cron: "*/10 * * * *",
+  queue: {
+    name: "aws-lambda-microvm-reconciliation",
+    concurrencyLimit: 1,
+  },
   retry: {
     maxAttempts: 3,
     factor: 2,
@@ -15,7 +19,10 @@ export const reconcileAwsLambdaMicrovmSessionState = schedules.task({
     maxTimeoutInMs: 30_000,
     randomize: true,
   },
-  maxDuration: 300,
+  // A forced workspace snapshot may use most of its ten-minute transfer
+  // budget. Serial execution plus the provider's one-cleanup-per-sweep limit
+  // prevents overlapping orphan cleanup while state checks continue in bulk.
+  maxDuration: 900,
   run: async () => {
     if (!process.env.CONVEX_SERVICE_ROLE_KEY?.trim()) {
       logger.info("AWS Lambda MicroVM reconciliation skipped", {

--- a/trigger/microvm-session-reconciliation.ts
+++ b/trigger/microvm-session-reconciliation.ts
@@ -12,6 +12,7 @@ export const reconcileAwsLambdaMicrovmSessionState = schedules.task({
     name: "aws-lambda-microvm-reconciliation",
     concurrencyLimit: 1,
   },
+  ttl: "10m",
   retry: {
     maxAttempts: 3,
     factor: 2,


### PR DESCRIPTION
## Summary

- add a same-region S3 Gateway VPC endpoint to each regional MicroVM stack and associate it with the private route table, while retaining the NAT Gateway and Elastic IP for arbitrary static internet egress
- localize a cross-region workspace restore with a destination-conditional S3 CopyObject before issuing the guest download URL, so the guest download uses its regional endpoint without overwriting a concurrent checkpoint
- replace unconditional two-minute full archive uploads with metadata-fingerprinted, changed-only checkpoints: five minutes after activity and ten minutes while quiet; normal completion and near-expiry snapshots remain forced
- make the ten-minute reconciler snapshot-suspend a physically running session only after 15 minutes of stale connection activity and authoritative checks for no active parent Agent run or subagent, then repeat that check after the snapshot immediately before suspend
- serialize reconciliation, expire queued runs after ten minutes, allow the forced-snapshot timeout budget, clean at most one confirmed orphan per sweep, and add structured cleanup counters/logs

## Cost evidence and expected impact

The August 24 anomaly measured 3,189.58 GB of NAT processing across the three MicroVM regions: $92.77 in us-east-1, $47.40 in eu-west-1, and $6.32 in us-west-2, or $146.49/day. The gateway endpoint can avoid up to that measured NAT-byte charge for same-region S3 traffic, approximately $4,395 per 30 days at that volume. NAT hourly charges remain because static public egress is still required.

The checkpoint reduction overlaps with the endpoint savings and must not be added to it. It additionally reduces guest compression, S3 requests, upload work, and timeout exposure. A 10% reduction in the measured MicroVM compute portion remains worth roughly $23/day or $696/month; orphan cleanup is intentionally conservative and should be evaluated from the new counters.

## Safety and rollout

- No AWS, Trigger, Convex, Vercel, or production state was changed manually by this PR.
- Existing S3 permissions are sufficient: CopyObject requires source GetObject and destination PutObject, which the workspace identity already needs in every regional bucket. No new AWS permission was added.
- Cross-region copies use destination If-Match/If-None-Match. A concurrent checkpoint wins a 409/412 conflict and remains the restore source.
- cloudformation.yaml remains outside the costly MicroVM image-release workflow. After merge, review a CloudFormation change set and update hackerai-lambda-microvm in us-east-1, us-west-2, and eu-west-1; no image rebuild is required.
- Verify one AWS::EC2::VPCEndpoint per regional VPC with type Gateway, the regional S3 service name, and EgressPrivateRouteTable association.
- After application and Trigger deployment, verify same-region workspace PUT/GET succeeds, a forced cross-region restore logs microvm_workspace_restore_localized, and reconciliation reports orphanCleanupChecked without cleaning active owners.
- Compare EC2-Other NatGateway-Bytes by region for 24 hours after the endpoint rollout. Keep NatGateway-Hours and the retained Elastic IPs as the expected static-egress baseline.

## Validation

- 425 Jest suites / 4,383 tests pass
- TypeScript typecheck passes
- ESLint passes with no errors (seven pre-existing frontend warnings)
- touched files pass Prettier and git diff checks
- added CloudFormation endpoint contract, conditional S3 copy/localization, changed-only checkpoint, ownership eligibility/recheck, and snapshot-suspend reconciliation coverage

## Manual verification

1. In a non-production MicroVM stack, apply the CloudFormation change and confirm the private route table contains the S3 prefix-list route while checkip.amazonaws.com still returns the regional retained Elastic IP.
2. Create a workspace, modify a file, wait five minutes, and confirm the regional object updates. Leave it unchanged for ten minutes and confirm LastModified does not advance.
3. Force regional failover and confirm the latest object is copied into the destination bucket before guest restore; race a destination upload and confirm the conditional copy preserves the newer local object.
4. Confirm an active parent run, active subagent, or recent connection heartbeat blocks reconciliation cleanup; reconnect during a deliberately orphaned session's forced snapshot and confirm the post-snapshot check keeps it running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Same-region S3 traffic now uses a dedicated gateway route.
  - Workspace restoration can localize the newest snapshot across regions with safeguards against overwriting newer data.
  - Cloud sessions track activity and active subagents for safer orphan detection.

- **Improvements**
  - Checkpoints skip unchanged content and use adaptive intervals.
  - Orphaned MicroVM cleanup rechecks ownership and reports protected sessions.
  - Reconciliation tasks use serialized processing and a longer operating window.

- **Bug Fixes**
  - Failed or conflicting snapshot localization no longer overwrites newer workspace data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->