### PR TITLE
Route fresh EU sandboxes to E2B EU

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -72,6 +72,12 @@ OPENAI_API_KEY=
 # CLOUD_SANDBOX_PROVIDER=e2b
 E2B_API_KEY=
 E2B_TEMPLATE=terminal-agent-sandbox
+# Optional EU cluster. When configured, fresh sandboxes created by Trigger
+# eu-central-1 runs use this separate account and domain. Existing US
+# sandboxes continue to be reused until they are gone.
+# E2B_EU_API_KEY=
+# E2B_EU_DOMAIN=e2b-juliett.dev
+# E2B_EU_TEMPLATE=terminal-agent-sandbox
 
 # =============================================================================
 # WEB SEARCH & SCRAPING (Optional)

--- a/e2b/README.md
+++ b/e2b/README.md
@@ -20,7 +20,7 @@ Before you begin, make sure you have:
 For the separate EU cluster, add its server-side credentials without replacing
 the US key:
 
-```
+```dotenv
 E2B_EU_API_KEY=your_eu_api_key_here
 E2B_EU_DOMAIN=e2b-juliett.dev
 ```

--- a/e2b/README.md
+++ b/e2b/README.md
@@ -17,6 +17,14 @@ Before you begin, make sure you have:
    E2B_API_KEY=your_api_key_here
    ```
 
+For the separate EU cluster, add its server-side credentials without replacing
+the US key:
+
+```
+E2B_EU_API_KEY=your_eu_api_key_here
+E2B_EU_DOMAIN=e2b-juliett.dev
+```
+
 ## Building the Template
 
 ```bash
@@ -25,7 +33,18 @@ pnpm run e2b:build:dev
 
 # For production
 pnpm run e2b:build:prod
+
+# For the EU development template
+pnpm run e2b:build:eu:dev
+
+# For the EU production template
+pnpm run e2b:build:eu:prod
 ```
+
+The EU commands pass the separate key and `e2b-juliett.dev` domain directly to
+the E2B SDK. They do not overwrite or reuse `E2B_API_KEY`. Set
+`E2B_EU_TEMPLATE` only when the EU template alias should differ from
+`terminal-agent-sandbox-dev` or `terminal-agent-sandbox`.
 
 ## Using the Template in a Sandbox
 

