### PR TITLE
Add automatic E2B fallback for AWS sandbox outages

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -68,8 +68,12 @@ OPENAI_API_KEY=
 # =============================================================================
 # CODE EXECUTION - CLOUD SANDBOX (Required for cloud Agent Mode)
 # =============================================================================
-# Provider defaults to AWS Lambda MicroVMs. Set this to E2B only for emergency rollback.
+# Provider defaults to AWS Lambda MicroVMs. Set this to E2B for a manual rollback.
 # CLOUD_SANDBOX_PROVIDER=e2b
+# With AWS selected, new Trigger Agent runs automatically use E2B while the
+# distributed AWS account/provider circuit is open. This defaults to enabled
+# when E2B and Upstash credentials are configured; set false to disable.
+# CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED=true
 E2B_API_KEY=
 E2B_TEMPLATE=terminal-agent-sandbox
 
@@ -98,7 +102,7 @@ E2B_TEMPLATE=terminal-agent-sandbox
 # REDIS_URL=redis://localhost:6379
 
 # =============================================================================
-# RATE LIMITING (Optional - Upstash Redis)
+# RATE LIMITING AND CLOUD PROVIDER CIRCUIT (Optional unless auto-failover is used)
 # =============================================================================
 # Sign up at: https://upstash.com/
 # UPSTASH_REDIS_REST_URL=https://your-endpoint.upstash.io

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -144,9 +144,14 @@ reuses a MicroVM:
 
 ```dotenv
 CLOUD_SANDBOX_PROVIDER=aws-lambda-microvm
+CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED=true
 AWS_LAMBDA_MICROVM_RELEASE_MANIFEST=<atomic JSON manifest produced by the release workflow>
 AWS_ACCESS_KEY_ID=<runtime identity key for an initial test>
 AWS_SECRET_ACCESS_KEY=<runtime identity secret for an initial test>
+E2B_API_KEY=<standby provider credential>
+E2B_TEMPLATE=terminal-agent-sandbox
+UPSTASH_REDIS_REST_URL=<shared provider-circuit store>
+UPSTASH_REDIS_REST_TOKEN=<shared provider-circuit credential>
 CONVEX_SERVICE_ROLE_KEY=<existing server role key>
 NEXT_PUBLIC_CONVEX_URL=<existing Convex deployment URL>
 ```
@@ -162,6 +167,23 @@ defaults explicitly to US East. A running or suspended sandbox remains pinned
 to its persisted region and image until it ends; a later request never silently
 migrates its memory, disk, or outbound source location. Neither Trigger.dev nor
 Vercel needs `AWS_REGION` or `AWS_LAMBDA_MICROVM_REGION` at runtime.
+
+When E2B and Upstash are configured, a one-minute Trigger health task detects
+account-wide AWS authentication or authorization loss and opens a distributed
+provider circuit. New parent Agent runs then select E2B before their tools and
+system prompt are created. A completed AWS acquisition can also close a
+half-open circuit; retryable provider failures open the global circuit only
+after three failures within two minutes and only after the launcher's regional
+recovery has already failed. Account-access failures retry AWS after six hours;
+provider outages retry after 15 minutes, with one distributed half-open probe.
+
+Provider selection remains fixed for each durable run. Existing AWS sessions
+and subagents are never migrated mid-run, and a command rejected by the Cloud
+scan-safety guard cannot activate or traverse the provider fallback. E2B does
+not restore the regional AWS S3 workspace archive, so continuity covers new
+Agent work rather than transparent recovery of an AWS MicroVM filesystem.
+Set `CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED=false` to disable automatic routing,
+or set `CLOUD_SANDBOX_PROVIDER=e2b` for an explicit operator rollback.
 
 For a new session only, a regional capacity failure can make one bounded
 cross-region attempt. US East tries Oregon, Oregon tries US East, and Ireland

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -168,14 +168,16 @@ to its persisted region and image until it ends; a later request never silently
 migrates its memory, disk, or outbound source location. Neither Trigger.dev nor
 Vercel needs `AWS_REGION` or `AWS_LAMBDA_MICROVM_REGION` at runtime.
 
-When E2B and Upstash are configured, a one-minute Trigger health task detects
-account-wide AWS authentication or authorization loss and opens a distributed
-provider circuit. New parent Agent runs then select E2B before their tools and
-system prompt are created. A completed AWS acquisition can also close a
-half-open circuit; retryable provider failures open the global circuit only
-after three failures within two minutes and only after the launcher's regional
-recovery has already failed. Account-access failures retry AWS after six hours;
-provider outages retry after 15 minutes, with one distributed half-open probe.
+When E2B and Upstash are configured and
+`CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED=true`, a one-minute Trigger health task
+detects account-wide AWS authentication or authorization loss and opens a
+distributed provider circuit. New parent Agent runs then select E2B before
+their tools and system prompt are created. A completed AWS acquisition can also
+close a half-open circuit; retryable provider failures open the global circuit
+only after three failures within two minutes and only after the launcher's
+regional recovery has already failed. Account-access failures retry AWS after
+six hours; provider outages retry after 15 minutes, with one distributed
+half-open probe.
 
 Provider selection remains fixed for each durable run. Existing AWS sessions
 and subagents are never migrated mid-run, and a command rejected by the Cloud

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -174,10 +174,11 @@ detects account-wide AWS authentication or authorization loss and opens a
 distributed provider circuit. New parent Agent runs then select E2B before
 their tools and system prompt are created. A completed AWS acquisition can also
 close a half-open circuit; retryable provider failures open the global circuit
-only after three failures within two minutes and only after the launcher's
-regional recovery has already failed. Account-access failures retry AWS after
-six hours; provider outages retry after 15 minutes, with one distributed
-half-open probe.
+only after three final acquisition failures within two minutes. This includes
+attach, endpoint, workspace-restore, and ready-state failures; a `run_microvm`
+failure is counted only after its bounded regional recovery has also failed.
+Account-access failures retry AWS after six hours; provider outages retry after
+15 minutes, with one distributed half-open probe.
 
 Provider selection remains fixed for each durable run. Existing AWS sessions
 and subagents are never migrated mid-run, and a command rejected by the Cloud

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -49,6 +49,7 @@ import { phLogger } from "@/lib/posthog/server";
 import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 import type { CloudSandboxAcquisitionContext } from "./utils/cloud-sandbox";
 import type { CloudSandboxProvider } from "./utils/cloud-sandbox-provider";
+import type { CloudSandboxProviderSelectionReason } from "./utils/cloud-sandbox-provider-circuit";
 
 export { isE2BSandbox };
 
@@ -58,6 +59,7 @@ export type CreateToolsRuntimePolicy = {
   ptyScopeId?: string;
   chargeSandboxRuntime?: boolean;
   cloudSandboxProvider?: CloudSandboxProvider;
+  cloudSandboxProviderSelectionReason?: CloudSandboxProviderSelectionReason;
   triggerRegion?: TriggerRunRegion;
 };
 
