### PR TITLE
Fix iOS chat scrolling in long conversations

### DIFF
--- a/app/hooks/__tests__/useMessageScroll.test.ts
+++ b/app/hooks/__tests__/useMessageScroll.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import {
   CHAT_TIMELINE_ANCHOR_OFFSET,
   getMessageScrollTarget,
@@ -14,6 +14,8 @@ let mockCapturedTargetScrollTop:
       },
     ) => number)
   | undefined;
+let mockScrollElement: HTMLElement | null = null;
+const mockStopScroll = jest.fn();
 
 jest.mock("use-stick-to-bottom", () => ({
   useStickToBottom: (options: {
@@ -21,14 +23,26 @@ jest.mock("use-stick-to-bottom", () => ({
   }) => {
     mockCapturedTargetScrollTop ??= options.targetScrollTop;
     return {
-      scrollRef: { current: null },
+      scrollRef: { current: mockScrollElement },
       contentRef: { current: null },
       isAtBottom: true,
       scrollToBottom: jest.fn(),
-      stopScroll: jest.fn(),
+      stopScroll: mockStopScroll,
     };
   },
 }));
+
+const dispatchTouch = (
+  element: HTMLElement,
+  type: "touchstart" | "touchmove" | "touchend",
+  point?: { clientX: number; clientY: number },
+) => {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, "touches", {
+    value: point ? [point] : [],
+  });
+  element.dispatchEvent(event);
+};
 
 const rect = (top: number, height: number): DOMRect =>
   ({
@@ -46,6 +60,8 @@ const rect = (top: number, height: number): DOMRect =>
 describe("getMessageScrollTarget", () => {
   beforeEach(() => {
     mockCapturedTargetScrollTop = undefined;
+    mockScrollElement = null;
+    mockStopScroll.mockReset();
   });
 
   it("keeps the active user row at the configured top offset", () => {
@@ -119,5 +135,79 @@ describe("getMessageScrollTarget", () => {
         contentElement,
       }),
     ).toBe(200 + 100 - 50 - CHAT_TIMELINE_ANCHOR_OFFSET);
+  });
+});
+
+describe("useMessageScroll touch navigation", () => {
+  beforeEach(() => {
+    mockScrollElement = document.createElement("div");
+    mockStopScroll.mockReset();
+    Object.defineProperties(mockScrollElement, {
+      clientHeight: { configurable: true, value: 600 },
+      scrollHeight: { configurable: true, value: 2_000 },
+      scrollTop: { configurable: true, writable: true, value: 1_200 },
+    });
+  });
+
+  it("escapes sticky follow when a touch gesture moves toward history", () => {
+    const { unmount } = renderHook(() => useMessageScroll("user-2"));
+    const scrollElement = mockScrollElement!;
+
+    act(() => {
+      dispatchTouch(scrollElement, "touchstart", {
+        clientX: 100,
+        clientY: 300,
+      });
+      dispatchTouch(scrollElement, "touchmove", {
+        clientX: 101,
+        clientY: 312,
+      });
+    });
+
+    expect(mockStopScroll).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("keeps sticky follow for taps and horizontal touch movement", () => {
+    const { unmount } = renderHook(() => useMessageScroll("user-2"));
+    const scrollElement = mockScrollElement!;
+
+    act(() => {
+      dispatchTouch(scrollElement, "touchstart", {
+        clientX: 100,
+        clientY: 300,
+      });
+      dispatchTouch(scrollElement, "touchmove", {
+        clientX: 120,
+        clientY: 302,
+      });
+      dispatchTouch(scrollElement, "touchend");
+    });
+
+    expect(mockStopScroll).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("does not escape when the transcript cannot scroll", () => {
+    Object.defineProperty(mockScrollElement, "scrollHeight", {
+      configurable: true,
+      value: 600,
+    });
+    const { unmount } = renderHook(() => useMessageScroll("user-2"));
+    const scrollElement = mockScrollElement!;
+
+    act(() => {
+      dispatchTouch(scrollElement, "touchstart", {
+        clientX: 100,
+        clientY: 300,
+      });
+      dispatchTouch(scrollElement, "touchmove", {
+        clientX: 100,
+        clientY: 320,
+      });
+    });
+
+    expect(mockStopScroll).not.toHaveBeenCalled();
+    unmount();
   });
 });

--- a/app/hooks/useMessageScroll.ts
+++ b/app/hooks/useMessageScroll.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { STICKY_BOTTOM_ESCAPE_EVENT } from "@/lib/utils/scroll-events";
 
 export const CHAT_TIMELINE_ANCHOR_OFFSET = 16;
+const TOUCH_SCROLL_INTENT_THRESHOLD_PX = 4;
 
 export function getMessageScrollTarget({
   defaultTargetScrollTop,
@@ -60,6 +61,8 @@ export const useMessageScroll = (anchorMessageId: string | null = null) => {
         ...elements,
       }),
   });
+  const stickyScrollRef = stickToBottom.scrollRef;
+  const stopStickyScroll = stickToBottom.stopScroll;
 
   const scrollToBottom = useCallback(
     (options?: {
@@ -84,28 +87,74 @@ export const useMessageScroll = (anchorMessageId: string | null = null) => {
   );
 
   useEffect(() => {
-    const scrollContainer = stickToBottom.scrollRef.current;
-    window.addEventListener(
-      STICKY_BOTTOM_ESCAPE_EVENT,
-      stickToBottom.stopScroll,
-    );
+    const scrollContainer = stickyScrollRef.current;
+    let touchStart:
+      { clientX: number; clientY: number; scrollTop: number } | undefined;
+    const handleTouchStart = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!touch) return;
+
+      touchStart = {
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+        scrollTop: scrollContainer?.scrollTop ?? 0,
+      };
+    };
+    const handleTouchMove = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!scrollContainer || !touchStart || !touch) return;
+      if (scrollContainer.scrollHeight <= scrollContainer.clientHeight) return;
+
+      const horizontalDelta = Math.abs(touch.clientX - touchStart.clientX);
+      const verticalDelta = touch.clientY - touchStart.clientY;
+      const hasUpwardScrollIntent =
+        verticalDelta > TOUCH_SCROLL_INTENT_THRESHOLD_PX &&
+        verticalDelta > horizontalDelta;
+      const hasMovedTowardHistory =
+        scrollContainer.scrollTop < touchStart.scrollTop;
+
+      if (hasUpwardScrollIntent || hasMovedTowardHistory) {
+        // use-stick-to-bottom has an explicit wheel escape, but touch scrolling
+        // can otherwise race its ResizeObserver animation on iOS. Escape as
+        // soon as the gesture moves toward history so Safari owns the scroll.
+        stopStickyScroll();
+        touchStart = undefined;
+      }
+    };
+    const clearTouchStart = () => {
+      touchStart = undefined;
+    };
+    window.addEventListener(STICKY_BOTTOM_ESCAPE_EVENT, stopStickyScroll);
 
     scrollContainer?.addEventListener(
       STICKY_BOTTOM_ESCAPE_EVENT,
-      stickToBottom.stopScroll,
+      stopStickyScroll,
     );
+    scrollContainer?.addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    scrollContainer?.addEventListener("touchmove", handleTouchMove, {
+      passive: true,
+    });
+    scrollContainer?.addEventListener("touchend", clearTouchStart, {
+      passive: true,
+    });
+    scrollContainer?.addEventListener("touchcancel", clearTouchStart, {
+      passive: true,
+    });
 
     return () => {
-      window.removeEventListener(
-        STICKY_BOTTOM_ESCAPE_EVENT,
-        stickToBottom.stopScroll,
-      );
+      window.removeEventListener(STICKY_BOTTOM_ESCAPE_EVENT, stopStickyScroll);
       scrollContainer?.removeEventListener(
         STICKY_BOTTOM_ESCAPE_EVENT,
-        stickToBottom.stopScroll,
+        stopStickyScroll,
       );
+      scrollContainer?.removeEventListener("touchstart", handleTouchStart);
+      scrollContainer?.removeEventListener("touchmove", handleTouchMove);
+      scrollContainer?.removeEventListener("touchend", clearTouchStart);
+      scrollContainer?.removeEventListener("touchcancel", clearTouchStart);
     };
-  }, [stickToBottom.scrollRef, stickToBottom.stopScroll]);
+  }, [stickyScrollRef, stopStickyScroll]);
 
   return {
     scrollRef: stickToBottom.scrollRef,


### PR DESCRIPTION
## Summary
- stop sticky live-follow when a touch gesture moves toward older chat history
- keep live-follow active for taps, horizontal gestures, and non-scrollable transcripts
- use passive touch listeners and clean them up with the chat scroll subscription
- add regression coverage for mobile touch navigation

## Validation
- `corepack pnpm exec jest app/hooks/__tests__/useMessageScroll.test.ts app/components/__tests__/Messages.edit.test.tsx --runInBand` (18 tests passed)
- `corepack pnpm run typecheck`
- focused ESLint and Prettier checks
- pre-commit full suite: 407 suites / 4,285 tests passed
- post-rebase focused suite: 6 tests passed

## Manual verification
1. On iOS Safari, open a long chat while the latest response is streaming or still resizing.
2. Swipe down in the transcript to move toward older messages.
3. Confirm the viewport follows the finger and stays at the chosen history position instead of snapping back toward the latest turn.
4. Tap or swipe horizontally near the live edge and confirm streaming follow remains active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message scrolling on touch devices by detecting swipe gestures toward message history.
  * Sticky-bottom scrolling now stops when users intentionally scroll upward, while taps and horizontal gestures remain unaffected.

* **Bug Fixes**
  * Prevented sticky scrolling from overriding touch-based navigation in non-scrollable or empty transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->