### PR TITLE
Enforce OpenRouter request size limit

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -13,6 +13,7 @@ import {
   MALFORMED_PDF_USER_RESPONSE,
   makeOpenRouterToolChoiceCompatibleWithXaiReasoning,
   normalizeOpenRouterRequestForKimi,
+  OPENROUTER_REQUEST_MAX_BYTES,
   PDF_PARSER_ENGINE_HEADER,
   PDF_PARSER_RECOVERY_HEADER,
   sanitizeOpenRouterEncryptedReasoning,
@@ -640,6 +641,166 @@ describe("makeOpenRouterToolChoiceCompatibleWithXaiReasoning", () => {
 });
 
 describe("OpenRouter request normalization", () => {
+  it("allows a request exactly at the complete serialized byte limit", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+    const body = " ".repeat(OPENROUTER_REQUEST_MAX_BYTES);
+
+    await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].body).toBe(body);
+  });
+
+  it("enforces the aggregate request limit and falls back to sandbox-backed files", async () => {
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+    const perFileData = "a".repeat(OPENROUTER_REQUEST_MAX_BYTES / 2);
+
+    try {
+      await patchedFetch("https://openrouter.test/chat", {
+        method: "POST",
+        headers: { "content-length": "stale" },
+        body: JSON.stringify({
+          model: "deepseek/deepseek-v4-flash-0731",
+          user: "user_test_request_size_guard",
+          plugins: [{ id: "file-parser" }],
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: '<attachment filename="first.bin" local_path="/home/user/upload/first.bin" /><attachment filename="second.bin" local_path="/home/user/upload/second.bin" />',
+                },
+                {
+                  type: "file",
+                  file: { filename: "first.bin", file_data: perFileData },
+                },
+                {
+                  type: "file",
+                  file: { filename: "second.bin", file_data: perFileData },
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const sentInit = fetchMock.mock.calls[0][1];
+      const sentBody = String(sentInit.body);
+      expect(new TextEncoder().encode(sentBody).byteLength).toBeLessThanOrEqual(
+        OPENROUTER_REQUEST_MAX_BYTES,
+      );
+      expect(new Headers(sentInit.headers).has("content-length")).toBe(false);
+      expect(sentBody).not.toContain(perFileData);
+      expect(sentBody).toContain("inspect the files with sandbox tools");
+      expect(JSON.parse(sentBody).plugins).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"sandbox_file_fallback"'),
+      );
+      const logEvent = JSON.parse(String(warnSpy.mock.calls[0][0]));
+      expect(logEvent).toMatchObject({
+        reason: "request_limit_exceeded",
+        user_id: "user_test_request_size_guard",
+      });
+      const serializedLogEvent = JSON.stringify(logEvent);
+      expect(serializedLogEvent).not.toContain("first.bin");
+      expect(serializedLogEvent).not.toContain(perFileData.slice(0, 1024));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("rejects an oversized request locally when no safe fallback can fit", async () => {
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const fetchMock = jest.fn();
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    try {
+      const response = await patchedFetch("https://openrouter.test/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "deepseek/deepseek-v4-flash-0731",
+          messages: [
+            {
+              role: "user",
+              content: "x".repeat(OPENROUTER_REQUEST_MAX_BYTES),
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(413);
+      expect(
+        response.headers.get("x-hackerai-openrouter-request-size-guard"),
+      ).toBe("rejected");
+      expect(await response.json()).toMatchObject({
+        error: { code: "request_too_large" },
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"rejected"'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("measures after encrypted reasoning normalization reduces the body", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    await patchedFetch("https://openrouter.test/chat", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "x-ai/grok-4.5",
+        messages: [
+          {
+            role: "assistant",
+            content: "Visible reasoning remains available.",
+            reasoning_details: [
+              {
+                type: "reasoning.encrypted",
+                data: "x".repeat(OPENROUTER_REQUEST_MAX_BYTES),
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const sentBody = String(fetchMock.mock.calls[0][1].body);
+    expect(new TextEncoder().encode(sentBody).byteLength).toBeLessThan(
+      OPENROUTER_REQUEST_MAX_BYTES,
+    );
+    expect(sentBody).not.toContain('"reasoning_details"');
+  });
+
   it("removes endpoint-pinned reasoning before a cross-model Agent step", async () => {
     const fetchMock = jest
       .fn()

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -766,6 +766,53 @@ describe("OpenRouter request normalization", () => {
     }
   });
 
+  it("rejects duplicate filenames instead of removing an ambiguous file part", async () => {
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const fetchMock = jest.fn();
+    const patchedFetch = createOpenRouterPatchFetch(
+      fetchMock as unknown as typeof fetch,
+    );
+    const perFileData = "a".repeat(OPENROUTER_REQUEST_MAX_BYTES / 2);
+
+    try {
+      const response = await patchedFetch("https://openrouter.test/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "deepseek/deepseek-v4-flash-0731",
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: '<attachment filename="report.pdf" local_path="/home/user/upload/report.pdf" />',
+                },
+                {
+                  type: "file",
+                  file: { filename: "report.pdf", file_data: perFileData },
+                },
+                {
+                  type: "file",
+                  file: { filename: "report.pdf", file_data: perFileData },
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(413);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"rejected"'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("measures after encrypted reasoning normalization reduces the body", async () => {
     const fetchMock = jest
       .fn()

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -508,7 +508,14 @@ const getFileRequestFilename = (part: unknown): string | undefined =>
     : undefined;
 
 const GENERIC_SANDBOX_ATTACHMENT_RECOVERY_INSTRUCTION =
-  "The provider could not parse one or more attached files. Use the corresponding local_path values and inspect the files with sandbox tools instead of asking the provider to parse them again.";
+  "Use the corresponding local_path values and inspect the files with sandbox tools instead of asking the provider to parse them again.";
+
+// OpenRouter enforces this against the complete serialized HTTP body, not
+// individual messages, attachments, or token estimates.
+export const OPENROUTER_REQUEST_MAX_BYTES = 5 * 1024 * 1024;
+
+const OPENROUTER_REQUEST_SIZE_GUARD_HEADER =
+  "x-hackerai-openrouter-request-size-guard";
 
 const createSandboxPdfRecoveryBody = (
   body: unknown,
@@ -613,6 +620,125 @@ const logPdfParserRecovery = (
       reason,
     }),
   );
+};
+
+const getUtf8ByteLength = (value: string): number =>
+  new TextEncoder().encode(value).byteLength;
+
+const getOpenRouterRequestLogContext = (
+  body: unknown,
+): { model?: string; userId?: string } => {
+  if (!isRecord(body)) return {};
+  const model =
+    typeof body.model === "string" &&
+    /^[a-z0-9][a-z0-9._/-]{0,127}$/i.test(body.model)
+      ? body.model
+      : undefined;
+  const userId =
+    typeof body.user === "string" && /^user_[a-z0-9_-]{1,128}$/i.test(body.user)
+      ? body.user
+      : undefined;
+  return { model, userId };
+};
+
+const logOpenRouterRequestSizeGuard = ({
+  action,
+  requestBytesBefore,
+  requestBytesAfter,
+  model,
+  userId,
+}: {
+  action: "sandbox_file_fallback" | "rejected";
+  requestBytesBefore: number;
+  requestBytesAfter: number;
+  model?: string;
+  userId?: string;
+}) => {
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: "warn",
+      event: "openrouter_request_size_guard",
+      service: "openrouter",
+      environment:
+        process.env.TRIGGER_ENV ??
+        process.env.VERCEL_ENV ??
+        process.env.NODE_ENV ??
+        "unknown",
+      reason: "request_limit_exceeded",
+      action,
+      model,
+      user_id: userId,
+      request_bytes_before: requestBytesBefore,
+      request_bytes_after: requestBytesAfter,
+      limit_bytes: OPENROUTER_REQUEST_MAX_BYTES,
+    }),
+  );
+};
+
+const createOpenRouterRequestTooLargeResponse = (
+  requestBytes: number,
+): Response =>
+  new Response(
+    JSON.stringify({
+      error: {
+        code: "request_too_large",
+        message: `OpenRouter request is ${requestBytes} bytes, exceeding the ${OPENROUTER_REQUEST_MAX_BYTES}-byte limit, and no safe request reduction fit within the limit.`,
+      },
+    }),
+    {
+      status: 413,
+      headers: {
+        "content-type": "application/json",
+        [OPENROUTER_REQUEST_SIZE_GUARD_HEADER]: "rejected",
+      },
+    },
+  );
+
+const enforceOpenRouterRequestSizeLimit = (
+  init: RequestInit,
+): { init: RequestInit; rejection?: Response } => {
+  if (typeof init.body !== "string") return { init };
+
+  const requestBytesBefore = getUtf8ByteLength(init.body);
+  if (requestBytesBefore <= OPENROUTER_REQUEST_MAX_BYTES) return { init };
+
+  let fallbackBody: string | undefined;
+  let requestContext: { model?: string; userId?: string } = {};
+  try {
+    const parsedBody = JSON.parse(init.body) as unknown;
+    requestContext = getOpenRouterRequestLogContext(parsedBody);
+    const fallback = createSandboxPdfRecoveryBody(parsedBody, true);
+    if (fallback.changed) fallbackBody = JSON.stringify(fallback.body);
+  } catch {
+    // Only valid JSON request bodies can use the attachment fallback.
+  }
+
+  const requestBytesAfter = fallbackBody
+    ? getUtf8ByteLength(fallbackBody)
+    : requestBytesBefore;
+  if (fallbackBody && requestBytesAfter <= OPENROUTER_REQUEST_MAX_BYTES) {
+    logOpenRouterRequestSizeGuard({
+      action: "sandbox_file_fallback",
+      requestBytesBefore,
+      requestBytesAfter,
+      ...requestContext,
+    });
+    const headers = new Headers(init.headers);
+    headers.delete("content-length");
+    return { init: { ...init, headers, body: fallbackBody } };
+  }
+
+  logOpenRouterRequestSizeGuard({
+    action: "rejected",
+    requestBytesBefore,
+    requestBytesAfter,
+    ...requestContext,
+  });
+  return {
+    init,
+    rejection: createOpenRouterRequestTooLargeResponse(requestBytesAfter),
+  };
 };
 
 /** Attach response headers to body-stream failures for later attribution. */
@@ -722,7 +848,15 @@ export const createOpenRouterPatchFetch =
       }
     }
 
-    const initialResponse = await fetchImplementation(url, nextInit);
+    const fetchWithinRequestLimit = async (
+      requestInit: RequestInit,
+    ): Promise<Response> => {
+      const guarded = enforceOpenRouterRequestSizeLimit(requestInit);
+      if (guarded.rejection) return guarded.rejection;
+      return fetchImplementation(url, guarded.init);
+    };
+
+    const initialResponse = await fetchWithinRequestLimit(nextInit);
     const parserFailure = await classifyPdfParserFailure(initialResponse);
     if (!parserFailure) {
       return attachOpenRouterStreamErrorMetadata(initialResponse);
@@ -735,7 +869,7 @@ export const createOpenRouterPatchFetch =
       }
 
       logPdfParserRecovery("unknown", "sandbox", parserFailure);
-      const sandboxResponse = await fetchImplementation(url, {
+      const sandboxResponse = await fetchWithinRequestLimit({
         ...nextInit,
         body: JSON.stringify(sandboxBody.body),
       });
@@ -755,7 +889,7 @@ export const createOpenRouterPatchFetch =
       }
 
       logPdfParserRecovery("cloudflare-ai", "sandbox", parserFailure);
-      const sandboxResponse = await fetchImplementation(url, {
+      const sandboxResponse = await fetchWithinRequestLimit({
         ...nextInit,
         body: JSON.stringify(sandboxBody.body),
       });
@@ -778,7 +912,7 @@ export const createOpenRouterPatchFetch =
     }
 
     logPdfParserRecovery("mistral-ocr", "cloudflare-ai", parserFailure);
-    const cloudflareResponse = await fetchImplementation(url, {
+    const cloudflareResponse = await fetchWithinRequestLimit({
       ...nextInit,
       body: JSON.stringify(cloudflareBody.body),
     });
@@ -800,7 +934,7 @@ export const createOpenRouterPatchFetch =
     }
 
     logPdfParserRecovery("cloudflare-ai", "sandbox", cloudflareFailure);
-    const sandboxResponse = await fetchImplementation(url, {
+    const sandboxResponse = await fetchWithinRequestLimit({
       ...nextInit,
       body: JSON.stringify(sandboxBody.body),
     });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -524,10 +524,7 @@ const createSandboxPdfRecoveryBody = (
   if (!isRecord(body) || !Array.isArray(body.messages)) {
     return { body, changed: false };
   }
-  const sandboxAttachmentFilenames = collectSandboxAttachmentFilenames(
-    body.messages,
-  );
-  if (sandboxAttachmentFilenames.size === 0) {
+  if (collectSandboxAttachmentFilenames(body.messages).size === 0) {
     return { body, changed: false };
   }
 
@@ -538,10 +535,28 @@ const createSandboxPdfRecoveryBody = (
     if (message.role === "user") lastUserMessageIndex = index;
     if (!Array.isArray(message.content)) return message;
 
+    // The provider file part does not retain a stable attachment ID. Limit a
+    // filename match to the same message and reject duplicate names there.
+    const sandboxAttachmentFilenames = collectSandboxAttachmentFilenames([
+      message,
+    ]);
+    const filePartFilenameCounts = new Map<string, number>();
+    message.content.forEach((part) => {
+      if (!isFileRequestPart(part)) return;
+      const filename = getFileRequestFilename(part);
+      if (!filename) return;
+      filePartFilenameCounts.set(
+        filename,
+        (filePartFilenameCounts.get(filename) ?? 0) + 1,
+      );
+    });
+
     const content = message.content.filter((part) => {
       const filename = getFileRequestFilename(part);
       const shouldRemove =
-        Boolean(filename && sandboxAttachmentFilenames.has(filename)) &&
+        filename !== undefined &&
+        sandboxAttachmentFilenames.has(filename) &&
+        filePartFilenameCounts.get(filename) === 1 &&
         (removeAllFileParts ? isFileRequestPart(part) : isPdfRequestPart(part));
       removedFilePart ||= shouldRemove;
       return !shouldRemove;


### PR DESCRIPTION
## Production evidence

Daily production error triage for the frozen window `2026-08-24T20:03:38Z`–`2026-08-25T20:03:38Z` found one current-worker deterministic provider failure:

- Trigger run `run_06g3kqud8j5tt34hudctkttoe1` on worker `20260825.12`
- exact root: `Content-Length 5247064 exceeds 5242880 byte limit`
- complete HTTP body: 5,247,064 bytes (4,184 bytes over OpenRouter's 5 MiB limit)
- safe trace shape: 82 messages, two file parts, 16 tools, 439,263 normalized message bytes
- the trace does not expose per-file/system/tool/provider-option byte attribution, so file encoding is plausible but not claimed as proven

This occurred after the current worker deployment. No suppression is involved.

## Root cause

The application tracked message/token size before provider serialization, but OpenRouter enforces its limit against the complete serialized request body, including system content, tool schemas, provider options, fallbacks, file encoding, and JSON overhead.

## Change

- enforce the 5 MiB limit at the shared OpenRouter fetch boundary after request normalization
- when the body is oversized, remove only file parts that have matching sandbox `local_path` attachment markers, remove the file-parser plugin, and preserve access through a sandbox instruction
- locally return a bounded 413 without contacting OpenRouter when no safe reduction fits
- apply the same guard to initial requests and PDF parser recovery requests
- emit a rare structured `openrouter_request_size_guard` warning with bounded action/reason/byte fields, model, and a validated opaque user ID; no prompt, file name, path, URL, tool content, or attachment data is logged

## Validation

- focused provider suite: 51/51 tests passed
- typecheck passed
- changed-file ESLint and Prettier passed
- dependency-scope guard passed
- commit hooks: 427 suites / 4,468 tests passed
- adversarial review covered exact and one-byte-over boundaries, aggregate multi-file size, normalization order, every shared provider caller, parser retries, safe partial progress, local rejection, deploy skew, and log privacy
- CodeRabbit's valid duplicate-filename finding was fixed by requiring a same-message unique filename match; ambiguous content is rejected rather than removed

## Manual verification

After deployment, run an Agent task with sandbox-backed attachments whose fully serialized request would exceed 5 MiB. Confirm:

1. the task continues using the sandbox copies rather than failing with the OpenRouter Content-Length error;
2. `openrouter_request_size_guard` reports `sandbox_file_fallback` and bounded before/after bytes;
3. no prompt, attachment name/path/URL, file data, or tool content appears in the event;
4. an oversized request without a safe sandbox fallback is rejected locally and never reaches OpenRouter.

Visual QA is not applicable to this backend-only provider boundary change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against oversized OpenRouter requests.
  * Large requests with removable file content now automatically fall back to sandbox-backed files when possible.
  * Requests that cannot fit within the limit receive a clear 413 error response.
  * Improved request-size calculations after removing encrypted reasoning content.
  * Improved handling of attachments with duplicate filenames within individual messages.
  * Added sanitized logging and response headers for rejected requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->