### PR TITLE
Fix raw provider payload telemetry leak

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -1160,6 +1160,60 @@ describe("createChatLogger provider stream termination", () => {
     }
   });
 
+  it("never emits opaque provider payloads in provider error telemetry", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_private_provider_payload",
+        endpoint: "/api/agent-long",
+      });
+      const privateAttachmentText = "PRIVATE_ATTACHMENT_TEXT";
+      const inlineImage = "data:image/png;base64,PRIVATE_INLINE_IMAGE";
+      const responseBody = JSON.stringify({
+        id: "gen-private-provider-payload",
+        error: {
+          code: 400,
+          message:
+            "The document could not be downloaded from the provided URL.",
+          metadata: {
+            provider_name: "DeepSeek",
+            file_annotations: [
+              { parsed_content: privateAttachmentText, preview: inlineImage },
+            ],
+          },
+        },
+      });
+      const err = Object.assign(new Error("Provider request failed"), {
+        name: "AI_APICallError",
+        statusCode: 400,
+        responseBody,
+        data: JSON.parse(responseBody),
+      });
+
+      chatLogger.recordProviderError(err, {
+        mode: "agent",
+        model: "model-deepseek-v4-pro",
+        requestedModelSlug: "deepseek/deepseek-v4-pro-0813",
+      });
+
+      const serializedTelemetry = errorSpy.mock.calls
+        .flat()
+        .map((value) =>
+          typeof value === "string" ? value : JSON.stringify(value),
+        )
+        .join("\n");
+      expect(serializedTelemetry).toContain('"responseBodyPresent":true');
+      expect(serializedTelemetry).toContain('"providerDataPresent":true');
+      expect(serializedTelemetry).not.toContain(privateAttachmentText);
+      expect(serializedTelemetry).not.toContain(inlineImage);
+      expect(serializedTelemetry).not.toContain('"responseBody":');
+      expect(serializedTelemetry).not.toContain('"providerData":');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("logs nested provider raw errors for generic 400 provider wrappers", () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
@@ -1278,7 +1332,8 @@ describe("createChatLogger provider stream termination", () => {
       expect(capturedError?.message).toBe(
         "tool_result without corresponding tool_use",
       );
-      expect(capturedError?.cause).toBe(providerError);
+      expect("cause" in (capturedError ?? {})).toBe(false);
+      expect(capturedError).not.toBe(providerError);
     } finally {
       errorSpy.mockRestore();
     }

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -156,13 +156,14 @@ function posthogProviderException(
     }
     return enriched;
   }
-  if (message === "Provider streaming error" || message === error.message) {
-    return error;
-  }
-
   const enriched = new Error(message);
   enriched.name = error.name;
-  (enriched as Error & { cause?: unknown }).cause = error;
+  if (typeof details.errorStack === "string") {
+    enriched.stack = details.errorStack;
+  }
+  // Do not attach the original provider error as a cause. AI SDK errors carry
+  // enumerable responseBody/data fields, and telemetry transports may traverse
+  // or serialize those properties even when the top-level message is safe.
   return enriched;
 }
 

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -151,6 +151,39 @@ describe("phLogger", () => {
     }
   });
 
