### PR TITLE
HAC-46: add 10% Pro $29 pricing experiment

### DIFF
--- a/app/api/pricing/pro-monthly-experiment/__tests__/route.test.ts
+++ b/app/api/pricing/pro-monthly-experiment/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockGetUserIDAndPro = jest.fn();
+const mockEvaluatePricingExperiment = jest.fn();
+const mockListPrices = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      headers: init?.headers,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserIDAndPro: mockGetUserIDAndPro,
+}));
+
+jest.mock("@/lib/experiments/pro-monthly-pricing.server", () => ({
+  evaluateProMonthlyPricingExperiment: mockEvaluatePricingExperiment,
+}));
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: { prices: { list: mockListPrices } },
+}));
+
+const testAssignment = {
+  key: "hac46-pro-monthly-29-pricing",
+  variant: "test",
+  priceLookupKey: "pro-monthly-plan-29-experiment",
+  displayedAmountDollars: 29,
+  currency: "usd",
+  billingInterval: "month",
+} as const;
+
+function price(args: {
+  id: string;
+  lookupKey: string;
+  amount: number;
+  product?: string;
+}) {
+  return {
+    id: args.id,
+    active: true,
+    lookup_key: args.lookupKey,
+    unit_amount: args.amount,
+    currency: "usd",
+    type: "recurring",
+    recurring: { interval: "month", interval_count: 1 },
+    product: args.product ?? "prod_pro",
+  };
+}
+
+describe("GET /api/pricing/pro-monthly-experiment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserIDAndPro.mockResolvedValue({
+      userId: "user_123",
+      subscription: "free",
+    } as never);
+  });
+
+  it("returns the server-resolved Stripe Price ID for analytics", async () => {
+    mockEvaluatePricingExperiment.mockResolvedValue(testAssignment);
+    mockListPrices.mockResolvedValue({
+      data: [
+        price({
+          id: "price_pro_29",
+          lookupKey: "pro-monthly-plan-29-experiment",
+          amount: 2_900,
+        }),
+        price({
+          id: "price_pro_25",
+          lookupKey: "pro-monthly-plan",
+          amount: 2_500,
+        }),
+      ],
+    } as never);
+
+    const { GET } = await import("../route");
+    const response = await GET({} as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ...testAssignment,
+      stripePriceId: "price_pro_29",
+    });
+    expect(mockListPrices).toHaveBeenCalledWith({
+      active: true,
+      lookup_keys: ["pro-monthly-plan-29-experiment", "pro-monthly-plan"],
+    });
+  });
+
+  it("fails closed when the experiment Price belongs to another Product", async () => {
+    mockEvaluatePricingExperiment.mockResolvedValue(testAssignment);
+    mockListPrices.mockResolvedValue({
+      data: [
+        price({
+          id: "price_pro_29",
+          lookupKey: "pro-monthly-plan-29-experiment",
+          amount: 2_900,
+          product: "prod_wrong",
+        }),
+        price({
+          id: "price_pro_25",
+          lookupKey: "pro-monthly-plan",
+          amount: 2_500,
+        }),
+      ],
+    } as never);
+
+    const { GET } = await import("../route");
+    const response = await GET({} as never);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Experimental subscription price is unavailable",
+    });
+  });
+
+  it("does not query Stripe when the user has no experiment assignment", async () => {
+    mockEvaluatePricingExperiment.mockResolvedValue(undefined);
+
+    const { GET } = await import("../route");
+    const response = await GET({} as never);
+
+    expect(response.status).toBe(200);
+    expect(mockListPrices).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      key: null,
+      variant: null,
+    });
+  });
+});

--- a/app/api/pricing/pro-monthly-experiment/route.ts
+++ b/app/api/pricing/pro-monthly-experiment/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import { evaluateProMonthlyPricingExperiment } from "@/lib/experiments/pro-monthly-pricing.server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const { userId, subscription } = await getUserIDAndPro(req);
+  const assignment = await evaluateProMonthlyPricingExperiment({
+    userId,
+    subscription,
+    requestedPlan: "pro-monthly-plan",
+  });
+
+  return NextResponse.json(
+    assignment ?? {
+      key: null,
+      variant: null,
+      priceLookupKey: "pro-monthly-plan",
+      displayedAmountDollars: 25,
+      currency: "usd",
+      billingInterval: "month",
+    },
+    {
+      headers: {
+        "Cache-Control": "private, no-store, max-age=0",
+      },
+    },
+  );
+}

--- a/app/api/pricing/pro-monthly-experiment/route.ts
+++ b/app/api/pricing/pro-monthly-experiment/route.ts
@@ -1,9 +1,39 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import type Stripe from "stripe";
 
+import { stripe } from "@/app/api/stripe";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import {
+  PRO_MONTHLY_CONTROL_LOOKUP_KEY,
+  type ProMonthlyPricingExperimentAssignment,
+  type ProMonthlyPricingExperimentPresentation,
+} from "@/lib/experiments/pro-monthly-pricing";
 import { evaluateProMonthlyPricingExperiment } from "@/lib/experiments/pro-monthly-pricing.server";
 
 export const dynamic = "force-dynamic";
+
+function stripeProductId(
+  product: Stripe.Price["product"] | undefined,
+): string | undefined {
+  return typeof product === "string" ? product : product?.id;
+}
+
+function isExpectedPrice(
+  price: Stripe.Price | undefined,
+  assignment: ProMonthlyPricingExperimentAssignment,
+): price is Stripe.Price {
+  return Boolean(
+    price &&
+    price.active &&
+    price.lookup_key === assignment.priceLookupKey &&
+    price.currency === assignment.currency &&
+    price.unit_amount === assignment.displayedAmountDollars * 100 &&
+    price.type === "recurring" &&
+    price.recurring?.interval === assignment.billingInterval &&
+    price.recurring.interval_count === 1,
+  );
+}
 
 export async function GET(req: NextRequest) {
   const { userId, subscription } = await getUserIDAndPro(req);
@@ -13,8 +43,62 @@ export async function GET(req: NextRequest) {
     requestedPlan: "pro-monthly-plan",
   });
 
