### PR TITLE
fix: harden E2B sandbox lifecycle recovery

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -68,7 +68,7 @@ OPENAI_API_KEY=
 # =============================================================================
 # CODE EXECUTION - CLOUD SANDBOX (Required for cloud Agent Mode)
 # =============================================================================
-# Provider defaults to AWS Lambda MicroVMs. Set this to E2B for a manual rollback.
+# Provider defaults to E2B. Set this explicitly only when overriding the default.
 # CLOUD_SANDBOX_PROVIDER=e2b
 # With AWS selected, new Trigger Agent runs automatically use E2B while the
 # distributed AWS account/provider circuit is open. This defaults to enabled
@@ -77,7 +77,7 @@ OPENAI_API_KEY=
 E2B_API_KEY=
 E2B_TEMPLATE=terminal-agent-sandbox
 
-# AWS Lambda MicroVM configuration. See aws-lambda-microvm/README.md.
+# AWS Lambda MicroVM rollback configuration. See aws-lambda-microvm/README.md.
 # CLOUD_SANDBOX_PROVIDER=aws-lambda-microvm
 # AWS_LAMBDA_MICROVM_IMAGE_ID=
 # AWS_LAMBDA_MICROVM_IMAGE_VERSION=

--- a/aws-lambda-microvm/README.md
+++ b/aws-lambda-microvm/README.md
@@ -384,11 +384,12 @@ local/desktop sandbox support also keeps its existing Centrifugo values there.
 Vercel retains only the AWS credentials and Convex key required by Data
 Controls cleanup. They are not copied through GitHub Actions.
 
-## 5. Validate the paid-plan release
+## 5. Validate the AWS rollback path
 
-AWS Lambda MicroVMs are the default cloud sandbox for every paid plan. The
-application continues to hard-gate Free users to local-only behavior, and
-`CLOUD_SANDBOX_PROVIDER=e2b` remains the explicit emergency rollback.
+E2B is the default cloud sandbox. AWS Lambda MicroVMs remain available for an
+explicit operational rollback with
+`CLOUD_SANDBOX_PROVIDER=aws-lambda-microvm`. The application continues to
+hard-gate Free users to local-only behavior.
 
 Measure provider health with `cloud_sandbox_provider_selected`. It includes the
 provider, transport (`aws_websocket` or `e2b_sdk`), subscription tier, Trigger
@@ -463,13 +464,14 @@ the MicroVM becomes `TERMINATED` in AWS. Check the
 `hackerai-agent_run` PostHog events plus structured `cloud_sandbox_*` logs for
 the test user.
 
-## Rollback
+## Switching to the AWS rollback
 
-To route production users to E2B, terminate existing AWS MicroVM sessions from
-Data Controls or AWS, set `CLOUD_SANDBOX_PROVIDER=e2b` in Trigger.dev, and
-redeploy it. Per-run AWS configuration or quota failures never silently retry
-on E2B; they remain attributed to AWS so the failure-rate guardrail stays
-honest.
+To route production users to AWS, first validate the regional release manifest
+and runtime credentials, set
+`CLOUD_SANDBOX_PROVIDER=aws-lambda-microvm` in Trigger.dev, and redeploy it.
+Per-run E2B failures never silently retry on AWS; provider selection stays
+explicit so failure-rate attribution remains honest. To return to the E2B
+default, remove the override or set `CLOUD_SANDBOX_PROVIDER=e2b` and redeploy.
 
 ## Known boundaries
 

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-provider.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-provider.test.ts
@@ -23,27 +23,32 @@ describe("cloud sandbox provider selection", () => {
     }
   });
 