@@ -123,6 +125,7 @@ export const createTools = (
     triggerRegion: runtimePolicy.triggerRegion,
     runKind:
       runtimePolicy.chargeSandboxRuntime === false ? "subagent" : "parent",
+    providerSelectionReason: runtimePolicy.cloudSandboxProviderSelectionReason,
   };
 
   const trackSandboxUsage = (newSandbox: AnySandbox) => {
@@ -153,6 +156,8 @@ export const createTools = (
         chat_id: chatId,
         trigger_run_id: triggerRunId,
         provider,
+        provider_selection_reason:
+          runtimePolicy.cloudSandboxProviderSelectionReason ?? "configured",
         cloud_sandbox_transport:
           provider === "aws-lambda-microvm" ? "aws_websocket" : "e2b_sdk",
         subscription,
@@ -197,7 +202,7 @@ export const createTools = (
           provider === "aws-lambda-microvm"
             ? sandboxBootInfo?.failover_duration_ms
             : undefined,
-        cloud_sandbox_provider_event_version: 5,
+        cloud_sandbox_provider_event_version: 6,
       });
     }
   };

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-provider-circuit.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-provider-circuit.test.ts
@@ -186,6 +186,11 @@ describe("cloud sandbox provider circuit", () => {
       opened: true,
       failureClass: "provider_unavailable",
     });