+  if (assignment) {
+    try {
+      const lookupKeys =
+        assignment.variant === "test"
+          ? [assignment.priceLookupKey, PRO_MONTHLY_CONTROL_LOOKUP_KEY]
+          : [assignment.priceLookupKey];
+      const prices = await stripe.prices.list({
+        active: true,
+        lookup_keys: lookupKeys,
+      });
+      const selectedPrice = prices.data.find(
+        (price) => price.lookup_key === assignment.priceLookupKey,
+      );
+      const controlPrice = prices.data.find(
+        (price) => price.lookup_key === PRO_MONTHLY_CONTROL_LOOKUP_KEY,
+      );
+      const selectedProductId = stripeProductId(selectedPrice?.product);
+      const controlProductId = stripeProductId(controlPrice?.product);
+      const hasMatchingProduct =
+        assignment.variant !== "test" ||
+        Boolean(
+          selectedProductId &&
+          controlProductId &&
+          selectedProductId === controlProductId,
+        );
+
+      if (!isExpectedPrice(selectedPrice, assignment) || !hasMatchingProduct) {
+        return NextResponse.json(
+          { error: "Experimental subscription price is unavailable" },
+          {
+            status: 503,
+            headers: { "Cache-Control": "private, no-store, max-age=0" },
+          },
+        );
+      }
+
+      const presentation: ProMonthlyPricingExperimentPresentation = {
+        ...assignment,
+        stripePriceId: selectedPrice.id,
+      };
+      return NextResponse.json(presentation, {
+        headers: { "Cache-Control": "private, no-store, max-age=0" },
+      });
+    } catch {
+      return NextResponse.json(
+        { error: "Experimental subscription price is unavailable" },
+        {
+          status: 503,
+          headers: { "Cache-Control": "private, no-store, max-age=0" },
+        },
+      );
+    }
+  }
+
   return NextResponse.json(
-    assignment ?? {
+    {
       key: null,
       variant: null,
       priceLookupKey: "pro-monthly-plan",

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -314,7 +314,7 @@ describe("POST /api/subscribe", () => {
     }
   });
 
-  it("reuses a matching legacy open Checkout Session", async () => {
+  it("reuses an open Checkout Session with matching experiment metadata", async () => {
     mockListOrganizationMemberships.mockResolvedValue({
       data: [
         {
@@ -353,6 +353,10 @@ describe("POST /api/subscribe", () => {
             metadata: {
               workOSOrganizationId: "org_team",
               requestedPlan: "pro-monthly-plan",
+              resolvedPriceLookupKey: "pro-monthly-plan",
+              pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+              pricingExperimentVariant: "control",
+              pricingExperimentPriceLookupKey: "pro-monthly-plan",
               checkoutAttemptId: "ca_original",
             },
           },
@@ -428,6 +432,60 @@ describe("POST /api/subscribe", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it("does not reuse a legacy session that lacks experiment metadata", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [{ organizationId: "org_team", role: { slug: "admin" } }],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_team",
+      stripeCustomerId: "cus_existing_org",
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_existing_org",
+      metadata: { workOSOrganizationId: "org_team" },
+    } as never);
+    mockListCheckoutSessions.mockResolvedValue({
+      data: [
+        {
+          id: "cs_legacy",
+          url: "https://stripe.example/legacy-checkout",
+          metadata: {
+            workOSOrganizationId: "org_team",
+            requestedPlan: "pro-monthly-plan",
+          },
+        },
+      ],
+      has_more: false,
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        plan: "pro-monthly-plan",
+        checkoutAttemptId: "ca_control_123",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateCheckoutSession).not.toHaveBeenCalled();
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+          pricingExperimentVariant: "control",
+          pricingExperimentPriceLookupKey: "pro-monthly-plan",
+        }),
+        subscription_data: {
+          metadata: expect.objectContaining({
+            pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+            pricingExperimentVariant: "control",
+            pricingExperimentPriceLookupKey: "pro-monthly-plan",
+          }),
+        },
+      }),
+    );
   });
 
   it("returns a safe conflict response when Stripe's pending-session limit is reached", async () => {

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -20,6 +20,7 @@ const mockCreateCheckoutSession = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogWarn = jest.fn();
 const mockPostHogFlush = jest.fn();
+const mockGetPostHogFeatureFlagVariant = jest.fn();
 const mockResponseCookieDelete = jest.fn();
 
 jest.mock("next/server", () => {
@@ -78,6 +79,7 @@ jest.mock("@/app/api/stripe", () => ({
 }));
 
 jest.mock("@/lib/posthog/server", () => ({
+  getPostHogFeatureFlagVariantForUser: mockGetPostHogFeatureFlagVariant,
   phLogger: {
     event: mockPostHogEvent,
     warn: mockPostHogWarn,
@@ -108,6 +110,7 @@ describe("POST /api/subscribe", () => {
     process.env.NEXT_PUBLIC_BASE_URL = "https://hackerai.example";
     process.env.CONVEX_SERVICE_ROLE_KEY = "service_key";
     delete process.env.REFERRAL_PROGRAM_ENABLED;
+    mockGetPostHogFeatureFlagVariant.mockResolvedValue("control");
 
     mockConvexMutation.mockResolvedValue(null);
 
@@ -127,6 +130,7 @@ describe("POST /api/subscribe", () => {
       data: [
         {
           id: "price_pro",
+          lookup_key: "pro-monthly-plan",
           recurring: { interval: "month", interval_count: 1 },
           unit_amount: 2000,
           currency: "usd",
@@ -369,10 +373,12 @@ describe("POST /api/subscribe", () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toEqual({
-        url: "https://stripe.example/existing-checkout",
-        checkoutAttemptId: "ca_retry_123",
-      });
+      expect(body).toEqual(
+        expect.objectContaining({
+          url: "https://stripe.example/existing-checkout",
+          checkoutAttemptId: "ca_retry_123",
+        }),
+      );
       expect(mockListCheckoutSessions).toHaveBeenNthCalledWith(1, {
         customer: "cus_existing_org",
         status: "open",
@@ -388,6 +394,10 @@ describe("POST /api/subscribe", () => {
         metadata: {
           workOSOrganizationId: "org_team",
           requestedPlan: "pro-monthly-plan",
+          resolvedPriceLookupKey: "pro-monthly-plan",
+          pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+          pricingExperimentVariant: "control",
+          pricingExperimentPriceLookupKey: "pro-monthly-plan",
           checkoutAttemptId: "ca_retry_123",
           userId: "user_123",
           checkoutQuantity: "1",
@@ -497,10 +507,12 @@ describe("POST /api/subscribe", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual({
-      url: "https://stripe.example/checkout",
-      checkoutAttemptId: expect.stringMatching(/^ca_/),
-    });
+    expect(body).toEqual(
+      expect.objectContaining({
+        url: "https://stripe.example/checkout",
+        checkoutAttemptId: expect.stringMatching(/^ca_/),
+      }),
+    );
     expect(mockRetrieveCustomer).toHaveBeenCalledWith("cus_existing_org");
     expect(mockUpdateCustomer).toHaveBeenCalledWith("cus_existing_org", {
       metadata: {
@@ -554,10 +566,12 @@ describe("POST /api/subscribe", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual({
-      url: "https://stripe.example/checkout",
-      checkoutAttemptId: expect.stringMatching(/^ca_/),
-    });
+    expect(body).toEqual(
+      expect.objectContaining({
+        url: "https://stripe.example/checkout",
+        checkoutAttemptId: expect.stringMatching(/^ca_/),
+      }),
+    );
     expect(mockCreateCustomer).not.toHaveBeenCalled();
     expect(mockUpdateOrganization).toHaveBeenCalledWith({
       organization: "org_team",
@@ -659,10 +673,12 @@ describe("POST /api/subscribe", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual({
-      url: "https://stripe.example/checkout",
-      checkoutAttemptId: expect.stringMatching(/^ca_/),
-    });
+    expect(body).toEqual(
+      expect.objectContaining({
+        url: "https://stripe.example/checkout",
+        checkoutAttemptId: expect.stringMatching(/^ca_/),
+      }),
+    );
     expect(mockConvexMutation).toHaveBeenNthCalledWith(
       1,
       expect.anything(),
@@ -846,6 +862,114 @@ describe("POST /api/subscribe", () => {
         reason: "monthly_exhausted",
         limit_type: "monthly",
         $insert_id: "checkout_started:ca_limit_pressure_123",
+      }),
+    );
+  });
+
+  it("uses the server-assigned $29 Price for the test cohort", async () => {
+    mockGetPostHogFeatureFlagVariant.mockResolvedValueOnce("test");
+    mockListOrganizationMemberships.mockResolvedValue({ data: [] } as never);
+    mockCreateOrganization.mockResolvedValue({ id: "org_new" } as never);
+    mockCreateCustomer.mockResolvedValue({
+      id: "cus_new",
+      metadata: {},
+    } as never);
+    mockListPrices.mockResolvedValue({
+      data: [
+        {
+          id: "price_pro_29",
+          lookup_key: "pro-monthly-plan-29-experiment",
+          active: true,
+          type: "recurring",
+          product: "prod_hackerai_pro",
+          recurring: { interval: "month", interval_count: 1 },
+          unit_amount: 2900,
+          currency: "usd",
+        },
+        {
+          id: "price_pro_25",
+          lookup_key: "pro-monthly-plan",
+          active: true,
+          type: "recurring",
+          product: "prod_hackerai_pro",
+          recurring: { interval: "month", interval_count: 1 },
+          unit_amount: 2500,
+          currency: "usd",
+        },
+      ],
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        plan: "pro-monthly-plan",
+        checkoutAttemptId: "ca_hac46_test_123",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockListPrices).toHaveBeenCalledWith({
+      lookup_keys: ["pro-monthly-plan-29-experiment", "pro-monthly-plan"],
+    });
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: "price_pro_29", quantity: 1 }],
+        integration_identifier: "hackerai_pricing_kqtmxvra",
+        metadata: expect.objectContaining({
+          requestedPlan: "pro-monthly-plan",
+          resolvedPriceLookupKey: "pro-monthly-plan-29-experiment",
+          pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+          pricingExperimentVariant: "test",
+          pricingExperimentPriceLookupKey: "pro-monthly-plan-29-experiment",
+        }),
+        subscription_data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            requestedPlan: "pro-monthly-plan",
+            resolvedPriceLookupKey: "pro-monthly-plan-29-experiment",
+            pricingExperimentVariant: "test",
+          }),
+        }),
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "checkout_started",
+      expect.objectContaining({
+        experiment_key: "hac46-pro-monthly-29-pricing",
+        experiment_variant: "test",
+        "$feature/hac46-pro-monthly-29-pricing": "test",
+        plan: "pro-monthly-plan-29-experiment",
+        stripe_price_lookup_key: "pro-monthly-plan-29-experiment",
+        displayed_amount_dollars: 29,
+        charged_amount_dollars: 29,
+        stripe_price_id: "price_pro_29",
+      }),
+    );
+  });
+
+  it("does not accept the experimental lookup key from the client", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({ data: [] } as never);
+    mockCreateOrganization.mockResolvedValue({ id: "org_new" } as never);
+    mockCreateCustomer.mockResolvedValue({
+      id: "cus_new",
+      metadata: {},
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({ plan: "pro-monthly-plan-29-experiment" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockListPrices).toHaveBeenCalledWith({
+      lookup_keys: ["pro-monthly-plan"],
+    });
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: "price_pro", quantity: 1 }],
+        metadata: expect.objectContaining({
+          requestedPlan: "pro-monthly-plan",
+          resolvedPriceLookupKey: "pro-monthly-plan",
+        }),
       }),
     );
   });

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -908,6 +908,17 @@ describe("POST /api/subscribe", () => {
     );
 
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      pricingExperiment: {
+        key: "hac46-pro-monthly-29-pricing",
+        variant: "test",
+        priceLookupKey: "pro-monthly-plan-29-experiment",
+        displayedAmountDollars: 29,
+        currency: "usd",
+        billingInterval: "month",
+        stripePriceId: "price_pro_29",
+      },
+    });
     expect(mockListPrices).toHaveBeenCalledWith({
       lookup_keys: ["pro-monthly-plan-29-experiment", "pro-monthly-plan"],
     });

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -27,6 +27,16 @@ import {
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
 import { checkoutStartedEventUuid } from "@/lib/analytics/paid-funnel-server";
+import {
+  PRO_MONTHLY_CONTROL_LOOKUP_KEY,
+  proMonthlyPricingExperimentMetadata,
+  proMonthlyPricingExperimentProperties,
+} from "@/lib/experiments/pro-monthly-pricing";
+import { evaluateProMonthlyPricingExperiment } from "@/lib/experiments/pro-monthly-pricing.server";
+
+function stripeProductId(product: Stripe.Price["product"]): string | undefined {
+  return typeof product === "string" ? product : product?.id;
+}
 
 function canManageOrganizationBilling(
   membership: Awaited<
@@ -52,16 +62,27 @@ function isReusableCheckoutSession(
   {
     organizationId,
     requestedPlan,
+    resolvedPriceLookupKey,
     quantity,
   }: {
     organizationId: string;
     requestedPlan: string;
+    resolvedPriceLookupKey: string;
     quantity: number;
   },
 ): boolean {
   if (!session.url) return false;
   if (session.metadata?.workOSOrganizationId !== organizationId) return false;
   if (session.metadata?.requestedPlan !== requestedPlan) return false;
+  const previousResolvedPriceLookupKey =
+    session.metadata?.resolvedPriceLookupKey;
+  if (
+    previousResolvedPriceLookupKey
+      ? previousResolvedPriceLookupKey !== resolvedPriceLookupKey
+      : resolvedPriceLookupKey !== requestedPlan
+  ) {
+    return false;
+  }
 
   const checkoutQuantity = session.metadata?.checkoutQuantity;
   return checkoutQuantity
@@ -177,11 +198,13 @@ async function findReusableCheckoutSession({
   customerId,
   organizationId,
   requestedPlan,
+  resolvedPriceLookupKey,
   quantity,
 }: {
   customerId: string;
   organizationId: string;
   requestedPlan: string;
+  resolvedPriceLookupKey: string;
   quantity: number;
 }): Promise<Stripe.Checkout.Session | undefined> {
   let startingAfter: string | undefined;
@@ -197,6 +220,7 @@ async function findReusableCheckoutSession({
       isReusableCheckoutSession(candidate, {
         organizationId,
         requestedPlan,
+        resolvedPriceLookupKey,
         quantity,
       }),
     );
@@ -320,6 +344,16 @@ export const POST = async (req: NextRequest) => {
             | "team-monthly-plan"
             | "team-yearly-plan")
         : "pro-monthly-plan";
+    const pricingExperiment = await evaluateProMonthlyPricingExperiment({
+      userId,
+      subscription,
+      requestedPlan: subscriptionLevel,
+    });
+    const resolvedPriceLookupKey =
+      pricingExperiment?.priceLookupKey ?? subscriptionLevel;
+    const pricingExperimentMetadata = pricingExperiment
+      ? proMonthlyPricingExperimentMetadata(pricingExperiment)
+      : {};
 
     // Quantity is only used for team plans, defaults to 1 for individual plans
     const quantity =
@@ -382,18 +416,23 @@ export const POST = async (req: NextRequest) => {
     }
 
     // Retrieve price ID from Stripe
-    // The Stripe look up key for the price *must* be the same as the subscription level string
+    // The client selects only a logical plan. The server-authoritative
+    // experiment assignment resolves that plan to an allowlisted Price lookup
+    // key, so a client can never submit an arbitrary Stripe Price.
     let price;
 
     try {
       price = await stripe.prices.list({
-        lookup_keys: [subscriptionLevel],
+        lookup_keys:
+          pricingExperiment?.variant === "test"
+            ? [resolvedPriceLookupKey, PRO_MONTHLY_CONTROL_LOOKUP_KEY]
+            : [resolvedPriceLookupKey],
       });
 
       // Check if price data exists and has at least one item
       if (!price.data || price.data.length === 0) {
         console.error(
-          `No price found for lookup key: ${subscriptionLevel}. This is likely because the products and prices have not been created yet. Run the setup script \`pnpm run setup\` to automatically create them.`,
+          `No price found for lookup key: ${resolvedPriceLookupKey}. This is likely because the products and prices have not been created yet.`,
         );
         return json(
           {
@@ -405,12 +444,53 @@ export const POST = async (req: NextRequest) => {
       }
     } catch (error) {
       console.error(
-        `Error retrieving price from Stripe for lookup key: ${subscriptionLevel}. This is likely because the products and prices have not been created yet. Run the setup script \`pnpm run setup\` to automatically create them.`,
+        `Error retrieving price from Stripe for lookup key: ${resolvedPriceLookupKey}.`,
         error,
       );
       return json(
         { error: "Error retrieving price from Stripe" },
         { status: 500 },
+      );
+    }
+
+    const selectedPrice =
+      price.data.find(
+        (candidate) => candidate.lookup_key === resolvedPriceLookupKey,
+      ) ?? price.data[0];
+    const controlPrice =
+      pricingExperiment?.variant === "test"
+        ? price.data.find(
+            (candidate) =>
+              candidate.lookup_key === PRO_MONTHLY_CONTROL_LOOKUP_KEY,
+          )
+        : undefined;
+    if (
+      pricingExperiment?.variant === "test" &&
+      (selectedPrice.lookup_key !== pricingExperiment.priceLookupKey ||
+        selectedPrice.active === false ||
+        selectedPrice.currency !== "usd" ||
+        selectedPrice.unit_amount !== 2_900 ||
+        selectedPrice.recurring?.interval !== "month" ||
+        selectedPrice.recurring.interval_count !== 1 ||
+        selectedPrice.type !== "recurring" ||
+        !controlPrice ||
+        stripeProductId(selectedPrice.product) !==
+          stripeProductId(controlPrice.product))
+    ) {
+      logger.error("Experimental Stripe Price is misconfigured", undefined, {
+        event: "billing.pricing_experiment_price_invalid",
+        request_id: requestId,
+        service: "hackerai-web",
+        environment: getEnvironment(),
+        route: "/api/subscribe",
+        experiment_key: pricingExperiment.key,
+        experiment_variant: pricingExperiment.variant,
+        stripe_price_id: selectedPrice.id,
+        stripe_price_lookup_key: selectedPrice.lookup_key,
+      });
+      return json(
+        { error: "Experimental subscription price is unavailable" },
+        { status: 503 },
       );
     }
 
@@ -523,6 +603,7 @@ export const POST = async (req: NextRequest) => {
       customerId: customer.id,
       organizationId: organization.id,
       requestedPlan: subscriptionLevel,
+      resolvedPriceLookupKey,
       quantity,
     });
     const reusedCheckoutSession = Boolean(session);
@@ -533,7 +614,7 @@ export const POST = async (req: NextRequest) => {
         billing_address_collection: "auto",
         line_items: [
           {
-            price: price.data[0].id,
+            price: selectedPrice.id,
             quantity: quantity,
           },
         ],
@@ -544,6 +625,8 @@ export const POST = async (req: NextRequest) => {
           userId,
           workOSOrganizationId: organization.id,
           requestedPlan: subscriptionLevel,
+          resolvedPriceLookupKey,
+          ...pricingExperimentMetadata,
           checkoutQuantity: String(quantity),
           checkoutAttemptId,
           ...(checkoutSource && { checkoutSource }),
@@ -557,6 +640,8 @@ export const POST = async (req: NextRequest) => {
             userId,
             workOSOrganizationId: organization.id,
             requestedPlan: subscriptionLevel,
+            resolvedPriceLookupKey,
+            ...pricingExperimentMetadata,
             checkoutQuantity: String(quantity),
             checkoutAttemptId,
             ...(checkoutSource && { checkoutSource }),
@@ -572,6 +657,7 @@ export const POST = async (req: NextRequest) => {
               "Renews monthly until cancelled. Cancel anytime in Settings.",
           },
         },
+        integration_identifier: "hackerai_pricing_kqtmxvra",
       });
     } else {
       const previousCheckoutAttemptId = session.metadata?.checkoutAttemptId;
@@ -581,6 +667,8 @@ export const POST = async (req: NextRequest) => {
           userId,
           workOSOrganizationId: organization.id,
           requestedPlan: subscriptionLevel,
+          resolvedPriceLookupKey,
+          ...pricingExperimentMetadata,
           checkoutQuantity: String(quantity),
           checkoutAttemptId,
           ...(checkoutSource && { checkoutSource }),
@@ -655,7 +743,6 @@ export const POST = async (req: NextRequest) => {
       }
     }
 
-    const selectedPrice = price.data[0];
     phLogger.event(
       PAID_FUNNEL_EVENTS.checkoutStarted,
       paidFunnelProperties({
@@ -666,7 +753,9 @@ export const POST = async (req: NextRequest) => {
         checkout_type: "new_subscription",
         from_tier: fromTier,
         to_tier: planLookupKeyToTier(subscriptionLevel),
-        plan: subscriptionLevel,
+        plan: resolvedPriceLookupKey,
+        requested_plan: subscriptionLevel,
+        stripe_price_lookup_key: resolvedPriceLookupKey,
         billing_interval: selectedPrice.recurring?.interval,
         billing_interval_count: selectedPrice.recurring?.interval_count,
         quantity,
@@ -675,6 +764,10 @@ export const POST = async (req: NextRequest) => {
         reason: checkoutReason,
         limit_type: checkoutLimitType,
         checkout_amount_dollars:
+          selectedPrice.unit_amount != null
+            ? (selectedPrice.unit_amount * quantity) / 100
+            : undefined,
+        charged_amount_dollars:
           selectedPrice.unit_amount != null
             ? (selectedPrice.unit_amount * quantity) / 100
             : undefined,
@@ -688,11 +781,16 @@ export const POST = async (req: NextRequest) => {
         $set: {
           last_checkout_started_at: new Date().toISOString(),
         },
+        ...proMonthlyPricingExperimentProperties(pricingExperiment),
       }),
     );
     after(() => phLogger.flush());
 
-    return json({ url: session.url, checkoutAttemptId });
+    return json({
+      url: session.url,
+      checkoutAttemptId,
+      ...(pricingExperiment && { pricingExperiment }),
+    });
   } catch (error: unknown) {
     if (error instanceof ChatSDKError) {
       return json(

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -789,7 +789,12 @@ export const POST = async (req: NextRequest) => {
     return json({
       url: session.url,
       checkoutAttemptId,
-      ...(pricingExperiment && { pricingExperiment }),
+      ...(pricingExperiment && {
+        pricingExperiment: {
+          ...pricingExperiment,
+          stripePriceId: selectedPrice.id,
+        },
+      }),
     });
   } catch (error: unknown) {
     if (error instanceof ChatSDKError) {

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -29,8 +29,10 @@ import {
 import { checkoutStartedEventUuid } from "@/lib/analytics/paid-funnel-server";
 import {
   PRO_MONTHLY_CONTROL_LOOKUP_KEY,
+  PRO_MONTHLY_PRICING_METADATA,
   proMonthlyPricingExperimentMetadata,
   proMonthlyPricingExperimentProperties,
+  type ProMonthlyPricingExperimentAssignment,
 } from "@/lib/experiments/pro-monthly-pricing";
 import { evaluateProMonthlyPricingExperiment } from "@/lib/experiments/pro-monthly-pricing.server";
 
@@ -63,11 +65,13 @@ function isReusableCheckoutSession(
     organizationId,
     requestedPlan,
     resolvedPriceLookupKey,
+    pricingExperiment,
     quantity,
   }: {
     organizationId: string;
     requestedPlan: string;
     resolvedPriceLookupKey: string;
+    pricingExperiment: ProMonthlyPricingExperimentAssignment | undefined;
     quantity: number;
   },
 ): boolean {
@@ -80,6 +84,16 @@ function isReusableCheckoutSession(
     previousResolvedPriceLookupKey
       ? previousResolvedPriceLookupKey !== resolvedPriceLookupKey
       : resolvedPriceLookupKey !== requestedPlan
+  ) {
+    return false;
+  }
+  if (
+    session.metadata?.[PRO_MONTHLY_PRICING_METADATA.experimentKey] !==
+      pricingExperiment?.key ||
+    session.metadata?.[PRO_MONTHLY_PRICING_METADATA.experimentVariant] !==
+      pricingExperiment?.variant ||
+    session.metadata?.[PRO_MONTHLY_PRICING_METADATA.priceLookupKey] !==
+      pricingExperiment?.priceLookupKey
   ) {
     return false;
   }
@@ -199,12 +213,14 @@ async function findReusableCheckoutSession({
   organizationId,
   requestedPlan,
   resolvedPriceLookupKey,
+  pricingExperiment,
   quantity,
 }: {
   customerId: string;
   organizationId: string;
   requestedPlan: string;
   resolvedPriceLookupKey: string;
+  pricingExperiment: ProMonthlyPricingExperimentAssignment | undefined;
   quantity: number;
 }): Promise<Stripe.Checkout.Session | undefined> {
   let startingAfter: string | undefined;
@@ -221,6 +237,7 @@ async function findReusableCheckoutSession({
         organizationId,
         requestedPlan,
         resolvedPriceLookupKey,
+        pricingExperiment,
         quantity,
       }),
     );
@@ -604,6 +621,7 @@ export const POST = async (req: NextRequest) => {
       organizationId: organization.id,
       requestedPlan: subscriptionLevel,
       resolvedPriceLookupKey,
+      pricingExperiment,
       quantity,
     });
     const reusedCheckoutSession = Boolean(session);

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -20,6 +20,7 @@ const mockUpdateSubscription = jest.fn();
 const mockListSubscriptions = jest.fn();
 const mockRetrieveInvoice = jest.fn();
 const mockRetrievePaymentIntent = jest.fn();
+const mockRetrieveCharge = jest.fn();
 const mockListMemberships = jest.fn();
 const mockConvexMutation = jest.fn();
 const mockFreezeRateLimitBucketForDelinquency = jest.fn();
@@ -62,6 +63,9 @@ jest.mock("@/app/api/stripe", () => ({
     },
     paymentIntents: {
       retrieve: mockRetrievePaymentIntent,
+    },
+    charges: {
+      retrieve: mockRetrieveCharge,
     },
   },
 }));
@@ -425,6 +429,170 @@ describe("POST /api/subscription/webhook", () => {
     expect(body).toEqual({ received: true });
     expect(mockConvexMutation).not.toHaveBeenCalled();
     expect(mockPostHogEvent).not.toHaveBeenCalled();
+  });
+
+  it("carries the HAC-46 assignment into checkout success analytics", async () => {
+    const experimentMetadata = {
+      pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+      pricingExperimentVariant: "test",
+      pricingExperimentPriceLookupKey: "pro-monthly-plan-29-experiment",
+    };
+    mockConstructEvent.mockReturnValue({
+      id: "evt_checkout_hac46",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_hac46",
+          mode: "subscription",
+          payment_status: "paid",
+          amount_total: 2900,
+          currency: "usd",
+          customer: "cus_hac46",
+          subscription: "sub_hac46",
+          metadata: {
+            userId: "user_hac46",
+            workOSOrganizationId: "org_hac46",
+            requestedPlan: "pro-monthly-plan",
+            checkoutAttemptId: "ca_hac46_123",
+            checkoutType: "new_subscription",
+            ...experimentMetadata,
+          },
+        },
+      },
+    });
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_hac46",
+      metadata: experimentMetadata,
+      items: {
+        data: [
+          {
+            quantity: 1,
+            price: {
+              id: "price_pro_29",
+              lookup_key: "pro-monthly-plan-29-experiment",
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_pro",
+                name: "HackerAI Pro",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "checkout_succeeded",
+      expect.objectContaining({
+        userId: "user_hac46",
+        experiment_key: "hac46-pro-monthly-29-pricing",
+        experiment_variant: "test",
+        "$feature/hac46-pro-monthly-29-pricing": "test",
+        plan: "pro-monthly-plan-29-experiment",
+        requested_plan: "pro-monthly-plan",
+        stripe_price_lookup_key: "pro-monthly-plan-29-experiment",
+        displayed_amount_dollars: 29,
+        charged_amount_dollars: 29,
+        stripe_price_id: "price_pro_29",
+      }),
+    );
+  });
+
+  it("records HAC-46 subscription refunds as negative contribution", async () => {
+    const experimentMetadata = {
+      pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+      pricingExperimentVariant: "test",
+      pricingExperimentPriceLookupKey: "pro-monthly-plan-29-experiment",
+    };
+    mockConstructEvent.mockReturnValue({
+      id: "evt_refund_hac46",
+      type: "refund.created",
+      data: {
+        object: {
+          id: "re_hac46",
+          status: "succeeded",
+          amount: 2900,
+          currency: "usd",
+          created: 1_788_000_000,
+          charge: "ch_hac46",
+          payment_intent: "pi_hac46",
+        },
+      },
+    });
+    mockRetrieveCharge.mockResolvedValue({
+      id: "ch_hac46",
+      customer: "cus_hac46",
+      invoice: "in_hac46",
+    } as never);
+    mockRetrieveInvoice.mockResolvedValue({
+      id: "in_hac46",
+      customer: "cus_hac46",
+      parent: {
+        subscription_details: { subscription: "sub_hac46" },
+      },
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_hac46",
+      deleted: false,
+      metadata: { workOSOrganizationId: "org_hac46" },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest.fn().mockResolvedValue([{ userId: "user_hac46" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_hac46",
+      metadata: experimentMetadata,
+      items: {
+        data: [
+          {
+            quantity: 1,
+            price: {
+              id: "price_pro_29",
+              lookup_key: "pro-monthly-plan-29-experiment",
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_pro",
+                name: "HackerAI Pro",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.objectContaining({
+        entityType: "user",
+        entityId: "user_hac46",
+        grossRevenueDollars: -29,
+        netRevenueDollars: -29,
+        stripePriceId: "price_pro_29",
+        plan: "pro-monthly-plan-29-experiment",
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "subscription_refunded",
+      expect.objectContaining({
+        userId: "user_hac46",
+        experiment_key: "hac46-pro-monthly-29-pricing",
+        experiment_variant: "test",
+        refund_amount_dollars: 29,
+        charged_amount_dollars: -29,
+        stripe_refund_id: "re_hac46",
+        stripe_price_lookup_key: "pro-monthly-plan-29-experiment",
+      }),
+    );
   });
 
   it("skips legacy PentestGPT invoices before resolving the old product as a HackerAI tier", async () => {

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -21,6 +21,7 @@ const mockListSubscriptions = jest.fn();
 const mockRetrieveInvoice = jest.fn();
 const mockRetrievePaymentIntent = jest.fn();
 const mockRetrieveCharge = jest.fn();
+const mockRetrievePrice = jest.fn();
 const mockListMemberships = jest.fn();
 const mockConvexMutation = jest.fn();
 const mockFreezeRateLimitBucketForDelinquency = jest.fn();
@@ -66,6 +67,9 @@ jest.mock("@/app/api/stripe", () => ({
     },
     charges: {
       retrieve: mockRetrieveCharge,
+    },
+    prices: {
+      retrieve: mockRetrievePrice,
     },
   },
 }));
@@ -535,6 +539,24 @@ describe("POST /api/subscription/webhook", () => {
       parent: {
         subscription_details: { subscription: "sub_hac46" },
       },
+      lines: {
+        data: [
+          {
+            amount: 2900,
+            subscription: "sub_hac46",
+            parent: {
+              type: "subscription_item_details",
+              subscription_item_details: {
+                subscription: "sub_hac46",
+                proration: false,
+              },
+            },
+            pricing: {
+              price_details: { price: "price_pro_29" },
+            },
+          },
+        ],
+      },
     } as never);
     mockRetrieveCustomer.mockResolvedValue({
       id: "cus_hac46",
@@ -552,12 +574,12 @@ describe("POST /api/subscription/webhook", () => {
           {
             quantity: 1,
             price: {
-              id: "price_pro_29",
-              lookup_key: "pro-monthly-plan-29-experiment",
+              id: "price_pro_plus_60",
+              lookup_key: "pro-plus-monthly-plan",
               recurring: { interval: "month", interval_count: 1 },
               product: {
-                id: "prod_pro",
-                name: "HackerAI Pro",
+                id: "prod_pro_plus",
+                name: "HackerAI Pro+",
                 metadata: {},
               },
             },
@@ -565,11 +587,18 @@ describe("POST /api/subscription/webhook", () => {
         ],
       },
     } as never);
+    mockRetrievePrice.mockResolvedValue({
+      id: "price_pro_29",
+      lookup_key: "pro-monthly-plan-29-experiment",
+      recurring: { interval: "month", interval_count: 1 },
+      product: "prod_pro",
+    } as never);
 
     const { POST } = await import("../route");
     const response = await POST(makeWebhookRequest());
 
     expect(response.status).toBe(200);
+    expect(mockRetrievePrice).toHaveBeenCalledWith("price_pro_29");
     expect(mockConvexMutation).toHaveBeenCalledWith(
       "unitEconomics.recordRevenueEvent",
       expect.objectContaining({
@@ -585,6 +614,7 @@ describe("POST /api/subscription/webhook", () => {
       "subscription_refunded",
       expect.objectContaining({
         userId: "user_hac46",
+        subscription_tier: "pro",
         experiment_key: "hac46-pro-monthly-29-pricing",
         experiment_variant: "test",
         refund_amount_dollars: 29,

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -566,7 +566,7 @@ describe("POST /api/subscription/webhook", () => {
         has_more: true,
         data: [
           {
-            amount: 500,
+            amount: 0,
             subscription: null,
             parent: {
               type: "invoice_item_details",
@@ -585,7 +585,7 @@ describe("POST /api/subscription/webhook", () => {
     mockListInvoiceLineItems.mockReturnValue({
       async *[Symbol.asyncIterator]() {
         yield {
-          amount: 500,
+          amount: 0,
           subscription: null,
           parent: {
             type: "invoice_item_details",
@@ -684,6 +684,133 @@ describe("POST /api/subscription/webhook", () => {
     );
   });
 
+  it("ignores refunds whose status is null", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_refund_null_status",
+      type: "refund.updated",
+      data: {
+        object: {
+          id: "re_null_status",
+          status: null,
+          amount: 2900,
+          currency: "usd",
+          charge: "ch_null_status",
+        },
+      },
+    });
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockRetrieveCharge).not.toHaveBeenCalled();
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.anything(),
+    );
+    expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+      "subscription_refunded",
+      expect.anything(),
+    );
+  });
+
+  it("skips a partial refund on a mixed subscription and add-on invoice", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_refund_mixed_invoice",
+      type: "refund.created",
+      data: {
+        object: {
+          id: "re_mixed_invoice",
+          status: "succeeded",
+          amount: 500,
+          currency: "usd",
+          charge: "ch_mixed_invoice",
+        },
+      },
+    });
+    mockRetrieveCharge.mockResolvedValue({
+      id: "ch_mixed_invoice",
+      customer: "cus_mixed_invoice",
+      invoice: "in_mixed_invoice",
+    } as never);
+    mockRetrieveInvoice.mockResolvedValue({
+      id: "in_mixed_invoice",
+      customer: "cus_mixed_invoice",
+      parent: {
+        subscription_details: { subscription: "sub_mixed_invoice" },
+      },
+      lines: {
+        data: [
+          subscriptionInvoiceLine("sub_mixed_invoice", "price_pro_29", 2900),
+          {
+            amount: 500,
+            subscription: null,
+            parent: {
+              type: "invoice_item_details",
+              invoice_item_details: {
+                subscription: null,
+                proration: false,
+              },
+            },
+            pricing: {
+              price_details: { price: "price_addon" },
+            },
+          },
+        ],
+      },
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_mixed_invoice",
+      deleted: false,
+      metadata: { workOSOrganizationId: "org_mixed_invoice" },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest
+        .fn()
+        .mockResolvedValue([{ userId: "user_mixed_invoice" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_mixed_invoice",
+      metadata: {},
+      items: {
+        data: [
+          {
+            price: {
+              id: "price_pro_29",
+              lookup_key: "pro-monthly-plan-29-experiment",
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockRetrievePrice).not.toHaveBeenCalled();
+    expect(mockPostHogWarn).toHaveBeenCalledWith(
+      "subscription_refund_attribution_unavailable",
+      expect.objectContaining({
+        stripe_refund_id: "re_mixed_invoice",
+        stripe_invoice_id: "in_mixed_invoice",
+        stripe_subscription_id: "sub_mixed_invoice",
+        refund_amount_dollars: 5,
+        billable_line_count: 2,
+        target_subscription_line_count: 1,
+        requires_manual_reconciliation: true,
+      }),
+    );
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.anything(),
+    );
+    expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+      "subscription_refunded",
+      expect.anything(),
+    );
+  });
+
   it("retries HAC-46 refunds when the historical invoice Price is unavailable", async () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_refund_hac46_retry",
@@ -772,7 +899,7 @@ describe("POST /api/subscription/webhook", () => {
     ).toHaveLength(1);
   });
 
-  it("retries refunds when the invoice has no line for the refunded subscription", async () => {
+  it("skips refunds without a line for the refunded subscription", async () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_refund_missing_subscription_line",
       type: "refund.created",
@@ -845,10 +972,21 @@ describe("POST /api/subscription/webhook", () => {
 
     const { POST } = await import("../route");
 
-    await expect(POST(makeWebhookRequest())).rejects.toThrow(
-      "Historical subscription Price missing from refund invoice",
-    );
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
     expect(mockRetrievePrice).not.toHaveBeenCalled();
+    expect(mockPostHogWarn).toHaveBeenCalledWith(
+      "subscription_refund_attribution_unavailable",
+      expect.objectContaining({
+        stripe_refund_id: "re_missing_subscription_line",
+        stripe_invoice_id: "in_missing_subscription_line",
+        stripe_subscription_id: "sub_missing_subscription_line",
+        billable_line_count: 1,
+        target_subscription_line_count: 0,
+        requires_manual_reconciliation: true,
+      }),
+    );
     expect(mockConvexMutation).not.toHaveBeenCalledWith(
       "unitEconomics.recordRevenueEvent",
       expect.anything(),

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -542,6 +542,20 @@ describe("POST /api/subscription/webhook", () => {
       lines: {
         data: [
           {
+            amount: 500,
+            subscription: null,
+            parent: {
+              type: "invoice_item_details",
+              invoice_item_details: {
+                subscription: null,
+                proration: false,
+              },
+            },
+            pricing: {
+              price_details: { price: "price_unrelated_addon" },
+            },
+          },
+          {
             amount: 2900,
             subscription: "sub_hac46",
             parent: {
@@ -623,6 +637,94 @@ describe("POST /api/subscription/webhook", () => {
         stripe_price_lookup_key: "pro-monthly-plan-29-experiment",
       }),
     );
+  });
+
+  it("retries HAC-46 refunds when the historical invoice Price is unavailable", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_refund_hac46_retry",
+      type: "refund.created",
+      data: {
+        object: {
+          id: "re_hac46_retry",
+          status: "succeeded",
+          amount: 2900,
+          currency: "usd",
+          charge: "ch_hac46_retry",
+        },
+      },
+    });
+    mockRetrieveCharge.mockResolvedValue({
+      id: "ch_hac46_retry",
+      customer: "cus_hac46_retry",
+      invoice: "in_hac46_retry",
+    } as never);
+    mockRetrieveInvoice.mockResolvedValue({
+      id: "in_hac46_retry",
+      customer: "cus_hac46_retry",
+      parent: {
+        subscription_details: { subscription: "sub_hac46_retry" },
+      },
+      lines: {
+        data: [
+          {
+            amount: 2900,
+            subscription: "sub_hac46_retry",
+            parent: {
+              type: "subscription_item_details",
+              subscription_item_details: {
+                subscription: "sub_hac46_retry",
+                proration: false,
+              },
+            },
+            pricing: {
+              price_details: { price: "price_pro_29" },
+            },
+          },
+        ],
+      },
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_hac46_retry",
+      deleted: false,
+      metadata: { workOSOrganizationId: "org_hac46_retry" },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest.fn().mockResolvedValue([{ userId: "user_retry" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_hac46_retry",
+      metadata: {},
+      items: {
+        data: [
+          {
+            price: {
+              id: "price_pro_plus_60",
+              lookup_key: "pro-plus-monthly-plan",
+            },
+          },
+        ],
+      },
+    } as never);
+    mockRetrievePrice.mockRejectedValue(new Error("Stripe unavailable"));
+
+    const { POST } = await import("../route");
+
+    await expect(POST(makeWebhookRequest())).rejects.toThrow(
+      "Stripe unavailable",
+    );
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.anything(),
+    );
+    expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+      "subscription_refunded",
+      expect.anything(),
+    );
+    expect(
+      mockConvexMutation.mock.calls.filter(
+        ([mutation]) => mutation === "extraUsage.checkAndMarkWebhook",
+      ),
+    ).toHaveLength(1);
   });
 
   it("skips legacy PentestGPT invoices before resolving the old product as a HackerAI tier", async () => {

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -19,6 +19,7 @@ const mockRetrieveSubscription = jest.fn();
 const mockUpdateSubscription = jest.fn();
 const mockListSubscriptions = jest.fn();
 const mockRetrieveInvoice = jest.fn();
+const mockListInvoiceLineItems = jest.fn();
 const mockRetrievePaymentIntent = jest.fn();
 const mockRetrieveCharge = jest.fn();
 const mockRetrievePrice = jest.fn();
@@ -61,6 +62,7 @@ jest.mock("@/app/api/stripe", () => ({
     },
     invoices: {
       retrieve: mockRetrieveInvoice,
+      listLineItems: mockListInvoiceLineItems,
     },
     paymentIntents: {
       retrieve: mockRetrievePaymentIntent,
@@ -540,6 +542,7 @@ describe("POST /api/subscription/webhook", () => {
         subscription_details: { subscription: "sub_hac46" },
       },
       lines: {
+        has_more: true,
         data: [
           {
             amount: 500,
@@ -555,21 +558,39 @@ describe("POST /api/subscription/webhook", () => {
               price_details: { price: "price_unrelated_addon" },
             },
           },
-          {
-            amount: 2900,
-            subscription: "sub_hac46",
-            parent: {
-              type: "subscription_item_details",
-              subscription_item_details: {
-                subscription: "sub_hac46",
-                proration: false,
-              },
-            },
-            pricing: {
-              price_details: { price: "price_pro_29" },
+        ],
+      },
+    } as never);
+    mockListInvoiceLineItems.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          amount: 500,
+          subscription: null,
+          parent: {
+            type: "invoice_item_details",
+            invoice_item_details: {
+              subscription: null,
+              proration: false,
             },
           },
-        ],
+          pricing: {
+            price_details: { price: "price_unrelated_addon" },
+          },
+        };
+        yield {
+          amount: 2900,
+          subscription: "sub_hac46",
+          parent: {
+            type: "subscription_item_details",
+            subscription_item_details: {
+              subscription: "sub_hac46",
+              proration: false,
+            },
+          },
+          pricing: {
+            price_details: { price: "price_pro_29" },
+          },
+        };
       },
     } as never);
     mockRetrieveCustomer.mockResolvedValue({
@@ -612,6 +633,9 @@ describe("POST /api/subscription/webhook", () => {
     const response = await POST(makeWebhookRequest());
 
     expect(response.status).toBe(200);
+    expect(mockListInvoiceLineItems).toHaveBeenCalledWith("in_hac46", {
+      limit: 100,
+    });
     expect(mockRetrievePrice).toHaveBeenCalledWith("price_pro_29");
     expect(mockConvexMutation).toHaveBeenCalledWith(
       "unitEconomics.recordRevenueEvent",
@@ -725,6 +749,93 @@ describe("POST /api/subscription/webhook", () => {
         ([mutation]) => mutation === "extraUsage.checkAndMarkWebhook",
       ),
     ).toHaveLength(1);
+  });
+
+  it("retries refunds when the invoice has no line for the refunded subscription", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_refund_missing_subscription_line",
+      type: "refund.created",
+      data: {
+        object: {
+          id: "re_missing_subscription_line",
+          status: "succeeded",
+          amount: 2900,
+          currency: "usd",
+          charge: "ch_missing_subscription_line",
+        },
+      },
+    });
+    mockRetrieveCharge.mockResolvedValue({
+      id: "ch_missing_subscription_line",
+      customer: "cus_missing_subscription_line",
+      invoice: "in_missing_subscription_line",
+    } as never);
+    mockRetrieveInvoice.mockResolvedValue({
+      id: "in_missing_subscription_line",
+      customer: "cus_missing_subscription_line",
+      parent: {
+        subscription_details: {
+          subscription: "sub_missing_subscription_line",
+        },
+      },
+      lines: {
+        data: [
+          {
+            amount: 2900,
+            subscription: "sub_different",
+            parent: {
+              type: "subscription_item_details",
+              subscription_item_details: {
+                subscription: "sub_different",
+                proration: false,
+              },
+            },
+            pricing: {
+              price_details: { price: "price_different" },
+            },
+          },
+        ],
+      },
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_missing_subscription_line",
+      deleted: false,
+      metadata: { workOSOrganizationId: "org_missing_subscription_line" },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest
+        .fn()
+        .mockResolvedValue([{ userId: "user_missing_subscription_line" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_missing_subscription_line",
+      metadata: {},
+      items: {
+        data: [
+          {
+            price: {
+              id: "price_current",
+              lookup_key: "pro-monthly-plan",
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+
+    await expect(POST(makeWebhookRequest())).rejects.toThrow(
+      "Historical subscription Price missing from refund invoice",
+    );
+    expect(mockRetrievePrice).not.toHaveBeenCalled();
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.anything(),
+    );
+    expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+      "subscription_refunded",
+      expect.anything(),
+    );
   });
 
   it("skips legacy PentestGPT invoices before resolving the old product as a HackerAI tier", async () => {

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -195,6 +195,27 @@ function hydratedPaymentIntent() {
   };
 }
 
+function subscriptionInvoiceLine(
+  subscriptionId: string,
+  priceId: string,
+  amount: number,
+) {
+  return {
+    amount,
+    subscription: subscriptionId,
+    parent: {
+      type: "subscription_item_details",
+      subscription_item_details: {
+        subscription: subscriptionId,
+        proration: false,
+      },
+    },
+    pricing: {
+      price_details: { price: priceId },
+    },
+  };
+}
+
 function mockInvoicePaymentFailedAnalytics({
   invoicePaymentIntent = expandedInvoicePaymentIntent(),
   paymentIntent = hydratedPaymentIntent(),
@@ -1003,6 +1024,11 @@ describe("POST /api/subscription/webhook", () => {
                 subscription: "sub_terminal",
               },
             },
+            lines: {
+              data: [
+                subscriptionInvoiceLine("sub_terminal", "price_pro", 2500),
+              ],
+            },
             status_transitions: {
               paid_at: 1_784_456_277,
             },
@@ -1122,6 +1148,11 @@ describe("POST /api/subscription/webhook", () => {
               subscription: "sub_old_invoice",
             },
           },
+          lines: {
+            data: [
+              subscriptionInvoiceLine("sub_old_invoice", "price_pro", 2500),
+            ],
+          },
           status_transitions: {
             paid_at: 1_784_456_277,
           },
@@ -1221,6 +1252,15 @@ describe("POST /api/subscription/webhook", () => {
             subscription_details: {
               subscription: "sub_pro_20",
             },
+          },
+          lines: {
+            data: [
+              subscriptionInvoiceLine(
+                "sub_pro_20",
+                HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+                2000,
+              ),
+            ],
           },
           status_transitions: {
             paid_at: 1_782_000_000,
@@ -1353,6 +1393,9 @@ describe("POST /api/subscription/webhook", () => {
           parent: {
             subscription_details: { subscription: "sub_team" },
           },
+          lines: {
+            data: [subscriptionInvoiceLine("sub_team", "price_team", 3000)],
+          },
           status_transitions: { paid_at: 1_782_000_000 },
         },
       },
@@ -1412,6 +1455,113 @@ describe("POST /api/subscription/webhook", () => {
     }
   });
 
+  it("attributes a paid invoice to its historical Price after the subscription Price changes", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_paid_historical_price",
+      type: "invoice.paid",
+      data: {
+        object: {
+          id: "in_historical_price",
+          customer: "cus_historical_price",
+          amount_paid: 2900,
+          currency: "usd",
+          billing_reason: "subscription_create",
+          parent: {
+            subscription_details: {
+              subscription: "sub_historical_price",
+            },
+          },
+          lines: {
+            data: [
+              subscriptionInvoiceLine(
+                "sub_historical_price",
+                "price_pro_29",
+                2900,
+              ),
+            ],
+          },
+          status_transitions: { paid_at: 1_782_000_000 },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_historical_price",
+      metadata: { workOSOrganizationId: "org_historical_price" },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest
+        .fn()
+        .mockResolvedValue([{ userId: "user_historical_price" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_historical_price",
+      status: "active",
+      latest_invoice: "in_historical_price",
+      metadata: {
+        pricingExperimentKey: "hac46-pro-monthly-29-pricing",
+        pricingExperimentVariant: "test",
+        pricingExperimentPriceLookupKey: "pro-monthly-plan-29-experiment",
+      },
+      items: {
+        data: [
+          {
+            quantity: 1,
+            current_period_end: 1_785_000_000,
+            price: {
+              id: "price_pro_plus_60",
+              lookup_key: "pro-plus-monthly-plan",
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_pro_plus",
+                name: "HackerAI Pro Plus",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+    mockRetrievePrice.mockResolvedValue({
+      id: "price_pro_29",
+      lookup_key: "pro-monthly-plan-29-experiment",
+      unit_amount: 2900,
+      recurring: { interval: "month", interval_count: 1 },
+      product: "prod_pro",
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockRetrievePrice).toHaveBeenCalledWith("price_pro_29");
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.objectContaining({
+        stripePriceId: "price_pro_29",
+        plan: "pro-monthly-plan-29-experiment",
+      }),
+    );
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "unitEconomics.recordPaidStartEvent",
+      expect.objectContaining({
+        stripePriceId: "price_pro_29",
+        plan: "pro-monthly-plan-29-experiment",
+      }),
+    );
+    for (const eventName of ["invoice_paid", "subscription_started"]) {
+      expect(mockPostHogEvent).toHaveBeenCalledWith(
+        eventName,
+        expect.objectContaining({
+          stripe_price_id: "price_pro_29",
+          stripe_price_lookup_key: "pro-monthly-plan-29-experiment",
+          experiment_key: "hac46-pro-monthly-29-pricing",
+          experiment_variant: "test",
+        }),
+      );
+    }
+  });
+
   it("emits recovery when invoice.paid arrives before the failure webhook", async () => {
     const periodEnd = 1_785_000_000;
     mockResetRateLimitBucketAfterPayment.mockResolvedValueOnce({
@@ -1431,6 +1581,15 @@ describe("POST /api/subscription/webhook", () => {
           attempt_count: 2,
           parent: {
             subscription_details: { subscription: "sub_reordered" },
+          },
+          lines: {
+            data: [
+              subscriptionInvoiceLine(
+                "sub_reordered",
+                HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+                2000,
+              ),
+            ],
           },
           status_transitions: { paid_at: 1_782_000_000 },
         },
@@ -1501,6 +1660,11 @@ describe("POST /api/subscription/webhook", () => {
           billing_reason: "subscription_update",
           parent: {
             subscription_details: { subscription: "sub_upgrade" },
+          },
+          lines: {
+            data: [
+              subscriptionInvoiceLine("sub_upgrade", "price_pro_plus", 1459),
+            ],
           },
           status_transitions: { paid_at: nowSeconds },
         },

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -96,6 +96,41 @@ function stripeEventOccurredAtMs(event: Stripe.Event): number {
     : Date.now();
 }
 
+/** Return the immutable Price ID recorded on a subscription invoice line. */
+function invoiceSubscriptionPriceId(
+  invoice: Stripe.Invoice,
+  subscriptionId: string,
+): string | undefined {
+  const lines = invoice.lines?.data ?? [];
+  const candidates = lines.filter((line) => {
+    const lineSubscriptionId =
+      stripeObjectId(line.subscription) ??
+      line.parent?.subscription_item_details?.subscription ??
+      line.parent?.invoice_item_details?.subscription ??
+      undefined;
+    return !lineSubscriptionId || lineSubscriptionId === subscriptionId;
+  });
+  const priceId = (line: Stripe.InvoiceLineItem) =>
+    stripeObjectId(line.pricing?.price_details?.price) ??
+    stripeObjectId(
+      (
+        line as Stripe.InvoiceLineItem & {
+          price?: string | Stripe.Price | null;
+        }
+      ).price,
+    );
+  const isProration = (line: Stripe.InvoiceLineItem) =>
+    line.parent?.subscription_item_details?.proration === true ||
+    line.parent?.invoice_item_details?.proration === true;
+
+  const recurringLine = candidates.find(
+    (line) => !isProration(line) && line.amount > 0 && priceId(line),
+  );
+  const selectedLine =
+    recurringLine ?? candidates.find((line) => priceId(line));
+  return selectedLine ? priceId(selectedLine) : undefined;
+}
+
 // =============================================================================
 // Tier Resolution
 // =============================================================================
@@ -1543,7 +1578,23 @@ async function handleSubscriptionRefund(
   const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
   if (userIds.length === 0) return;
 
-  const price = resolved.subscription.items?.data[0]?.price;
+  const currentPrice = resolved.subscription.items?.data[0]?.price;
+  const invoicePriceId = invoiceSubscriptionPriceId(invoice, subscriptionId);
+  let price = currentPrice;
+  if (invoicePriceId) {
+    try {
+      price = await stripe.prices.retrieve(invoicePriceId);
+    } catch (error) {
+      phLogger.warn("subscription_refund_invoice_price_retrieve_failed", {
+        stripe_invoice_id: invoiceId,
+        stripe_price_id: invoicePriceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  const refundedTier = price?.lookup_key
+    ? (planLookupKeyToTier(price.lookup_key) ?? resolved.tier)
+    : resolved.tier;
   const pricingExperiment = proMonthlyPricingAssignmentFromMetadata(
     resolved.subscription.metadata,
     price?.lookup_key,
@@ -1612,7 +1663,7 @@ async function handleSubscriptionRefund(
       paidFunnelProperties({
         userId,
         org_id: orgId,
-        subscription_tier: resolved.tier,
+        subscription_tier: refundedTier,
         plan: price?.lookup_key,
         stripe_price_lookup_key: price?.lookup_key,
         billing_interval: priceBillingInterval(price),

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -97,11 +97,19 @@ function stripeEventOccurredAtMs(event: Stripe.Event): number {
 }
 
 /** Return the immutable Price ID recorded on a subscription invoice line. */
-function invoiceSubscriptionPriceId(
+async function invoiceSubscriptionPriceId(
   invoice: Stripe.Invoice,
   subscriptionId: string,
-): string | undefined {
-  const lines = invoice.lines?.data ?? [];
+): Promise<string | undefined> {
+  let lines = invoice.lines?.data ?? [];
+  if (invoice.lines?.has_more) {
+    lines = [];
+    for await (const line of stripe.invoices.listLineItems(invoice.id, {
+      limit: 100,
+    })) {
+      lines.push(line);
+    }
+  }
   const candidates = lines.filter((line) => {
     const lineSubscriptionId =
       stripeObjectId(line.subscription) ??
@@ -1578,20 +1586,29 @@ async function handleSubscriptionRefund(
   const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
   if (userIds.length === 0) return;
 
-  const currentPrice = resolved.subscription.items?.data[0]?.price;
-  const invoicePriceId = invoiceSubscriptionPriceId(invoice, subscriptionId);
-  let price = currentPrice;
-  if (invoicePriceId) {
-    try {
-      price = await stripe.prices.retrieve(invoicePriceId);
-    } catch (error) {
-      phLogger.warn("subscription_refund_invoice_price_retrieve_failed", {
-        stripe_invoice_id: invoiceId,
-        stripe_price_id: invoicePriceId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
+  const invoicePriceId = await invoiceSubscriptionPriceId(
+    invoice,
+    subscriptionId,
+  );
+  if (!invoicePriceId) {
+    phLogger.warn("subscription_refund_invoice_price_missing", {
+      stripe_invoice_id: invoiceId,
+      stripe_subscription_id: subscriptionId,
+    });
+    throw new Error(
+      "Historical subscription Price missing from refund invoice",
+    );
+  }
+  let price: Stripe.Price;
+  try {
+    price = await stripe.prices.retrieve(invoicePriceId);
+  } catch (error) {
+    phLogger.warn("subscription_refund_invoice_price_retrieve_failed", {
+      stripe_invoice_id: invoiceId,
+      stripe_price_id: invoicePriceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
   }
   const refundedTier = price?.lookup_key
     ? (planLookupKeyToTier(price.lookup_key) ?? resolved.tier)
@@ -2235,7 +2252,8 @@ async function handleSubscriptionDeleted(
  * - Endpoint URL: https://your-domain.com/api/subscription/webhook
  * - Events: checkout.session.completed, invoice.paid,
  *   invoice.payment_failed, customer.subscription.updated,
- *   customer.subscription.deleted, payment_method.attached, customer.updated
+ *   customer.subscription.deleted, payment_method.attached, customer.updated,
+ *   refund.created, refund.updated
  */
 export async function POST(req: NextRequest) {
   const body = await req.text();

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -108,7 +108,7 @@ function invoiceSubscriptionPriceId(
       line.parent?.subscription_item_details?.subscription ??
       line.parent?.invoice_item_details?.subscription ??
       undefined;
-    return !lineSubscriptionId || lineSubscriptionId === subscriptionId;
+    return lineSubscriptionId === subscriptionId;
   });
   const priceId = (line: Stripe.InvoiceLineItem) =>
     stripeObjectId(line.pricing?.price_details?.price) ??
@@ -1590,6 +1590,7 @@ async function handleSubscriptionRefund(
         stripe_price_id: invoicePriceId,
         error: error instanceof Error ? error.message : String(error),
       });
+      throw error;
     }
   }
   const refundedTier = price?.lookup_key

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -96,11 +96,10 @@ function stripeEventOccurredAtMs(event: Stripe.Event): number {
     : Date.now();
 }
 
-/** Return the immutable Price ID recorded on a subscription invoice line. */
-async function invoiceSubscriptionPriceId(
+/** Return every invoice line, following Stripe pagination when necessary. */
+async function invoiceLineItems(
   invoice: Stripe.Invoice,
-  subscriptionId: string,
-): Promise<string | undefined> {
+): Promise<Stripe.InvoiceLineItem[]> {
   let lines = invoice.lines?.data ?? [];
   if (invoice.lines?.has_more) {
     lines = [];
@@ -110,15 +109,22 @@ async function invoiceSubscriptionPriceId(
       lines.push(line);
     }
   }
-  const candidates = lines.filter((line) => {
-    const lineSubscriptionId =
-      stripeObjectId(line.subscription) ??
-      line.parent?.subscription_item_details?.subscription ??
-      line.parent?.invoice_item_details?.subscription ??
-      undefined;
-    return lineSubscriptionId === subscriptionId;
-  });
-  const priceId = (line: Stripe.InvoiceLineItem) =>
+  return lines;
+}
+
+function invoiceLineSubscriptionId(
+  line: Stripe.InvoiceLineItem,
+): string | undefined {
+  return (
+    stripeObjectId(line.subscription) ??
+    line.parent?.subscription_item_details?.subscription ??
+    line.parent?.invoice_item_details?.subscription ??
+    undefined
+  );
+}
+
+function invoiceLinePriceId(line: Stripe.InvoiceLineItem): string | undefined {
+  return (
     stripeObjectId(line.pricing?.price_details?.price) ??
     stripeObjectId(
       (
@@ -126,17 +132,73 @@ async function invoiceSubscriptionPriceId(
           price?: string | Stripe.Price | null;
         }
       ).price,
-    );
-  const isProration = (line: Stripe.InvoiceLineItem) =>
+    ) ??
+    undefined
+  );
+}
+
+function invoiceLineIsProration(line: Stripe.InvoiceLineItem): boolean {
+  return (
     line.parent?.subscription_item_details?.proration === true ||
-    line.parent?.invoice_item_details?.proration === true;
+    line.parent?.invoice_item_details?.proration === true
+  );
+}
+
+/** Return the immutable Price ID recorded on a subscription invoice line. */
+async function invoiceSubscriptionPriceId(
+  invoice: Stripe.Invoice,
+  subscriptionId: string,
+): Promise<string | undefined> {
+  const lines = await invoiceLineItems(invoice);
+  const candidates = lines.filter(
+    (line) => invoiceLineSubscriptionId(line) === subscriptionId,
+  );
 
   const recurringLine = candidates.find(
-    (line) => !isProration(line) && line.amount > 0 && priceId(line),
+    (line) =>
+      !invoiceLineIsProration(line) &&
+      line.amount > 0 &&
+      invoiceLinePriceId(line),
   );
   const selectedLine =
-    recurringLine ?? candidates.find((line) => priceId(line));
-  return selectedLine ? priceId(selectedLine) : undefined;
+    recurringLine ?? candidates.find((line) => invoiceLinePriceId(line));
+  return selectedLine ? invoiceLinePriceId(selectedLine) : undefined;
+}
+
+/**
+ * Attribute a refund only when every positive priced line belongs to the same
+ * subscription and Price. Mixed invoices need explicit line-level evidence
+ * from an operator workflow before they can safely affect subscription revenue.
+ */
+async function subscriptionRefundPriceId(
+  invoice: Stripe.Invoice,
+  subscriptionId: string,
+): Promise<{
+  priceId?: string;
+  billableLineCount: number;
+  targetLineCount: number;
+}> {
+  const billableLines = (await invoiceLineItems(invoice)).filter(
+    (line) => line.amount > 0 && invoiceLinePriceId(line),
+  );
+  const targetLines = billableLines.filter(
+    (line) => invoiceLineSubscriptionId(line) === subscriptionId,
+  );
+  const targetPriceIds = new Set(
+    targetLines
+      .map((line) => invoiceLinePriceId(line))
+      .filter((priceId): priceId is string => Boolean(priceId)),
+  );
+  const isUnambiguous =
+    billableLines.length > 0 &&
+    targetLines.length === billableLines.length &&
+    targetPriceIds.size === 1;
+
+  return {
+    priceId: isUnambiguous ? [...targetPriceIds][0] : undefined,
+    billableLineCount: billableLines.length,
+    targetLineCount: targetLines.length,
+  };
 }
 
 // =============================================================================
@@ -1595,7 +1657,7 @@ async function handleSubscriptionRefund(
   stripeEventId: string,
   stripeEventType: "refund.created" | "refund.updated",
 ): Promise<void> {
-  if (refund.status && refund.status !== "succeeded") return;
+  if (refund.status !== "succeeded") return;
 
   const chargeId = stripeObjectId(refund.charge);
   if (!chargeId || refund.amount <= 0) return;
@@ -1621,18 +1683,22 @@ async function handleSubscriptionRefund(
   const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
   if (userIds.length === 0) return;
 
-  const invoicePriceId = await invoiceSubscriptionPriceId(
+  const refundAttribution = await subscriptionRefundPriceId(
     invoice,
     subscriptionId,
   );
+  const invoicePriceId = refundAttribution.priceId;
   if (!invoicePriceId) {
-    phLogger.warn("subscription_refund_invoice_price_missing", {
+    phLogger.warn("subscription_refund_attribution_unavailable", {
+      stripe_refund_id: refund.id,
       stripe_invoice_id: invoiceId,
       stripe_subscription_id: subscriptionId,
+      refund_amount_dollars: centsToDollars(refund.amount),
+      billable_line_count: refundAttribution.billableLineCount,
+      target_subscription_line_count: refundAttribution.targetLineCount,
+      requires_manual_reconciliation: true,
     });
-    throw new Error(
-      "Historical subscription Price missing from refund invoice",
-    );
+    return;
   }
   let price: Stripe.Price;
   try {

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -574,6 +574,7 @@ async function setReferralCodesPaidEligibility(args: {
 
 async function recordSubscriptionRevenue({
   invoice,
+  invoicePrice,
   customerId,
   userIds,
   orgId,
@@ -582,6 +583,7 @@ async function recordSubscriptionRevenue({
   reason,
 }: {
   invoice: Stripe.Invoice;
+  invoicePrice: Stripe.Price;
   customerId: string;
   userIds: string[];
   orgId?: string;
@@ -596,14 +598,13 @@ async function recordSubscriptionRevenue({
   if (grossRevenueDollars <= 0 || userIds.length === 0) return;
 
   const item = subscription.items?.data[0];
-  const price = item?.price;
   const occurredAt = invoicePaidAtMs(invoice);
   const attributedRevenueDollars = grossRevenueDollars / userIds.length;
   const attributionStrategy = userIds.length > 1 ? "split_evenly" : "direct";
   const mrrDollars =
     reason === "subscription_create" || reason === "subscription_cycle"
       ? subscriptionMrrDollars({
-          price,
+          price: invoicePrice,
           quantity: item?.quantity ?? 1,
           fallbackTotalIntervalAmountDollars: grossRevenueDollars,
         })
@@ -630,8 +631,8 @@ async function recordSubscriptionRevenue({
         stripeCustomerId: customerId,
         stripeSubscriptionId: subscription.id,
         stripeInvoiceId: invoice.id,
-        stripePriceId: price?.id,
-        plan: price?.lookup_key ?? tier,
+        stripePriceId: invoicePrice.id,
+        plan: invoicePrice.lookup_key ?? tier,
         quantity: item?.quantity,
         userCount: userIds.length,
         description: reason,
@@ -655,8 +656,8 @@ async function recordSubscriptionRevenue({
             stripeCustomerId: customerId,
             stripeSubscriptionId: subscription.id,
             stripeInvoiceId: invoice.id,
-            stripePriceId: price?.id,
-            plan: price?.lookup_key ?? tier,
+            stripePriceId: invoicePrice.id,
+            plan: invoicePrice.lookup_key ?? tier,
             quantity: item?.quantity,
             userCount: userIds.length,
             description: reason,
@@ -668,6 +669,7 @@ async function recordSubscriptionRevenue({
 
 function emitInvoicePaidRevenueAnalytics({
   invoice,
+  invoicePrice,
   stripeEventId,
   customerId,
   userIds,
@@ -676,6 +678,7 @@ function emitInvoicePaidRevenueAnalytics({
   subscription,
 }: {
   invoice: Stripe.Invoice;
+  invoicePrice: Stripe.Price;
   stripeEventId: string;
   customerId: string;
   userIds: string[];
@@ -686,10 +689,9 @@ function emitInvoicePaidRevenueAnalytics({
   const amountPaidDollars = centsToDollars(invoice.amount_paid);
   if (amountPaidDollars <= 0 || userIds.length === 0) return;
 
-  const price = subscription.items?.data[0]?.price;
   const pricingExperiment = proMonthlyPricingAssignmentFromMetadata(
     subscription.metadata,
-    price?.lookup_key,
+    invoicePrice.lookup_key,
   );
   const attributedRevenueDollars = amountPaidDollars / userIds.length;
 
@@ -700,10 +702,10 @@ function emitInvoicePaidRevenueAnalytics({
         userId: uid,
         org_id: orgId,
         subscription_tier: tier,
-        plan: price?.lookup_key ?? tier,
-        stripe_price_lookup_key: price?.lookup_key,
-        billing_interval: priceBillingInterval(price),
-        billing_interval_count: price?.recurring?.interval_count,
+        plan: invoicePrice.lookup_key ?? tier,
+        stripe_price_lookup_key: invoicePrice.lookup_key,
+        billing_interval: priceBillingInterval(invoicePrice),
+        billing_interval_count: invoicePrice.recurring?.interval_count,
         billing_reason: invoice.billing_reason,
         attempt_count: invoice.attempt_count ?? undefined,
         ...(typeof invoice.attempt_count === "number" &&
@@ -717,7 +719,7 @@ function emitInvoicePaidRevenueAnalytics({
         stripe_customer_id: customerId,
         stripe_subscription_id: subscription.id,
         stripe_invoice_id: invoice.id,
-        stripe_price_id: price?.id,
+        stripe_price_id: invoicePrice.id,
         charged_amount_dollars: amountPaidDollars,
         ...proMonthlyPricingExperimentProperties(pricingExperiment),
         $insert_id: `${PAID_FUNNEL_EVENTS.invoicePaid}:${stripeEventId}:${uid}`,
@@ -731,6 +733,7 @@ function emitInvoicePaidRevenueAnalytics({
 
 async function recordPaidStartMix({
   invoice,
+  invoicePrice,
   customerId,
   userIds,
   orgId,
@@ -738,6 +741,7 @@ async function recordPaidStartMix({
   subscription,
 }: {
   invoice: Stripe.Invoice;
+  invoicePrice: Stripe.Price;
   customerId: string;
   userIds: string[];
   orgId?: string;
@@ -748,7 +752,6 @@ async function recordPaidStartMix({
   if (!paidStartTier || userIds.length === 0) return;
 
   const item = subscription.items?.data[0];
-  const price = item?.price;
   const occurredAt = invoicePaidAtMs(invoice);
   const entityType = orgId ? "organization" : "user";
   const entityId = orgId ?? userIds[0];
@@ -765,18 +768,18 @@ async function recordPaidStartMix({
     occurredAt,
     conversionType: "free_to_paid",
     tier: paidStartTier,
-    plan: price?.lookup_key ?? paidStartTier,
+    plan: invoicePrice.lookup_key ?? paidStartTier,
     paidAccountStartCount: 1,
     paidUserStartCount: userIds.length,
     paidSeatCount,
-    billingInterval: priceBillingInterval(price),
-    billingIntervalCount: price?.recurring?.interval_count,
+    billingInterval: priceBillingInterval(invoicePrice),
+    billingIntervalCount: invoicePrice.recurring?.interval_count,
     quantity: item?.quantity,
     userCount: userIds.length,
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscription.id,
     stripeInvoiceId: invoice.id,
-    stripePriceId: price?.id,
+    stripePriceId: invoicePrice.id,
   });
 }
 
@@ -973,6 +976,36 @@ async function handleInvoicePaid(
   }
 
   const { tier, subscription } = resolved;
+  const entitlementItem = subscription.items?.data[0];
+  const entitlementPrice = entitlementItem?.price;
+  const invoicePriceId = await invoiceSubscriptionPriceId(
+    invoice,
+    subscriptionId,
+  );
+  if (!invoicePriceId) {
+    phLogger.warn("invoice_paid_historical_price_missing", {
+      stripe_invoice_id: invoice.id,
+      stripe_subscription_id: subscriptionId,
+    });
+    throw new Error("Historical subscription Price missing from paid invoice");
+  }
+
+  let invoicePrice: Stripe.Price;
+  if (entitlementPrice?.id === invoicePriceId) {
+    invoicePrice = entitlementPrice;
+  } else {
+    try {
+      invoicePrice = await stripe.prices.retrieve(invoicePriceId);
+    } catch (error) {
+      phLogger.warn("invoice_paid_historical_price_retrieve_failed", {
+        stripe_invoice_id: invoice.id,
+        stripe_subscription_id: subscriptionId,
+        stripe_price_id: invoicePriceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
 
   // A paid historical invoice does not reactivate its subscription. Only the
   // current invoice of an entitled subscription may restore paid benefits.
@@ -992,7 +1025,7 @@ async function handleInvoicePaid(
       orgId: orgId ?? undefined,
       stripeSubscriptionId: subscription.id,
       tier,
-      price: subscription.items?.data[0]?.price,
+      price: invoicePrice,
       invoicePaidEligible: false,
     });
     phLogger.warn("billing_invoice_paid_ineligible_subscription_skipped", {
@@ -1018,7 +1051,7 @@ async function handleInvoicePaid(
   }
 
   const includedUsagePoints = includedUsagePointsForStripePrice(
-    subscription.items?.data[0]?.price?.id,
+    entitlementPrice?.id,
   );
 
   await setReferralCodesPaidEligibility({
@@ -1031,6 +1064,7 @@ async function handleInvoicePaid(
   try {
     await recordSubscriptionRevenue({
       invoice,
+      invoicePrice,
       customerId,
       userIds,
       orgId: orgId ?? undefined,
@@ -1052,6 +1086,7 @@ async function handleInvoicePaid(
 
   emitInvoicePaidRevenueAnalytics({
     invoice,
+    invoicePrice,
     stripeEventId,
     customerId,
     userIds,
@@ -1125,7 +1160,7 @@ async function handleInvoicePaid(
     });
   }
 
-  const recoveryPrice = subscription.items?.data[0]?.price;
+  const recoveryPrice = invoicePrice;
   const isRecoveredReset = (
     result: (typeof resetResults)[number] | undefined,
   ): boolean =>
@@ -1196,8 +1231,7 @@ async function handleInvoicePaid(
   }
 
   if (resetMode.reason === "subscription_create") {
-    const item = subscription.items?.data[0];
-    const price = item?.price;
+    const item = entitlementItem;
     const checkoutAttemptId = metadataString(
       subscription.metadata,
       "checkoutAttemptId",
@@ -1219,13 +1253,13 @@ async function handleInvoicePaid(
     );
     const attributedRevenueDollars =
       userIds.length > 0 ? invoiceAmountPaidDollars / userIds.length : 0;
-    const billingInterval = priceBillingInterval(price);
+    const billingInterval = priceBillingInterval(invoicePrice);
     const pricingExperiment = proMonthlyPricingAssignmentFromMetadata(
       subscription.metadata,
-      price?.lookup_key,
+      invoicePrice.lookup_key,
     );
     const subscriptionMrr = subscriptionMrrDollars({
-      price,
+      price: invoicePrice,
       quantity: item?.quantity ?? 1,
       fallbackTotalIntervalAmountDollars: invoiceAmountPaidDollars,
     });
@@ -1238,6 +1272,7 @@ async function handleInvoicePaid(
     try {
       await recordPaidStartMix({
         invoice,
+        invoicePrice,
         customerId,
         userIds,
         orgId: orgId ?? undefined,
@@ -1263,17 +1298,17 @@ async function handleInvoicePaid(
         conversion_type: "free_to_paid",
         org_id: orgId,
         user_count: userIds.length,
-        plan: price?.lookup_key,
-        stripe_price_lookup_key: price?.lookup_key,
+        plan: invoicePrice.lookup_key,
+        stripe_price_lookup_key: invoicePrice.lookup_key,
         paid_account_start_count: index === 0 ? 1 : 0,
         paid_user_start_count: 1,
         paid_account_user_count: userIds.length,
         paid_seat_count: paidSeatCount,
-        paid_start_plan: price?.lookup_key ?? tier,
+        paid_start_plan: invoicePrice.lookup_key ?? tier,
         paid_start_tier: tier,
         billing_interval: billingInterval,
         paid_start_billing_interval: billingInterval ?? "unknown",
-        billing_interval_count: price?.recurring?.interval_count,
+        billing_interval_count: invoicePrice.recurring?.interval_count,
         quantity: item?.quantity,
         checkout_attempt_id: checkoutAttemptId,
         checkout_type:
@@ -1292,7 +1327,7 @@ async function handleInvoicePaid(
         stripe_subscription_id: subscription.id,
         stripe_invoice_id: invoice.id,
         stripe_checkout_session_id: checkoutSessionId,
-        stripe_price_id: price?.id,
+        stripe_price_id: invoicePrice.id,
         charged_amount_dollars: invoiceAmountPaidDollars,
         ...proMonthlyPricingExperimentProperties(pricingExperiment),
         $set: {
@@ -1310,7 +1345,7 @@ async function handleInvoicePaid(
       tier,
       subscription,
       customerId,
-      plan: price?.lookup_key ?? undefined,
+      plan: invoicePrice.lookup_key ?? undefined,
       invoiceId: invoice.id,
       checkoutSessionId,
       checkoutAttemptId,

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -38,6 +38,10 @@ import {
   type BillingFailureProperties,
 } from "@/lib/billing/subscription-payment-failure";
 import { includedUsagePointsForStripePrice } from "@/lib/billing/included-usage";
+import {
+  proMonthlyPricingAssignmentFromMetadata,
+  proMonthlyPricingExperimentProperties,
+} from "@/lib/experiments/pro-monthly-pricing";
 
 const WEBHOOK_LOG_PREFIX = "[Subscription Webhook]";
 const WEBHOOK_LOG_CONTEXT = {
@@ -640,6 +644,10 @@ function emitInvoicePaidRevenueAnalytics({
   if (amountPaidDollars <= 0 || userIds.length === 0) return;
 
   const price = subscription.items?.data[0]?.price;
+  const pricingExperiment = proMonthlyPricingAssignmentFromMetadata(
+    subscription.metadata,
+    price?.lookup_key,
+  );
   const attributedRevenueDollars = amountPaidDollars / userIds.length;
 
   for (const uid of userIds) {
@@ -650,6 +658,7 @@ function emitInvoicePaidRevenueAnalytics({
         org_id: orgId,
         subscription_tier: tier,
         plan: price?.lookup_key ?? tier,
+        stripe_price_lookup_key: price?.lookup_key,
         billing_interval: priceBillingInterval(price),
         billing_interval_count: price?.recurring?.interval_count,
         billing_reason: invoice.billing_reason,
@@ -666,6 +675,8 @@ function emitInvoicePaidRevenueAnalytics({
         stripe_subscription_id: subscription.id,
         stripe_invoice_id: invoice.id,
         stripe_price_id: price?.id,
+        charged_amount_dollars: amountPaidDollars,
+        ...proMonthlyPricingExperimentProperties(pricingExperiment),
         $insert_id: `${PAID_FUNNEL_EVENTS.invoicePaid}:${stripeEventId}:${uid}`,
         $set: {
           subscription_tier: tier,
@@ -1166,6 +1177,10 @@ async function handleInvoicePaid(
     const attributedRevenueDollars =
       userIds.length > 0 ? invoiceAmountPaidDollars / userIds.length : 0;
     const billingInterval = priceBillingInterval(price);
+    const pricingExperiment = proMonthlyPricingAssignmentFromMetadata(
+      subscription.metadata,
+      price?.lookup_key,
+    );
     const subscriptionMrr = subscriptionMrrDollars({
       price,
       quantity: item?.quantity ?? 1,
@@ -1206,6 +1221,7 @@ async function handleInvoicePaid(
         org_id: orgId,
         user_count: userIds.length,
         plan: price?.lookup_key,
+        stripe_price_lookup_key: price?.lookup_key,
         paid_account_start_count: index === 0 ? 1 : 0,
         paid_user_start_count: 1,
         paid_account_user_count: userIds.length,
@@ -1234,6 +1250,8 @@ async function handleInvoicePaid(
         stripe_invoice_id: invoice.id,
         stripe_checkout_session_id: checkoutSessionId,
         stripe_price_id: price?.id,
+        charged_amount_dollars: invoiceAmountPaidDollars,
+        ...proMonthlyPricingExperimentProperties(pricingExperiment),
         $set: {
           subscription_tier: tier,
           last_subscription_started_at: new Date().toISOString(),
@@ -1494,6 +1512,131 @@ async function handlePaymentMethodUpdated(args: {
   }
 }
 
+async function handleSubscriptionRefund(
+  refund: Stripe.Refund,
+  stripeEventId: string,
+  stripeEventType: "refund.created" | "refund.updated",
+): Promise<void> {
+  if (refund.status && refund.status !== "succeeded") return;
+
+  const chargeId = stripeObjectId(refund.charge);
+  if (!chargeId || refund.amount <= 0) return;
+
+  const charge = await stripe.charges.retrieve(chargeId);
+  const invoiceId = stripeObjectId(
+    (charge as Stripe.Charge & { invoice?: string | Stripe.Invoice | null })
+      .invoice,
+  );
+  if (!invoiceId) return;
+
+  const invoice = await stripe.invoices.retrieve(invoiceId);
+  const subscriptionId = invoiceSubscriptionId(invoice);
+  if (!subscriptionId) return;
+
+  const resolved = await resolveSubscription(subscriptionId);
+  if (!resolved || resolved.kind === "legacy_pentestgpt") return;
+
+  const customerId =
+    stripeObjectId(invoice.customer) ?? stripeObjectId(charge.customer);
+  if (!customerId) return;
+
+  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+  if (userIds.length === 0) return;
+
+  const price = resolved.subscription.items?.data[0]?.price;
+  const pricingExperiment = proMonthlyPricingAssignmentFromMetadata(
+    resolved.subscription.metadata,
+    price?.lookup_key,
+  );
+  const refundAmountDollars = centsToDollars(refund.amount);
+  const attributedRefundDollars = refundAmountDollars / userIds.length;
+  const occurredAt = refund.created ? refund.created * 1000 : Date.now();
+
+  await Promise.all([
+    ...userIds.map((userId) =>
+      getConvexClient().mutation(api.unitEconomics.recordRevenueEvent, {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        entityType: "user",
+        entityId: userId,
+        userId,
+        organizationId: orgId ?? undefined,
+        source: "subscription",
+        sourceEventId: refund.id,
+        idempotencyKey: `subscription_refund:${refund.id}:user:${userId}`,
+        grossRevenueDollars: -attributedRefundDollars,
+        netRevenueDollars: -attributedRefundDollars,
+        currency: refund.currency,
+        occurredAt,
+        attributionStrategy: userIds.length > 1 ? "split_evenly" : "direct",
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: subscriptionId,
+        stripeInvoiceId: invoiceId,
+        stripePaymentIntentId: stripeObjectId(refund.payment_intent),
+        stripePriceId: price?.id,
+        plan: price?.lookup_key ?? resolved.tier,
+        userCount: userIds.length,
+        description: "refund",
+      }),
+    ),
+    ...(orgId
+      ? [
+          getConvexClient().mutation(api.unitEconomics.recordRevenueEvent, {
+            serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+            entityType: "organization",
+            entityId: orgId,
+            organizationId: orgId,
+            source: "subscription",
+            sourceEventId: refund.id,
+            idempotencyKey: `subscription_refund:${refund.id}:organization:${orgId}`,
+            grossRevenueDollars: -refundAmountDollars,
+            netRevenueDollars: -refundAmountDollars,
+            currency: refund.currency,
+            occurredAt,
+            attributionStrategy: "organization_pool",
+            stripeCustomerId: customerId,
+            stripeSubscriptionId: subscriptionId,
+            stripeInvoiceId: invoiceId,
+            stripePaymentIntentId: stripeObjectId(refund.payment_intent),
+            stripePriceId: price?.id,
+            plan: price?.lookup_key ?? resolved.tier,
+            userCount: userIds.length,
+            description: "refund",
+          }),
+        ]
+      : []),
+  ]);
+
+  for (const userId of userIds) {
+    phLogger.event(
+      PAID_FUNNEL_EVENTS.subscriptionRefunded,
+      paidFunnelProperties({
+        userId,
+        org_id: orgId,
+        subscription_tier: resolved.tier,
+        plan: price?.lookup_key,
+        stripe_price_lookup_key: price?.lookup_key,
+        billing_interval: priceBillingInterval(price),
+        billing_interval_count: price?.recurring?.interval_count,
+        refund_amount_dollars: refundAmountDollars,
+        attributed_refund_dollars: attributedRefundDollars,
+        charged_amount_dollars: -attributedRefundDollars,
+        currency: refund.currency,
+        stripe_event_id: stripeEventId,
+        stripe_event_type: stripeEventType,
+        stripe_customer_id: customerId,
+        stripe_subscription_id: subscriptionId,
+        stripe_invoice_id: invoiceId,
+        stripe_payment_intent_id: stripeObjectId(refund.payment_intent),
+        stripe_charge_id: chargeId,
+        stripe_refund_id: refund.id,
+        stripe_price_id: price?.id,
+        ...proMonthlyPricingExperimentProperties(pricingExperiment),
+        $insert_id: `${PAID_FUNNEL_EVENTS.subscriptionRefunded}:${refund.id}:${userId}`,
+      }),
+    );
+  }
+}
+
 /** Handle checkout.session.completed — attach Checkout Session IDs to saved referral attribution. */
 async function handleCheckoutSessionCompleted(
   session: Stripe.Checkout.Session,
@@ -1565,6 +1708,15 @@ async function handleCheckoutSessionCompleted(
 
   const price = resolved.subscription.items?.data[0]?.price;
   const existingMetadata = resolved.subscription.metadata ?? {};
+  const pricingExperiment =
+    proMonthlyPricingAssignmentFromMetadata(
+      existingMetadata,
+      price?.lookup_key,
+    ) ??
+    proMonthlyPricingAssignmentFromMetadata(
+      session.metadata,
+      price?.lookup_key,
+    );
   if (checkoutAttemptId || checkoutSource || checkoutSurface) {
     try {
       await stripe.subscriptions.update(subscriptionId, {
@@ -1598,9 +1750,9 @@ async function handleCheckoutSessionCompleted(
         checkout_type: checkoutType,
         from_tier: "free",
         to_tier: resolved.tier,
-        plan:
-          metadataString(session.metadata, "requestedPlan") ??
-          price?.lookup_key,
+        plan: price?.lookup_key,
+        requested_plan: metadataString(session.metadata, "requestedPlan"),
+        stripe_price_lookup_key: price?.lookup_key,
         billing_interval: priceBillingInterval(price),
         billing_interval_count: price?.recurring?.interval_count,
         quantity: resolved.subscription.items?.data[0]?.quantity,
@@ -1612,7 +1764,9 @@ async function handleCheckoutSessionCompleted(
         stripe_subscription_id: subscriptionId,
         stripe_checkout_session_id: session.id,
         stripe_price_id: price?.id,
+        charged_amount_dollars: centsToDollars(session.amount_total),
         payment_status: session.payment_status,
+        ...proMonthlyPricingExperimentProperties(pricingExperiment),
         $insert_id: `${PAID_FUNNEL_EVENTS.checkoutSucceeded}:${session.id}`,
         $set: {
           last_checkout_succeeded_at: new Date().toISOString(),
@@ -1818,6 +1972,10 @@ async function recordCancellationCompleted(args: {
     : undefined;
   const completedAt =
     args.completionType === "deleted" ? (canceledAt ?? Date.now()) : Date.now();
+  const pricingExperiment = proMonthlyPricingAssignmentFromMetadata(
+    args.subscription.metadata,
+    args.price?.lookup_key,
+  );
 
   let updatedCount = 0;
   try {
@@ -1857,6 +2015,7 @@ async function recordCancellationCompleted(args: {
         subscription_tier: args.tier,
         org_id: args.orgId,
         plan: args.price?.lookup_key,
+        stripe_price_lookup_key: args.price?.lookup_key,
         billing_interval: priceBillingInterval(args.price),
         billing_interval_count: args.price?.recurring?.interval_count,
         cancellation_reason: stripeCancellationReason,
@@ -1865,6 +2024,7 @@ async function recordCancellationCompleted(args: {
         stripe_customer_id: args.customerId,
         stripe_subscription_id: args.subscription.id,
         stripe_price_id: args.price?.id,
+        ...proMonthlyPricingExperimentProperties(pricingExperiment),
         $insert_id: cancellationCompletionInsertId(args.subscription.id),
       }),
     );
@@ -2175,6 +2335,15 @@ export async function POST(req: NextRequest) {
           eventOccurredAtMs: stripeEventOccurredAtMs(event),
         });
       }
+      break;
+    }
+    case "refund.created":
+    case "refund.updated": {
+      await handleSubscriptionRefund(
+        event.data.object as Stripe.Refund,
+        event.id,
+        event.type,
+      );
       break;
     }
   }

--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -55,6 +55,30 @@ function formatCancellationDate(currentPeriodEnd?: number) {
   }).format(new Date(currentPeriodEnd));
 }
 
+function formatRenewalPrice(status: AccountCancellationStatus | null) {
+  if (
+    status?.renewalAmountDollars === undefined ||
+    !status.renewalCurrency ||
+    !status.renewalInterval
+  ) {
+    return null;
+  }
+
+  const amount = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: status.renewalCurrency.toUpperCase(),
+    maximumFractionDigits: Number.isInteger(status.renewalAmountDollars)
+      ? 0
+      : 2,
+  }).format(status.renewalAmountDollars);
+  const intervalCount = status.renewalIntervalCount ?? 1;
+  const interval =
+    intervalCount === 1
+      ? status.renewalInterval
+      : `${intervalCount} ${status.renewalInterval}s`;
+  return `${amount} every ${interval}`;
+}
+
 const AccountTab = () => {
   const { subscription, setMigrateFromPentestgptDialogOpen } = useGlobalState();
   const [showDeleteAccount, setShowDeleteAccount] = useState(false);
@@ -98,6 +122,7 @@ const AccountTab = () => {
   const cancellationEndDate = formatCancellationDate(
     currentCancellationStatus?.currentPeriodEnd,
   );
+  const renewalPrice = formatRenewalPrice(currentCancellationStatus);
   const noActiveSubscription =
     currentCancellationStatus?.hasActiveSubscription === false;
   const cancellationScheduled =
@@ -215,6 +240,11 @@ const AccountTab = () => {
                       ? "HackerAI Pro"
                       : "Get HackerAI Pro"}
             </div>
+            {renewalPrice && (
+              <div className="mt-0.5 text-sm text-muted-foreground">
+                Renews at {renewalPrice}
+              </div>
+            )}
           </div>
           {subscription !== "free" ? (
             canManageBilling ? (

--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -57,6 +57,7 @@ function formatCancellationDate(currentPeriodEnd?: number) {
 
 function formatRenewalPrice(status: AccountCancellationStatus | null) {
   if (
+    status?.cancelAtPeriodEnd ||
     status?.renewalAmountDollars === undefined ||
     !status.renewalCurrency ||
     !status.renewalInterval

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -70,6 +70,9 @@ type PricingIntentCopy = {
   ultraButtonText: string;
 };
 
+const PRICING_EXPOSURE_RETRY_MS = 500;
+const PRICING_EXPOSURE_MAX_ATTEMPTS = 10;
+
 export function getPricingIntentCopy(
   context: PricingDialogContext | undefined,
   subscription: string,
@@ -227,6 +230,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
   const { upgradeLoading, handleUpgrade } = useUpgrade();
   const [isYearly, setIsYearly] = React.useState(false);
   const capturedPricingCtaImpressionRef = React.useRef(false);
+  const capturedPricingExperimentExposureRef = React.useRef(false);
   const [pricingExperiment, setPricingExperiment] = React.useState<
     ProMonthlyPricingExperimentPresentation | undefined
   >();
@@ -256,10 +260,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
 
   React.useEffect(() => {
     if (!isOpen || pricingExperimentResolved) return;
-    if (subscription !== "free") {
-      setPricingExperimentResolved(true);
-      return;
-    }
+    if (subscription !== "free") return;
 
     const controller = new AbortController();
     setPricingExperimentUnavailable(false);
@@ -316,6 +317,45 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
 
   React.useEffect(() => {
     if (!isOpen) {
+      capturedPricingExperimentExposureRef.current = false;
+      return;
+    }
+    if (
+      !activePricingExperiment ||
+      capturedPricingExperimentExposureRef.current
+    ) {
+      return;
+    }
+
+    let exposureCaptureAttempts = 0;
+    let exposureRetryTimeout: ReturnType<typeof setTimeout> | undefined;
+    const captureExperimentExposure = () => {
+      exposureCaptureAttempts += 1;
+      if (
+        captureAuthenticatedEvent(
+          PRO_MONTHLY_PRICING_EXPOSURE_EVENT,
+          proMonthlyPricingExperimentProperties(activePricingExperiment),
+        )
+      ) {
+        capturedPricingExperimentExposureRef.current = true;
+        return;
+      }
+      if (exposureCaptureAttempts < PRICING_EXPOSURE_MAX_ATTEMPTS) {
+        exposureRetryTimeout = setTimeout(
+          captureExperimentExposure,
+          PRICING_EXPOSURE_RETRY_MS,
+        );
+      }
+    };
+    captureExperimentExposure();
+
+    return () => {
+      if (exposureRetryTimeout) clearTimeout(exposureRetryTimeout);
+    };
+  }, [activePricingExperiment, isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen) {
       capturedPricingCtaImpressionRef.current = false;
       return;
     }
@@ -327,12 +367,6 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
       return;
     }
     capturedPricingCtaImpressionRef.current = true;
-    if (activePricingExperiment) {
-      captureAuthenticatedEvent(
-        PRO_MONTHLY_PRICING_EXPOSURE_EVENT,
-        proMonthlyPricingExperimentProperties(activePricingExperiment),
-      );
-    }
     captureUpgradeCtaImpression({
       surface: "pricing_dialog",
       source: context?.source ?? "plan_cards",

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -232,6 +232,8 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
   >();
   const [pricingExperimentResolved, setPricingExperimentResolved] =
     React.useState(false);
+  const [pricingExperimentUnavailable, setPricingExperimentUnavailable] =
+    React.useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
   const [pendingUpgrade, setPendingUpgrade] = React.useState<{
     plan: string;
@@ -244,9 +246,11 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
       ? pricingExperiment.displayedAmountDollars
       : PRICING.pro.monthly;
   const displayedMonthlyProPrice =
-    subscription === "free" && !pricingExperimentResolved
-      ? "…"
-      : monthlyProPrice;
+    subscription === "free" && pricingExperimentUnavailable
+      ? "—"
+      : subscription === "free" && !pricingExperimentResolved
+        ? "…"
+        : monthlyProPrice;
   const activePricingExperiment =
     subscription === "free" && !isYearly ? pricingExperiment : undefined;
 
@@ -258,6 +262,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
     }
 
     const controller = new AbortController();
+    setPricingExperimentUnavailable(false);
     void fetch("/api/pricing/pro-monthly-experiment", {
       cache: "no-store",
       signal: controller.signal,
@@ -270,6 +275,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
           priceLookupKey?: unknown;
           displayedAmountDollars?: unknown;
         };
+        if (controller.signal.aborted) return;
         const expected = proMonthlyPricingAssignmentForVariant(
           value.variant === "test" ? "test" : "control",
         );
@@ -277,16 +283,15 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
           value.key === expected.key &&
           value.priceLookupKey === expected.priceLookupKey &&
           value.displayedAmountDollars === expected.displayedAmountDollars;
-        setPricingExperiment(
-          isValid ? expected : proMonthlyPricingAssignmentForVariant("control"),
-        );
+        if (!isValid) throw new Error("Invalid pricing assignment");
+        setPricingExperiment(expected);
+        setPricingExperimentResolved(true);
       })
       .catch((error: unknown) => {
         if ((error as { name?: unknown })?.name === "AbortError") return;
-        setPricingExperiment(proMonthlyPricingAssignmentForVariant("control"));
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setPricingExperimentResolved(true);
+        setPricingExperiment(undefined);
+        setPricingExperimentUnavailable(true);
+        setPricingExperimentResolved(false);
       });
 
     return () => controller.abort();
@@ -446,10 +451,13 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
       };
     } else if (user) {
       return {
-        text: pricingIntentCopy?.proButtonText ?? "Get Pro",
+        text:
+          subscription === "free" && !isYearly && pricingExperimentUnavailable
+            ? "Pricing unavailable"
+            : (pricingIntentCopy?.proButtonText ?? "Get Pro"),
         disabled:
           upgradeLoading ||
-          (subscription === "free" && !pricingExperimentResolved),
+          (subscription === "free" && !isYearly && !pricingExperimentResolved),
         className: "",
         variant: "default" as const,
         onClick: () =>

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -20,8 +20,17 @@ import {
 } from "@/lib/pricing/features";
 import BillingFrequencySelector from "./BillingFrequencySelector";
 import UpgradeConfirmationDialog from "./UpgradeConfirmationDialog";
-import { captureUpgradeCtaImpression } from "@/lib/analytics/client";
+import {
+  captureAuthenticatedEvent,
+  captureUpgradeCtaImpression,
+} from "@/lib/analytics/client";
 import type { PricingDialogContext } from "../hooks/usePricingDialog";
+import {
+  PRO_MONTHLY_PRICING_EXPOSURE_EVENT,
+  proMonthlyPricingAssignmentForVariant,
+  proMonthlyPricingExperimentProperties,
+  type ProMonthlyPricingExperimentAssignment,
+} from "@/lib/experiments/pro-monthly-pricing";
 
 interface PricingDialogProps {
   isOpen: boolean;
@@ -31,7 +40,7 @@ interface PricingDialogProps {
 
 interface PlanCardProps {
   planName: string;
-  price: number;
+  price: number | string;
   description: string;
   features: Array<{
     icon: React.ComponentType<{ className?: string }>;
@@ -218,6 +227,11 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
   const { upgradeLoading, handleUpgrade } = useUpgrade();
   const [isYearly, setIsYearly] = React.useState(false);
   const capturedPricingCtaImpressionRef = React.useRef(false);
+  const [pricingExperiment, setPricingExperiment] = React.useState<
+    ProMonthlyPricingExperimentAssignment | undefined
+  >();
+  const [pricingExperimentResolved, setPricingExperimentResolved] =
+    React.useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
   const [pendingUpgrade, setPendingUpgrade] = React.useState<{
     plan: string;
@@ -225,6 +239,58 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
     price: number;
   } | null>(null);
   const pricingIntentCopy = getPricingIntentCopy(context, subscription);
+  const monthlyProPrice =
+    subscription === "free" && pricingExperiment
+      ? pricingExperiment.displayedAmountDollars
+      : PRICING.pro.monthly;
+  const displayedMonthlyProPrice =
+    subscription === "free" && !pricingExperimentResolved
+      ? "…"
+      : monthlyProPrice;
+  const activePricingExperiment =
+    subscription === "free" && !isYearly ? pricingExperiment : undefined;
+
+  React.useEffect(() => {
+    if (!isOpen || pricingExperimentResolved) return;
+    if (subscription !== "free") {
+      setPricingExperimentResolved(true);
+      return;
+    }
+
+    const controller = new AbortController();
+    void fetch("/api/pricing/pro-monthly-experiment", {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Pricing assignment unavailable");
+        const value = (await response.json()) as {
+          key?: unknown;
+          variant?: unknown;
+          priceLookupKey?: unknown;
+          displayedAmountDollars?: unknown;
+        };
+        const expected = proMonthlyPricingAssignmentForVariant(
+          value.variant === "test" ? "test" : "control",
+        );
+        const isValid =
+          value.key === expected.key &&
+          value.priceLookupKey === expected.priceLookupKey &&
+          value.displayedAmountDollars === expected.displayedAmountDollars;
+        setPricingExperiment(
+          isValid ? expected : proMonthlyPricingAssignmentForVariant("control"),
+        );
+      })
+      .catch((error: unknown) => {
+        if ((error as { name?: unknown })?.name === "AbortError") return;
+        setPricingExperiment(proMonthlyPricingAssignmentForVariant("control"));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setPricingExperimentResolved(true);
+      });
+
+    return () => controller.abort();
+  }, [isOpen, pricingExperimentResolved, subscription]);
 
   // Auto-close pricing dialog for ultra/team users (pro-plus can still upgrade to ultra)
   React.useEffect(() => {
@@ -239,8 +305,19 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
       return;
     }
 
-    if (capturedPricingCtaImpressionRef.current) return;
+    if (
+      capturedPricingCtaImpressionRef.current ||
+      (subscription === "free" && !pricingExperimentResolved)
+    ) {
+      return;
+    }
     capturedPricingCtaImpressionRef.current = true;
+    if (activePricingExperiment) {
+      captureAuthenticatedEvent(
+        PRO_MONTHLY_PRICING_EXPOSURE_EVENT,
+        proMonthlyPricingExperimentProperties(activePricingExperiment),
+      );
+    }
     captureUpgradeCtaImpression({
       surface: "pricing_dialog",
       source: context?.source ?? "plan_cards",
@@ -248,12 +325,15 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
       cta_text: "plan_card_buttons",
       ...(context?.reason && { reason: context.reason }),
       ...(context?.limitType && { limit_type: context.limitType }),
+      ...proMonthlyPricingExperimentProperties(activePricingExperiment),
     });
   }, [
     context?.limitType,
     context?.reason,
     context?.source,
     isOpen,
+    activePricingExperiment,
+    pricingExperimentResolved,
     subscription,
   ]);
 
@@ -280,6 +360,8 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
           surface: "pricing_dialog",
           reason: context?.reason,
           limit_type: context?.limitType,
+          pricing_experiment:
+            plan === "pro-monthly-plan" ? activePricingExperiment : undefined,
         });
         // Don't close dialog on success - let the redirect happen
       } catch (error) {
@@ -365,14 +447,16 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
     } else if (user) {
       return {
         text: pricingIntentCopy?.proButtonText ?? "Get Pro",
-        disabled: upgradeLoading,
+        disabled:
+          upgradeLoading ||
+          (subscription === "free" && !pricingExperimentResolved),
         className: "",
         variant: "default" as const,
         onClick: () =>
           handleUpgradeClick(
             isYearly ? "pro-yearly-plan" : "pro-monthly-plan",
             "Pro",
-            isYearly ? PRICING.pro.yearly : PRICING.pro.monthly,
+            isYearly ? PRICING.pro.yearly : monthlyProPrice,
           ),
         loading: upgradeLoading,
       };
@@ -551,7 +635,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
 
               <PlanCard
                 planName="Pro"
-                price={isYearly ? PRICING.pro.yearly : PRICING.pro.monthly}
+                price={isYearly ? PRICING.pro.yearly : displayedMonthlyProPrice}
                 description={
                   pricingIntentCopy?.proDescription ??
                   "For everyday productivity"

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -29,7 +29,7 @@ import {
   PRO_MONTHLY_PRICING_EXPOSURE_EVENT,
   proMonthlyPricingAssignmentForVariant,
   proMonthlyPricingExperimentProperties,
-  type ProMonthlyPricingExperimentAssignment,
+  type ProMonthlyPricingExperimentPresentation,
 } from "@/lib/experiments/pro-monthly-pricing";
 
 interface PricingDialogProps {
@@ -228,7 +228,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
   const [isYearly, setIsYearly] = React.useState(false);
   const capturedPricingCtaImpressionRef = React.useRef(false);
   const [pricingExperiment, setPricingExperiment] = React.useState<
-    ProMonthlyPricingExperimentAssignment | undefined
+    ProMonthlyPricingExperimentPresentation | undefined
   >();
   const [pricingExperimentResolved, setPricingExperimentResolved] =
     React.useState(false);
@@ -274,17 +274,27 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
           variant?: unknown;
           priceLookupKey?: unknown;
           displayedAmountDollars?: unknown;
+          stripePriceId?: unknown;
         };
         if (controller.signal.aborted) return;
         const expected = proMonthlyPricingAssignmentForVariant(
           value.variant === "test" ? "test" : "control",
         );
+        const stripePriceId =
+          typeof value.stripePriceId === "string" &&
+          value.stripePriceId.length > 0
+            ? value.stripePriceId
+            : undefined;
         const isValid =
           value.key === expected.key &&
           value.priceLookupKey === expected.priceLookupKey &&
-          value.displayedAmountDollars === expected.displayedAmountDollars;
+          value.displayedAmountDollars === expected.displayedAmountDollars &&
+          stripePriceId;
         if (!isValid) throw new Error("Invalid pricing assignment");
-        setPricingExperiment(expected);
+        setPricingExperiment({
+          ...expected,
+          stripePriceId,
+        });
         setPricingExperimentResolved(true);
       })
       .catch((error: unknown) => {

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -77,6 +77,21 @@ describe("AccountTab", () => {
     window.history.replaceState(null, "", "/");
   });
 
+  it("shows the actual Stripe renewal amount and interval", async () => {
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: false,
+      renewalAmountDollars: 29,
+      renewalCurrency: "usd",
+      renewalInterval: "month",
+      renewalIntervalCount: 1,
+    } as never);
+
+    render(<AccountTab />);
+
+    expect(await screen.findByText("Renews at $29 every month")).toBeVisible();
+  });
+
   it("shows scheduled cancellation state instead of the cancel action", async () => {
     const currentPeriodEnd = Date.UTC(2026, 6, 31, 12);
     const expectedPeriodEnd = new Intl.DateTimeFormat(undefined, {

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -104,6 +104,10 @@ describe("AccountTab", () => {
       hasActiveSubscription: true,
       cancelAtPeriodEnd: true,
       currentPeriodEnd,
+      renewalAmountDollars: 29,
+      renewalCurrency: "usd",
+      renewalInterval: "month",
+      renewalIntervalCount: 1,
     } as never);
 
     render(<AccountTab />);
@@ -112,6 +116,7 @@ describe("AccountTab", () => {
     expect(
       screen.getByText(`Your plan stays active until ${expectedPeriodEnd}.`),
     ).toBeVisible();
+    expect(screen.queryByText(/renews at/i)).not.toBeInTheDocument();
 
     const user = userEvent.setup();
     await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);

--- a/app/components/__tests__/PricingDialog.experiment.test.tsx
+++ b/app/components/__tests__/PricingDialog.experiment.test.tsx
@@ -87,6 +87,7 @@ describe("PricingDialog HAC-46 assignment", () => {
           variant: "test",
           priceLookupKey: "pro-monthly-plan-29-experiment",
           displayedAmountDollars: 29,
+          stripePriceId: "price_pro_29",
         }),
       });
     });
@@ -103,6 +104,7 @@ describe("PricingDialog HAC-46 assignment", () => {
         variant: "control",
         priceLookupKey: "pro-monthly-plan",
         displayedAmountDollars: 25,
+        stripePriceId: "price_pro_25",
       }),
     });
 

--- a/app/components/__tests__/PricingDialog.experiment.test.tsx
+++ b/app/components/__tests__/PricingDialog.experiment.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
 const mockHandleUpgrade = jest.fn();
 const mockFetch = jest.fn();
+const mockCaptureAuthenticatedEvent = jest.fn();
 
 jest.mock("@workos-inc/authkit-nextjs/components", () => ({
   useAuth: () => ({ user: { id: "user_free" } }),
@@ -29,7 +30,7 @@ jest.mock("@/app/hooks/useTauri", () => ({
 }));
 
 jest.mock("@/lib/analytics/client", () => ({
-  captureAuthenticatedEvent: jest.fn(),
+  captureAuthenticatedEvent: mockCaptureAuthenticatedEvent,
   captureUpgradeCtaImpression: jest.fn(),
 }));
 
@@ -60,10 +61,15 @@ const PricingDialog = require("../PricingDialog")
 describe("PricingDialog HAC-46 assignment", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCaptureAuthenticatedEvent.mockReturnValue(true);
     Object.defineProperty(globalThis, "fetch", {
       configurable: true,
       value: mockFetch,
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("keeps monthly Pro disabled until the $29 assignment resolves", async () => {
@@ -121,5 +127,38 @@ describe("PricingDialog HAC-46 assignment", () => {
     await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
     expect(await screen.findByText("25")).toBeVisible();
     expect(screen.getByRole("button", { name: "Get Pro" })).toBeEnabled();
+  });
+
+  it("retries experiment exposure until PostHog accepts it", async () => {
+    jest.useFakeTimers();
+    mockCaptureAuthenticatedEvent
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        key: "hac46-pro-monthly-29-pricing",
+        variant: "test",
+        priceLookupKey: "pro-monthly-plan-29-experiment",
+        displayedAmountDollars: 29,
+        stripePriceId: "price_pro_29",
+      }),
+    });
+
+    render(<PricingDialog isOpen onClose={jest.fn()} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("29")).toBeVisible();
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledTimes(1);
+
+    act(() => jest.advanceTimersByTime(500));
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledTimes(2);
+
+    act(() => jest.advanceTimersByTime(500));
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledTimes(3);
   });
 });

--- a/app/components/__tests__/PricingDialog.experiment.test.tsx
+++ b/app/components/__tests__/PricingDialog.experiment.test.tsx
@@ -1,0 +1,123 @@
+import "@testing-library/jest-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockHandleUpgrade = jest.fn();
+const mockFetch = jest.fn();
+
+jest.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAuth: () => ({ user: { id: "user_free" } }),
+}));
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    subscription: "free",
+    isCheckingProPlan: false,
+    setTeamPricingDialogOpen: jest.fn(),
+  }),
+}));
+
+jest.mock("@/app/hooks/useUpgrade", () => ({
+  useUpgrade: () => ({
+    upgradeLoading: false,
+    handleUpgrade: mockHandleUpgrade,
+  }),
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  navigateToAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: jest.fn(),
+  captureUpgradeCtaImpression: jest.fn(),
+}));
+
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <>{children}</> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+jest.mock("../BillingFrequencySelector", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("../UpgradeConfirmationDialog", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const PricingDialog = require("../PricingDialog")
+  .default as typeof import("../PricingDialog").default;
+
+describe("PricingDialog HAC-46 assignment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: mockFetch,
+    });
+  });
+
+  it("keeps monthly Pro disabled until the $29 assignment resolves", async () => {
+    let resolveRequest: (value: unknown) => void = () => {};
+    mockFetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    render(<PricingDialog isOpen onClose={jest.fn()} />);
+
+    expect(screen.getByText("…")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Get Pro" })).toBeDisabled();
+
+    await act(async () => {
+      resolveRequest({
+        ok: true,
+        json: async () => ({
+          key: "hac46-pro-monthly-29-pricing",
+          variant: "test",
+          priceLookupKey: "pro-monthly-plan-29-experiment",
+          displayedAmountDollars: 29,
+        }),
+      });
+    });
+
+    expect(await screen.findByText("29")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Get Pro" })).toBeEnabled();
+  });
+
+  it("keeps checkout disabled after an assignment failure and retries when reopened", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false }).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        key: "hac46-pro-monthly-29-pricing",
+        variant: "control",
+        priceLookupKey: "pro-monthly-plan",
+        displayedAmountDollars: 25,
+      }),
+    });
+
+    const { rerender } = render(<PricingDialog isOpen onClose={jest.fn()} />);
+
+    expect(
+      await screen.findByRole("button", { name: "Pricing unavailable" }),
+    ).toBeDisabled();
+    expect(screen.getByText("—")).toBeVisible();
+
+    rerender(<PricingDialog isOpen={false} onClose={jest.fn()} />);
+    rerender(<PricingDialog isOpen onClose={jest.fn()} />);
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("25")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Get Pro" })).toBeEnabled();
+  });
+});

--- a/app/hooks/__tests__/useUpgrade.test.ts
+++ b/app/hooks/__tests__/useUpgrade.test.ts
@@ -326,14 +326,41 @@ describe("useUpgrade checkout attempts", () => {
       response({
         ok: true,
         status: 200,
-        body: { url: `${window.location.origin}/#checkout` },
+        body: {
+          url: `${window.location.origin}/#checkout`,
+          pricingExperiment: {
+            key: "hac46-pro-monthly-29-pricing",
+            variant: "test",
+            priceLookupKey: "pro-monthly-plan-29-experiment",
+            displayedAmountDollars: 29,
+            currency: "usd",
+            billingInterval: "month",
+            stripePriceId: "price_pro_29",
+          },
+        },
       }),
     );
     mockNewCheckoutAttemptId.mockReturnValue("ca_redirect_123");
     const { result } = renderHook(() => useUpgrade());
 
     await act(async () => {
-      await result.current.handleUpgrade("pro-monthly-plan");
+      await result.current.handleUpgrade(
+        "pro-monthly-plan",
+        undefined,
+        undefined,
+        "free",
+        {
+          pricing_experiment: {
+            key: "hac46-pro-monthly-29-pricing",
+            variant: "test",
+            priceLookupKey: "pro-monthly-plan-29-experiment",
+            displayedAmountDollars: 29,
+            currency: "usd",
+            billingInterval: "month",
+            stripePriceId: "price_pro_29",
+          },
+        },
+      );
     });
     await act(async () => {
       await result.current.handleUpgrade("pro-monthly-plan");
@@ -343,5 +370,13 @@ describe("useUpgrade checkout attempts", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(mockNewCheckoutAttemptId).toHaveBeenCalledTimes(1);
     expect(result.current.upgradeLoading).toBe(true);
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledWith(
+      "checkout_intent_clicked",
+      expect.objectContaining({ stripe_price_id: "price_pro_29" }),
+    );
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledWith(
+      "checkout_redirected",
+      expect.objectContaining({ stripe_price_id: "price_pro_29" }),
+    );
   });
 });

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -17,6 +17,10 @@ import {
   getRecentCheckoutNavigation,
   rememberCheckoutNavigation,
 } from "@/lib/billing/checkout-navigation-guard";
+import {
+  proMonthlyPricingExperimentProperties,
+  type ProMonthlyPricingExperimentAssignment,
+} from "@/lib/experiments/pro-monthly-pricing";
 
 // Keep a tab's upgrade ownership across pricing dialog remounts. Server routes
 // remain authoritative across page loads and tabs, including open-session reuse.
@@ -36,6 +40,7 @@ export const useUpgrade = () => {
       surface?: string;
       reason?: string;
       limit_type?: string;
+      pricing_experiment?: ProMonthlyPricingExperimentAssignment;
     } = {},
   ) => {
     e?.preventDefault();
@@ -70,6 +75,9 @@ export const useUpgrade = () => {
             limit_type: analyticsContext.limit_type,
             suppression_reason: "recent_navigation",
             guard_window_ms: CHECKOUT_NAVIGATION_GUARD_WINDOW_MS,
+            ...proMonthlyPricingExperimentProperties(
+              analyticsContext.pricing_experiment,
+            ),
           },
         );
         toast.info("Checkout is already opening", {
@@ -126,6 +134,9 @@ export const useUpgrade = () => {
           reason: analyticsContext.reason,
           limit_type: analyticsContext.limit_type,
           checkout_type: "new_subscription",
+          ...proMonthlyPricingExperimentProperties(
+            analyticsContext.pricing_experiment,
+          ),
         });
 
         const res = await fetch("/api/subscribe", {
@@ -146,7 +157,7 @@ export const useUpgrade = () => {
           return;
         }
 
-        const { error, url } = data;
+        const { error, url, pricingExperiment } = data;
 
         if (url) {
           window.location.href = url;
@@ -161,12 +172,15 @@ export const useUpgrade = () => {
             quantity,
             from_tier: currentSubscription ?? "free",
             to_tier: toTier,
-            billing_interval: billingInterval,
             surface: analyticsContext.surface,
             source: analyticsContext.source,
             reason: analyticsContext.reason,
             limit_type: analyticsContext.limit_type,
             checkout_type: "new_subscription",
+            ...proMonthlyPricingExperimentProperties(
+              pricingExperiment ?? analyticsContext.pricing_experiment,
+            ),
+            billing_interval: billingInterval,
           });
           navigationStarted = true;
           return;

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -19,7 +19,7 @@ import {
 } from "@/lib/billing/checkout-navigation-guard";
 import {
   proMonthlyPricingExperimentProperties,
-  type ProMonthlyPricingExperimentAssignment,
+  type ProMonthlyPricingExperimentPresentation,
 } from "@/lib/experiments/pro-monthly-pricing";
 
 // Keep a tab's upgrade ownership across pricing dialog remounts. Server routes
@@ -40,7 +40,7 @@ export const useUpgrade = () => {
       surface?: string;
       reason?: string;
       limit_type?: string;
-      pricing_experiment?: ProMonthlyPricingExperimentAssignment;
+      pricing_experiment?: ProMonthlyPricingExperimentPresentation;
     } = {},
   ) => {
     e?.preventDefault();

--- a/lib/actions/__tests__/subscription-status.test.ts
+++ b/lib/actions/__tests__/subscription-status.test.ts
@@ -40,6 +40,20 @@ describe("getSubscriptionCancellationStatusAction", () => {
           status: "active",
           cancel_at_period_end: true,
           current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                quantity: 1,
+                price: {
+                  id: "price_pro_29",
+                  lookup_key: "pro-monthly-plan-29-experiment",
+                  unit_amount: 2900,
+                  currency: "usd",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
         },
       ],
     } as never);
@@ -52,11 +66,18 @@ describe("getSubscriptionCancellationStatusAction", () => {
       cancelAtPeriodEnd: true,
       currentPeriodEnd: 1_782_444_800_000,
       subscriptionStatus: "active",
+      stripePriceId: "price_pro_29",
+      stripePriceLookupKey: "pro-monthly-plan-29-experiment",
+      renewalAmountDollars: 29,
+      renewalCurrency: "usd",
+      renewalInterval: "month",
+      renewalIntervalCount: 1,
     });
     expect(mockListSubscriptions).toHaveBeenCalledWith({
       customer: "cus_123",
       status: "all",
       limit: 10,
+      expand: ["data.items.data.price"],
     });
   });
 

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -25,6 +25,11 @@ import {
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
 import type { SubscriptionTier } from "@/types";
+import {
+  proMonthlyPricingAssignmentFromMetadata,
+  proMonthlyPricingExperimentProperties,
+  type ProMonthlyPricingExperimentAssignment,
+} from "@/lib/experiments/pro-monthly-pricing";
 
 type CancellationReasonInput = {
   reasonCategory?: unknown;
@@ -50,6 +55,7 @@ type SubscriptionContext = {
   tier?: SubscriptionTier;
   currentPeriodEnd?: number;
   cancelAtPeriodEnd: boolean;
+  pricingExperiment?: ProMonthlyPricingExperimentAssignment;
 };
 
 function parseCancellationReasonInput(
@@ -141,6 +147,10 @@ async function getActiveSubscriptionContext(
     tier: subscriptionTierFromLookupKey(price?.lookup_key),
     currentPeriodEnd: currentPeriodEndMs(currentSubscription),
     cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
+    pricingExperiment: proMonthlyPricingAssignmentFromMetadata(
+      currentSubscription.metadata,
+      price?.lookup_key,
+    ),
   };
 }
 
@@ -337,11 +347,15 @@ export default async function cancelSubscriptionAction(
       org_id: organizationId,
       subscription_tier: subscriptionContext.tier,
       plan: subscriptionContext.plan,
+      stripe_price_lookup_key: subscriptionContext.plan,
       reason_category: cancellationReason.reasonCategory,
       reason_subcategory: cancellationReason.reasonSubcategory,
       reason_details_length: cancellationReason.reasonDetails.length,
       stripe_customer_id: stripeCustomerId,
       stripe_subscription_id: subscriptionContext.id,
+      ...proMonthlyPricingExperimentProperties(
+        subscriptionContext.pricingExperiment,
+      ),
     }),
   );
   if (shouldEmitCancellationCompleted) {
@@ -352,6 +366,7 @@ export default async function cancelSubscriptionAction(
         org_id: organizationId,
         subscription_tier: subscriptionContext.tier,
         plan: subscriptionContext.plan,
+        stripe_price_lookup_key: subscriptionContext.plan,
         reason_category: cancellationReason.reasonCategory,
         reason_subcategory: cancellationReason.reasonSubcategory,
         cancellation_completion_type: cancelImmediately
@@ -361,6 +376,9 @@ export default async function cancelSubscriptionAction(
         stripe_customer_id: stripeCustomerId,
         stripe_subscription_id: subscriptionContext.id,
         stripe_price_id: subscriptionContext.priceId,
+        ...proMonthlyPricingExperimentProperties(
+          subscriptionContext.pricingExperiment,
+        ),
         $insert_id: cancellationCompletionInsertId(subscriptionContext.id),
       }),
     );

--- a/lib/actions/subscription-status.ts
+++ b/lib/actions/subscription-status.ts
@@ -61,6 +61,7 @@ export default async function getSubscriptionCancellationStatusAction(): Promise
       customer: stripeCustomerId,
       status: "all",
       limit: 10,
+      expand: ["data.items.data.price"],
     });
   } catch (error) {
     phLogger.error("billing_subscription_status_action_failed", {
@@ -84,11 +85,27 @@ export default async function getSubscriptionCancellationStatusAction(): Promise
   }
 
   const latestInvoiceId = stripeObjectId(currentSubscription.latest_invoice);
+  const item = currentSubscription.items?.data[0];
+  const price = item?.price;
+  const renewalAmountDollars =
+    price?.unit_amount == null
+      ? undefined
+      : (price.unit_amount * (item.quantity ?? 1)) / 100;
   return {
     hasActiveSubscription: true,
     cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
     currentPeriodEnd: currentPeriodEndMs(currentSubscription),
     subscriptionStatus: currentSubscription.status,
     ...(latestInvoiceId && { latestInvoiceId }),
+    ...(price?.id && { stripePriceId: price.id }),
+    ...(price?.lookup_key && { stripePriceLookupKey: price.lookup_key }),
+    ...(renewalAmountDollars !== undefined && { renewalAmountDollars }),
+    ...(price?.currency && { renewalCurrency: price.currency }),
+    ...(price?.recurring?.interval && {
+      renewalInterval: price.recurring.interval,
+    }),
+    ...(price?.recurring?.interval_count && {
+      renewalIntervalCount: price.recurring.interval_count,
+    }),
   };
 }

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -28,6 +28,7 @@ export const PAID_FUNNEL_EVENTS = {
   paymentUpdateOpened: "payment_update_opened",
   paymentMethodUpdated: "payment_method_updated",
   invoicePaid: "invoice_paid",
+  subscriptionRefunded: "subscription_refunded",
   limitHit: "limit_hit",
   paidDailyFreeAllowanceImpressed: "paid_daily_free_allowance_impressed",
   paidDailyFreeAllowanceClicked: "paid_daily_free_allowance_clicked",

--- a/lib/billing/api-types.ts
+++ b/lib/billing/api-types.ts
@@ -9,6 +9,12 @@ export type SubscriptionCancellationStatus = {
   currentPeriodEnd?: number;
   subscriptionStatus?: "active" | "trialing" | "past_due" | "unpaid";
   latestInvoiceId?: string;
+  stripePriceId?: string;
+  stripePriceLookupKey?: string;
+  renewalAmountDollars?: number;
+  renewalCurrency?: string;
+  renewalInterval?: string;
+  renewalIntervalCount?: number;
 };
 
 export type BillingPortalFlow = "payment_method";

--- a/lib/experiments/__tests__/pro-monthly-pricing.test.ts
+++ b/lib/experiments/__tests__/pro-monthly-pricing.test.ts
@@ -1,0 +1,58 @@
+import {
+  PRO_MONTHLY_PRICING_EXPERIMENT_KEY,
+  isEligibleForProMonthlyPricingExperiment,
+  proMonthlyPricingAssignmentForVariant,
+  proMonthlyPricingAssignmentFromMetadata,
+  proMonthlyPricingExperimentMetadata,
+} from "@/lib/experiments/pro-monthly-pricing";
+
+describe("HAC-46 Pro monthly pricing experiment", () => {
+  it("limits eligibility to free-user Pro monthly acquisition", () => {
+    expect(
+      isEligibleForProMonthlyPricingExperiment({
+        subscription: "free",
+        requestedPlan: "pro-monthly-plan",
+      }),
+    ).toBe(true);
+
+    for (const input of [
+      { subscription: "pro", requestedPlan: "pro-monthly-plan" },
+      { subscription: "free", requestedPlan: "pro-yearly-plan" },
+      { subscription: "free", requestedPlan: "pro-plus-monthly-plan" },
+      { subscription: "free", requestedPlan: "ultra-monthly-plan" },
+      { subscription: "free", requestedPlan: "team-monthly-plan" },
+    ]) {
+      expect(isEligibleForProMonthlyPricingExperiment(input)).toBe(false);
+    }
+  });
+
+  it("maps variants to an explicit immutable lookup-key allowlist", () => {
+    expect(proMonthlyPricingAssignmentForVariant("control")).toMatchObject({
+      key: PRO_MONTHLY_PRICING_EXPERIMENT_KEY,
+      variant: "control",
+      priceLookupKey: "pro-monthly-plan",
+      displayedAmountDollars: 25,
+    });
+    expect(proMonthlyPricingAssignmentForVariant("test")).toMatchObject({
+      key: PRO_MONTHLY_PRICING_EXPERIMENT_KEY,
+      variant: "test",
+      priceLookupKey: "pro-monthly-plan-29-experiment",
+      displayedAmountDollars: 29,
+    });
+  });
+
+  it("round-trips valid Stripe metadata and rejects price mismatches", () => {
+    const assignment = proMonthlyPricingAssignmentForVariant("test");
+    const metadata = proMonthlyPricingExperimentMetadata(assignment);
+
+    expect(
+      proMonthlyPricingAssignmentFromMetadata(
+        metadata,
+        "pro-monthly-plan-29-experiment",
+      ),
+    ).toEqual(assignment);
+    expect(
+      proMonthlyPricingAssignmentFromMetadata(metadata, "pro-monthly-plan"),
+    ).toBeUndefined();
+  });
+});

--- a/lib/experiments/__tests__/pro-monthly-pricing.test.ts
+++ b/lib/experiments/__tests__/pro-monthly-pricing.test.ts
@@ -4,6 +4,7 @@ import {
   proMonthlyPricingAssignmentForVariant,
   proMonthlyPricingAssignmentFromMetadata,
   proMonthlyPricingExperimentMetadata,
+  proMonthlyPricingExperimentProperties,
 } from "@/lib/experiments/pro-monthly-pricing";
 
 describe("HAC-46 Pro monthly pricing experiment", () => {
@@ -54,5 +55,18 @@ describe("HAC-46 Pro monthly pricing experiment", () => {
     expect(
       proMonthlyPricingAssignmentFromMetadata(metadata, "pro-monthly-plan"),
     ).toBeUndefined();
+  });
+
+  it("includes the resolved Stripe Price ID in client analytics", () => {
+    expect(
+      proMonthlyPricingExperimentProperties({
+        ...proMonthlyPricingAssignmentForVariant("test"),
+        stripePriceId: "price_pro_29",
+      }),
+    ).toMatchObject({
+      experiment_variant: "test",
+      stripe_price_lookup_key: "pro-monthly-plan-29-experiment",
+      stripe_price_id: "price_pro_29",
+    });
   });
 });

--- a/lib/experiments/pro-monthly-pricing.server.ts
+++ b/lib/experiments/pro-monthly-pricing.server.ts
@@ -1,0 +1,27 @@
+import {
+  PRO_MONTHLY_PRICING_EXPERIMENT_KEY,
+  isEligibleForProMonthlyPricingExperiment,
+  proMonthlyPricingAssignmentForVariant,
+  type ProMonthlyPricingExperimentAssignment,
+} from "@/lib/experiments/pro-monthly-pricing";
+import { getPostHogFeatureFlagVariantForUser } from "@/lib/posthog/server";
+
+export async function evaluateProMonthlyPricingExperiment(args: {
+  userId: string;
+  subscription: string;
+  requestedPlan: string;
+}): Promise<ProMonthlyPricingExperimentAssignment | undefined> {
+  if (!isEligibleForProMonthlyPricingExperiment(args)) return undefined;
+
+  const flagValue = await getPostHogFeatureFlagVariantForUser(
+    PRO_MONTHLY_PRICING_EXPERIMENT_KEY,
+    args.userId,
+    { sendFeatureFlagEvents: false },
+  );
+
+  // Fail closed to the established price. The only value authorized to select
+  // the experimental Stripe Price is the explicit PostHog `test` variant.
+  return proMonthlyPricingAssignmentForVariant(
+    flagValue === "test" ? "test" : "control",
+  );
+}

--- a/lib/experiments/pro-monthly-pricing.ts
+++ b/lib/experiments/pro-monthly-pricing.ts
@@ -1,0 +1,121 @@
+import type Stripe from "stripe";
+
+export const PRO_MONTHLY_PRICING_EXPERIMENT_KEY =
+  "hac46-pro-monthly-29-pricing";
+export const PRO_MONTHLY_PRICING_EXPOSURE_EVENT =
+  "hac46_pro_monthly_pricing_experiment_exposed";
+export const PRO_MONTHLY_PRICING_FEATURE_PROPERTY = `$feature/${PRO_MONTHLY_PRICING_EXPERIMENT_KEY}`;
+
+export const PRO_MONTHLY_CONTROL_LOOKUP_KEY = "pro-monthly-plan";
+export const PRO_MONTHLY_TEST_LOOKUP_KEY = "pro-monthly-plan-29-experiment";
+
+export type ProMonthlyPricingExperimentVariant = "control" | "test";
+
+export type ProMonthlyPricingExperimentAssignment = {
+  key: typeof PRO_MONTHLY_PRICING_EXPERIMENT_KEY;
+  variant: ProMonthlyPricingExperimentVariant;
+  priceLookupKey:
+    typeof PRO_MONTHLY_CONTROL_LOOKUP_KEY | typeof PRO_MONTHLY_TEST_LOOKUP_KEY;
+  displayedAmountDollars: 25 | 29;
+  currency: "usd";
+  billingInterval: "month";
+};
+
+const ASSIGNMENTS: Record<
+  ProMonthlyPricingExperimentVariant,
+  ProMonthlyPricingExperimentAssignment
+> = {
+  control: {
+    key: PRO_MONTHLY_PRICING_EXPERIMENT_KEY,
+    variant: "control",
+    priceLookupKey: PRO_MONTHLY_CONTROL_LOOKUP_KEY,
+    displayedAmountDollars: 25,
+    currency: "usd",
+    billingInterval: "month",
+  },
+  test: {
+    key: PRO_MONTHLY_PRICING_EXPERIMENT_KEY,
+    variant: "test",
+    priceLookupKey: PRO_MONTHLY_TEST_LOOKUP_KEY,
+    displayedAmountDollars: 29,
+    currency: "usd",
+    billingInterval: "month",
+  },
+};
+
+export const PRO_MONTHLY_PRICING_METADATA = {
+  experimentKey: "pricingExperimentKey",
+  experimentVariant: "pricingExperimentVariant",
+  priceLookupKey: "pricingExperimentPriceLookupKey",
+} as const;
+
+export function isEligibleForProMonthlyPricingExperiment(args: {
+  subscription: string;
+  requestedPlan: string;
+}): boolean {
+  return (
+    args.subscription === "free" &&
+    args.requestedPlan === PRO_MONTHLY_CONTROL_LOOKUP_KEY
+  );
+}
+
+export function proMonthlyPricingAssignmentForVariant(
+  variant: ProMonthlyPricingExperimentVariant,
+): ProMonthlyPricingExperimentAssignment {
+  return ASSIGNMENTS[variant];
+}
+
+export function proMonthlyPricingExperimentMetadata(
+  assignment: ProMonthlyPricingExperimentAssignment,
+): Stripe.MetadataParam {
+  return {
+    [PRO_MONTHLY_PRICING_METADATA.experimentKey]: assignment.key,
+    [PRO_MONTHLY_PRICING_METADATA.experimentVariant]: assignment.variant,
+    [PRO_MONTHLY_PRICING_METADATA.priceLookupKey]: assignment.priceLookupKey,
+  };
+}
+
+export function proMonthlyPricingExperimentProperties(
+  assignment: ProMonthlyPricingExperimentAssignment | undefined,
+): Record<string, unknown> {
+  if (!assignment) return {};
+  return {
+    experiment_key: assignment.key,
+    experiment_variant: assignment.variant,
+    [PRO_MONTHLY_PRICING_FEATURE_PROPERTY]: assignment.variant,
+    stripe_price_lookup_key: assignment.priceLookupKey,
+    displayed_amount_dollars: assignment.displayedAmountDollars,
+    billing_interval: assignment.billingInterval,
+    currency: assignment.currency,
+  };
+}
+
+export function proMonthlyPricingAssignmentFromMetadata(
+  metadata: Stripe.Metadata | null | undefined,
+  priceLookupKey?: string | null,
+): ProMonthlyPricingExperimentAssignment | undefined {
+  if (
+    metadata?.[PRO_MONTHLY_PRICING_METADATA.experimentKey] !==
+    PRO_MONTHLY_PRICING_EXPERIMENT_KEY
+  ) {
+    return undefined;
+  }
+
+  const variant =
+    metadata[PRO_MONTHLY_PRICING_METADATA.experimentVariant] === "test"
+      ? "test"
+      : metadata[PRO_MONTHLY_PRICING_METADATA.experimentVariant] === "control"
+        ? "control"
+        : undefined;
+  if (!variant) return undefined;
+
+  const assignment = ASSIGNMENTS[variant];
+  const metadataLookupKey =
+    metadata[PRO_MONTHLY_PRICING_METADATA.priceLookupKey];
+  if (metadataLookupKey !== assignment.priceLookupKey) return undefined;
+  if (priceLookupKey && priceLookupKey !== assignment.priceLookupKey) {
+    return undefined;
+  }
+
+  return assignment;
+}

--- a/lib/experiments/pro-monthly-pricing.ts
+++ b/lib/experiments/pro-monthly-pricing.ts
@@ -21,6 +21,11 @@ export type ProMonthlyPricingExperimentAssignment = {
   billingInterval: "month";
 };
 
+export type ProMonthlyPricingExperimentPresentation =
+  ProMonthlyPricingExperimentAssignment & {
+    stripePriceId: string;
+  };
+
 const ASSIGNMENTS: Record<
   ProMonthlyPricingExperimentVariant,
   ProMonthlyPricingExperimentAssignment
@@ -79,6 +84,11 @@ export function proMonthlyPricingExperimentProperties(
   assignment: ProMonthlyPricingExperimentAssignment | undefined,
 ): Record<string, unknown> {
   if (!assignment) return {};
+  const stripePriceId =
+    "stripePriceId" in assignment &&
+    typeof assignment.stripePriceId === "string"
+      ? assignment.stripePriceId
+      : undefined;
   return {
     experiment_key: assignment.key,
     experiment_variant: assignment.variant,
@@ -87,6 +97,7 @@ export function proMonthlyPricingExperimentProperties(
     displayed_amount_dollars: assignment.displayedAmountDollars,
     billing_interval: assignment.billingInterval,
     currency: assignment.currency,
+    ...(stripePriceId && { stripe_price_id: stripePriceId }),
   };
 }
 

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -23,6 +23,7 @@ jest.mock("@/lib/posthog/logs", () => ({
 const {
   getPostHogFeatureFlagForUser,
   getPostHogFeatureFlagValueForUser,
+  getPostHogFeatureFlagVariantForUser,
   phLogger,
 } = require("../server") as typeof import("../server");
 
@@ -61,6 +62,38 @@ describe("phLogger", () => {
     await expect(
       getPostHogFeatureFlagValueForUser("example-feature-flag", "user_123"),
     ).resolves.toBeNull();
+  });
+
+  it("evaluates multivariate flags and ignores non-variant values", async () => {
+    mockGetFeatureFlag.mockResolvedValueOnce("test");
+    await expect(
+      getPostHogFeatureFlagVariantForUser(
+        "hac46-pro-monthly-29-pricing",
+        "user_123",
+        { sendFeatureFlagEvents: false },
+      ),
+    ).resolves.toBe("test");
+    expect(mockGetFeatureFlag).toHaveBeenLastCalledWith(
+      "hac46-pro-monthly-29-pricing",
+      "user_123",
+      { sendFeatureFlagEvents: false },
+    );
+
+    mockGetFeatureFlag.mockResolvedValueOnce(true);
+    await expect(
+      getPostHogFeatureFlagVariantForUser(
+        "hac46-pro-monthly-29-pricing",
+        "user_123",
+      ),
+    ).resolves.toBeUndefined();
+
+    mockGetFeatureFlag.mockRejectedValueOnce(new Error("unavailable"));
+    await expect(
+      getPostHogFeatureFlagVariantForUser(
+        "hac46-pro-monthly-29-pricing",
+        "user_123",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("keeps info and warning records in Logs without duplicating product events", () => {

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -44,6 +44,7 @@ describe("phLogger", () => {
     expect(mockGetFeatureFlag).toHaveBeenCalledWith(
       "agent-subagents",
       "user_123",
+      { sendFeatureFlagEvents: false },
     );
 
     mockGetFeatureFlag.mockRejectedValueOnce(new Error("unavailable"));
@@ -69,6 +70,24 @@ describe("phLogger", () => {
     await expect(
       getPostHogFeatureFlagVariantForUser("free_usage_budget_v1", "user_123"),
     ).resolves.toBe("activation_0_10_monthly_0_15");
+    expect(mockGetFeatureFlag).toHaveBeenLastCalledWith(
+      "free_usage_budget_v1",
+      "user_123",
+    );
+
+    mockGetFeatureFlag.mockResolvedValueOnce("test");
+    await expect(
+      getPostHogFeatureFlagVariantForUser(
+        "hac46-pro-monthly-29-pricing",
+        "user_123",
+        { sendFeatureFlagEvents: false },
+      ),
+    ).resolves.toBe("test");
+    expect(mockGetFeatureFlag).toHaveBeenLastCalledWith(
+      "hac46-pro-monthly-29-pricing",
+      "user_123",
+      { sendFeatureFlagEvents: false },
+    );
 
     mockGetFeatureFlag.mockResolvedValueOnce(true);
     await expect(

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -44,7 +44,6 @@ describe("phLogger", () => {
     expect(mockGetFeatureFlag).toHaveBeenCalledWith(
       "agent-subagents",
       "user_123",
-      { sendFeatureFlagEvents: false },
     );
 
     mockGetFeatureFlag.mockRejectedValueOnce(new Error("unavailable"));

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -33,6 +33,23 @@ export async function getPostHogFeatureFlagValueForUser(
   }
 }
 
+export async function getPostHogFeatureFlagVariantForUser(
+  flagKey: string,
+  userId: string,
+  options?: { sendFeatureFlagEvents?: boolean },
+): Promise<string | undefined> {
+  const client = getClient();
+  if (!client) return undefined;
+  try {
+    const value = options
+      ? await client.getFeatureFlag(flagKey, userId, options)
+      : await client.getFeatureFlag(flagKey, userId);
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 type LogFields = Record<string, unknown> & {
   userId?: string;
   error?: unknown;

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -26,9 +26,7 @@ export async function getPostHogFeatureFlagValueForUser(
   const client = getClient();
   if (!client) return null;
   try {
-    const value = await client.getFeatureFlag(flagKey, userId, {
-      sendFeatureFlagEvents: false,
-    });
+    const value = await client.getFeatureFlag(flagKey, userId);
     return typeof value === "boolean" ? value : null;
   } catch {
     return null;

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -26,7 +26,9 @@ export async function getPostHogFeatureFlagValueForUser(
   const client = getClient();
   if (!client) return null;
   try {
-    const value = await client.getFeatureFlag(flagKey, userId);
+    const value = await client.getFeatureFlag(flagKey, userId, {
+      sendFeatureFlagEvents: false,
+    });
     return typeof value === "boolean" ? value : null;
   } catch {
     return null;
@@ -36,11 +38,14 @@ export async function getPostHogFeatureFlagValueForUser(
 export async function getPostHogFeatureFlagVariantForUser(
   flagKey: string,
   userId: string,
+  options?: { sendFeatureFlagEvents?: boolean },
 ): Promise<string | undefined> {
   const client = getClient();
   if (!client) return undefined;
   try {
-    const value = await client.getFeatureFlag(flagKey, userId);
+    const value = options
+      ? await client.getFeatureFlag(flagKey, userId, options)
+      : await client.getFeatureFlag(flagKey, userId);
     return typeof value === "string" ? value : undefined;
   } catch {
     return undefined;


### PR DESCRIPTION
## Summary

- add server-authoritative, deterministic PostHog assignment for the monthly Pro pricing experiment
- map 90/10 variants to explicit Stripe lookup keys and reject invalid, mismatched, or client-supplied Prices
- preserve the resolved Stripe Price ID and experiment assignment from pricing impression through checkout, invoices, refunds, cancellation, and renewal-price display
- grandfather existing paid users and exclude annual, Team, Pro+, Ultra, and migration flows
- add privacy-safe exposure and paid-funnel attribution

## Launch state

- HAC-80 is complete and no longer blocks this experiment.
- Preview PostHog project `401167`: flag `hac46-pro-monthly-29-pricing` is active, with 100% of the eligible population assigned to `test` for QA.
- Production PostHog project `144137`: the separate flag is configured 90% `control` / 10% `test` and remains **inactive**.
- The live $25 and $29 monthly Prices are active on the same HackerAI Pro Product; the $25 Price remains the default.
- Both Prices use the existing Pro Product tax code and inclusive tax behavior. This experiment makes no tax-registration or automatic-tax change.
- The production webhook is enabled for `refund.created` and `refund.updated`.
- The default Billing Portal cannot switch subscription Prices, so grandfathered subscribers cannot self-migrate to $29.

Do not activate the Production flag until this PR is merged/deployed, eligible-Free-user Preview checkout QA passes, and a human approves the 10% launch.

## Experiment contract

- **Hypothesis:** $29 increases 30-day contribution per eligible exposed visitor without materially weakening individual-user acquisition.
- **Population:** authenticated Free users viewing monthly Pro. Existing paid users, annual billing, Team, Pro+, Ultra, and plan changes are excluded.
- **Exposure:** `hac46_pro_monthly_pricing_experiment_exposed`, emitted only when an eligible user sees the resolved monthly offer.
- **Primary metric:** 30-day net subscription plus Extra Usage revenue, including refunds, minus tracked provider/model/tool cost per eligible exposed user. Join privacy-safe PostHog exposure IDs to Convex `unit_economics_daily`; do not send user content.
- **Minimum sample:** at least 5,000 test exposures and 100 test paid starts.
- **Maturation:** enroll for at least 30 complete days, then wait the full 30-day outcome window; earliest final readout is launch + 60 days.
- **Acquisition guardrail:** reject $29 if pricing-to-paid conversion is more than 5% relatively below control. Treat smaller differences as directional because the 10% arm is not powered for small conversion effects.
- **Early pause:** sample-ratio mismatch, elevated checkout/Stripe errors, Price/Product mismatch, or a >10% relative conversion decline after at least 50 test paid starts.
- **Decision:** roll out $29 only if matured contribution per exposed visitor is positive versus control and the acquisition guardrail passes.
- **Owner:** Ross Manko.
- **Cleanup:** after the matured readout, choose one Price, remove the flag and mapping, and archive the losing experimental Price when appropriate.

## Validation

- `pnpm typecheck`
- `pnpm test --runInBand` — 434 suites / 4,524 tests passed
- `pnpm lint` — zero errors; seven unrelated existing warnings
- focused route/UI/hook tests verify the resolved Stripe Price ID is present on impression, intent, redirect, and server checkout analytics

## Manual verification before Production activation

1. In the new Vercel Preview, sign in with an eligible Free account and open monthly Pro pricing.
2. Confirm the UI shows $29 and the assignment endpoint returns the test lookup key plus a resolved Stripe Price ID.
3. Start Checkout and confirm Stripe shows $29/month for the existing Pro Product; cancel before payment unless a disposable test transaction is intended.
4. Confirm Preview PostHog receives exposure, checkout intent, redirect, and checkout-start events with the test variant, lookup key, and Price ID.
5. Reconfirm the Production flag is inactive and still exactly 90% control / 10% test.

Linear: [HAC-46](https://linear.app/hackerai/issue/HAC-46/run-10percent-pro-dollar29month-pricing-experiment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Pro monthly pricing experiments for eligible subscribers.
  * Displayed experiment-aware pricing during upgrades, with safeguards while pricing loads or is unavailable.
  * Added renewal price and billing interval details to account information.
  * Added pricing context to checkout, subscription, cancellation, and refund tracking.
  * Added support for refund event processing and historical invoice pricing.

* **Bug Fixes**
  * Improved checkout session reuse to match resolved pricing.
  * Prevented unavailable or mismatched experimental prices from being used.
  * Improved attribution for historical invoice prices, refunds, and analytics.
  * Improved handling of ambiguous or incomplete refund data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->