+  it("omits enumerable provider payloads from error console fallbacks", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const privateAttachmentText = "PRIVATE_ATTACHMENT_TEXT";
+    const inlineImage = "data:image/png;base64,PRIVATE_INLINE_IMAGE";
+    const error = Object.assign(new Error("Provider request failed"), {
+      responseBody: JSON.stringify({
+        file_annotations: [{ parsed_content: privateAttachmentText }],
+      }),
+      data: { preview: inlineImage },
+    });
+    mockCaptureException.mockImplementationOnce(() => {
+      throw new Error("telemetry unavailable");
+    });
+
+    try {
+      phLogger.error("provider_failed", { error });
+
+      const safeFields = consoleError.mock.calls[0]?.[1] as
+        { error?: Error } | undefined;
+      const serialized = JSON.stringify(consoleError.mock.calls);
+      expect(safeFields?.error).toBeInstanceOf(Error);
+      expect(safeFields?.error?.message).toBe("Provider request failed");
+      expect("responseBody" in (safeFields?.error ?? {})).toBe(false);
+      expect(serialized).not.toContain(privateAttachmentText);
+      expect(serialized).not.toContain(inlineImage);
+      expect(serialized).not.toContain("responseBody");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("passes stable event UUIDs to PostHog without leaking them into properties", () => {
     phLogger.event("checkout_started", {
       userId: "user_123",

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -134,14 +134,9 @@ function sanitizeExceptionForCapture(error: Error): Error {
 
 function sanitizeErrorForConsole(error: unknown): unknown {
   if (error instanceof Error) {
-    const serialized = [
-      error.message,
-      error.stack ?? "",
-      stringifyUnknown(error),
-    ].join("\n");
-    return redactSensitiveErrorMessage(serialized) === serialized
-      ? error
-      : sanitizeExceptionForCapture(error);
+    // Always clone Error instances so enumerable provider-specific fields such
+    // as responseBody, data, and cause cannot reach console/Trigger telemetry.
+    return sanitizeExceptionForCapture(error);
   }
   if (error === undefined) return undefined;
   return redactSensitiveErrorMessage(stringifyUnknown(error));

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -280,6 +280,83 @@ describe("extractErrorDetails -> wrapped provider errors", () => {
     expect(getProviderErrorCategory(details)).toBe("provider_4xx");
     expect(JSON.stringify(details)).not.toContain("SECRET_PROMPT_TEXT");
   });
+
+  it("omits opaque provider payloads while retaining bounded diagnostics", () => {
+    const privateAttachmentText = "PRIVATE_ATTACHMENT_TEXT";
+    const inlineImage = "data:image/png;base64,PRIVATE_INLINE_IMAGE";
+    const responseBody = JSON.stringify({
+      id: "gen-private-provider-payload",
+      error: {
+        code: 400,
+        message: "The document could not be downloaded from the provided URL.",
+        metadata: {
+          provider_name: "DeepSeek",
+          file_annotations: [
+            { parsed_content: privateAttachmentText, preview: inlineImage },
+          ],
+        },
+      },
+    });
+    const err = apiCallError({
+      statusCode: 400,
+      responseBody,
+      data: {
+        id: "gen-private-provider-payload",
+        error: {
+          code: 400,
+          message:
+            "The document could not be downloaded from the provided URL.",
+          metadata: {
+            provider_name: "DeepSeek",
+            file_annotations: [
+              { parsed_content: privateAttachmentText, preview: inlineImage },
+            ],
+          },
+        },
+      },
+    });
+
+    const details = extractErrorDetails(err);
+    const serialized = JSON.stringify(details);
+
+    expect(details).toMatchObject({
+      statusCode: 400,
+      responseBodyPresent: true,
+      responseBodyLength: responseBody.length,
+      providerDataPresent: true,
+      providerName: "DeepSeek",
+      providerErrorCode: 400,
+      providerErrorMessage:
+        "The document could not be downloaded from the provided URL.",
+      openrouterGenerationId: "gen-private-provider-payload",
+    });
+    expect(details).not.toHaveProperty("responseBody");
+    expect(details).not.toHaveProperty("providerData");
+    expect(serialized).not.toContain(privateAttachmentText);
+    expect(serialized).not.toContain(inlineImage);
+  });
+
+  it("omits malformed response bodies and circular provider data", () => {
+    const privateAttachmentText = "PRIVATE_ATTACHMENT_TEXT";
+    const responseBody = `<html>${privateAttachmentText}</html>`;
+    const providerData: Record<string, unknown> = {
+      annotation: privateAttachmentText,
+    };
+    providerData.circular = providerData;
+    const err = apiCallError({ responseBody, data: providerData });
+
+    const details = extractErrorDetails(err);
+    const serialized = JSON.stringify(details);
+
+    expect(details).toMatchObject({
+      responseBodyPresent: true,
+      responseBodyLength: responseBody.length,
+      providerDataPresent: true,
+    });
+    expect(details).not.toHaveProperty("responseBody");
+    expect(details).not.toHaveProperty("providerData");
+    expect(serialized).not.toContain(privateAttachmentText);
+  });
 });
 
 describe("provider error classification", () => {

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -25,14 +25,6 @@ const truncate = (str: string, max: number): string => {
   return str.length > max ? str.slice(0, max) + "…" : str;
 };
 
-const SENSITIVE_KEYS = new Set([
-  "requestBodyValues",
-  "prompt",
-  "messages",
-  "content",
-  "text",
-]);
-
 const OPENROUTER_DETAIL_MAX_LENGTH = 500;
 
 const parseJsonObject = (
@@ -236,44 +228,6 @@ export const isProviderContextOrMediaOverflowError = (
 ): boolean => classifyProviderOverflowError(error) !== null;
 
 /**
- * Removes sensitive user data from provider error objects.
- * Fields containing user prompts/messages are completely removed.
- * Uses WeakSet to guard against circular references.
- */
-const removeSensitiveData = (data: unknown): unknown => {
-  const seen = new WeakSet<object>();
-
-  const recurse = (value: unknown): unknown => {
-    if (value === null || value === undefined) return value;
-    if (typeof value === "string") {
-      return redactSensitiveErrorMessage(value);
-    }
-    if (typeof value !== "object") return value;
-
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-
-    if (Array.isArray(value)) {
-      return value.map(recurse);
-    }
-
-    const obj = value as Record<string, unknown>;
-    const cleaned: Record<string, unknown> = {};
-
-    for (const [key, val] of Object.entries(obj)) {
-      if (SENSITIVE_KEYS.has(key)) {
-        continue;
-      }
-      cleaned[key] = recurse(val);
-    }
-
-    return cleaned;
-  };
-
-  return recurse(data);
-};
-
-/**
  * Extracts structured error details for logging to PostHog or other services.
  * Handles both standard Error objects and provider-specific error formats (AI SDK, etc.)
  * Sensitive user data (prompts, messages) is removed from the output.
@@ -313,14 +267,23 @@ export const extractErrorDetails = (
           ? redactSensitiveErrorMessage(source.url)
           : source.url;
     }
-    if (details.responseBody === undefined && "responseBody" in source) {
-      details.responseBody = removeSensitiveData(source.responseBody);
+    if (details.responseBodyPresent === undefined && "responseBody" in source) {
+      // Provider response bodies can contain parsed attachments, file
+      // annotations, inline images, or user text under provider-specific keys.
+      // Keep only presence/size diagnostics; getOpenRouterProviderInfo below
+      // extracts the bounded status, provider, request ID, and reason fields.
+      details.responseBodyPresent = source.responseBody !== undefined;
+      if (typeof source.responseBody === "string") {
+        details.responseBodyLength = source.responseBody.length;
+      }
     }
     if (details.isRetryable === undefined && "isRetryable" in source) {
       details.isRetryable = source.isRetryable;
     }
-    if (details.providerData === undefined && "data" in source) {
-      details.providerData = removeSensitiveData(source.data);
+    if (details.providerDataPresent === undefined && "data" in source) {
+      // `data` is an opaque provider payload with the same privacy risks as a
+      // response body. Never copy it into telemetry.
+      details.providerDataPresent = source.data !== undefined;
     }
     if (details.cause === undefined && "cause" in source && source.cause) {
       details.cause = redactSensitiveErrorMessage(


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-08-25T20:01:46Z`–`2026-08-26T20:01:46Z`.

A representative production Trigger.dev provider-error span on worker `20260826.1` (deployment `ikmjh5qk`, deployed `2026-08-26T14:43:39Z`) retained an opaque OpenRouter `responseBody` containing parsed attachment content and an inline image. The inspected occurrence was after the current worker deployment. The raw content is intentionally omitted.

The affected top-level provider-error signature occurred 10 times; 37 provider-terminal spans were in the potential population. One occurrence was directly confirmed.

## Root cause

`extractErrorDetails` recursively filtered object payloads but treated string response bodies as safe after only credential/URL redaction. Provider response schemas can place user content under arbitrary fields, so denylisting keys was not a sufficient privacy boundary. The PostHog console fallback could also re-serialize an enriched error's raw `cause`.

## Change

- Never copy opaque `responseBody` or provider `data` payloads into telemetry.
- Retain bounded presence/length, status, provider, category, fingerprint, and opaque request/generation identifiers.
- Clone provider exceptions without a raw cause.
- Always clone Error objects before console/Trigger fallback serialization.
- Cover structured, malformed, inline-image, circular-data, and fallback paths.

## Validation

- Pre-commit hook: 408 suites, 4,254 tests passed.
- Focused post-rebase suite: 90 tests passed.
- Related provider/fallback suites: 359 tests passed.
- Typecheck passed.
- Changed-file ESLint and Prettier checks passed.
- Adversarial review covered every `extractErrorDetails` caller, retry/classification behavior, alternate console/PostHog paths, and Vercel/Trigger deploy skew.

## Manual verification

After deploying the Trigger worker:

1. Run Agent mode with a bounded attachment request that produces a provider-side document download rejection.
2. Confirm the user receives the existing actionable provider error.
3. Inspect the Trigger provider-error span and PostHog log.
4. Verify status/category/provider/fingerprint and `responseBodyPresent`/`responseBodyLength` remain, while `responseBody`, provider `data`, file annotations, attachment text, and inline image data are absent.

Visual verification is not applicable because this is a backend telemetry-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error and provider telemetry sanitization to prevent response bodies, payloads, attachments, and inline images from being exposed.
  * Preserved safe diagnostic indicators, such as whether provider data exists and the length of string responses.
  * Ensured logged and reported errors use distinct, sanitized error details without retaining raw underlying causes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->