-  it("defaults to AWS after the full rollout", () => {
+  it("defaults to E2B", () => {
     delete process.env.CLOUD_SANDBOX_PROVIDER;
     delete process.env.AWS_LAMBDA_MICROVM_IMAGE_ID;
     delete process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST;
-    expect(getCloudSandboxProvider()).toBe("aws-lambda-microvm");
+    expect(getCloudSandboxProvider()).toBe("e2b");
   });
 
-  it("selects AWS when an atomic regional release manifest is configured", () => {
+  it("does not let a stale AWS release manifest override the E2B default", () => {
     delete process.env.CLOUD_SANDBOX_PROVIDER;
     delete process.env.AWS_LAMBDA_MICROVM_IMAGE_ID;
     process.env.AWS_LAMBDA_MICROVM_RELEASE_MANIFEST = "{}";
-    expect(getCloudSandboxProvider()).toBe("aws-lambda-microvm");
+    expect(getCloudSandboxProvider()).toBe("e2b");
   });
 
-  it("selects AWS when an image is explicitly configured", () => {
+  it("does not let a stale AWS image override the E2B default", () => {
     delete process.env.CLOUD_SANDBOX_PROVIDER;
     process.env.AWS_LAMBDA_MICROVM_IMAGE_ID = "arn:aws:lambda:microvm-image";
+    expect(getCloudSandboxProvider()).toBe("e2b");
+  });
+
+  it("honors an explicit AWS rollback", () => {
+    process.env.CLOUD_SANDBOX_PROVIDER = "aws-lambda-microvm";
     expect(getCloudSandboxProvider()).toBe("aws-lambda-microvm");
   });
 
-  it("honors an explicit E2B rollback even when an AWS image remains set", () => {
+  it("honors explicit E2B even when an AWS image remains set", () => {
     process.env.CLOUD_SANDBOX_PROVIDER = "e2b";
     process.env.AWS_LAMBDA_MICROVM_IMAGE_ID = "arn:aws:lambda:microvm-image";
     expect(getCloudSandboxProvider()).toBe("e2b");

--- a/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
@@ -62,6 +62,36 @@ describe("sandbox health resource observations", () => {
     });
   });
 
+  test("lets the readiness command auto-resume a paused sandbox", async () => {
+    const sandbox = makeE2BSandbox();
+    (sandbox.isRunning as jest.Mock).mockResolvedValue(false);
+    const onResourceMetrics = jest.fn();
+
+    await expect(
+      waitForSandboxReady(sandbox, 1, undefined, onResourceMetrics),
+    ).resolves.toBeUndefined();
+
+    expect(sandbox.commands.run).toHaveBeenCalledWith("echo ready", {
+      timeoutMs: 5000,
+      displayName: "",
+    });
+    expect(sandbox.getMetrics).toHaveBeenCalledTimes(1);
+    expect(onResourceMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "health_sample" }),
+    );
+  });
+
+  test("uses the command as authoritative when the status probe fails", async () => {
+    const sandbox = makeE2BSandbox();
+    (sandbox.isRunning as jest.Mock).mockRejectedValue(
+      new Error("temporary status failure"),
+    );
+
+    await expect(waitForSandboxReady(sandbox, 1)).resolves.toBeUndefined();
+
+    expect(sandbox.commands.run).toHaveBeenCalledTimes(1);
+  });
+
   test("reports final readiness failures with the latest resource metrics", async () => {
     const sandbox = makeE2BSandbox();
     (sandbox.commands.run as jest.Mock).mockRejectedValue(
@@ -71,7 +101,7 @@ describe("sandbox health resource observations", () => {
 
     await expect(
       waitForSandboxReady(sandbox, 1, undefined, onResourceMetrics),
-    ).rejects.toThrow("Sandbox running but not ready");
+    ).rejects.toThrow("Sandbox not ready");
 
     expect(onResourceMetrics).toHaveBeenLastCalledWith({
       kind: "failure",

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -225,6 +225,105 @@ describe("E2B sandbox lease lifecycle", () => {
     expect(setSandbox).toHaveBeenCalledWith(connectedSandbox);
   });
 
+  it("creates new sandboxes with pause and automatic resume enabled", async () => {
+    const createdSandbox = { sandboxId: "sandbox-2" } as unknown as Sandbox;
+    sandboxApi.list.mockReturnValue({
+      nextItems: jest.fn(async () => []),
+    });
+    sandboxApi.create.mockResolvedValue(createdSandbox);
+
+    const result = await ensureSandboxConnection({
+      userID: "user-1",
+      setSandbox: jest.fn(),
+    });
+
+    expect(result.sandbox).toBe(createdSandbox);
+    expect(sandboxApi.create).toHaveBeenCalledWith(
+      "terminal-agent-sandbox",
+      expect.objectContaining({
+        timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
+        lifecycle: { onTimeout: "pause", autoResume: true },
+        secure: true,
+        metadata: expect.objectContaining({ sandboxVersion: "v12" }),
+      }),
+    );
+  });
+
+  it("prefers a running sandbox over a newer paused duplicate", async () => {
+    const connectedSandbox = {
+      sandboxId: "sandbox-running",
+    } as unknown as Sandbox;
+    sandboxApi.list.mockReturnValue({
+      nextItems: jest.fn(async () => [
+        {
+          sandboxId: "sandbox-paused",
+          state: "paused",
+          metadata: { sandboxVersion: "v12" },
+        },
+        {
+          sandboxId: "sandbox-running",
+          state: "running",
+          metadata: { sandboxVersion: "v12" },
+        },
+      ]),
+    });
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+
+    const result = await ensureSandboxConnection({
+      userID: "user-1",
+      setSandbox: jest.fn(),
+    });
+
+    expect(result.sandbox).toBe(connectedSandbox);
+    expect(sandboxApi.connect).toHaveBeenCalledWith("sandbox-running", {
+      timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
+    });
+  });
+
+  it("retries a transient connect failure before reusing the sandbox", async () => {
+    jest.useFakeTimers();
+    const connectedSandbox = { sandboxId: "sandbox-1" } as unknown as Sandbox;
+    listSandbox();
+    sandboxApi.connect
+      .mockRejectedValueOnce(new Error("temporary transport failure"))
+      .mockResolvedValue(connectedSandbox);
+
+    const connection = ensureSandboxConnection({
+      userID: "user-1",
+      setSandbox: jest.fn(),
+    });
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    await expect(connection).resolves.toEqual({ sandbox: connectedSandbox });
+    expect(sandboxApi.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a transient sandbox discovery failure", async () => {
+    jest.useFakeTimers();
+    const connectedSandbox = { sandboxId: "sandbox-1" } as unknown as Sandbox;
+    const nextItems = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary list failure"))
+      .mockResolvedValue([
+        {
+          sandboxId: "sandbox-1",
+          state: "running",
+          metadata: { sandboxVersion: "v12" },
+        },
+      ]);
+    sandboxApi.list.mockReturnValue({ nextItems });
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+
+    const connection = ensureSandboxConnection({
+      userID: "user-1",
+      setSandbox: jest.fn(),
+    });
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    await expect(connection).resolves.toEqual({ sandbox: connectedSandbox });
+    expect(nextItems).toHaveBeenCalledTimes(2);
+  });
+
   it("defers version replacement while the shared sandbox is running", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     try {

--- a/lib/ai/tools/utils/cloud-sandbox-provider.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-provider.ts
@@ -1,5 +1,9 @@
 export type CloudSandboxProvider = "e2b" | "aws-lambda-microvm";
 
+/**
+ * Resolve the configured cloud sandbox provider, defaulting to E2B and
+ * rejecting unsupported values instead of silently selecting a provider.
+ */
 export function getCloudSandboxProvider(): CloudSandboxProvider {
   const configured = process.env.CLOUD_SANDBOX_PROVIDER?.trim();
   if (configured === "e2b" || configured === "aws-lambda-microvm") {

--- a/lib/ai/tools/utils/cloud-sandbox-provider.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-provider.ts
@@ -11,7 +11,7 @@ export function getCloudSandboxProvider(): CloudSandboxProvider {
     );
   }
 
-  // AWS is the fully released provider. Keep the explicit environment setting
-  // above as an emergency rollback to E2B.
-  return "aws-lambda-microvm";
+  // E2B is the default cloud provider. AWS remains available through the
+  // explicit environment setting above as an operational rollback.
+  return "e2b";
 }

--- a/lib/ai/tools/utils/sandbox-health.ts
+++ b/lib/ai/tools/utils/sandbox-health.ts
@@ -234,26 +234,36 @@ export async function waitForSandboxReady(
   try {
     await retryWithBackoff(
       async () => {
-        // For E2B Sandbox, check if it's running first
+        let observedMetrics = false;
+
+        // isRunning() is a useful diagnostic, but it is not authoritative for
+        // readiness: a paused E2B sandbox can be resumed by the command below.
         if (isE2BSandbox(sandbox)) {
-          const running = await sandbox.isRunning();
-          if (!running) {
-            throw new Error("Sandbox is not running");
+          let running = false;
+          try {
+            running = await sandbox.isRunning();
+          } catch {
+            // A transient control-plane status failure should not prevent the
+            // command path from proving that the sandbox is usable.
           }
 
-          // Check resource metrics for early warning
-          const metrics = await checkSandboxMetrics(sandbox);
-          if (metrics) {
-            notifyResourceObserver(onResourceMetrics, {
-              kind: "health_sample",
-              source: "pre_command_health_check",
-              metrics: stripWarning(metrics)!,
-            });
-          }
-          if (metrics?.warning) {
-            console.warn(
-              `[Sandbox Health] Resource pressure detected: ${metrics.warning}`,
-            );
+          if (running) {
+            // Check resource metrics for early warning without making metrics
+            // availability part of the readiness decision.
+            const metrics = await checkSandboxMetrics(sandbox);
+            if (metrics) {
+              observedMetrics = true;
+              notifyResourceObserver(onResourceMetrics, {
+                kind: "health_sample",
+                source: "pre_command_health_check",
+                metrics: stripWarning(metrics)!,
+              });
+            }
+            if (metrics?.warning) {
+              console.warn(
+                `[Sandbox Health] Resource pressure detected: ${metrics.warning}`,
+              );
+            }
           }
         }
 
@@ -264,6 +274,25 @@ export async function waitForSandboxReady(
             // Hide from local CLI output (empty string = hide)
             displayName: "",
           } as { timeoutMs: number; displayName?: string });
+
+          // If the status probe saw a paused sandbox (or failed), the command
+          // above is the operation that can auto-resume it. Sample metrics only
+          // after that succeeds so a paused state is not treated as a failure.
+          if (isE2BSandbox(sandbox) && !observedMetrics) {
+            const metrics = await checkSandboxMetrics(sandbox);
+            if (metrics) {
+              notifyResourceObserver(onResourceMetrics, {
+                kind: "health_sample",
+                source: "pre_command_health_check",
+                metrics: stripWarning(metrics)!,
+              });
+            }
+            if (metrics?.warning) {
+              console.warn(
+                `[Sandbox Health] Resource pressure detected: ${metrics.warning}`,
+              );
+            }
+          }
         } catch (error) {
           // Enrich error with metrics context for debugging
           let metricsContext = "";
@@ -276,11 +305,11 @@ export async function waitForSandboxReady(
           // Re-throw original error to preserve instanceof checks for
           // isPermanentError (AuthenticationError, TemplateError, etc.)
           if (error instanceof Error) {
-            error.message = `Sandbox running but not ready to execute commands${metricsContext}: ${error.message}`;
+            error.message = `Sandbox not ready to execute commands${metricsContext}: ${error.message}`;
             throw error;
           }
           throw new Error(
-            `Sandbox running but not ready to execute commands${metricsContext}: ${error}`,
+            `Sandbox not ready to execute commands${metricsContext}: ${error}`,
           );
         }
       },

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -2,6 +2,7 @@ import { Sandbox } from "@e2b/code-interpreter";
 import type { SandboxBootInfo, SandboxContext } from "@/types";
 import { NotFoundError, getUserFacingE2BErrorMessage } from "./e2b-errors";
 import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
+import { retryWithBackoff } from "./retry-with-backoff";
 
 type SandboxReadyPath = SandboxBootInfo["path"];
 
@@ -12,6 +13,8 @@ export const E2B_SANDBOX_LEASE_REQUEST_TIMEOUT_MS = 5 * 1000;
 // Retry config for E2B 429 rate limits
 const RATE_LIMIT_COOLDOWN_MS = 1_000;
 const MAX_CREATE_RETRIES = 3;
+const MAX_DISCOVERY_RETRIES = 3;
+const MAX_CONNECT_RETRIES = 3;
 
 export const refreshE2BSandboxLease = async (
   sandbox: Sandbox,
@@ -181,7 +184,30 @@ export const ensureSandboxConnection = async (
         },
       },
     });
-    const existingSandbox = (await paginator.nextItems())[0];
+    const listedSandboxes = await retryWithBackoff(
+      () => paginator.nextItems(),
+      {
+        maxRetries: MAX_DISCOVERY_RETRIES,
+        baseDelayMs: 400,
+        jitterMs: 40,
+      },
+    );
+    // A user should normally have one sandbox. If a previous ambiguous create
+    // produced duplicates, prefer an active compatible sandbox so we do not
+    // attach to a newer paused duplicate while work is still running.
+    const existingSandbox =
+      listedSandboxes.find(
+        (candidate) =>
+          candidate.state === "running" &&
+          candidate.metadata?.sandboxVersion === SANDBOX_VERSION,
+      ) ??
+      listedSandboxes.find((candidate) => candidate.state === "running") ??
+      listedSandboxes.find(
+        (candidate) =>
+          candidate.state === "paused" &&
+          candidate.metadata?.sandboxVersion === SANDBOX_VERSION,
+      ) ??
+      listedSandboxes[0];
 
     const hasVersionMismatch =
       existingSandbox &&
@@ -227,9 +253,17 @@ export const ensureSandboxConnection = async (
       // With auto-pause, we don't need to manually pause before resuming
       // Sandbox.connect() handles both running and paused sandboxes automatically
       try {
-        const sandbox = await Sandbox.connect(existingSandbox.sandboxId, {
-          timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
-        });
+        const sandbox = await retryWithBackoff(
+          () =>
+            Sandbox.connect(existingSandbox.sandboxId, {
+              timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
+            }),
+          {
+            maxRetries: MAX_CONNECT_RETRIES,
+            baseDelayMs: 400,
+            jitterMs: 40,
+          },
+        );
         setSandbox(sandbox);
         reportBoot("reuse_existing", 0);
         return { sandbox };
@@ -251,7 +285,8 @@ export const ensureSandboxConnection = async (
           // The listed state can become stale while connect is pending. Never
           // destroy a shared user sandbox here: another run may have resumed
           // it by the time this failure is observed. The attachment path owns
-          // bounded provider recovery and can retry safely on AWS.
+          // bounded provider recovery after the E2B reconnect retries are
+          // exhausted.
           throw e;
         }
       }
@@ -270,7 +305,7 @@ export const ensureSandboxConnection = async (
       try {
         const sandbox = await Sandbox.create(SANDBOX_TEMPLATE, {
           timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
-          lifecycle: { onTimeout: "pause" },
+          lifecycle: { onTimeout: "pause", autoResume: true },
           secure: true,
           metadata: {
             userID,


### PR DESCRIPTION
## Summary

- restore E2B as the default cloud sandbox while keeping AWS as an explicit rollback
- enable E2B automatic resume for newly created paused sandboxes
- treat command execution as the authoritative readiness check so paused sandboxes can wake
- retry transient E2B discovery and reconnect failures and prefer active sandboxes if duplicates exist
- update provider documentation and add focused lifecycle, readiness, retry, and selection coverage

## Why

The previous readiness path called `isRunning()` first and failed when it returned false. That prevented the following command from exercising E2B's supported auto-resume behavior and made a paused sandbox look unavailable. Discovery and reconnect also had no bounded transient retry, while the first listed sandbox could be a paused duplicate even when an active compatible sandbox existed.

## Validation

- `pnpm typecheck`
- ESLint on changed TypeScript files
- Prettier checks on changed files
- `pnpm check:local-dependencies`
- `pnpm test --runInBand` — 427 suites, 4,470 tests passed after rebasing onto current `main`
- `git diff --check`

## Manual verification

This checkout does not have an E2B API key, so perform the live lifecycle check in a configured development or staging environment:

1. Confirm `CLOUD_SANDBOX_PROVIDER=e2b` in the Trigger environment.
2. Start a paid cloud Agent session that creates a file and record its sandbox ID.
3. Leave the sandbox idle beyond the seven-minute lease so E2B pauses it.
4. Send another command in the same session.
5. Verify the same sandbox resumes, the file remains present, and no `sandbox_not_running` readiness failure is emitted.
6. Confirm a newly created sandbox can repeat the pause/resume cycle without manual intervention.

## Rollback

Set `CLOUD_SANDBOX_PROVIDER=aws-lambda-microvm` and redeploy the Trigger environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * E2B is now the default cloud sandbox provider.
  * Eligible AWS-selected runs can automatically fail over to E2B, while AWS remains available as an explicit rollback option.
  * Paused sandboxes can resume automatically, with improved readiness checks and recovery.

* **Bug Fixes**
  * Sandbox discovery and reconnection now retry transient failures more reliably.
  * Running sandboxes are prioritized over paused or duplicate instances.
  * Readiness checks provide clearer results when status probes fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->