--- a/e2b/build.eu.ts
+++ b/e2b/build.eu.ts
@@ -1,0 +1,39 @@
+import { config } from "dotenv";
+import { resolve } from "path";
+import { Template, defaultBuildLogger } from "e2b";
+import { template } from "./template";
+
+config({ path: resolve(__dirname, "../.env.local") });
+
+const EU_DOMAIN = "e2b-juliett.dev";
+
+async function main() {
+  const target = process.argv[2];
+  if (target !== "dev" && target !== "prod") {
+    throw new Error("Expected an E2B EU build target: dev or prod");
+  }
+
+  const apiKey = process.env.E2B_EU_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("E2B_EU_API_KEY is required to build the EU template");
+  }
+
+  const templateName =
+    process.env.E2B_EU_TEMPLATE?.trim() ||
+    (target === "dev"
+      ? "terminal-agent-sandbox-dev"
+      : "terminal-agent-sandbox");
+
+  await Template.build(template, templateName, {
+    apiKey,
+    domain: process.env.E2B_EU_DOMAIN?.trim() || EU_DOMAIN,
+    cpuCount: 4,
+    memoryMB: 4096,
+    onBuildLogs: defaultBuildLogger(),
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/lib/ai/subagents/__tests__/runtime-contracts.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-contracts.test.ts
@@ -36,7 +36,8 @@ describe("security validation subagent runtime contracts", () => {
   it("starts asynchronously, waits durably, and scopes the browser token to the owned child run", () => {
     const tools = read("lib/ai/tools/subagent-tools.ts");
     const tokenRoute = read("app/api/subagents/[subagentId]/token/route.ts");
-    expect(tools).toContain("subagentTask.trigger(");
+    expect(tools).toContain("tasks.trigger<typeof subagentTask>(");
+    expect(tools).toContain('"hackerai-subagent"');
     expect(tools).toContain("triggerRegion: config.triggerRegion");
     expect(tools).toContain("region: config.triggerRegion");
     expect(tools).not.toContain("triggerAndWait");

--- a/lib/ai/subagents/__tests__/runtime-contracts.test.ts
+++ b/lib/ai/subagents/__tests__/runtime-contracts.test.ts
@@ -37,7 +37,8 @@ describe("security validation subagent runtime contracts", () => {
     const tools = read("lib/ai/tools/subagent-tools.ts");
     const tokenRoute = read("app/api/subagents/[subagentId]/token/route.ts");
     expect(tools).toContain("subagentTask.trigger(");
-    expect(tools).toContain("{ subagentId, convexUrl: getConvexUrl() }");
+    expect(tools).toContain("triggerRegion: config.triggerRegion");
+    expect(tools).toContain("region: config.triggerRegion");
     expect(tools).not.toContain("triggerAndWait");
     expect(tools).toContain("claimNextTerminalSubagentForParent");
     expect(tools).toContain("await wait.for");
@@ -49,6 +50,7 @@ describe("security validation subagent runtime contracts", () => {
       "expirationTime: `${SUBAGENT_TOKEN_TTL_SECONDS}s`",
     );
     const child = read("trigger/subagent.ts");
+    expect(child).toContain("triggerRegion: payload.triggerRegion");
     expectMarkerOrder(
       child,
       "setConvexUrl(payload.convexUrl)",

--- a/lib/ai/tools/subagent-tools.ts
+++ b/lib/ai/tools/subagent-tools.ts
@@ -1,6 +1,7 @@
 import {
   idempotencyKeys,
   logger as triggerLogger,
+  tasks,
   wait,
 } from "@trigger.dev/sdk";
 import { tool, type UIMessageStreamWriter } from "ai";
@@ -51,7 +52,7 @@ import {
   subagentOperationEventUuid,
   subagentResultClaimedEventUuid,
 } from "@/lib/analytics/subagents";
-import { subagentTask } from "@/trigger/subagent";
+import type { subagentTask } from "@/trigger/subagent";
 import { resultFromPersistedSubagent } from "@/lib/ai/subagents/persisted-result";
 import { toSubagentHandle } from "@/lib/ai/subagents/agent-handle";
 import { cancelAgentTriggerRun } from "@/lib/api/agent-approval-session";
@@ -291,7 +292,8 @@ export const createCreateAgentTool = (
           const key = await idempotencyKeys.create([profile, subagentId], {
             scope: "global",
           });
-          await subagentTask.trigger(
+          await tasks.trigger<typeof subagentTask>(
+            "hackerai-subagent",
             {
               subagentId,
               convexUrl: getConvexUrl(),

--- a/lib/ai/tools/subagent-tools.ts
+++ b/lib/ai/tools/subagent-tools.ts
@@ -55,6 +55,7 @@ import { subagentTask } from "@/trigger/subagent";
 import { resultFromPersistedSubagent } from "@/lib/ai/subagents/persisted-result";
 import { toSubagentHandle } from "@/lib/ai/subagents/agent-handle";
 import { cancelAgentTriggerRun } from "@/lib/api/agent-approval-session";
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 
 export type SubagentToolsRuntimeConfig = {
   organizationId?: string;
@@ -62,6 +63,7 @@ export type SubagentToolsRuntimeConfig = {
   permissionMode: AgentPermissionMode;
   subscription: SubscriptionTier;
   freeQuotaSubject?: string;
+  triggerRegion?: TriggerRunRegion;
   securityTaskEnabled: boolean;
   securityValidationEnabled: boolean;
 };
@@ -290,7 +292,11 @@ export const createCreateAgentTool = (
             scope: "global",
           });
           await subagentTask.trigger(
-            { subagentId, convexUrl: getConvexUrl() },
+            {
+              subagentId,
+              convexUrl: getConvexUrl(),
+              triggerRegion: config.triggerRegion,
+            },
             {
               idempotencyKey: key,
               idempotencyKeyTTL: "6h",
@@ -306,6 +312,7 @@ export const createCreateAgentTool = (
                 parentToolCallId: execution.toolCallId,
                 profile,
               },
+              region: config.triggerRegion,
             },
           );
         } catch {

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-cleanup.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-cleanup.test.ts
@@ -22,6 +22,9 @@ describe("cloud sandbox cleanup", () => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
     delete process.env.E2B_API_KEY;
+    delete process.env.E2B_EU_API_KEY;
+    delete process.env.E2B_EU_DOMAIN;
+    delete process.env.E2B_EU_TEMPLATE;
   });
 
   afterAll(() => {
@@ -67,5 +70,38 @@ describe("cloud sandbox cleanup", () => {
     );
 
     errorSpy.mockRestore();
+  });
+
+  it("terminates sandboxes in both configured clusters", async () => {
+    process.env.E2B_API_KEY = "e2b-us-test-key";
+    process.env.E2B_EU_API_KEY = "e2b-eu-test-key";
+    mockListE2BSandboxes
+      .mockReturnValueOnce({
+        nextItems: jest.fn(async () => [{ sandboxId: "sandbox-us" }]),
+        hasNext: false,
+      } as ReturnType<typeof Sandbox.list>)
+      .mockReturnValueOnce({
+        nextItems: jest.fn(async () => [{ sandboxId: "sandbox-eu" }]),
+        hasNext: false,
+      } as ReturnType<typeof Sandbox.list>);
+    mockKillE2BSandbox.mockResolvedValue(undefined);
+
+    await expect(terminateCloudSandboxesForUser("user_123")).resolves.toEqual({
+      total: 2,
+      killed: 2,
+      alreadyGone: 0,
+    });
+    expect(mockListE2BSandboxes).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        apiKey: "e2b-eu-test-key",
+        domain: "e2b-juliett.dev",
+      }),
+    );
+    expect(mockKillE2BSandbox).toHaveBeenNthCalledWith(1, "sandbox-us");
+    expect(mockKillE2BSandbox).toHaveBeenNthCalledWith(2, "sandbox-eu", {
+      apiKey: "e2b-eu-test-key",
+      domain: "e2b-juliett.dev",
+    });
   });
 });

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -297,7 +297,17 @@ describe("E2B sandbox lease lifecycle", () => {
     const connectedSandbox = {
       sandboxId: "sandbox-us",
     } as unknown as Sandbox;
-    listSandbox({ sandboxId: "sandbox-us" });
+    sandboxApi.list
+      .mockReturnValueOnce({
+        nextItems: jest.fn(async () => [
+          {
+            sandboxId: "sandbox-us",
+            state: "running",
+            metadata: { sandboxVersion: "v12" },
+          },
+        ]),
+      })
+      .mockReturnValueOnce({ nextItems: jest.fn(async () => []) });
     sandboxApi.connect.mockResolvedValue(connectedSandbox);
 
     const result = await ensureSandboxConnection(
@@ -306,7 +316,7 @@ describe("E2B sandbox lease lifecycle", () => {
     );
 
     expect(result.sandbox).toBe(connectedSandbox);
-    expect(sandboxApi.list).toHaveBeenCalledTimes(1);
+    expect(sandboxApi.list).toHaveBeenCalledTimes(2);
     expect(sandboxApi.connect).toHaveBeenCalledWith("sandbox-us", {
       timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
     });
@@ -363,6 +373,47 @@ describe("E2B sandbox lease lifecycle", () => {
       domain: "e2b-juliett.dev",
       timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
     });
+  });
+
+  it("prefers a running compatible EU sandbox over a stale paused US sandbox", async () => {
+    process.env.E2B_EU_API_KEY = "e2b-eu-test-key";
+    const connectedSandbox = {
+      sandboxId: "sandbox-eu",
+    } as unknown as Sandbox;
+    sandboxApi.list
+      .mockReturnValueOnce({
+        nextItems: jest.fn(async () => [
+          {
+            sandboxId: "sandbox-us-stale",
+            state: "paused",
+            metadata: { sandboxVersion: "v10" },
+          },
+        ]),
+      })
+      .mockReturnValueOnce({
+        nextItems: jest.fn(async () => [
+          {
+            sandboxId: "sandbox-eu",
+            state: "running",
+            metadata: { sandboxVersion: "v12" },
+          },
+        ]),
+      });
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+
+    const result = await ensureSandboxConnection(
+      { userID: "user-1", setSandbox: jest.fn() },
+      { triggerRegion: "eu-central-1" },
+    );
+
+    expect(result.sandbox).toBe(connectedSandbox);
+    expect(sandboxApi.connect).toHaveBeenCalledWith("sandbox-eu", {
+      apiKey: "e2b-eu-test-key",
+      domain: "e2b-juliett.dev",
+      timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
+    });
+    expect(sandboxApi.kill).not.toHaveBeenCalled();
+    expect(sandboxApi.create).not.toHaveBeenCalled();
   });
 
   it("creates the replacement in EU when a listed US sandbox has expired", async () => {

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -59,12 +59,22 @@ const listSandbox = (
 };
 
 describe("E2B sandbox lease lifecycle", () => {
+  const originalEnv = process.env;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.E2B_EU_API_KEY;
+    delete process.env.E2B_EU_DOMAIN;
+    delete process.env.E2B_EU_TEMPLATE;
   });
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
   });
 
   it("always refreshes the same fixed cloud lease", async () => {
@@ -247,6 +257,140 @@ describe("E2B sandbox lease lifecycle", () => {
         metadata: expect.objectContaining({ sandboxVersion: "v12" }),
       }),
     );
+  });
+
+  it("creates a fresh EU sandbox for an EU Trigger run when EU is configured", async () => {
+    process.env.E2B_EU_API_KEY = "e2b-eu-test-key";
+    process.env.E2B_EU_DOMAIN = "e2b-juliett.dev";
+    const createdSandbox = { sandboxId: "sandbox-eu" } as unknown as Sandbox;
+    sandboxApi.list
+      .mockReturnValueOnce({ nextItems: jest.fn(async () => []) })
+      .mockReturnValueOnce({ nextItems: jest.fn(async () => []) });
+    sandboxApi.create.mockResolvedValue(createdSandbox);
+
+    const result = await ensureSandboxConnection(
+      { userID: "user-1", setSandbox: jest.fn() },
+      { triggerRegion: "eu-central-1" },
+    );
+
+    expect(result.sandbox).toBe(createdSandbox);
+    expect(sandboxApi.list).toHaveBeenCalledTimes(2);
+    expect(sandboxApi.list).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        apiKey: "e2b-eu-test-key",
+        domain: "e2b-juliett.dev",
+      }),
+    );
+    expect(sandboxApi.create).toHaveBeenCalledWith(
+      "terminal-agent-sandbox",
+      expect.objectContaining({
+        apiKey: "e2b-eu-test-key",
+        domain: "e2b-juliett.dev",
+        metadata: expect.objectContaining({ e2bCluster: "eu" }),
+      }),
+    );
+  });
+
+  it("keeps reusing an existing US sandbox for an EU Trigger run", async () => {
+    process.env.E2B_EU_API_KEY = "e2b-eu-test-key";
+    const connectedSandbox = {
+      sandboxId: "sandbox-us",
+    } as unknown as Sandbox;
+    listSandbox({ sandboxId: "sandbox-us" });
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+
+    const result = await ensureSandboxConnection(
+      { userID: "user-1", setSandbox: jest.fn() },
+      { triggerRegion: "eu-central-1" },
+    );
+
+    expect(result.sandbox).toBe(connectedSandbox);
+    expect(sandboxApi.list).toHaveBeenCalledTimes(1);
+    expect(sandboxApi.connect).toHaveBeenCalledWith("sandbox-us", {
+      timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
+    });
+  });
+
+  it("falls back to the US cluster when the optional EU key is absent", async () => {
+    const createdSandbox = { sandboxId: "sandbox-us" } as unknown as Sandbox;
+    sandboxApi.list.mockReturnValue({
+      nextItems: jest.fn(async () => []),
+    });
+    sandboxApi.create.mockResolvedValue(createdSandbox);
+
+    await ensureSandboxConnection(
+      { userID: "user-1", setSandbox: jest.fn() },
+      { triggerRegion: "eu-central-1" },
+    );
+
+    expect(sandboxApi.list).toHaveBeenCalledTimes(1);
+    expect(sandboxApi.create).toHaveBeenCalledWith(
+      "terminal-agent-sandbox",
+      expect.not.objectContaining({
+        apiKey: expect.anything(),
+        domain: expect.anything(),
+      }),
+    );
+  });
+
+  it("reuses an EU sandbox if a later run is placed in a US Trigger region", async () => {
+    process.env.E2B_EU_API_KEY = "e2b-eu-test-key";
+    const connectedSandbox = {
+      sandboxId: "sandbox-eu",
+    } as unknown as Sandbox;
+    sandboxApi.list
+      .mockReturnValueOnce({ nextItems: jest.fn(async () => []) })
+      .mockReturnValueOnce({
+        nextItems: jest.fn(async () => [
+          {
+            sandboxId: "sandbox-eu",
+            state: "paused",
+            metadata: { sandboxVersion: "v12" },
+          },
+        ]),
+      });
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+
+    const result = await ensureSandboxConnection(
+      { userID: "user-1", setSandbox: jest.fn() },
+      { triggerRegion: "us-east-1" },
+    );
+
+    expect(result.sandbox).toBe(connectedSandbox);
+    expect(sandboxApi.connect).toHaveBeenCalledWith("sandbox-eu", {
+      apiKey: "e2b-eu-test-key",
+      domain: "e2b-juliett.dev",
+      timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
+    });
+  });
+
+  it("creates the replacement in EU when a listed US sandbox has expired", async () => {
+    process.env.E2B_EU_API_KEY = "e2b-eu-test-key";
+    const createdSandbox = { sandboxId: "sandbox-eu" } as unknown as Sandbox;
+    listSandbox({ sandboxId: "sandbox-expired-us" });
+    sandboxApi.connect.mockRejectedValue(new Error("sandbox not found"));
+    sandboxApi.create.mockResolvedValue(createdSandbox);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const result = await ensureSandboxConnection(
+        { userID: "user-1", setSandbox: jest.fn() },
+        { triggerRegion: "eu-central-1" },
+      );
+
+      expect(result.sandbox).toBe(createdSandbox);
+      expect(sandboxApi.create).toHaveBeenCalledWith(
+        "terminal-agent-sandbox",
+        expect.objectContaining({
+          apiKey: "e2b-eu-test-key",
+          domain: "e2b-juliett.dev",
+          metadata: expect.objectContaining({ e2bCluster: "eu" }),
+        }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("prefers a running sandbox over a newer paused duplicate", async () => {

--- a/lib/ai/tools/utils/cloud-sandbox.ts
+++ b/lib/ai/tools/utils/cloud-sandbox.ts
@@ -5,6 +5,7 @@ import { ensureSandboxConnection } from "./sandbox";
 import { isE2BSandbox } from "./sandbox-types";
 import { phLogger } from "@/lib/posthog/server";
 import type { TriggerRunRegion } from "@/lib/api/trigger-region";
+import { getConfiguredE2BClustersForCleanup } from "./e2b-cluster";
 
 export type CloudSandboxAcquisitionContext = {
   provider?: CloudSandboxProvider;
@@ -20,6 +21,7 @@ const ensureE2BCloudSandboxConnection = (options: {
   initialSandbox?: AnySandbox | null;
   setSandbox: (sandbox: AnySandbox) => void;
   onBoot?: (info: SandboxBootInfo) => void;
+  context?: CloudSandboxAcquisitionContext;
 }) =>
   ensureSandboxConnection(
     {
@@ -32,6 +34,7 @@ const ensureE2BCloudSandboxConnection = (options: {
         options.initialSandbox && isE2BSandbox(options.initialSandbox)
           ? options.initialSandbox
           : null,
+      triggerRegion: options.context?.triggerRegion,
     },
   );
 
@@ -73,8 +76,10 @@ export async function terminateCloudSandboxesForUser(userId: string): Promise<{
 }> {
   const totals = { total: 0, killed: 0, alreadyGone: 0 };
 
-  if (process.env.E2B_API_KEY) {
-    const paginator = (await import("@e2b/code-interpreter")).Sandbox.list({
+  for (const cluster of getConfiguredE2BClustersForCleanup()) {
+    const { Sandbox } = await import("@e2b/code-interpreter");
+    const paginator = Sandbox.list({
+      ...cluster.connectionOptions,
       query: { metadata: { userID: userId } },
     });
     const sandboxes = [];
@@ -85,10 +90,13 @@ export async function terminateCloudSandboxesForUser(userId: string): Promise<{
     let alreadyGone = 0;
     const { isExpectedMissingResourceCleanupError } =
       await import("@/lib/utils/cleanup-errors");
-    const { Sandbox } = await import("@e2b/code-interpreter");
     for (const sandbox of sandboxes) {
       try {
-        await Sandbox.kill(sandbox.sandboxId);
+        if (cluster.connectionOptions) {
+          await Sandbox.kill(sandbox.sandboxId, cluster.connectionOptions);
+        } else {
+          await Sandbox.kill(sandbox.sandboxId);
+        }
         killed++;
       } catch (error) {
         if (isExpectedMissingResourceCleanupError(error)) {

--- a/lib/ai/tools/utils/e2b-cluster.ts
+++ b/lib/ai/tools/utils/e2b-cluster.ts
@@ -1,0 +1,73 @@
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
+
+export const E2B_EU_DOMAIN = "e2b-juliett.dev";
+
+export type E2BCluster = "us" | "eu";
+
+export type E2BConnectionOptions = {
+  apiKey: string;
+  domain: string;
+};
+
+export type E2BClusterConfig = {
+  cluster: E2BCluster;
+  template: string;
+  connectionOptions?: E2BConnectionOptions;
+};
+
+const envValue = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+};
+
+const getUsClusterConfig = (): E2BClusterConfig => ({
+  cluster: "us",
+  template: envValue(process.env.E2B_TEMPLATE) ?? "terminal-agent-sandbox",
+});
+
+const getEuClusterConfig = (): E2BClusterConfig | null => {
+  const apiKey = envValue(process.env.E2B_EU_API_KEY);
+  if (!apiKey) return null;
+
+  return {
+    cluster: "eu",
+    template:
+      envValue(process.env.E2B_EU_TEMPLATE) ??
+      envValue(process.env.E2B_TEMPLATE) ??
+      "terminal-agent-sandbox",
+    connectionOptions: {
+      apiKey,
+      domain: envValue(process.env.E2B_EU_DOMAIN) ?? E2B_EU_DOMAIN,
+    },
+  };
+};
+
+/**
+ * US stays first so users keep their existing sandbox until it disappears or
+ * is intentionally replaced. EU is an optional second cluster, enabled only
+ * when its separate API key is present.
+ */
+export const getE2BClusterRouting = (
+  triggerRegion?: TriggerRunRegion,
+): {
+  discoveryClusters: E2BClusterConfig[];
+  createCluster: E2BClusterConfig;
+} => {
+  const us = getUsClusterConfig();
+  const eu = getEuClusterConfig();
+
+  return {
+    discoveryClusters: eu ? [us, eu] : [us],
+    createCluster: triggerRegion === "eu-central-1" && eu ? eu : us,
+  };
+};
+
+export const getConfiguredE2BClustersForCleanup = (): E2BClusterConfig[] => {
+  const clusters: E2BClusterConfig[] = [];
+  if (envValue(process.env.E2B_API_KEY)) {
+    clusters.push(getUsClusterConfig());
+  }
+  const eu = getEuClusterConfig();
+  if (eu) clusters.push(eu);
+  return clusters;
+};

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -181,15 +181,14 @@ export const ensureSandboxConnection = async (
       getE2BClusterRouting(triggerRegion);
 
     // Step 1: Look for an existing sandbox across configured clusters. US is
-    // deliberately checked first so this rollout never migrates a live user.
-    let existingSandbox:
-      | {
-          info: Awaited<
-            ReturnType<ReturnType<typeof Sandbox.list>["nextItems"]>
-          >[number];
-          cluster: E2BClusterConfig;
-        }
-      | undefined;
+    // deliberately checked first so it wins ties between equally viable ones.
+    type DiscoveredSandbox = {
+      info: Awaited<
+        ReturnType<ReturnType<typeof Sandbox.list>["nextItems"]>
+      >[number];
+      cluster: E2BClusterConfig;
+    };
+    const discoveredSandboxes: DiscoveredSandbox[] = [];
     for (const cluster of discoveryClusters) {
       const paginator = Sandbox.list({
         ...cluster.connectionOptions,
@@ -208,26 +207,26 @@ export const ensureSandboxConnection = async (
           jitterMs: 40,
         },
       );
-      // A user should normally have one sandbox. If a previous ambiguous
-      // create produced duplicates, prefer an active compatible sandbox.
-      const candidate =
-        listedSandboxes.find(
-          (sandbox) =>
-            sandbox.state === "running" &&
-            sandbox.metadata?.sandboxVersion === SANDBOX_VERSION,
-        ) ??
-        listedSandboxes.find((sandbox) => sandbox.state === "running") ??
-        listedSandboxes.find(
-          (sandbox) =>
-            sandbox.state === "paused" &&
-            sandbox.metadata?.sandboxVersion === SANDBOX_VERSION,
-        ) ??
-        listedSandboxes[0];
-      if (candidate) {
-        existingSandbox = { info: candidate, cluster };
-        break;
-      }
+      discoveredSandboxes.push(
+        ...listedSandboxes.map((info) => ({ info, cluster })),
+      );
     }
+
+    // Rank across both clusters so a compatible running sandbox always wins.
+    // Discovery order keeps US as the tie-breaker for equally ranked entries.
+    const existingSandbox =
+      discoveredSandboxes.find(
+        ({ info }) =>
+          info.state === "running" &&
+          info.metadata?.sandboxVersion === SANDBOX_VERSION,
+      ) ??
+      discoveredSandboxes.find(({ info }) => info.state === "running") ??
+      discoveredSandboxes.find(
+        ({ info }) =>
+          info.state === "paused" &&
+          info.metadata?.sandboxVersion === SANDBOX_VERSION,
+      ) ??
+      discoveredSandboxes[0];
 
     const existingSandboxInfo = existingSandbox?.info;
     const existingCluster = existingSandbox?.cluster;

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -3,10 +3,11 @@ import type { SandboxBootInfo, SandboxContext } from "@/types";
 import { NotFoundError, getUserFacingE2BErrorMessage } from "./e2b-errors";
 import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
 import { retryWithBackoff } from "./retry-with-backoff";
+import { getE2BClusterRouting, type E2BClusterConfig } from "./e2b-cluster";
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 
 type SandboxReadyPath = SandboxBootInfo["path"];
 
-const SANDBOX_TEMPLATE = process.env.E2B_TEMPLATE || "terminal-agent-sandbox";
 export const BASH_SANDBOX_AUTOPAUSE_TIMEOUT = 7 * 60 * 1000;
 export const E2B_SANDBOX_LEASE_HEARTBEAT_INTERVAL_MS = 60 * 1000;
 export const E2B_SANDBOX_LEASE_REQUEST_TIMEOUT_MS = 5 * 1000;
@@ -156,10 +157,11 @@ export const ensureSandboxConnection = async (
   context: SandboxContext,
   options: {
     initialSandbox?: Sandbox | null;
+    triggerRegion?: TriggerRunRegion;
   } = {},
 ): Promise<{ sandbox: Sandbox }> => {
   const { userID, setSandbox, onBoot } = context;
-  const { initialSandbox } = options;
+  const { initialSandbox, triggerRegion } = options;
 
   // Return existing sandbox if already connected
   if (initialSandbox) {
@@ -175,60 +177,87 @@ export const ensureSandboxConnection = async (
     });
   };
   try {
-    // Step 1: Look for existing sandbox for this user
-    const paginator = Sandbox.list({
-      query: {
-        metadata: {
-          userID,
-          template: SANDBOX_TEMPLATE,
-        },
-      },
-    });
-    const listedSandboxes = await retryWithBackoff(
-      () => paginator.nextItems(),
-      {
-        maxRetries: MAX_DISCOVERY_RETRIES,
-        baseDelayMs: 400,
-        jitterMs: 40,
-      },
-    );
-    // A user should normally have one sandbox. If a previous ambiguous create
-    // produced duplicates, prefer an active compatible sandbox so we do not
-    // attach to a newer paused duplicate while work is still running.
-    const existingSandbox =
-      listedSandboxes.find(
-        (candidate) =>
-          candidate.state === "running" &&
-          candidate.metadata?.sandboxVersion === SANDBOX_VERSION,
-      ) ??
-      listedSandboxes.find((candidate) => candidate.state === "running") ??
-      listedSandboxes.find(
-        (candidate) =>
-          candidate.state === "paused" &&
-          candidate.metadata?.sandboxVersion === SANDBOX_VERSION,
-      ) ??
-      listedSandboxes[0];
+    const { discoveryClusters, createCluster } =
+      getE2BClusterRouting(triggerRegion);
 
+    // Step 1: Look for an existing sandbox across configured clusters. US is
+    // deliberately checked first so this rollout never migrates a live user.
+    let existingSandbox:
+      | {
+          info: Awaited<
+            ReturnType<ReturnType<typeof Sandbox.list>["nextItems"]>
+          >[number];
+          cluster: E2BClusterConfig;
+        }
+      | undefined;
+    for (const cluster of discoveryClusters) {
+      const paginator = Sandbox.list({
+        ...cluster.connectionOptions,
+        query: {
+          metadata: {
+            userID,
+            template: cluster.template,
+          },
+        },
+      });
+      const listedSandboxes = await retryWithBackoff(
+        () => paginator.nextItems(),
+        {
+          maxRetries: MAX_DISCOVERY_RETRIES,
+          baseDelayMs: 400,
+          jitterMs: 40,
+        },
+      );
+      // A user should normally have one sandbox. If a previous ambiguous
+      // create produced duplicates, prefer an active compatible sandbox.
+      const candidate =
+        listedSandboxes.find(
+          (sandbox) =>
+            sandbox.state === "running" &&
+            sandbox.metadata?.sandboxVersion === SANDBOX_VERSION,
+        ) ??
+        listedSandboxes.find((sandbox) => sandbox.state === "running") ??
+        listedSandboxes.find(
+          (sandbox) =>
+            sandbox.state === "paused" &&
+            sandbox.metadata?.sandboxVersion === SANDBOX_VERSION,
+        ) ??
+        listedSandboxes[0];
+      if (candidate) {
+        existingSandbox = { info: candidate, cluster };
+        break;
+      }
+    }
+
+    const existingSandboxInfo = existingSandbox?.info;
+    const existingCluster = existingSandbox?.cluster;
     const hasVersionMismatch =
-      existingSandbox &&
-      existingSandbox.metadata?.sandboxVersion !== SANDBOX_VERSION;
+      existingSandboxInfo &&
+      existingSandboxInfo.metadata?.sandboxVersion !== SANDBOX_VERSION;
     const canReplaceExistingSandbox =
-      hasVersionMismatch && existingSandbox.state === "paused";
+      hasVersionMismatch && existingSandboxInfo.state === "paused";
 
     // Step 2: Migrate only an idle, paused sandbox. A running sandbox may
     // contain commands owned by another Agent run for the same user.
-    if (canReplaceExistingSandbox) {
+    if (canReplaceExistingSandbox && existingCluster) {
       console.log(
         `[${userID}] Sandbox version mismatch (expected ${SANDBOX_VERSION}), deleting old sandbox`,
       );
       try {
-        await Sandbox.kill(existingSandbox.sandboxId);
+        if (existingCluster.connectionOptions) {
+          await Sandbox.kill(
+            existingSandboxInfo.sandboxId,
+            existingCluster.connectionOptions,
+          );
+        } else {
+          await Sandbox.kill(existingSandboxInfo.sandboxId);
+        }
       } catch (killError) {
         logSandboxKillFailure(userID, "Failed to kill old sandbox", killError);
       }
       createPath = "create_after_version_mismatch";
       // Skip to creating new sandbox
-    } else if (existingSandbox?.sandboxId) {
+    } else if (existingSandboxInfo?.sandboxId && existingCluster) {
       if (hasVersionMismatch) {
         console.warn(
           JSON.stringify({
@@ -240,10 +269,10 @@ export const ensureSandboxConnection = async (
               process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
             request_id: process.env.VERCEL_REQUEST_ID ?? null,
             user_id: userID,
-            sandbox_id: existingSandbox.sandboxId,
-            sandbox_state: existingSandbox.state,
+            sandbox_id: existingSandboxInfo.sandboxId,
+            sandbox_state: existingSandboxInfo.state,
             current_version:
-              existingSandbox.metadata?.sandboxVersion ?? "missing",
+              existingSandboxInfo.metadata?.sandboxVersion ?? "missing",
             expected_version: SANDBOX_VERSION,
           }),
         );
@@ -255,7 +284,8 @@ export const ensureSandboxConnection = async (
       try {
         const sandbox = await retryWithBackoff(
           () =>
-            Sandbox.connect(existingSandbox.sandboxId, {
+            Sandbox.connect(existingSandboxInfo.sandboxId, {
+              ...existingCluster.connectionOptions,
               timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
             }),
           {
@@ -274,12 +304,12 @@ export const ensureSandboxConnection = async (
           (e instanceof Error && e.message?.includes("not found"))
         ) {
           console.error(
-            `[${userID}] Sandbox ${existingSandbox.sandboxId} expired/deleted, creating new one`,
+            `[${userID}] Sandbox ${existingSandboxInfo.sandboxId} expired/deleted, creating new one`,
           );
           createPath = "create_after_expired";
         } else {
           console.error(
-            `[${userID}] Unexpected error resuming sandbox ${existingSandbox.sandboxId}:`,
+            `[${userID}] Unexpected error resuming sandbox ${existingSandboxInfo.sandboxId}:`,
             e,
           );
           // The listed state can become stale while connect is pending. Never
@@ -303,15 +333,17 @@ export const ensureSandboxConnection = async (
       }
 
       try {
-        const sandbox = await Sandbox.create(SANDBOX_TEMPLATE, {
+        const sandbox = await Sandbox.create(createCluster.template, {
+          ...createCluster.connectionOptions,
           timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
           lifecycle: { onTimeout: "pause", autoResume: true },
           secure: true,
           metadata: {
             userID,
-            template: SANDBOX_TEMPLATE,
+            template: createCluster.template,
             secure: "true",
             sandboxVersion: SANDBOX_VERSION,
+            e2bCluster: createCluster.cluster,
           },
         });
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "s3:validate": "npx ts-node scripts/validate-s3-security.ts",
     "e2b:build:dev": "npx tsx e2b/build.dev.ts",
     "e2b:build:prod": "npx tsx e2b/build.prod.ts",
+    "e2b:build:eu:dev": "npx tsx e2b/build.eu.ts dev",
+    "e2b:build:eu:prod": "npx tsx e2b/build.eu.ts prod",
     "local-sandbox": "npx tsx packages/local/src/index.ts",
     "local-sandbox:build": "cd packages/local && pnpm build",
     "desktop:dev": "cd packages/desktop && pnpm dev",

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -3182,6 +3182,7 @@ export const agentLongTask = task({
                           permissionMode: agentPermissionMode,
                           subscription,
                           freeQuotaSubject,
+                          triggerRegion,
                           securityTaskEnabled: securityTaskSubagentsEnabled,
                           securityValidationEnabled:
                             securityValidationSubagentsEnabled,

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -105,6 +105,7 @@ import {
   getUserFriendlyProviderError,
 } from "@/lib/utils/error-utils";
 import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
+import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 
 type SubagentTaskOutput = {
   subagentId: string;
@@ -127,6 +128,7 @@ const loadPersistedTerminalOutput = async (
 type SubagentTaskPayload = {
   subagentId: string;
   convexUrl?: string;
+  triggerRegion?: TriggerRunRegion;
 };
 
 type CancellationCleanup = {
@@ -718,6 +720,7 @@ export const subagentTask = task({
                 }),
                 ptyScopeId: row.subagent_id,
                 chargeSandboxRuntime: false,
+                triggerRegion: payload.triggerRegion,
               },
             );
             const tools = guardSubagentToolExecutions(


### PR DESCRIPTION
## Summary

- add optional E2B EU cluster configuration using a separate API key and scoped `e2b-juliett.dev` domain
- preserve existing US sandboxes; create in EU only for fresh/expired sandboxes on `eu-central-1` Trigger runs
- keep subagents in the parent Trigger region and clean up sandboxes across both clusters
- add dedicated EU development and production template build commands

## Rollout

- build the matching template alias in the EU E2B account first
- configure `E2B_EU_API_KEY`, `E2B_EU_DOMAIN=e2b-juliett.dev`, and optional `E2B_EU_TEMPLATE` separately in Trigger Preview and Production
- configure the same server-only EU credentials in Vercel Preview and Production so deletion endpoints clean both clusters
- without `E2B_EU_API_KEY`, behavior remains US-only
- rollback by removing `E2B_EU_API_KEY`; existing EU sandboxes remain discoverable while the credential is configured

## Validation

- `pnpm typecheck`
- full Jest suite: 408 suites / 4,271 tests passed
- focused EU lifecycle, cleanup, and subagent region tests
- `pnpm lint` (0 errors; unrelated UI warnings only)

## Manual verification

1. In Trigger Preview, run Agent mode for a new European test user and confirm the run region is `eu-central-1`.
2. Confirm the sandbox appears in the EU E2B account with `e2bCluster=eu` metadata and the configured template alias.
3. Run as a European user who already has a US sandbox and confirm the existing sandbox ID is reused.
4. Remove the EU key in Preview and confirm a fresh EU-region Agent run still succeeds using US E2B.

No Docker sandbox image workflow is triggered by this change; its workflow is scoped to `docker/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for EU-region sandbox execution with separate credentials, domains, and templates.
  - Sandbox discovery, creation, reuse, and cleanup now route based on execution region.
  - Added development and production commands for building EU sandbox templates.
  - Subagent tasks now preserve region information throughout execution.

- **Bug Fixes**
  - Improved cleanup across multiple configured sandbox regions.
  - Added safer fallback and replacement behavior when sandboxes expire or become unavailable.

- **Documentation**
  - Added setup guidance for configuring EU sandbox credentials and templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->