### PR TITLE
Hotfix: contain broad Cloud Agent scans automatically

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -291,7 +291,9 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("CIDRs broader than one host");
     expect(prompt).toContain("full-port sweeps");
     expect(prompt).toContain("HackerAI Desktop or Remote Control");
-    expect(prompt).toContain("The Cloud session is terminated automatically");
+    expect(prompt).toContain(
+      "Cloud connection is closed and MicroVM termination is attempted automatically",
+    );
   });
 
   it("adds a compact finding quality contract in cloud and local agent modes", async () => {

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -271,6 +271,29 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     );
   });
 
+  it("routes high-throughput AWS Cloud scans to Desktop or Remote", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      null,
+      "full_access",
+      false,
+      "aws-lambda-microvm",
+    );
+
+    expect(prompt).toContain("Cloud egress safeguard:");
+    expect(prompt).toContain(
+      "bounded nmap and naabu port scans of one target and at most 1,000 ports",
+    );
+    expect(prompt).toContain("CIDRs broader than one host");
+    expect(prompt).toContain("full-port sweeps");
+    expect(prompt).toContain("HackerAI Desktop or Remote Control");
+    expect(prompt).toContain("The Cloud session is terminated automatically");
+  });
+
   it("adds a compact finding quality contract in cloud and local agent modes", async () => {
     const cloudPrompt = await systemPrompt(
       "user_123",

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import type { ToolContext } from "@/types";
+import type { AnySandbox, ToolContext } from "@/types";
 import type { PtySession } from "./utils/pty-session-manager";
 import {
   cleanPtyForUI,
@@ -24,6 +24,10 @@ import {
   getSandboxWithFallbackGuard,
   resolveToolErrorMessage,
 } from "./utils/sandbox-fallback";
+import {
+  enforceCloudScanSafety,
+  updateTerminalScanSafetyInput,
+} from "./utils/cloud-scan-safety";
 
 // ─── Interactive PTY constants ──────────────────────────────────────────
 const MAX_INPUT_BYTES_PER_SEND = 8 * 1024;
@@ -287,9 +291,9 @@ export const createInteractTerminalSession = (context: ToolContext) => {
           `Session ${sid} changed while HackerAI was reviewing the action. ${attemptedAction === "send" ? "The input was not sent." : "The session was not killed."} Use action=view to refresh the terminal state, then retry the exact interaction.`,
         );
 
-      const verifySessionSandboxIdentity = async (
+      const getMatchingSessionSandbox = async (
         session: PtySession,
-      ): Promise<ActionResult | null> => {
+      ): Promise<{ sandbox: AnySandbox } | { error: ActionResult }> => {
         try {
           const { sandbox } = await getSandboxWithFallbackGuard({
             sandboxManager: context.sandboxManager,
@@ -297,14 +301,23 @@ export const createInteractTerminalSession = (context: ToolContext) => {
           if (
             getAgentApprovalSandboxIdentity(sandbox) !== session.sandboxIdentity
           ) {
-            return errorResult(
-              "The selected sandbox no longer matches the sandbox that created this terminal session. The action was not run. Return to the original sandbox or start a new terminal session in the current sandbox.",
-            );
+            return {
+              error: errorResult(
+                "The selected sandbox no longer matches the sandbox that created this terminal session. The action was not run. Return to the original sandbox or start a new terminal session in the current sandbox.",
+              ),
+            };
           }
-          return null;
+          return { sandbox: sandbox as AnySandbox };
         } catch (error) {
-          return errorResult(resolveToolErrorMessage(error));
+          return { error: errorResult(resolveToolErrorMessage(error)) };
         }
+      };
+
+      const verifySessionSandboxIdentity = async (
+        session: PtySession,
+      ): Promise<ActionResult | null> => {
+        const result = await getMatchingSessionSandbox(session);
+        return "error" in result ? result.error : null;
       };
 
       // ─── Handler: send ─────────────────────────────────────────────────────
@@ -352,9 +365,40 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         });
         if ("denied" in approvalResult) return approvalResult.denied;
 
-        const postApprovalSandboxMismatch =
-          await verifySessionSandboxIdentity(session);
-        if (postApprovalSandboxMismatch) return postApprovalSandboxMismatch;
+        const postApprovalSandbox = await getMatchingSessionSandbox(session);
+        if ("error" in postApprovalSandbox) return postApprovalSandbox.error;
+
+        const translatedInput = new TextDecoder().decode(bytes);
+        const bufferedInput = updateTerminalScanSafetyInput(
+          session.scanSafetyInputLine,
+          translatedInput,
+        );
+        try {
+          const safety = await enforceCloudScanSafety({
+            command: bufferedInput.inspection,
+            sandbox: postApprovalSandbox.sandbox,
+            context,
+            toolCallId,
+            source: "terminal_interaction",
+          });
+          if (safety.blocked) {
+            await ptySessionManager
+              .close(ptyScopeId, session.sessionId)
+              .catch(() => undefined);
+            return {
+              result: {
+                output: "",
+                exitCode: 126,
+                error: safety.error,
+                cloudScanSafetyBlocked: true,
+                cloudSessionTerminationStatus: safety.terminationStatus,
+              },
+            };
+          }
+        } catch (error) {
+          return errorResult(resolveToolErrorMessage(error));
+        }
+
         if (
           approvalResult.autoReviewed &&
           terminalStateChanged(sessionId, reviewState.state)
@@ -368,6 +412,7 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         // raw text has a trailing newline normalized to CR for submission.
         try {
           await session.handle.sendInput(bytes);
+          session.scanSafetyInputLine = bufferedInput.currentLine;
         } catch (err) {
           // sendInput may have raced with a natural exit between the
           // pre-check and now — surface that explicitly when it's the cause.

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -65,6 +65,7 @@ import {
   terminalInspectionMatches,
 } from "@/lib/chat/agent-auto-review-evidence";
 import { isLocalCommandRelayUnsubscribedError } from "./utils/local-sandbox-errors";
+import { enforceCloudScanSafety } from "./utils/cloud-scan-safety";
 
 const DEFAULT_STREAM_TIMEOUT_SECONDS =
   RUN_TERMINAL_DEFAULT_STREAM_TIMEOUT_SECONDS;
@@ -370,10 +371,36 @@ export const createRunTerminalCmd = (context: ToolContext) => {
         return result;
       };
 
+      const enforceAwsCloudScanGuard = async (
+        sandbox: Awaited<
+          ReturnType<typeof getApprovedExecutionSandbox>
+        >["sandbox"],
+      ) => {
+        const safety = await enforceCloudScanSafety({
+          command,
+          sandbox,
+          context,
+          toolCallId,
+          source: "terminal_exec",
+        });
+        if (!safety.blocked) return null;
+        return {
+          result: {
+            output: "",
+            exitCode: 126,
+            error: safety.error,
+            cloudScanSafetyBlocked: true,
+            cloudSessionTerminationStatus: safety.terminationStatus,
+          },
+        };
+      };
+
       // ─── Interactive PTY exec branch ─────────────────────────────────
       if (interactive) {
         try {
           const { sandbox } = await getApprovedExecutionSandbox();
+          const cloudScanBlock = await enforceAwsCloudScanGuard(sandbox);
+          if (cloudScanBlock) return cloudScanBlock;
           const isCentrifugo = isCentrifugoSandbox(sandbox);
           const isE2B = isE2BSandbox(sandbox);
 
@@ -513,6 +540,8 @@ export const createRunTerminalCmd = (context: ToolContext) => {
       try {
         // Get fresh sandbox and verify it's ready
         const { sandbox } = await getApprovedExecutionSandbox();
+        const cloudScanBlock = await enforceAwsCloudScanGuard(sandbox);
+        if (cloudScanBlock) return cloudScanBlock;
 
         const executeWithLocalRelayRecovery = async (
           sandboxInstance: typeof sandbox,

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -1363,6 +1363,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       terminateAwsLambdaMicrovmForSafety({
         userId: "user-safety",
         microvmId: "microvm-target",
+        scanner: "nmap",
       }),
     ).resolves.toEqual({ status: "terminated" });
 
@@ -1397,6 +1398,7 @@ describe("AWS Lambda MicroVM development logging", () => {
       terminateAwsLambdaMicrovmForSafety({
         userId: "user-safety",
         microvmId: "microvm-unowned",
+        scanner: "masscan",
       }),
     ).resolves.toEqual({ status: "ownership_not_found" });
 

--- a/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
+++ b/lib/ai/tools/utils/__tests__/aws-lambda-microvm-logging.test.ts
@@ -87,6 +87,7 @@ import {
   isRegionalFailoverEligibleError,
   reconcileAwsLambdaMicrovmSessions,
   suspendAwsLambdaMicrovmsForUser,
+  terminateAwsLambdaMicrovmForSafety,
   terminateAwsLambdaMicrovmForUser,
 } from "../aws-lambda-microvm";
 
@@ -1335,6 +1336,73 @@ describe("AWS Lambda MicroVM development logging", () => {
 
     warnSpy.mockRestore();
     infoSpy.mockRestore();
+  });
+
+  it("terminates only the exact active MicroVM owned by the user for scan safety", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        sessionId: "session-target",
+        status: "running",
+        microvmId: "microvm-target",
+        region: "us-east-1",
+      },
+      {
+        sessionId: "session-other",
+        status: "running",
+        microvmId: "microvm-other",
+        region: "us-west-2",
+      },
+    ]);
+    mockSend
+      .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } })
+      .mockResolvedValueOnce({ state: "TERMINATED" });
+    mockMutation.mockResolvedValue(true);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    await expect(
+      terminateAwsLambdaMicrovmForSafety({
+        userId: "user-safety",
+        microvmId: "microvm-target",
+      }),
+    ).resolves.toEqual({ status: "terminated" });
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(mockSend).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        input: { microvmIdentifier: "microvm-target" },
+      }),
+    );
+    expect(mockMutation).toHaveBeenCalledTimes(1);
+    expect(mockMutation.mock.calls[0][1]).toMatchObject({
+      userId: "user-safety",
+      sessionId: "session-target",
+      failureCode: "cloud_scan_safety_guard",
+    });
+    warnSpy.mockRestore();
+  });
+
+  it("refuses scan-safety termination when active ownership is absent", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        sessionId: "session-other",
+        status: "running",
+        microvmId: "microvm-other",
+        region: "us-east-1",
+      },
+    ]);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    await expect(
+      terminateAwsLambdaMicrovmForSafety({
+        userId: "user-safety",
+        microvmId: "microvm-unowned",
+      }),
+    ).resolves.toEqual({ status: "ownership_not_found" });
+
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockMutation).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it("resolves an attachment race before declaring a starting session gone", async () => {

--- a/lib/ai/tools/utils/__tests__/cloud-scan-safety.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-scan-safety.test.ts
@@ -24,6 +24,8 @@ describe("Cloud scan safety", () => {
     ["naabu -host 203.0.113.10 -p 1-1001", "naabu"],
     [`bash -lc 'nmap -p- 203.0.113.10'`, "nmap"],
     [`bash -c "nmap -p- 203.0.113.10" sentinel`, "nmap"],
+    ["bash -c nmap -p- 203.0.113.10", "nmap"],
+    [`eval "nmap -p- 203.0.113.10"`, "nmap"],
     ["nuclei --list targets.txt", "bulk_http_probe"],
     ["nuclei -list targets.txt", "bulk_http_probe"],
     ["httpx -l targets.txt", "bulk_http_probe"],
@@ -47,6 +49,10 @@ describe("Cloud scan safety", () => {
     "nuclei -u https://example.com",
     "httpx -u https://example.com",
     "httpx --version",
+    "httpx",
+    "nuclei",
+    "sudo apt install nmap",
+    "sudo apt install httpx",
     "nmap -sV 203.0.113.10",
     "nmap -p 1-1000 203.0.113.10",
     "nmap -p 22,80,443 example.com",
@@ -95,6 +101,7 @@ describe("Cloud scan safety", () => {
     expect(terminate).toHaveBeenCalledWith({
       userId: "user-1",
       microvmId: "microvm-owned",
+      scanner: "nmap",
     });
     expect(resetSandbox).toHaveBeenCalledWith("cloud_scan_safety_guard");
     expect(warn.mock.calls.flat().join(" ")).not.toContain(target);

--- a/lib/ai/tools/utils/__tests__/cloud-scan-safety.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-scan-safety.test.ts
@@ -44,6 +44,8 @@ describe("Cloud scan safety", () => {
     "python3 -m pytest",
     "echo nmap",
     "command -v nmap",
+    "command -v nmap >/dev/null 2>&1 || echo missing",
+    "command -p -V /usr/bin/nmap",
     "nmap --version",
     "printf 'use naabu on Desktop'",
     "nuclei -u https://example.com",

--- a/lib/ai/tools/utils/__tests__/cloud-scan-safety.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-scan-safety.test.ts
@@ -1,0 +1,151 @@
+import {
+  detectCloudScanCommand,
+  enforceCloudScanSafety,
+  updateTerminalScanSafetyInput,
+} from "../cloud-scan-safety";
+
+describe("Cloud scan safety", () => {
+  it.each([
+    ["cd /tmp && masscan 203.0.113.0/24 -p-", "masscan"],
+    ["cat targets.txt | zmap -p 443", "zmap"],
+    ["RATE=1000 nmap -p- 203.0.113.10", "nmap"],
+    ["nmap -sV 203.0.113.0/24", "nmap"],
+    ["nmap -p 1-1001 203.0.113.10", "nmap"],
+    ["nmap --top-ports=1001 203.0.113.10", "nmap"],
+    ["nmap -sV 203.0.113.10 203.0.113.11", "nmap"],
+    ["nmap -iL targets.txt", "nmap"],
+    ["time nmap -p- 203.0.113.10", "nmap"],
+    [`"nmap" -p- 203.0.113.10`, "nmap"],
+    [String.raw`n\map -p- 203.0.113.10`, "nmap"],
+    ["xargs nmap -p- < targets.txt", "nmap"],
+    ["nmap -p 80 203.0.113.{1..254}", "nmap"],
+    ["nmap -p 80 hosts?", "nmap"],
+    ["naabu -list targets.txt", "naabu"],
+    ["naabu -host 203.0.113.10 -p 1-1001", "naabu"],
+    [`bash -lc 'nmap -p- 203.0.113.10'`, "nmap"],
+    [`bash -c "nmap -p- 203.0.113.10" sentinel`, "nmap"],
+    ["nuclei --list targets.txt", "bulk_http_probe"],
+    ["nuclei -list targets.txt", "bulk_http_probe"],
+    ["httpx -l targets.txt", "bulk_http_probe"],
+    ["httpx -list targets.txt", "bulk_http_probe"],
+    ["cat targets.txt | nuclei", "bulk_http_probe"],
+    ["cat targets.txt | httpx", "bulk_http_probe"],
+    ["httpx -u https://one.example -u https://two.example", "bulk_http_probe"],
+    ["nuclei -target 203.0.113.0/24", "bulk_http_probe"],
+    ["httpx -u 'https://site{1..10}.example'", "bulk_http_probe"],
+  ])("detects broad or high-throughput command %s", (command, scanner) => {
+    expect(detectCloudScanCommand(command)).toMatchObject({ scanner });
+  });
+
+  it.each([
+    "curl https://example.com/api",
+    "python3 -m pytest",
+    "echo nmap",
+    "command -v nmap",
+    "nmap --version",
+    "printf 'use naabu on Desktop'",
+    "nuclei -u https://example.com",
+    "httpx -u https://example.com",
+    "httpx --version",
+    "nmap -sV 203.0.113.10",
+    "nmap -p 1-1000 203.0.113.10",
+    "nmap -p 22,80,443 example.com",
+    "nmap -sV 203.0.113.10/32",
+    "naabu -host 203.0.113.10",
+    "naabu --host=example.com --ports=80,443",
+    "nmap --script-timeout 10s -p 80 example.com",
+    "bash -lc 'nmap -sV 203.0.113.10'",
+    "cat > notes.txt <<'EOF'\nnmap -p- 203.0.113.10\nEOF",
+  ])("allows non-fan-out command %s", (command) => {
+    expect(detectCloudScanCommand(command)).toBeNull();
+  });
+
+  it("terminates only an AWS Cloud MicroVM and does not log its target", async () => {
+    const resetSandbox = jest.fn(async () => undefined);
+    const terminate = jest.fn(async () => ({
+      status: "terminated" as const,
+    }));
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const target = "203.0.113.77";
+    const result = await enforceCloudScanSafety({
+      command: `nmap -p- ${target}`,
+      sandbox: {
+        sandboxKind: "centrifugo",
+        getCloudProvider: () => "aws-lambda-microvm",
+        getConnectionId: () => "microvm-owned",
+      } as never,
+      context: {
+        chatId: "chat-1",
+        sandboxManager: { resetSandbox } as never,
+        subscription: "pro",
+        triggerRunId: "run-1",
+        userID: "user-1",
+      },
+      toolCallId: "tool-1",
+      source: "terminal_exec",
+      dependencies: { terminate },
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      microvmId: "microvm-owned",
+      scanner: "nmap",
+      terminationStatus: "terminated",
+    });
+    expect(terminate).toHaveBeenCalledWith({
+      userId: "user-1",
+      microvmId: "microvm-owned",
+    });
+    expect(resetSandbox).toHaveBeenCalledWith("cloud_scan_safety_guard");
+    expect(warn.mock.calls.flat().join(" ")).not.toContain(target);
+    warn.mockRestore();
+  });
+
+  it("does not apply the guard to Desktop or Remote sandboxes", async () => {
+    const terminate = jest.fn();
+    const result = await enforceCloudScanSafety({
+      command: "nmap -sV 203.0.113.77",
+      sandbox: {
+        sandboxKind: "centrifugo",
+        getCloudProvider: () => null,
+        getConnectionId: () => "desktop-1",
+      } as never,
+      context: {
+        chatId: "chat-1",
+        sandboxManager: {} as never,
+        userID: "user-1",
+      },
+      toolCallId: "tool-1",
+      source: "terminal_exec",
+      dependencies: { terminate },
+    });
+
+    expect(result).toEqual({ blocked: false });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("retains an unsubmitted PTY line so split sends cannot bypass detection", () => {
+    const first = updateTerminalScanSafetyInput("", "nm");
+    expect(detectCloudScanCommand(first.inspection)).toBeNull();
+
+    const second = updateTerminalScanSafetyInput(
+      first.currentLine,
+      "ap -p- 203.0.113.10\r",
+    );
+    expect(detectCloudScanCommand(second.inspection)).toMatchObject({
+      scanner: "nmap",
+    });
+    expect(second.currentLine).toBe("");
+  });
+
+  it("models terminal cancellation and editing without retaining stale input", () => {
+    expect(updateTerminalScanSafetyInput("nmap -p-", "\u0003")).toEqual({
+      inspection: "",
+      currentLine: "",
+    });
+    expect(updateTerminalScanSafetyInput("nma", "\bap host")).toEqual({
+      inspection: "nmap host",
+      currentLine: "nmap host",
+    });
+  });
+});

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -1947,6 +1947,7 @@ export async function terminateAwsLambdaMicrovmForUser(
 export async function terminateAwsLambdaMicrovmForSafety(args: {
   userId: string;
   microvmId: string;
+  scanner: string;
 }): Promise<{
   status: "terminated" | "already_gone" | "ownership_not_found";
 }> {
@@ -1966,6 +1967,7 @@ export async function terminateAwsLambdaMicrovmForSafety(args: {
     log("warn", "cloud_scan_safety_termination_skipped", {
       user_id: args.userId,
       microvm_id: args.microvmId,
+      scanner: args.scanner,
       reason: "active_ownership_not_found",
     });
     return { status: "ownership_not_found" };
@@ -2027,6 +2029,7 @@ export async function terminateAwsLambdaMicrovmForSafety(args: {
   log("warn", "cloud_scan_safety_microvm_terminated", {
     user_id: args.userId,
     microvm_id: args.microvmId,
+    scanner: args.scanner,
     region,
     sessions_ended: ownedSessions.length,
     termination_status: outcome,

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -1940,6 +1940,101 @@ export async function terminateAwsLambdaMicrovmForUser(
 }
 
 /**
+ * Terminate one currently owned MicroVM after the Cloud scan safety guard
+ * blocks a command. The durable ownership check prevents a stale worker from
+ * terminating another user's replacement MicroVM.
+ */
+export async function terminateAwsLambdaMicrovmForSafety(args: {
+  userId: string;
+  microvmId: string;
+}): Promise<{
+  status: "terminated" | "already_gone" | "ownership_not_found";
+}> {
+  const serviceKey = required("CONVEX_SERVICE_ROLE_KEY");
+  const sessions = (await getConvexClient().query(
+    api.localSandbox.listActiveCloudSessionsForBackend,
+    {
+      serviceKey,
+      userId: args.userId,
+    },
+  )) as CloudSession[];
+  const ownedSessions = sessions.filter(
+    (session) => session.microvmId === args.microvmId,
+  );
+
+  if (ownedSessions.length === 0) {
+    log("warn", "cloud_scan_safety_termination_skipped", {
+      user_id: args.userId,
+      microvm_id: args.microvmId,
+      reason: "active_ownership_not_found",
+    });
+    return { status: "ownership_not_found" };
+  }
+
+  const regions = new Set(ownedSessions.map((session) => session.region));
+  if (regions.size !== 1) {
+    throw new Error(
+      "Owned Cloud sessions disagree about the MicroVM region; refusing safety termination",
+    );
+  }
+  const region = ownedSessions[0].region;
+  const outcome = await terminateMicrovm(args.microvmId, region);
+  if (outcome === "failed") {
+    await Promise.all(
+      ownedSessions.map((session) =>
+        markCleanupPending(
+          args.userId,
+          session.sessionId,
+          { serviceKey },
+          "cloud_scan_safety_termination_retry_required",
+        ),
+      ),
+    );
+    throw new Error("AWS did not accept the Cloud scan safety termination");
+  }
+
+  if (outcome === "terminated") {
+    try {
+      await confirmMicrovmTerminated(args.microvmId, region);
+    } catch (error) {
+      await Promise.all(
+        ownedSessions.map((session) =>
+          markCleanupPending(
+            args.userId,
+            session.sessionId,
+            { serviceKey },
+            "cloud_scan_safety_termination_confirmation_required",
+          ),
+        ),
+      );
+      throw error;
+    }
+  }
+
+  await Promise.all(
+    ownedSessions.map((session) =>
+      markEnded(
+        args.userId,
+        session.sessionId,
+        { serviceKey },
+        "terminated",
+        outcome === "already_gone"
+          ? "microvm_not_found"
+          : "cloud_scan_safety_guard",
+      ),
+    ),
+  );
+  log("warn", "cloud_scan_safety_microvm_terminated", {
+    user_id: args.userId,
+    microvm_id: args.microvmId,
+    region,
+    sessions_ended: ownedSessions.length,
+    termination_status: outcome,
+  });
+  return { status: outcome };
+}
+
+/**
  * Stop compute for a user's reusable MicroVMs while retaining their state.
  *
  * The caller must first verify that no other Agent run is using the user's

--- a/lib/ai/tools/utils/cloud-scan-safety.ts
+++ b/lib/ai/tools/utils/cloud-scan-safety.ts
@@ -232,6 +232,19 @@ const resolveExecutedCommand = (
   while (index < tokens.length) {
     const name = executableName(tokens[index]);
     if (!EXECUTION_WRAPPERS.has(name)) return { index, name };
+    if (name === "command") {
+      const args = tokens.slice(index + 1);
+      const operandIndex = args.findIndex((token) => !token.startsWith("-"));
+      const options = args.slice(
+        0,
+        operandIndex < 0 ? args.length : operandIndex,
+      );
+      if (
+        options.some((token) => /^-[pvV]+$/.test(token) && /[vV]/.test(token))
+      ) {
+        return null;
+      }
+    }
     index = skipWrapperOptions(tokens, index + 1, name);
     while (/^[A-Z_][A-Z0-9_]*=/i.test(tokens[index] ?? "")) index++;
     if (name === "timeout" || name === "taskset") index++;

--- a/lib/ai/tools/utils/cloud-scan-safety.ts
+++ b/lib/ai/tools/utils/cloud-scan-safety.ts
@@ -2,7 +2,7 @@ import type { AnySandbox, ToolContext } from "@/types";
 import { isAwsLambdaMicrovmSandbox } from "./sandbox-types";
 
 const CLOUD_SCAN_BLOCK_MESSAGE =
-  "HackerAI Cloud permits bounded port scans of one target and at most 1,000 ports. This command used or obscured a broader scope, so the cloud session was terminated before it ran. Narrow the command to one target and 1,000 or fewer ports, or use HackerAI Desktop or Remote Control for larger authorized scans.";
+  "HackerAI Cloud permits bounded port scans of one target and at most 1,000 ports. This command used or obscured a broader scope, so it was blocked before execution, the Cloud connection was closed, and MicroVM termination was attempted. Narrow the command to one target and 1,000 or fewer ports, or use HackerAI Desktop or Remote Control for larger authorized scans.";
 
 const HIGH_THROUGHPUT_SCANNERS = [
   "hping",
@@ -74,16 +74,19 @@ const stripHeredocBodies = (command: string): string => {
   return kept.join("\n");
 };
 
-const shellCommandSegments = (rawCommand: string): string[] => {
+type ShellCommandSegment = { command: string; receivesPipe: boolean };
+
+const shellCommandSegments = (rawCommand: string): ShellCommandSegment[] => {
   const command = stripHeredocBodies(rawCommand);
-  const segments: string[] = [];
+  const segments: ShellCommandSegment[] = [];
   let start = 0;
   let quote: "'" | '"' | null = null;
   let escaped = false;
+  let receivesPipe = false;
 
   const push = (end: number) => {
     const segment = command.slice(start, end).trim();
-    if (segment) segments.push(segment);
+    if (segment) segments.push({ command: segment, receivesPipe });
   };
 
   for (let index = 0; index < command.length; index++) {
@@ -112,15 +115,18 @@ const shellCommandSegments = (rawCommand: string): string[] => {
       char === "\n"
     ) {
       push(index);
-      if (char === "|" && command[index + 1] === char) {
+      const logicalOr = char === "|" && command[index + 1] === char;
+      if (logicalOr) {
         index++;
       }
+      receivesPipe = char === "|" && !logicalOr;
       start = index + 1;
       continue;
     }
     if (char === "&" && command[index + 1] === "&") {
       push(index);
       index++;
+      receivesPipe = false;
       start = index + 1;
     }
   }
@@ -150,8 +156,102 @@ const EXECUTION_WRAPPERS = new Set([
   "xargs",
 ]);
 
+const WRAPPER_VALUE_OPTIONS: Record<string, ReadonlySet<string>> = {
+  env: new Set(["-C", "-S", "-u", "--chdir", "--split-string", "--unset"]),
+  ionice: new Set(["-c", "-n", "-p", "-P", "-u"]),
+  nice: new Set(["-n", "--adjustment"]),
+  stdbuf: new Set(["-e", "-i", "-o", "--error", "--input", "--output"]),
+  sudo: new Set([
+    "-C",
+    "-D",
+    "-g",
+    "-h",
+    "-p",
+    "-R",
+    "-r",
+    "-T",
+    "-t",
+    "-u",
+    "--chdir",
+    "--group",
+    "--host",
+    "--prompt",
+    "--role",
+    "--type",
+    "--user",
+  ]),
+  time: new Set(["-f", "-o", "--format", "--output"]),
+  timeout: new Set(["-k", "-s", "--kill-after", "--signal"]),
+  xargs: new Set([
+    "-a",
+    "-d",
+    "-E",
+    "-I",
+    "-L",
+    "-n",
+    "-P",
+    "-s",
+    "--arg-file",
+    "--delimiter",
+    "--eof",
+    "--max-args",
+    "--max-chars",
+    "--max-lines",
+    "--max-procs",
+    "--replace",
+  ]),
+};
+
 const executableName = (token: string): string =>
   token.split("/").at(-1)?.toLowerCase() ?? "";
+
+const skipWrapperOptions = (
+  tokens: string[],
+  start: number,
+  wrapper: string,
+): number => {
+  const valueOptions = WRAPPER_VALUE_OPTIONS[wrapper] ?? new Set<string>();
+  let index = start;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token === "--") return index + 1;
+    if (!token.startsWith("-") || token === "-") break;
+    const option = token.split("=", 1)[0];
+    index++;
+    if (valueOptions.has(option) && token === option) index++;
+  }
+  return index;
+};
+
+const resolveExecutedCommand = (
+  tokens: string[],
+): { index: number; name: string } | null => {
+  let index = 0;
+  while (/^[A-Z_][A-Z0-9_]*=/i.test(tokens[index] ?? "")) index++;
+
+  while (index < tokens.length) {
+    const name = executableName(tokens[index]);
+    if (!EXECUTION_WRAPPERS.has(name)) return { index, name };
+    index = skipWrapperOptions(tokens, index + 1, name);
+    while (/^[A-Z_][A-Z0-9_]*=/i.test(tokens[index] ?? "")) index++;
+    if (name === "timeout" || name === "taskset") index++;
+  }
+  return null;
+};
+
+const nestedShellPayload = (tokens: string[]): string | null => {
+  const command = resolveExecutedCommand(tokens);
+  if (!command) return null;
+  if (command.name === "eval") {
+    return tokens.slice(command.index + 1).join(" ");
+  }
+  if (!/^(?:bash|sh|zsh)$/.test(command.name)) return null;
+  const args = tokens.slice(command.index + 1);
+  const commandOption = args.findIndex((token) =>
+    /^-[A-Za-z]*c[A-Za-z]*$/.test(token),
+  );
+  return commandOption < 0 ? null : (args[commandOption + 1] ?? null);
+};
 
 const scannerInExecutingPosition = (
   segment: string,
@@ -161,25 +261,16 @@ const scannerInExecutingPosition = (
   index: number;
 } | null => {
   const tokens = shellTokens(segment);
-  let first = 0;
-  while (/^[A-Z_][A-Z0-9_]*=/i.test(tokens[first] ?? "")) first++;
-  const index = tokens.findIndex((token, tokenIndex) => {
-    if (tokenIndex < first) return false;
-    return HIGH_THROUGHPUT_SCANNERS.includes(
-      executableName(token) as HighThroughputScanner,
-    );
-  });
-  if (index < 0) return null;
+  const command = resolveExecutedCommand(tokens);
   if (
-    index !== first &&
-    !EXECUTION_WRAPPERS.has(executableName(tokens[first] ?? ""))
-  ) {
+    !command ||
+    !HIGH_THROUGHPUT_SCANNERS.includes(command.name as HighThroughputScanner)
+  )
     return null;
-  }
   return {
-    scanner: executableName(tokens[index]) as HighThroughputScanner,
+    scanner: command.name as HighThroughputScanner,
     tokens,
-    index,
+    index: command.index,
   };
 };
 
@@ -367,21 +458,11 @@ const isBoundedCloudPortScan = (
   );
 };
 
-const isBulkHttpProbe = (segment: string): boolean => {
-  const tokens = shellTokens(segment);
-  let first = 0;
-  while (/^[A-Z_][A-Z0-9_]*=/i.test(tokens[first] ?? "")) first++;
-  const toolIndex = tokens.findIndex((token) =>
-    /^(?:nuclei|httpx)$/i.test(executableName(token)),
-  );
-  if (toolIndex < 0) return false;
-  if (
-    toolIndex !== first &&
-    !EXECUTION_WRAPPERS.has(executableName(tokens[first] ?? ""))
-  ) {
-    return false;
-  }
-  const args = tokens.slice(toolIndex + 1);
+const isBulkHttpProbe = (segment: ShellCommandSegment): boolean => {
+  const tokens = shellTokens(segment.command);
+  const command = resolveExecutedCommand(tokens);
+  if (!command || !/^(?:nuclei|httpx)$/i.test(command.name)) return false;
+  const args = tokens.slice(command.index + 1);
   if (
     args.length === 1 &&
     /^(?:-h|--help|-version|--version)$/i.test(args[0])
@@ -412,6 +493,7 @@ const isBulkHttpProbe = (segment: string): boolean => {
         !/^(?:-u|--url|-target|--target)$/i.test(args[index - 1] ?? ""),
     ),
   );
+  if (targets.length === 0) return segment.receivesPipe;
   return targets.length !== 1 || !probeTargetIsSingleHost(targets[0]);
 };
 
@@ -433,13 +515,19 @@ export function detectCloudScanCommand(
   }
 
   for (const segment of shellCommandSegments(command)) {
-    const wrappedCommand = segment.match(shellWrapperPattern)?.[2];
+    const wrappedCommand = segment.command.match(shellWrapperPattern)?.[2];
     if (wrappedCommand) {
       const wrappedDetection = detectCloudScanCommand(wrappedCommand);
       if (wrappedDetection) return wrappedDetection;
     }
 
-    const scannerMatch = scannerInExecutingPosition(segment);
+    const nestedPayload = nestedShellPayload(shellTokens(segment.command));
+    if (nestedPayload) {
+      const nestedDetection = detectCloudScanCommand(nestedPayload);
+      if (nestedDetection) return nestedDetection;
+    }
+
+    const scannerMatch = scannerInExecutingPosition(segment.command);
     if (scannerMatch) {
       const scannerArgs = scannerMatch.tokens.slice(scannerMatch.index + 1);
       if (
@@ -474,6 +562,7 @@ export function detectCloudScanCommand(
   return null;
 }
 
+/** Reconstruct the current interactive shell line without retaining history. */
 export function updateTerminalScanSafetyInput(
   currentLine: string,
   input: string,
@@ -523,7 +612,11 @@ const logSafetyEvent = (
 };
 
 type SafetyDependencies = {
-  terminate: (args: { userId: string; microvmId: string }) => Promise<{
+  terminate: (args: {
+    userId: string;
+    microvmId: string;
+    scanner: CloudScanSafetyDetection["scanner"];
+  }) => Promise<{
     status: "terminated" | "already_gone" | "ownership_not_found";
   }>;
 };
@@ -576,6 +669,7 @@ export async function enforceCloudScanSafety(args: {
     const result = await (args.dependencies ?? defaultDependencies).terminate({
       userId: args.context.userID,
       microvmId,
+      scanner: detection.scanner,
     });
     terminationStatus = result.status;
     logSafetyEvent("warn", "cloud_scan_session_contained", {

--- a/lib/ai/tools/utils/cloud-scan-safety.ts
+++ b/lib/ai/tools/utils/cloud-scan-safety.ts
@@ -1,0 +1,608 @@
+import type { AnySandbox, ToolContext } from "@/types";
+import { isAwsLambdaMicrovmSandbox } from "./sandbox-types";
+
+const CLOUD_SCAN_BLOCK_MESSAGE =
+  "HackerAI Cloud permits bounded port scans of one target and at most 1,000 ports. This command used or obscured a broader scope, so the cloud session was terminated before it ran. Narrow the command to one target and 1,000 or fewer ports, or use HackerAI Desktop or Remote Control for larger authorized scans.";
+
+const HIGH_THROUGHPUT_SCANNERS = [
+  "hping",
+  "hping2",
+  "hping3",
+  "masscan",
+  "naabu",
+  "nmap",
+  "nping",
+  "rustscan",
+  "unicornscan",
+  "zgrab",
+  "zgrab2",
+  "zmap",
+] as const;
+
+type HighThroughputScanner = (typeof HIGH_THROUGHPUT_SCANNERS)[number];
+
+export type CloudScanSafetyDetection = {
+  scanner: HighThroughputScanner | "bulk_http_probe";
+  reason: "host_port_scanner" | "bulk_http_probe";
+};
+
+export type CloudScanSafetyResult =
+  | { blocked: false }
+  | {
+      blocked: true;
+      error: string;
+      microvmId: string;
+      scanner: CloudScanSafetyDetection["scanner"];
+      terminationStatus:
+        "terminated" | "already_gone" | "ownership_not_found" | "failed";
+    };
+
+const safeScannerIntrospectionPattern = new RegExp(
+  String.raw`^\s*(?:(?:command\s+-v|which|type)\s+(?:${HIGH_THROUGHPUT_SCANNERS.join(
+    "|",
+  )})|(?:${HIGH_THROUGHPUT_SCANNERS.join(
+    "|",
+  )})\s+(?:--version|-V|--help|-h))\s*$`,
+  "i",
+);
+
+const shellWrapperPattern =
+  /^(?:[^\s]*\/)?(?:bash|sh|zsh)\s+-[a-z]*c\s+(["'])([\s\S]*)\1(?:\s+[\s\S]*)?$/i;
+
+const stripHeredocBodies = (command: string): string => {
+  const lines = command.split("\n");
+  const kept: string[] = [];
+  let delimiter: string | null = null;
+  let stripTabs = false;
+
+  for (const line of lines) {
+    if (delimiter) {
+      const candidate = stripTabs ? line.replace(/^\t+/, "") : line;
+      if (candidate === delimiter) {
+        delimiter = null;
+        stripTabs = false;
+      }
+      continue;
+    }
+    kept.push(line);
+    const match = line.match(/<<(-)?\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?/);
+    if (match) {
+      stripTabs = Boolean(match[1]);
+      delimiter = match[2];
+    }
+  }
+  return kept.join("\n");
+};
+
+const shellCommandSegments = (rawCommand: string): string[] => {
+  const command = stripHeredocBodies(rawCommand);
+  const segments: string[] = [];
+  let start = 0;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  const push = (end: number) => {
+    const segment = command.slice(start, end).trim();
+    if (segment) segments.push(segment);
+  };
+
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (
+      char === ";" ||
+      char === "|" ||
+      char === "(" ||
+      char === ")" ||
+      char === "\n"
+    ) {
+      push(index);
+      if (char === "|" && command[index + 1] === char) {
+        index++;
+      }
+      start = index + 1;
+      continue;
+    }
+    if (char === "&" && command[index + 1] === "&") {
+      push(index);
+      index++;
+      start = index + 1;
+    }
+  }
+  push(command.length);
+  return segments;
+};
+
+const shellTokens = (segment: string): string[] =>
+  (segment.match(/"[^"]*"|'[^']*'|\S+/g) ?? []).map((token) =>
+    token
+      .replace(/^(["'])([\s\S]*)\1$/, "$2")
+      .replace(/\\([A-Za-z0-9._/-])/g, "$1"),
+  );
+
+const EXECUTION_WRAPPERS = new Set([
+  "command",
+  "env",
+  "exec",
+  "ionice",
+  "nice",
+  "nohup",
+  "stdbuf",
+  "sudo",
+  "taskset",
+  "time",
+  "timeout",
+  "xargs",
+]);
+
+const executableName = (token: string): string =>
+  token.split("/").at(-1)?.toLowerCase() ?? "";
+
+const scannerInExecutingPosition = (
+  segment: string,
+): {
+  scanner: HighThroughputScanner;
+  tokens: string[];
+  index: number;
+} | null => {
+  const tokens = shellTokens(segment);
+  let first = 0;
+  while (/^[A-Z_][A-Z0-9_]*=/i.test(tokens[first] ?? "")) first++;
+  const index = tokens.findIndex((token, tokenIndex) => {
+    if (tokenIndex < first) return false;
+    return HIGH_THROUGHPUT_SCANNERS.includes(
+      executableName(token) as HighThroughputScanner,
+    );
+  });
+  if (index < 0) return null;
+  if (
+    index !== first &&
+    !EXECUTION_WRAPPERS.has(executableName(tokens[first] ?? ""))
+  ) {
+    return null;
+  }
+  return {
+    scanner: executableName(tokens[index]) as HighThroughputScanner,
+    tokens,
+    index,
+  };
+};
+
+const NMAP_VALUE_OPTIONS = new Set([
+  "--datadir",
+  "--dns-servers",
+  "--exclude",
+  "--excludefile",
+  "--exclude-ports",
+  "--host-timeout",
+  "--max-parallelism",
+  "--max-rate",
+  "--max-retries",
+  "--min-parallelism",
+  "--min-rate",
+  "--proxies",
+  "--scan-delay",
+  "--script",
+  "--script-args",
+  "--script-args-file",
+  "--script-help",
+  "--script-timeout",
+  "--source-port",
+  "--spoof-mac",
+  "--stylesheet",
+  "--version-intensity",
+  "--max-hostgroup",
+  "--min-hostgroup",
+  "--max-rtt-timeout",
+  "--min-rtt-timeout",
+  "--initial-rtt-timeout",
+  "--max-scan-delay",
+  "--max-os-tries",
+  "--mtu",
+  "--port-ratio",
+  "--ttl",
+  "-D",
+  "-S",
+  "-e",
+  "-g",
+  "-oA",
+  "-oG",
+  "-oN",
+  "-oX",
+]);
+
+const NAABU_VALUE_OPTIONS = new Set([
+  "--exclude-cdn",
+  "--exclude-hosts",
+  "--exclude-ports",
+  "--output",
+  "--rate",
+  "--retries",
+  "--scan-type",
+  "--timeout",
+  "-c",
+  "-ec",
+  "-eh",
+  "-ep",
+  "-o",
+  "-rate",
+  "-retries",
+  "-scan-type",
+  "-timeout",
+]);
+
+const countPortSpec = (value: string): number => {
+  let count = 0;
+  for (const rawPart of value.split(",")) {
+    const part = rawPart.replace(/^[TUSAP]+:/i, "");
+    if (part === "-") return Number.POSITIVE_INFINITY;
+    if (/^\d+$/.test(part)) {
+      count++;
+      continue;
+    }
+    const range = part.match(/^(\d+)-(\d+)$/);
+    if (!range) return Number.POSITIVE_INFINITY;
+    const start = Number(range[1]);
+    const end = Number(range[2]);
+    if (start < 0 || end < start || end > 65_535) {
+      return Number.POSITIVE_INFINITY;
+    }
+    count += end - start + 1;
+    if (count > 1_000) return count;
+  }
+  return count;
+};
+
+const targetIsSingleHost = (target: string): boolean => {
+  if (!target || /[*,{}[\]?$`~\\]/.test(target)) return false;
+  if (/(?:^|\.)\d+-\d+(?:\.|$)/.test(target)) return false;
+  if (!target.includes("/")) return true;
+  return /\/32$/.test(target) || /\/128$/.test(target);
+};
+
+const probeTargetIsSingleHost = (target: string): boolean => {
+  if (/^https?:\/\//i.test(target)) {
+    try {
+      return targetIsSingleHost(new URL(target).hostname);
+    } catch {
+      return false;
+    }
+  }
+  return targetIsSingleHost(target);
+};
+
+const isBoundedCloudPortScan = (
+  scanner: HighThroughputScanner,
+  tokens: string[],
+  scannerIndex: number,
+): boolean => {
+  if (scanner !== "nmap" && scanner !== "naabu") return false;
+
+  const valueOptions =
+    scanner === "nmap" ? NMAP_VALUE_OPTIONS : NAABU_VALUE_OPTIONS;
+  const targets: string[] = [];
+  let requestedPorts = scanner === "nmap" ? 1_000 : 100;
+
+  for (let index = scannerIndex + 1; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (
+      token === "-iL" ||
+      token === "-iR" ||
+      token === "-l" ||
+      token === "-list" ||
+      token === "--list"
+    ) {
+      return false;
+    }
+
+    if (token === "-p" || token === "--ports" || token === "-port") {
+      const value = tokens[++index];
+      if (!value) return false;
+      requestedPorts = countPortSpec(value);
+      continue;
+    }
+    const explicitPorts = token.match(/^(?:--ports|-port)=(.+)$/i);
+    if (explicitPorts) {
+      requestedPorts = countPortSpec(explicitPorts[1]);
+      continue;
+    }
+    if (/^-p(?:\d|[TUSAP]:|-)/i.test(token)) {
+      requestedPorts = countPortSpec(token.slice(2));
+      continue;
+    }
+    if (token === "--top-ports" || token === "-top-ports" || token === "-tp") {
+      const value = tokens[++index];
+      if (!value || !/^\d+$/.test(value)) return false;
+      requestedPorts = Number(value);
+      continue;
+    }
+    const explicitTopPorts = token.match(
+      /^(?:--top-ports|-top-ports|-tp)=(.+)$/i,
+    );
+    if (explicitTopPorts) {
+      if (!/^\d+$/.test(explicitTopPorts[1])) return false;
+      requestedPorts = Number(explicitTopPorts[1]);
+      continue;
+    }
+    if (token === "-host" || token === "--host") {
+      const value = tokens[++index];
+      if (!value) return false;
+      targets.push(value);
+      continue;
+    }
+    const explicitHost = token.match(/^(?:-host|--host)=(.+)$/i);
+    if (explicitHost) {
+      targets.push(explicitHost[1]);
+      continue;
+    }
+
+    const optionName = token.split("=", 1)[0];
+    if (valueOptions.has(optionName)) {
+      if (!token.includes("=")) index++;
+      continue;
+    }
+    if (token.startsWith("-")) continue;
+    targets.push(token);
+  }
+
+  return (
+    requestedPorts <= 1_000 &&
+    targets.length === 1 &&
+    targetIsSingleHost(targets[0])
+  );
+};
+
+const isBulkHttpProbe = (segment: string): boolean => {
+  const tokens = shellTokens(segment);
+  let first = 0;
+  while (/^[A-Z_][A-Z0-9_]*=/i.test(tokens[first] ?? "")) first++;
+  const toolIndex = tokens.findIndex((token) =>
+    /^(?:nuclei|httpx)$/i.test(executableName(token)),
+  );
+  if (toolIndex < 0) return false;
+  if (
+    toolIndex !== first &&
+    !EXECUTION_WRAPPERS.has(executableName(tokens[first] ?? ""))
+  ) {
+    return false;
+  }
+  const args = tokens.slice(toolIndex + 1);
+  if (
+    args.length === 1 &&
+    /^(?:-h|--help|-version|--version)$/i.test(args[0])
+  ) {
+    return false;
+  }
+  if (args.some((token) => /^(?:-l|-list|--list)(?:=|$)/i.test(token))) {
+    return true;
+  }
+  const targets: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const assignedTarget = args[index].match(
+      /^(?:-u|--url|-target|--target)=(\S+)$/i,
+    );
+    if (assignedTarget) {
+      targets.push(assignedTarget[1]);
+    } else if (/^(?:-u|--url|-target|--target)$/i.test(args[index])) {
+      if (!args[index + 1]) return true;
+      targets.push(args[index + 1]);
+      index++;
+    }
+  }
+  targets.push(
+    ...args.filter(
+      (token, index) =>
+        !token.startsWith("-") &&
+        /^https?:\/\//i.test(token) &&
+        !/^(?:-u|--url|-target|--target)$/i.test(args[index - 1] ?? ""),
+    ),
+  );
+  return targets.length !== 1 || !probeTargetIsSingleHost(targets[0]);
+};
+
+/**
+ * Detect commands that can fan out across hosts or ports fast enough to put
+ * HackerAI's shared AWS egress identity at risk. This deliberately does not
+ * inspect or retain targets.
+ */
+export function detectCloudScanCommand(
+  command: string,
+): CloudScanSafetyDetection | null {
+  if (!command.trim() || safeScannerIntrospectionPattern.test(command)) {
+    return null;
+  }
+
+  const topLevelWrappedCommand = command.trim().match(shellWrapperPattern)?.[2];
+  if (topLevelWrappedCommand) {
+    return detectCloudScanCommand(topLevelWrappedCommand);
+  }
+
+  for (const segment of shellCommandSegments(command)) {
+    const wrappedCommand = segment.match(shellWrapperPattern)?.[2];
+    if (wrappedCommand) {
+      const wrappedDetection = detectCloudScanCommand(wrappedCommand);
+      if (wrappedDetection) return wrappedDetection;
+    }
+
+    const scannerMatch = scannerInExecutingPosition(segment);
+    if (scannerMatch) {
+      const scannerArgs = scannerMatch.tokens.slice(scannerMatch.index + 1);
+      if (
+        scannerArgs.length === 1 &&
+        /^(?:-h|--help|-V|--version)$/i.test(scannerArgs[0])
+      ) {
+        continue;
+      }
+      if (
+        isBoundedCloudPortScan(
+          scannerMatch.scanner,
+          scannerMatch.tokens,
+          scannerMatch.index,
+        )
+      ) {
+        continue;
+      }
+      return {
+        scanner: scannerMatch.scanner,
+        reason: "host_port_scanner",
+      };
+    }
+
+    if (isBulkHttpProbe(segment)) {
+      return {
+        scanner: "bulk_http_probe",
+        reason: "bulk_http_probe",
+      };
+    }
+  }
+
+  return null;
+}
+
+export function updateTerminalScanSafetyInput(
+  currentLine: string,
+  input: string,
+): { inspection: string; currentLine: string } {
+  let line = currentLine;
+  const submitted: string[] = [];
+  for (const char of input) {
+    if (char === "\r" || char === "\n") {
+      submitted.push(line);
+      line = "";
+    } else if (char === "\u0003" || char === "\u0015") {
+      line = "";
+    } else if (char === "\b" || char === "\u007f") {
+      line = line.slice(0, -1);
+    } else if (char >= " " || char === "\t") {
+      line += char;
+    }
+  }
+  return {
+    inspection: [...submitted, line].filter(Boolean).join("\n"),
+    currentLine: line.slice(-64 * 1024),
+  };
+}
+
+const environment = () =>
+  process.env.TRIGGER_ENV ??
+  process.env.VERCEL_ENV ??
+  process.env.NODE_ENV ??
+  "unknown";
+
+const logSafetyEvent = (
+  level: "warn" | "error",
+  event: string,
+  fields: Record<string, unknown>,
+) => {
+  const payload = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    service: fields.trigger_run_id ? "agent-long" : "chat-handler",
+    environment: environment(),
+    request_id: fields.trigger_run_id ?? process.env.VERCEL_REQUEST_ID ?? null,
+    ...fields,
+  });
+  if (level === "error") console.error(payload);
+  else console.warn(payload);
+};
+
+type SafetyDependencies = {
+  terminate: (args: { userId: string; microvmId: string }) => Promise<{
+    status: "terminated" | "already_gone" | "ownership_not_found";
+  }>;
+};
+
+const defaultDependencies: SafetyDependencies = {
+  terminate: async (args) => {
+    const { terminateAwsLambdaMicrovmForSafety } =
+      await import("./aws-lambda-microvm");
+    return terminateAwsLambdaMicrovmForSafety(args);
+  },
+};
+
+/** Block the command and contain only the current AWS MicroVM. */
+export async function enforceCloudScanSafety(args: {
+  command: string;
+  sandbox: AnySandbox;
+  context: Pick<
+    ToolContext,
+    "chatId" | "sandboxManager" | "subscription" | "triggerRunId" | "userID"
+  >;
+  toolCallId: string;
+  source: "terminal_exec" | "terminal_interaction";
+  dependencies?: SafetyDependencies;
+}): Promise<CloudScanSafetyResult> {
+  if (!isAwsLambdaMicrovmSandbox(args.sandbox)) return { blocked: false };
+
+  const detection = detectCloudScanCommand(args.command);
+  if (!detection) return { blocked: false };
+
+  const microvmId = args.sandbox.getConnectionId();
+  const correlation = {
+    trigger_run_id: args.context.triggerRunId ?? null,
+    chat_id: args.context.chatId,
+    user_id: args.context.userID,
+    subscription: args.context.subscription ?? "unknown",
+    tool_call_id: args.toolCallId,
+    microvm_id: microvmId,
+    source: args.source,
+    scanner: detection.scanner,
+    reason: detection.reason,
+    command_length: args.command.length,
+  };
+  logSafetyEvent("warn", "cloud_scan_command_blocked", correlation);
+
+  let terminationStatus: Extract<
+    CloudScanSafetyResult,
+    { blocked: true }
+  >["terminationStatus"] = "failed";
+  try {
+    const result = await (args.dependencies ?? defaultDependencies).terminate({
+      userId: args.context.userID,
+      microvmId,
+    });
+    terminationStatus = result.status;
+    logSafetyEvent("warn", "cloud_scan_session_contained", {
+      ...correlation,
+      termination_status: terminationStatus,
+    });
+  } catch (error) {
+    logSafetyEvent("error", "cloud_scan_session_containment_failed", {
+      ...correlation,
+      failure_class: error instanceof Error ? error.name : typeof error,
+    });
+  } finally {
+    await args.context.sandboxManager
+      .resetSandbox?.("cloud_scan_safety_guard")
+      .catch((error) => {
+        logSafetyEvent("error", "cloud_scan_sandbox_reset_failed", {
+          ...correlation,
+          failure_class: error instanceof Error ? error.name : typeof error,
+        });
+      });
+  }
+
+  return {
+    blocked: true,
+    error: CLOUD_SCAN_BLOCK_MESSAGE,
+    microvmId,
+    scanner: detection.scanner,
+    terminationStatus,
+  };
+}

--- a/lib/ai/tools/utils/pty-session-manager.ts
+++ b/lib/ai/tools/utils/pty-session-manager.ts
@@ -66,6 +66,8 @@ export interface PtySession {
   readCursor: number;
   /** Flipped once when the ring first drops any bytes. Never reset. */
   bufferTruncated: boolean;
+  /** Unsubmitted interactive input retained only for Cloud scan inspection. */
+  scanSafetyInputLine: string;
 }
 
 export interface CreateSessionOpts {
@@ -164,6 +166,7 @@ export class PtySessionManager {
         buffer: [],
         readCursor: 0,
         bufferTruncated: false,
+        scanSafetyInputLine: "",
         droppedBytes: 0,
         idleTimer: null,
         lifetimeTimer: null,

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -225,6 +225,14 @@ const getDefaultSandboxEnvironmentSection = (
 - Treat implausible Cloud Agent port-scan output as invalid or unverified. Do not keep retrying broad scans, claim the ports are confirmed open, or blame the scanning tool when the environment is the likely cause.
 - When the user needs reliable port scanning or normal TCP, UDP, or raw-socket behavior, explain this Cloud Agent limitation and recommend selecting the HackerAI Desktop App or a Remote Control connection as the execution environment so the tools use that machine's native network stack.`
       : "";
+  const cloudScanSafetySection =
+    provider === "aws-lambda-microvm"
+      ? `Cloud egress safeguard:
+- AWS Cloud permits bounded nmap and naabu port scans of one target and at most 1,000 ports.
+- CIDRs broader than one host, target lists, multiple targets, full-port sweeps, dedicated mass scanners such as masscan, zmap, and rustscan, and bulk nuclei or httpx target lists are unavailable in Cloud.
+- Use HackerAI Desktop or Remote Control for larger authorized scans. Normal web, API, browser, package, repository, and bounded application-security traffic remains available in Cloud.
+- Do not retry a blocked scan through shell wrappers, aliases, encoding, custom fan-out scripts, or alternative bulk scanners. The Cloud session is terminated automatically when this safeguard blocks a command.`
+      : "";
   const systemEnvironment =
     provider === "aws-lambda-microvm"
       ? `- OS: Kali Linux rolling, linux/arm64 (with internet access)
@@ -244,6 +252,8 @@ Local/internal target access:
 - Do not invent host aliases or imply the cloud sandbox can directly reach private/internal assets unless the user has provided a reachable route.
 
 ${portScanningSection}
+
+${cloudScanSafetySection}
 
 System Environment:
 ${systemEnvironment}

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -231,7 +231,7 @@ const getDefaultSandboxEnvironmentSection = (
 - AWS Cloud permits bounded nmap and naabu port scans of one target and at most 1,000 ports.
 - CIDRs broader than one host, target lists, multiple targets, full-port sweeps, dedicated mass scanners such as masscan, zmap, and rustscan, and bulk nuclei or httpx target lists are unavailable in Cloud.
 - Use HackerAI Desktop or Remote Control for larger authorized scans. Normal web, API, browser, package, repository, and bounded application-security traffic remains available in Cloud.
-- Do not retry a blocked scan through shell wrappers, aliases, encoding, custom fan-out scripts, or alternative bulk scanners. The Cloud session is terminated automatically when this safeguard blocks a command.`
+- Do not retry a blocked scan through shell wrappers, aliases, encoding, custom fan-out scripts, or alternative bulk scanners. When this safeguard blocks a command, the Cloud connection is closed and MicroVM termination is attempted automatically. If termination cannot be confirmed, the command remains blocked; do not retry in Cloud.`
       : "";
   const systemEnvironment =
     provider === "aws-lambda-microvm"


### PR DESCRIPTION
## Incident context
AWS reported scan-like traffic through the shared MicroVM NAT, including millions of connection attempts in a short window. This hotfix adds immediate application-layer containment while preserving bounded security validation.

## Behavior
- Allow nmap and naabu in AWS Cloud for exactly one target and at most 1,000 ports.
- Block CIDRs broader than one host, target lists, multiple targets, full-port sweeps, mass scanners, and bulk nuclei/httpx inputs before execution.
- Inspect both one-shot commands and stateful interactive PTY input, including split sends and common shell wrappers/expansions.
- Terminate only the exact active AWS MicroVM after a durable user/connection ownership check; Desktop and Remote sandboxes are unaffected.
- Emit structured incident logs with correlation IDs and scanner class, without command text, target text, or target-derived hashes.
- Tell the Agent not to retry blocked work through wrappers or custom fan-out, and direct larger authorized scans to Desktop or Remote.

## Safety and limitations
This is an emergency application-layer guard, not a complete network enforcement boundary. Renamed binaries or custom scanner implementations can evade command classification. A follow-up should add VPC Flow Logs/per-session egress attribution and network-layer destination/connection-rate controls so enforcement cannot be bypassed by arbitrary guest code.

A blocked command terminates the user's current reusable Cloud MicroVM immediately. This favors AWS abuse containment over an additional pre-termination checkpoint; recent changes remain protected only by the normal workspace checkpoint cadence.

## Validation
- pnpm typecheck
- pnpm lint (0 errors; 7 unrelated existing warnings)
- pnpm exec jest --runInBand (425 suites, 4,431 tests)
- focused parser, split-PTY, AWS ownership, and Desktop/Remote regression tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards for cloud-based network scans, including limits on targets, ports, and scanning volume.
  * Blocked unsafe scans with clear errors and automatically ended affected cloud sessions.
  * Added guidance to use Desktop or Remote execution for broader scans.
  * Improved safety checks for interactive terminal input, including split commands, edits, and nested commands.

* **Bug Fixes**
  * Ensured only verified, active cloud sessions are terminated during safety enforcement.

* **Tests**
  * Added comprehensive coverage for scan detection, session termination, command handling, and prompt guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->