+    expect(
+      redis.values.has(
+        `${CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.failureCounterPrefix}:provider_unavailable`,
+      ),
+    ).toBe(false);
   });
 
   test("does not open globally for a transient health-probe failure", async () => {
@@ -305,6 +310,14 @@ describe("cloud sandbox provider circuit", () => {
       CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.halfOpenLockKey,
       "probe",
     );
+    redis.values.set(
+      `${CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.failureCounterPrefix}:account_access`,
+      1,
+    );
+    redis.values.set(
+      `${CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.failureCounterPrefix}:provider_unavailable`,
+      3,
+    );
 
     await recordAwsSandboxHalfOpenSuccess(
       { requestId: "probe" },
@@ -316,6 +329,16 @@ describe("cloud sandbox provider circuit", () => {
     expect(
       redis.values.has(
         CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.halfOpenLockKey,
+      ),
+    ).toBe(false);
+    expect(
+      redis.values.has(
+        `${CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.failureCounterPrefix}:account_access`,
+      ),
+    ).toBe(false);
+    expect(
+      redis.values.has(
+        `${CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.failureCounterPrefix}:provider_unavailable`,
       ),
     ).toBe(false);
   });

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-provider-circuit.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-provider-circuit.test.ts
@@ -1,0 +1,369 @@
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: { error: jest.fn() },
+}));
+
+import {
+  CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS,
+  classifyAwsCircuitFailure,
+  recordAwsAccountHealthProbeSuccess,
+  recordAwsSandboxAcquisitionFailure,
+  recordAwsSandboxHalfOpenSuccess,
+  resetCloudSandboxProviderCircuitStateForTests,
+  resolveCloudSandboxProviderForRun,
+} from "../cloud-sandbox-provider-circuit";
+
+class FakeRedis {
+  readonly values = new Map<string, unknown>();
+  readonly expirations = new Map<string, number>();
+
+  async get(key: string): Promise<unknown> {
+    return this.values.get(key) ?? null;
+  }
+
+  async set(
+    key: string,
+    value: unknown,
+    options?: { nx?: boolean; ex?: number },
+  ): Promise<"OK" | null> {
+    if (options?.nx && this.values.has(key)) return null;
+    this.values.set(key, value);
+    if (options?.ex) this.expirations.set(key, options.ex);
+    return "OK";
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = Number(this.values.get(key) ?? 0) + 1;
+    this.values.set(key, next);
+    return next;
+  }
+
+  async expire(key: string, seconds: number): Promise<number> {
+    if (!this.values.has(key)) return 0;
+    this.expirations.set(key, seconds);
+    return 1;
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let removed = 0;
+    for (const key of keys) {
+      if (this.values.delete(key)) removed++;
+      this.expirations.delete(key);
+    }
+    return removed;
+  }
+
+  async eval<T>(_script: string, keys: string[], args: unknown[]): Promise<T> {
+    const current = this.values.get(keys[0]);
+    const serialized =
+      typeof current === "string" ? current : JSON.stringify(current);
+    if (serialized !== args[0]) return 0 as T;
+    await this.del(...keys);
+    return 1 as T;
+  }
+}
+
+const originalProvider = process.env.CLOUD_SANDBOX_PROVIDER;
+const originalAutoFailover = process.env.CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED;
+const originalE2bApiKey = process.env.E2B_API_KEY;
+
+describe("cloud sandbox provider circuit", () => {
+  beforeEach(() => {
+    process.env.CLOUD_SANDBOX_PROVIDER = "aws-lambda-microvm";
+    process.env.CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED = "true";
+    process.env.E2B_API_KEY = "test-e2b-key";
+    resetCloudSandboxProviderCircuitStateForTests();
+  });
+
+  afterAll(() => {
+    if (originalProvider === undefined)
+      delete process.env.CLOUD_SANDBOX_PROVIDER;
+    else process.env.CLOUD_SANDBOX_PROVIDER = originalProvider;
+    if (originalAutoFailover === undefined) {
+      delete process.env.CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED;
+    } else {
+      process.env.CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED = originalAutoFailover;
+    }
+    if (originalE2bApiKey === undefined) delete process.env.E2B_API_KEY;
+    else process.env.E2B_API_KEY = originalE2bApiKey;
+  });
+
+  test("classifies nested AWS account access failures", () => {
+    const cause = Object.assign(new Error("account is suspended"), {
+      name: "AccessDeniedException",
+      $metadata: { httpStatusCode: 403 },
+    });
+    const error = new Error("Failed creating AWS sandbox", { cause });
+
+    expect(classifyAwsCircuitFailure(error)).toEqual({
+      failureClass: "account_access",
+      failureName: "AccessDeniedException",
+    });
+  });
+
+  test("classifies provider failures but ignores configuration errors", () => {
+    expect(
+      classifyAwsCircuitFailure(
+        Object.assign(new Error("service unavailable"), {
+          name: "InternalServerException",
+          $metadata: { httpStatusCode: 503 },
+        }),
+      ),
+    ).toEqual({
+      failureClass: "provider_unavailable",
+      failureName: "InternalServerException",
+    });
+    expect(
+      classifyAwsCircuitFailure(
+        Object.assign(new Error("bad release manifest"), {
+          name: "ValidationException",
+          $metadata: { httpStatusCode: 400 },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("opens immediately for account access loss and selects E2B", async () => {
+    const redis = new FakeRedis();
+    const now = Date.parse("2026-08-25T18:00:00.000Z");
+    const log = jest.fn();
+    const error = Object.assign(new Error("denied"), {
+      name: "AccessDeniedException",
+      $metadata: { httpStatusCode: 403 },
+    });
+
+    await expect(
+      recordAwsSandboxAcquisitionFailure(
+        error,
+        { requestId: "run-1", source: "health_probe" },
+        { redis, now: () => now, log },
+      ),
+    ).resolves.toEqual({ opened: true, failureClass: "account_access" });
+
+    await expect(
+      resolveCloudSandboxProviderForRun(
+        { requestId: "run-2" },
+        { redis, now: () => now + 1, log },
+      ),
+    ).resolves.toMatchObject({
+      provider: "e2b",
+      reason: "circuit_open",
+      circuitFailureClass: "account_access",
+    });
+    expect(log).toHaveBeenCalledWith(
+      "warn",
+      "cloud_sandbox_provider_circuit_opened",
+      expect.objectContaining({ request_id: "run-1" }),
+    );
+  });
+
+  test("requires three acquisition failures before opening a transient circuit", async () => {
+    const redis = new FakeRedis();
+    const error = Object.assign(new Error("unavailable"), {
+      name: "InternalServerException",
+      $metadata: { httpStatusCode: 503 },
+    });
+    const dependencies = { redis, now: () => 1_000, log: jest.fn() };
+
+    await expect(
+      recordAwsSandboxAcquisitionFailure(
+        error,
+        { source: "sandbox_acquisition" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({ opened: false });
+    await recordAwsSandboxAcquisitionFailure(
+      error,
+      { source: "sandbox_acquisition" },
+      dependencies,
+    );
+    await expect(
+      recordAwsSandboxAcquisitionFailure(
+        error,
+        { source: "sandbox_acquisition" },
+        dependencies,
+      ),
+    ).resolves.toEqual({
+      opened: true,
+      failureClass: "provider_unavailable",
+    });
+  });
+
+  test("does not open globally for a transient health-probe failure", async () => {
+    const redis = new FakeRedis();
+    const error = Object.assign(new Error("regional outage"), {
+      name: "InternalServerException",
+      $metadata: { httpStatusCode: 503 },
+    });
+
+    for (let attempt = 0; attempt < 4; attempt++) {
+      await expect(
+        recordAwsSandboxAcquisitionFailure(
+          error,
+          { source: "health_probe" },
+          { redis, now: () => 1_000, log: jest.fn() },
+        ),
+      ).resolves.toEqual({
+        opened: false,
+        failureClass: "provider_unavailable",
+      });
+    }
+    expect(
+      redis.values.has(CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey),
+    ).toBe(false);
+  });
+
+  test("allows only one half-open AWS run while other runs stay on E2B", async () => {
+    const redis = new FakeRedis();
+    const openedAt = "2026-08-25T18:00:00.000Z";
+    const retryAt = "2026-08-25T18:15:00.000Z";
+    redis.values.set(
+      CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey,
+      JSON.stringify({
+        version: 1,
+        state: "open",
+        failureClass: "provider_unavailable",
+        failureName: "InternalServerException",
+        openedAt,
+        retryAt,
+      }),
+    );
+    const now = Date.parse(retryAt) + 1;
+    const dependencies = { redis, now: () => now, log: jest.fn() };
+
+    await expect(
+      resolveCloudSandboxProviderForRun({ requestId: "probe" }, dependencies),
+    ).resolves.toMatchObject({
+      provider: "aws-lambda-microvm",
+      reason: "circuit_half_open_probe",
+    });
+    await expect(
+      resolveCloudSandboxProviderForRun({ requestId: "other" }, dependencies),
+    ).resolves.toMatchObject({ provider: "e2b", reason: "circuit_open" });
+  });
+
+  test("reopens immediately when the single half-open AWS run fails", async () => {
+    const redis = new FakeRedis();
+    const retryAt = "2026-08-25T18:15:00.000Z";
+    const now = Date.parse(retryAt) + 1;
+    redis.values.set(
+      CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey,
+      JSON.stringify({
+        version: 1,
+        state: "open",
+        failureClass: "provider_unavailable",
+        failureName: "InternalServerException",
+        openedAt: "2026-08-25T18:00:00.000Z",
+        retryAt,
+      }),
+    );
+    const dependencies = { redis, now: () => now, log: jest.fn() };
+    await resolveCloudSandboxProviderForRun(
+      { requestId: "half-open" },
+      dependencies,
+    );
+
+    await expect(
+      recordAwsSandboxAcquisitionFailure(
+        Object.assign(new Error("still unavailable"), {
+          name: "InternalServerException",
+          $metadata: { httpStatusCode: 503 },
+        }),
+        { source: "sandbox_acquisition", halfOpenProbe: true },
+        dependencies,
+      ),
+    ).resolves.toEqual({
+      opened: true,
+      failureClass: "provider_unavailable",
+    });
+    await expect(
+      resolveCloudSandboxProviderForRun(
+        { requestId: "next-run" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({ provider: "e2b", reason: "circuit_open" });
+    expect(
+      redis.values.has(
+        CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.halfOpenLockKey,
+      ),
+    ).toBe(false);
+  });
+
+  test("closes a half-open circuit after a successful AWS acquisition", async () => {
+    const redis = new FakeRedis();
+    redis.values.set(
+      CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey,
+      JSON.stringify({
+        version: 1,
+        state: "open",
+        failureClass: "provider_unavailable",
+        failureName: "TimeoutError",
+        openedAt: "2026-08-25T18:00:00.000Z",
+        retryAt: "2026-08-25T18:15:00.000Z",
+      }),
+    );
+    redis.values.set(
+      CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.halfOpenLockKey,
+      "probe",
+    );
+
+    await recordAwsSandboxHalfOpenSuccess(
+      { requestId: "probe" },
+      { redis, log: jest.fn() },
+    );
+    expect(
+      redis.values.has(CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey),
+    ).toBe(false);
+    expect(
+      redis.values.has(
+        CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.halfOpenLockKey,
+      ),
+    ).toBe(false);
+  });
+
+  test("health success closes account circuits but not provider-outage circuits", async () => {
+    const redis = new FakeRedis();
+    const setState = (
+      failureClass: "account_access" | "provider_unavailable",
+    ) =>
+      redis.values.set(
+        CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey,
+        JSON.stringify({
+          version: 1,
+          state: "open",
+          failureClass,
+          failureName: "failure",
+          openedAt: "2026-08-25T18:00:00.000Z",
+          retryAt: "2026-08-25T18:15:00.000Z",
+        }),
+      );
+
+    setState("provider_unavailable");
+    await recordAwsAccountHealthProbeSuccess({}, { redis, log: jest.fn() });
+    expect(
+      redis.values.has(CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey),
+    ).toBe(true);
+
+    setState("account_access");
+    await recordAwsAccountHealthProbeSuccess({}, { redis, log: jest.fn() });
+    expect(
+      redis.values.has(CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS.circuitKey),
+    ).toBe(false);
+  });
+
+  test("manual E2B selection and disabled auto-failover bypass the circuit", async () => {
+    const redis = new FakeRedis();
+    process.env.CLOUD_SANDBOX_PROVIDER = "e2b";
+    await expect(
+      resolveCloudSandboxProviderForRun({}, { redis, log: jest.fn() }),
+    ).resolves.toEqual({ provider: "e2b", reason: "configured_e2b" });
+
+    process.env.CLOUD_SANDBOX_PROVIDER = "aws-lambda-microvm";
+    process.env.CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED = "false";
+    await expect(
+      resolveCloudSandboxProviderForRun({}, { redis, log: jest.fn() }),
+    ).resolves.toEqual({
+      provider: "aws-lambda-microvm",
+      reason: "primary_aws",
+    });
+  });
+});

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-telemetry.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-telemetry.test.ts
@@ -1,4 +1,7 @@
 const mockEnsureSandboxConnection = jest.fn();
+const mockEnsureAwsLambdaMicrovmConnection = jest.fn();
+const mockRecordAwsSandboxAcquisitionFailure = jest.fn();
+const mockRecordAwsSandboxHalfOpenSuccess = jest.fn();
 const mockEvent = jest.fn();
 
 jest.mock("../sandbox", () => ({
@@ -10,9 +13,27 @@ jest.mock("@/lib/posthog/server", () => ({
   phLogger: { event: (...args: unknown[]) => mockEvent(...args) },
 }));
 
+jest.mock("../aws-lambda-microvm", () => ({
+  ensureAwsLambdaMicrovmConnection: (...args: unknown[]) =>
+    mockEnsureAwsLambdaMicrovmConnection(...args),
+}));
+
+jest.mock("../cloud-sandbox-provider-circuit", () => ({
+  recordAwsSandboxAcquisitionFailure: (...args: unknown[]) =>
+    mockRecordAwsSandboxAcquisitionFailure(...args),
+  recordAwsSandboxHalfOpenSuccess: (...args: unknown[]) =>
+    mockRecordAwsSandboxHalfOpenSuccess(...args),
+}));
+
 import { ensureCloudSandboxConnection } from "../cloud-sandbox";
 
 describe("cloud sandbox operational telemetry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRecordAwsSandboxAcquisitionFailure.mockResolvedValue({ opened: false });
+    mockRecordAwsSandboxHalfOpenSuccess.mockResolvedValue(undefined);
+  });
+
   it("attributes acquisition failures without rollout properties", async () => {
     const failure = Object.assign(new Error("private target detail"), {
       name: "SandboxUnavailableError",
@@ -56,5 +77,58 @@ describe("cloud sandbox operational telemetry", () => {
     expect(JSON.stringify(mockEvent.mock.calls[0])).not.toContain(
       "private target detail",
     );
+  });
+
+  it("records only final AWS acquisition failures in the provider circuit", async () => {
+    const failure = Object.assign(new Error("denied"), {
+      name: "AccessDeniedException",
+    });
+    mockEnsureAwsLambdaMicrovmConnection.mockRejectedValueOnce(failure);
+
+    await expect(
+      ensureCloudSandboxConnection({
+        userId: "user-ultra",
+        setSandbox: jest.fn(),
+        context: {
+          provider: "aws-lambda-microvm",
+          providerSelectionReason: "primary_aws",
+          triggerRunId: "run-aws",
+        },
+      }),
+    ).rejects.toBe(failure);
+
+    expect(mockRecordAwsSandboxAcquisitionFailure).toHaveBeenCalledWith(
+      failure,
+      {
+        requestId: "run-aws",
+        source: "sandbox_acquisition",
+        halfOpenProbe: false,
+      },
+    );
+    expect(mockRecordAwsSandboxHalfOpenSuccess).not.toHaveBeenCalled();
+  });
+
+  it("closes a half-open circuit only after AWS acquisition succeeds", async () => {
+    const sandbox = { getConnectionId: () => "microvm-1" };
+    mockEnsureAwsLambdaMicrovmConnection.mockResolvedValueOnce(sandbox);
+    const setSandbox = jest.fn();
+
+    await expect(
+      ensureCloudSandboxConnection({
+        userId: "user-ultra",
+        setSandbox,
+        context: {
+          provider: "aws-lambda-microvm",
+          providerSelectionReason: "circuit_half_open_probe",
+          triggerRunId: "run-probe",
+        },
+      }),
+    ).resolves.toEqual({ sandbox });
+
+    expect(mockRecordAwsSandboxHalfOpenSuccess).toHaveBeenCalledWith({
+      requestId: "run-probe",
+    });
+    expect(setSandbox).toHaveBeenCalledWith(sandbox);
+    expect(mockRecordAwsSandboxAcquisitionFailure).not.toHaveBeenCalled();
   });
 });

--- a/lib/ai/tools/utils/aws-lambda-microvm.ts
+++ b/lib/ai/tools/utils/aws-lambda-microvm.ts
@@ -2,6 +2,7 @@ import {
   CreateMicrovmAuthTokenCommand,
   GetMicrovmCommand,
   LambdaMicrovmsClient,
+  ListMicrovmsCommand,
   ResumeMicrovmCommand,
   RunMicrovmCommand,
   type RunMicrovmCommandInput,
@@ -433,6 +434,13 @@ function getClient(region: string): LambdaMicrovmsClient {
   const created = new LambdaMicrovmsClient({ region, maxAttempts: 4 });
   clients.set(region, created);
   return created;
+}
+
+/** Read-only control-plane probe used to detect account-wide access loss. */
+export async function probeAwsLambdaMicrovmAccountAccess(): Promise<void> {
+  await getClient(AWS_LAMBDA_MICROVM_REGION).send(
+    new ListMicrovmsCommand({ maxResults: 1 }),
+  );
 }
 
 function getConfigForPersistedSession(

--- a/lib/ai/tools/utils/cloud-sandbox-provider-circuit.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-provider-circuit.ts
@@ -387,7 +387,7 @@ export async function recordAwsSandboxAcquisitionFailure(
         ex: CIRCUIT_STATE_TTL_SECONDS,
       });
     }
-    await redis.del(HALF_OPEN_LOCK_KEY);
+    await redis.del(HALF_OPEN_LOCK_KEY, counterKey);
     if (newlyOpened) {
       log("warn", "cloud_sandbox_provider_circuit_opened", {
         request_id: options.requestId ?? null,
@@ -457,13 +457,17 @@ async function closeAwsSandboxCircuit(
       await redis.eval(
         `
           if redis.call("GET", KEYS[1]) == ARGV[1] then
-            redis.call("DEL", KEYS[1])
-            redis.call("DEL", KEYS[2])
+            redis.call("DEL", KEYS[1], KEYS[2], KEYS[3], KEYS[4])
             return 1
           end
           return 0
         `,
-        [CIRCUIT_KEY, HALF_OPEN_LOCK_KEY],
+        [
+          CIRCUIT_KEY,
+          HALF_OPEN_LOCK_KEY,
+          `${FAILURE_COUNTER_PREFIX}:account_access`,
+          `${FAILURE_COUNTER_PREFIX}:provider_unavailable`,
+        ],
         [JSON.stringify(previousState)],
       ),
     );
@@ -495,6 +499,7 @@ export async function recordAwsAccountHealthProbeSuccess(
 export const CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS = {
   circuitKey: CIRCUIT_KEY,
   halfOpenLockKey: HALF_OPEN_LOCK_KEY,
+  failureCounterPrefix: FAILURE_COUNTER_PREFIX,
   transientFailureThreshold: TRANSIENT_FAILURE_THRESHOLD,
   accountRetryDelayMs: ACCOUNT_RETRY_DELAY_MS,
   transientRetryDelayMs: TRANSIENT_RETRY_DELAY_MS,

--- a/lib/ai/tools/utils/cloud-sandbox-provider-circuit.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-provider-circuit.ts
@@ -1,0 +1,505 @@
+import type { Redis } from "@upstash/redis";
+import { createRedisClient } from "@/lib/rate-limit/redis";
+import { phLogger } from "@/lib/posthog/server";
+import {
+  getCloudSandboxProvider,
+  type CloudSandboxProvider,
+} from "./cloud-sandbox-provider";
+
+const CIRCUIT_KEY = "cloud-sandbox:provider-circuit:aws:v1";
+const HALF_OPEN_LOCK_KEY = `${CIRCUIT_KEY}:half-open`;
+const FAILURE_COUNTER_PREFIX = `${CIRCUIT_KEY}:failures`;
+const CIRCUIT_STATE_TTL_SECONDS = 7 * 24 * 60 * 60;
+const HALF_OPEN_LOCK_SECONDS = 2 * 60;
+const FAILURE_WINDOW_SECONDS = 2 * 60;
+const ACCOUNT_RETRY_DELAY_MS = 6 * 60 * 60 * 1000;
+const TRANSIENT_RETRY_DELAY_MS = 15 * 60 * 1000;
+const TRANSIENT_FAILURE_THRESHOLD = 3;
+
+const ACCOUNT_FAILURE_NAMES = new Set([
+  "AccessDeniedException",
+  "AccountSuspendedException",
+  "CredentialsProviderError",
+  "ExpiredTokenException",
+  "InvalidClientTokenId",
+  "InvalidSignatureException",
+  "UnrecognizedClientException",
+]);
+
+const TRANSIENT_FAILURE_NAMES = new Set([
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "InternalServerException",
+  "NetworkingError",
+  "RequestTimeout",
+  "ServiceQuotaExceededException",
+  "ThrottlingException",
+  "TimeoutError",
+  "TooManyRequestsException",
+]);
+
+export type AwsCircuitFailureClass = "account_access" | "provider_unavailable";
+
+export type CloudSandboxProviderSelectionReason =
+  | "configured_e2b"
+  | "primary_aws"
+  | "circuit_open"
+  | "circuit_half_open_probe"
+  | "automatic_failover_unavailable"
+  | "persisted_subagent";
+
+export type CloudSandboxProviderSelection = {
+  provider: CloudSandboxProvider;
+  reason: CloudSandboxProviderSelectionReason;
+  circuitFailureClass?: AwsCircuitFailureClass;
+  circuitOpenedAt?: string;
+  circuitRetryAt?: string;
+};
+
+type AwsCircuitState = {
+  version: 1;
+  state: "open";
+  failureClass: AwsCircuitFailureClass;
+  failureName: string;
+  openedAt: string;
+  retryAt: string;
+};
+
+type ErrorDetails = {
+  name: string;
+  message: string;
+  httpStatusCode?: number;
+  code?: string;
+};
+
+type CircuitDependencies = {
+  redis?: Pick<
+    Redis,
+    "del" | "eval" | "expire" | "get" | "incr" | "set"
+  > | null;
+  now?: () => number;
+  log?: (
+    level: "info" | "warn" | "error",
+    event: string,
+    fields: Record<string, unknown>,
+  ) => void;
+};
+
+let circuitStoreUnavailableLogged = false;
+
+const runtimeEnvironment = (): string =>
+  process.env.TRIGGER_ENV ??
+  process.env.VERCEL_ENV ??
+  process.env.NODE_ENV ??
+  "unknown";
+
+const defaultLog: NonNullable<CircuitDependencies["log"]> = (
+  level,
+  event,
+  fields,
+) => {
+  const payload = {
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    service: "cloud-sandbox-provider-circuit",
+    environment: runtimeEnvironment(),
+    request_id: null,
+    ...fields,
+  };
+  const message = JSON.stringify(payload);
+  if (level === "error") console.error(message);
+  else if (level === "warn") console.warn(message);
+  else console.info(message);
+};
+
+const getDependencies = (dependencies?: CircuitDependencies) => ({
+  redis:
+    dependencies && "redis" in dependencies
+      ? dependencies.redis
+      : createRedisClient(),
+  now: dependencies?.now ?? Date.now,
+  log: dependencies?.log ?? defaultLog,
+});
+
+const automaticFailoverEnabled = (): boolean =>
+  process.env.CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED?.trim().toLowerCase() !==
+  "false";
+
+const e2bFallbackConfigured = (): boolean =>
+  Boolean(process.env.E2B_API_KEY?.trim());
+
+export const isCloudSandboxAutomaticFailoverConfigured = (): boolean =>
+  getCloudSandboxProvider() === "aws-lambda-microvm" &&
+  automaticFailoverEnabled() &&
+  e2bFallbackConfigured() &&
+  Boolean(createRedisClient());
+
+const toErrorDetails = (error: unknown): ErrorDetails | null => {
+  if (!error || typeof error !== "object") return null;
+  const record = error as {
+    name?: unknown;
+    message?: unknown;
+    code?: unknown;
+    $metadata?: { httpStatusCode?: unknown };
+  };
+  return {
+    name:
+      typeof record.name === "string" && record.name
+        ? record.name
+        : "UnknownError",
+    message: typeof record.message === "string" ? record.message : "",
+    code: typeof record.code === "string" ? record.code : undefined,
+    httpStatusCode:
+      typeof record.$metadata?.httpStatusCode === "number"
+        ? record.$metadata.httpStatusCode
+        : undefined,
+  };
+};
+
+const errorChain = (error: unknown): ErrorDetails[] => {
+  const details: ErrorDetails[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  for (let depth = 0; depth < 8 && current && !seen.has(current); depth++) {
+    seen.add(current);
+    const detail = toErrorDetails(current);
+    if (detail) details.push(detail);
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return details;
+};
+
+export function classifyAwsCircuitFailure(
+  error: unknown,
+): { failureClass: AwsCircuitFailureClass; failureName: string } | null {
+  for (const detail of errorChain(error)) {
+    const name = detail.code ?? detail.name;
+    if (
+      ACCOUNT_FAILURE_NAMES.has(detail.name) ||
+      (detail.code ? ACCOUNT_FAILURE_NAMES.has(detail.code) : false) ||
+      detail.httpStatusCode === 401 ||
+      detail.httpStatusCode === 403 ||
+      /account\s+(?:is\s+)?(?:blocked|closed|disabled|suspended)|account suspension/i.test(
+        detail.message,
+      )
+    ) {
+      return { failureClass: "account_access", failureName: name };
+    }
+  }
+
+  for (const detail of errorChain(error)) {
+    const name = detail.code ?? detail.name;
+    if (
+      TRANSIENT_FAILURE_NAMES.has(detail.name) ||
+      (detail.code ? TRANSIENT_FAILURE_NAMES.has(detail.code) : false) ||
+      detail.httpStatusCode === 429 ||
+      (detail.httpStatusCode !== undefined && detail.httpStatusCode >= 500)
+    ) {
+      return { failureClass: "provider_unavailable", failureName: name };
+    }
+  }
+
+  return null;
+}
+
+const parseCircuitState = (value: unknown): AwsCircuitState | null => {
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const state = parsed as Partial<AwsCircuitState>;
+  if (
+    state.version !== 1 ||
+    state.state !== "open" ||
+    (state.failureClass !== "account_access" &&
+      state.failureClass !== "provider_unavailable") ||
+    typeof state.failureName !== "string" ||
+    typeof state.openedAt !== "string" ||
+    typeof state.retryAt !== "string"
+  ) {
+    return null;
+  }
+  return state as AwsCircuitState;
+};
+
+export async function resolveCloudSandboxProviderForRun(
+  options: { requestId?: string } = {},
+  dependencies?: CircuitDependencies,
+): Promise<CloudSandboxProviderSelection> {
+  const configured = getCloudSandboxProvider();
+  if (configured === "e2b") {
+    return { provider: "e2b", reason: "configured_e2b" };
+  }
+
+  if (!automaticFailoverEnabled() || !e2bFallbackConfigured()) {
+    return {
+      provider: "aws-lambda-microvm",
+      reason: automaticFailoverEnabled()
+        ? "automatic_failover_unavailable"
+        : "primary_aws",
+    };
+  }
+
+  const { redis, now, log } = getDependencies(dependencies);
+  if (!redis) {
+    if (!circuitStoreUnavailableLogged) {
+      circuitStoreUnavailableLogged = true;
+      log("error", "cloud_sandbox_provider_circuit_store_unavailable", {
+        request_id: options.requestId ?? null,
+        provider: "aws-lambda-microvm",
+        fallback_provider: "e2b",
+      });
+    }
+    return {
+      provider: "aws-lambda-microvm",
+      reason: "automatic_failover_unavailable",
+    };
+  }
+
+  try {
+    const state = parseCircuitState(await redis.get(CIRCUIT_KEY));
+    if (!state) {
+      return { provider: "aws-lambda-microvm", reason: "primary_aws" };
+    }
+
+    const nowMs = now();
+    const retryAtMs = Date.parse(state.retryAt);
+    if (!Number.isFinite(retryAtMs) || nowMs < retryAtMs) {
+      return {
+        provider: "e2b",
+        reason: "circuit_open",
+        circuitFailureClass: state.failureClass,
+        circuitOpenedAt: state.openedAt,
+        circuitRetryAt: state.retryAt,
+      };
+    }
+
+    const probeClaimed = await redis.set(
+      HALF_OPEN_LOCK_KEY,
+      options.requestId ?? String(nowMs),
+      { nx: true, ex: HALF_OPEN_LOCK_SECONDS },
+    );
+    if (probeClaimed) {
+      log("info", "cloud_sandbox_provider_circuit_half_opened", {
+        request_id: options.requestId ?? null,
+        provider: "aws-lambda-microvm",
+        fallback_provider: "e2b",
+        failure_class: state.failureClass,
+        circuit_opened_at: state.openedAt,
+        circuit_retry_at: state.retryAt,
+      });
+      return {
+        provider: "aws-lambda-microvm",
+        reason: "circuit_half_open_probe",
+        circuitFailureClass: state.failureClass,
+        circuitOpenedAt: state.openedAt,
+        circuitRetryAt: state.retryAt,
+      };
+    }
+
+    return {
+      provider: "e2b",
+      reason: "circuit_open",
+      circuitFailureClass: state.failureClass,
+      circuitOpenedAt: state.openedAt,
+      circuitRetryAt: state.retryAt,
+    };
+  } catch (error) {
+    log("error", "cloud_sandbox_provider_circuit_read_failed", {
+      request_id: options.requestId ?? null,
+      provider: "aws-lambda-microvm",
+      fallback_provider: "e2b",
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return {
+      provider: "aws-lambda-microvm",
+      reason: "automatic_failover_unavailable",
+    };
+  }
+}
+
+export async function recordAwsSandboxAcquisitionFailure(
+  error: unknown,
+  options: {
+    requestId?: string;
+    source: "health_probe" | "sandbox_acquisition";
+    halfOpenProbe?: boolean;
+  },
+  dependencies?: CircuitDependencies,
+): Promise<{ opened: boolean; failureClass?: AwsCircuitFailureClass }> {
+  if (!automaticFailoverEnabled() || !e2bFallbackConfigured()) {
+    return { opened: false };
+  }
+  const classification = classifyAwsCircuitFailure(error);
+  if (!classification) return { opened: false };
+  if (
+    options.source === "health_probe" &&
+    classification.failureClass !== "account_access"
+  ) {
+    return { opened: false, failureClass: classification.failureClass };
+  }
+
+  const { redis, now, log } = getDependencies(dependencies);
+  if (!redis)
+    return { opened: false, failureClass: classification.failureClass };
+
+  const counterKey = `${FAILURE_COUNTER_PREFIX}:${classification.failureClass}`;
+  try {
+    const failureCount = Number(await redis.incr(counterKey));
+    await redis.expire(counterKey, FAILURE_WINDOW_SECONDS);
+    const threshold =
+      options.halfOpenProbe || classification.failureClass === "account_access"
+        ? 1
+        : TRANSIENT_FAILURE_THRESHOLD;
+    if (failureCount < threshold) {
+      return { opened: false, failureClass: classification.failureClass };
+    }
+
+    const nowMs = now();
+    const retryDelayMs =
+      classification.failureClass === "account_access"
+        ? ACCOUNT_RETRY_DELAY_MS
+        : TRANSIENT_RETRY_DELAY_MS;
+    const state: AwsCircuitState = {
+      version: 1,
+      state: "open",
+      failureClass: classification.failureClass,
+      failureName: classification.failureName,
+      openedAt: new Date(nowMs).toISOString(),
+      retryAt: new Date(nowMs + retryDelayMs).toISOString(),
+    };
+    const newlyOpened = await redis.set(CIRCUIT_KEY, JSON.stringify(state), {
+      nx: true,
+      ex: CIRCUIT_STATE_TTL_SECONDS,
+    });
+    if (!newlyOpened) {
+      await redis.set(CIRCUIT_KEY, JSON.stringify(state), {
+        ex: CIRCUIT_STATE_TTL_SECONDS,
+      });
+    }
+    await redis.del(HALF_OPEN_LOCK_KEY);
+    if (newlyOpened) {
+      log("warn", "cloud_sandbox_provider_circuit_opened", {
+        request_id: options.requestId ?? null,
+        provider: "aws-lambda-microvm",
+        fallback_provider: "e2b",
+        source: options.source,
+        failure_class: classification.failureClass,
+        failure_name: classification.failureName,
+        failure_count: failureCount,
+        failure_threshold: threshold,
+        circuit_opened_at: state.openedAt,
+        circuit_retry_at: state.retryAt,
+      });
+      phLogger.error("AWS Cloud sandbox circuit opened", {
+        event: "cloud_sandbox_provider_circuit_opened",
+        request_id: options.requestId ?? null,
+        provider: "aws-lambda-microvm",
+        fallback_provider: "e2b",
+        source: options.source,
+        failure_class: classification.failureClass,
+        failure_name: classification.failureName,
+        circuit_retry_at: state.retryAt,
+      });
+    }
+    return {
+      opened: true,
+      failureClass: classification.failureClass,
+    };
+  } catch (circuitError) {
+    log("error", "cloud_sandbox_provider_circuit_write_failed", {
+      request_id: options.requestId ?? null,
+      provider: "aws-lambda-microvm",
+      fallback_provider: "e2b",
+      source: options.source,
+      failure_class: classification.failureClass,
+      error_name:
+        circuitError instanceof Error ? circuitError.name : "UnknownError",
+    });
+    return { opened: false, failureClass: classification.failureClass };
+  }
+}
+
+export async function recordAwsSandboxHalfOpenSuccess(
+  options: { requestId?: string },
+  dependencies?: CircuitDependencies,
+): Promise<void> {
+  await closeAwsSandboxCircuit(options, undefined, dependencies);
+}
+
+async function closeAwsSandboxCircuit(
+  options: { requestId?: string },
+  expectedFailureClass: AwsCircuitFailureClass | undefined,
+  dependencies?: CircuitDependencies,
+): Promise<void> {
+  const { redis, log } = getDependencies(dependencies);
+  if (!redis) return;
+  try {
+    const previousState = parseCircuitState(await redis.get(CIRCUIT_KEY));
+    if (!previousState) return;
+    if (
+      expectedFailureClass &&
+      previousState.failureClass !== expectedFailureClass
+    ) {
+      return;
+    }
+    const deleted = Number(
+      await redis.eval(
+        `
+          if redis.call("GET", KEYS[1]) == ARGV[1] then
+            redis.call("DEL", KEYS[1])
+            redis.call("DEL", KEYS[2])
+            return 1
+          end
+          return 0
+        `,
+        [CIRCUIT_KEY, HALF_OPEN_LOCK_KEY],
+        [JSON.stringify(previousState)],
+      ),
+    );
+    if (deleted !== 1) return;
+    log("info", "cloud_sandbox_provider_circuit_closed", {
+      request_id: options.requestId ?? null,
+      provider: "aws-lambda-microvm",
+      fallback_provider: "e2b",
+      previous_failure_class: previousState.failureClass,
+      circuit_opened_at: previousState.openedAt,
+    });
+  } catch (error) {
+    log("error", "cloud_sandbox_provider_circuit_close_failed", {
+      request_id: options.requestId ?? null,
+      provider: "aws-lambda-microvm",
+      fallback_provider: "e2b",
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+  }
+}
+
+export async function recordAwsAccountHealthProbeSuccess(
+  options: { requestId?: string },
+  dependencies?: CircuitDependencies,
+): Promise<void> {
+  await closeAwsSandboxCircuit(options, "account_access", dependencies);
+}
+
+export const CLOUD_SANDBOX_PROVIDER_CIRCUIT_CONSTANTS = {
+  circuitKey: CIRCUIT_KEY,
+  halfOpenLockKey: HALF_OPEN_LOCK_KEY,
+  transientFailureThreshold: TRANSIENT_FAILURE_THRESHOLD,
+  accountRetryDelayMs: ACCOUNT_RETRY_DELAY_MS,
+  transientRetryDelayMs: TRANSIENT_RETRY_DELAY_MS,
+} as const;
+
+export function resetCloudSandboxProviderCircuitStateForTests(): void {
+  circuitStoreUnavailableLogged = false;
+}

--- a/lib/ai/tools/utils/cloud-sandbox.ts
+++ b/lib/ai/tools/utils/cloud-sandbox.ts
@@ -8,6 +8,11 @@ import { ensureSandboxConnection } from "./sandbox";
 import { isAwsLambdaMicrovmSandbox, isE2BSandbox } from "./sandbox-types";
 import { phLogger } from "@/lib/posthog/server";
 import type { TriggerRunRegion } from "@/lib/api/trigger-region";
+import type { CloudSandboxProviderSelectionReason } from "./cloud-sandbox-provider-circuit";
+import {
+  recordAwsSandboxAcquisitionFailure,
+  recordAwsSandboxHalfOpenSuccess,
+} from "./cloud-sandbox-provider-circuit";
 
 export type CloudSandboxAcquisitionContext = {
   provider?: CloudSandboxProvider;
@@ -16,6 +21,7 @@ export type CloudSandboxAcquisitionContext = {
   triggerRunId?: string;
   runKind?: "parent" | "subagent";
   triggerRegion?: TriggerRunRegion;
+  providerSelectionReason?: CloudSandboxProviderSelectionReason;
 };
 
 export type CloudSandboxSuspensionSummary = {
@@ -50,6 +56,13 @@ export async function ensureCloudSandboxConnection(options: {
         options.context?.triggerRegion,
         options.context?.triggerRunId,
       );
+      if (
+        options.context?.providerSelectionReason === "circuit_half_open_probe"
+      ) {
+        await recordAwsSandboxHalfOpenSuccess({
+          requestId: options.context?.triggerRunId,
+        });
+      }
       options.setSandbox(sandbox);
       return { sandbox };
     }
@@ -68,6 +81,15 @@ export async function ensureCloudSandboxConnection(options: {
       },
     );
   } catch (error) {
+    if (provider === "aws-lambda-microvm") {
+      await recordAwsSandboxAcquisitionFailure(error, {
+        requestId: options.context?.triggerRunId,
+        source: "sandbox_acquisition",
+        halfOpenProbe:
+          options.context?.providerSelectionReason ===
+          "circuit_half_open_probe",
+      });
+    }
     phLogger.event("cloud_sandbox_acquisition_failed", {
       userId: options.userId,
       chat_id: options.context?.chatId,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2131,9 +2131,9 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/recordFreeMonthlyCost\(\s*freeUsageSubject/);
   });
 
-  test("agent-long resolves the configured cloud provider once for tools and prompt", () => {
+  test("agent-long resolves one circuit-aware cloud provider for tools and prompt", () => {
     const providerIdx = taskSrc.indexOf(
-      "const cloudSandboxProvider = getCloudSandboxProvider();",
+      "await resolveCloudSandboxProviderForRun({ requestId: ctx.run.id });",
     );
     const toolsIdx = taskSrc.indexOf("createTools(", providerIdx);
     const promptIdx = taskSrc.indexOf("systemPrompt(", toolsIdx);
@@ -2143,6 +2143,9 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(promptIdx).toBeGreaterThan(toolsIdx);
     expect(taskSrc.slice(toolsIdx, promptIdx)).toContain(
       "cloudSandboxProvider",
+    );
+    expect(taskSrc.slice(toolsIdx, promptIdx)).toContain(
+      "cloudSandboxProviderSelectionReason",
     );
     expect(taskSrc.slice(promptIdx, promptIdx + 700)).toContain(
       "cloudSandboxProvider",

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -20,7 +20,7 @@ import {
 import type { Geo } from "@vercel/functions";
 import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 import PostHogClient from "@/app/posthog";
-import { getCloudSandboxProvider } from "@/lib/ai/tools/utils/cloud-sandbox-provider";
+import { resolveCloudSandboxProviderForRun } from "@/lib/ai/tools/utils/cloud-sandbox-provider-circuit";
 import { recordGroupedSpikeAlert } from "@/lib/observability/grouped-spike-alert";
 
 import { systemPrompt } from "@/lib/system-prompt";
@@ -2621,7 +2621,9 @@ export const agentLongTask = task({
         selectedModelOverride,
       });
       const posthog = PostHogClient();
-      const cloudSandboxProvider = getCloudSandboxProvider();
+      const cloudSandboxProviderSelection =
+        await resolveCloudSandboxProviderForRun({ requestId: ctx.run.id });
+      const cloudSandboxProvider = cloudSandboxProviderSelection.provider;
 
       const baseTodos: Todo[] = getBaseTodosForRequest(
         (chat?.todos as unknown as Todo[]) || [],
@@ -3294,6 +3296,8 @@ export const agentLongTask = task({
               auxiliaryVision,
               {
                 cloudSandboxProvider,
+                cloudSandboxProviderSelectionReason:
+                  cloudSandboxProviderSelection.reason,
                 triggerRegion,
                 ...(subagentsEnabled
                   ? {

--- a/trigger/cloud-sandbox-provider-health.ts
+++ b/trigger/cloud-sandbox-provider-health.ts
@@ -1,0 +1,50 @@
+import { logger, schedules } from "@trigger.dev/sdk";
+import {
+  isCloudSandboxAutomaticFailoverConfigured,
+  recordAwsAccountHealthProbeSuccess,
+  recordAwsSandboxAcquisitionFailure,
+} from "@/lib/ai/tools/utils/cloud-sandbox-provider-circuit";
+import { probeAwsLambdaMicrovmAccountAccess } from "@/lib/ai/tools/utils/aws-lambda-microvm";
+
+export const probeAwsCloudSandboxProviderAccess = schedules.task({
+  id: "probe-aws-cloud-sandbox-provider-access",
+  cron: "* * * * *",
+  queue: {
+    name: "aws-cloud-sandbox-provider-health",
+    concurrencyLimit: 1,
+  },
+  ttl: "2m",
+  maxDuration: 45,
+  retry: { maxAttempts: 1 },
+  run: async (_payload, { ctx }) => {
+    if (!isCloudSandboxAutomaticFailoverConfigured()) {
+      return { status: "skipped" as const };
+    }
+
+    try {
+      await probeAwsLambdaMicrovmAccountAccess();
+      await recordAwsAccountHealthProbeSuccess({ requestId: ctx.run.id });
+      return { status: "healthy" as const };
+    } catch (error) {
+      const result = await recordAwsSandboxAcquisitionFailure(error, {
+        requestId: ctx.run.id,
+        source: "health_probe",
+      });
+      logger.warn("AWS Cloud sandbox account probe failed", {
+        event: "cloud_sandbox_provider_health_probe_failed",
+        provider: "aws-lambda-microvm",
+        fallback_provider: "e2b",
+        request_id: ctx.run.id,
+        failure_class: result.failureClass ?? "unclassified",
+        circuit_opened: result.opened,
+        error_name: error instanceof Error ? error.name : "UnknownError",
+      });
+      return {
+        status: result.opened
+          ? ("circuit_opened" as const)
+          : ("failed" as const),
+        failureClass: result.failureClass,
+      };
+    }
+  },
+});

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -727,6 +727,7 @@ export const subagentTask = task({
                 ptyScopeId: row.subagent_id,
                 chargeSandboxRuntime: false,
                 cloudSandboxProvider,
+                cloudSandboxProviderSelectionReason: "persisted_subagent",
               },
             );
             const tools = guardSubagentToolExecutions(


### PR DESCRIPTION
## Summary

- add a shared Upstash circuit breaker that routes only new parent Agent runs from AWS Lambda MicroVMs to E2B after AWS account-access loss or repeated final acquisition failures
- add a bounded one-minute read-only AWS account-access probe, distributed half-open recovery, provider-selection telemetry, and structured state-transition logs
- keep the selected provider fixed for each durable run and its subagents so existing sessions and workspaces are never migrated mid-run
- keep scan-safety rejections outside the failover signal path; E2B failures never open the AWS circuit
- document the production configuration, recovery behavior, and the limitation that E2B cannot restore an AWS regional S3 workspace archive

## Safety behavior

- AWS account-access failures open immediately; retryable acquisition failures require 3 failures in 2 minutes
- unknown, validation, resource-not-found, and E2B errors do not open the circuit
- one distributed half-open run tests recovery; atomic state closure cannot erase a newer failure
- missing/unreadable shared Redis state keeps AWS selected and emits an operational error instead of making an uncoordinated provider switch
- manual `CLOUD_SANDBOX_PROVIDER=e2b` remains available

## Validation

- `corepack pnpm exec jest --runInBand` — 426 suites, 4,454 tests passed
- `corepack pnpm typecheck`
- ESLint on all changed TypeScript files
- Prettier and `git diff --check`
- Trigger production-project dry run: `trigger deploy --dry-run --env prod --project-ref proj_fixirhycbcnfdpicejfb` (build only; no deployment)

## Rollout notes

This PR does not modify AWS, E2B, Upstash, Trigger, Vercel, or production configuration. After merge, Trigger Production must contain the existing E2B and Upstash credentials plus `CLOUD_SANDBOX_AUTO_FAILOVER_ENABLED=true`, and the new worker must be deployed before the fallback becomes live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic AWS-to-E2B failover for cloud sandboxes when configured conditions and credentials permit.
  * Added persistent provider selection per run, including manual rollback and recovery controls.
  * Added scheduled AWS health checks and distributed circuit-state tracking.
  * Added configurable failure thresholds, retry intervals, and shared failover state.

* **Documentation**
  * Expanded configuration guidance for AWS defaults, E2B rollback, failover settings, circuit behavior, and operational controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->