### PR TITLE
Fix canceled Agent locks and remote-control errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,3 +182,13 @@ Manual steps should say:
 - What should happen.
 
 If manual verification is not needed, say automated validation was sufficient.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -146,6 +146,7 @@ export const MessageErrorState = ({
   const canUpgrade = shouldShowUpgradeCta({ subscription, capReason });
   const extraUsageCta = getExtraUsageLimitCta({ subscription, capReason });
   const limitType = getLimitTypeForCapReason(capReason);
+  const isConcurrencyLimit = limitType === "concurrency";
   const upgradeCtaText =
     subscription === "free" &&
     (limitType === "daily_requests" || limitType === "free_monthly")
@@ -170,7 +171,8 @@ export const MessageErrorState = ({
     canUsePaidDailyFreeAllowance &&
     extraUsageCta?.analyticsText === "Add Credits";
   const showRateLimitRetry = !shouldFocusPaidAllowanceActions;
-  const showRateLimitUsage = !shouldFocusPaidAllowanceActions;
+  const showRateLimitUsage =
+    !shouldFocusPaidAllowanceActions && !isConcurrencyLimit;
   const showUpgrade = canUpgrade && !shouldFocusPaidAllowanceActions;
   const isDirectAddCredits = extraUsageCta?.analyticsText === "Add Credits";
   const isPaymentRecovery = capReason === "auto_reload_failed";

--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -185,6 +185,8 @@ const RemoteControlTab = () => {
     subscription,
   });
 
+  const activeConnections = connections ?? [];
+
   const handleGetToken = async () => {
     setIsLoadingToken(true);
     try {
@@ -264,27 +266,30 @@ const RemoteControlTab = () => {
         <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
           Connections
         </h4>
-        {connections && connections.filter((c) => !c.isDesktop).length > 0 ? (
+        {activeConnections.length > 0 ? (
           <div className="space-y-2">
-            {connections
-              .filter((conn) => !conn.isDesktop)
-              .map((conn) => (
-                <div
-                  key={conn.connectionId}
-                  className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg"
-                >
-                  <div className="relative">
-                    <Circle className="h-2.5 w-2.5 fill-green-500 text-green-500" />
-                    <Circle className="h-2.5 w-2.5 fill-green-500 text-green-500 absolute inset-0 animate-ping opacity-75" />
+            {activeConnections.map((conn) => (
+              <div
+                key={conn.connectionId}
+                className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg"
+              >
+                <div className="relative">
+                  <Circle className="h-2.5 w-2.5 fill-green-500 text-green-500" />
+                  <Circle className="h-2.5 w-2.5 fill-green-500 text-green-500 absolute inset-0 animate-ping opacity-75" />
+                </div>
+                <Server className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm">
+                    {conn.osInfo?.hostname || conn.name}
                   </div>
-                  <Server className="h-4 w-4 text-muted-foreground shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-sm">
-                      {conn.osInfo?.hostname || conn.name}
-                    </div>
+                  <div className="text-xs text-muted-foreground">
+                    {conn.isDesktop
+                      ? "Desktop app connected"
+                      : "Remote Control connected"}
                   </div>
                 </div>
-              ))}
+              </div>
+            ))}
           </div>
         ) : (
           <div className="flex flex-col items-center justify-center py-6 px-4 bg-muted/30 rounded-lg">

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -6,9 +6,11 @@ import type { ReactNode } from "react";
 import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
 import { getPaidDailyFreeAllowanceCtaText } from "@/lib/limit-pressure";
 
+let mockSubscription: "free" | "pro" = "pro";
+
 jest.mock("@/app/contexts/GlobalState", () => ({
   GlobalStateProvider: ({ children }: { children: ReactNode }) => children,
-  useGlobalState: () => ({ subscription: "pro" }),
+  useGlobalState: () => ({ subscription: mockSubscription }),
 }));
 
 jest.mock("@/lib/utils/settings-dialog", () => ({
@@ -46,6 +48,7 @@ const { openSettingsDialog } = require("@/lib/utils/settings-dialog");
 describe("MessageErrorState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSubscription = "pro";
     mockConvexAction.mockResolvedValue({
       hasPaymentMethod: true,
       paymentMethodLast4: "4242",
@@ -101,6 +104,34 @@ describe("MessageErrorState", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a concurrency retry without usage or upgrade actions", () => {
+    mockSubscription = "free";
+    const error = new ChatSDKError(
+      "rate_limit:chat",
+      "You already have a free request running. Please wait for it to finish before starting another one.",
+      {
+        subscription: "free",
+        capReason: "free_concurrency",
+        limitType: "concurrency",
+      },
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState error={error} onRetry={jest.fn()} />
+      </TestWrapper>,
+    );
+
+    expect(
+      screen.getByText(/already have a free request running/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Try Again" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "View Usage" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Upgrade Plan" })).toBeNull();
   });
 
   it("shows a focused Add Credits plus free Ask CTA when allowance is available", async () => {

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -90,6 +90,19 @@ const remoteConnection: MockConnection = {
   isDesktop: false,
 };
 
+const desktopConnection: MockConnection = {
+  connectionId: "conn-desktop-1",
+  name: "HackerAI Desktop",
+  osInfo: {
+    platform: "darwin",
+    arch: "arm64",
+    release: "25.0.0",
+    hostname: "bobbys-mac",
+  },
+  lastSeen: 123,
+  isDesktop: true,
+};
+
 describe("RemoteControlTab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -140,6 +153,16 @@ describe("RemoteControlTab", () => {
     expect(mockSetSelectedModel).not.toHaveBeenCalled();
     expect(mockSetChatMode).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows a desktop bridge as an active connection", () => {
+    mockConnections = [desktopConnection];
+
+    render(<RemoteControlTab />);
+
+    expect(screen.getByText("bobbys-mac")).toBeInTheDocument();
+    expect(screen.getByText("Desktop app connected")).toBeInTheDocument();
+    expect(screen.queryByText("No active connections")).not.toBeInTheDocument();
   });
 
   it("reports command copy success only after the clipboard write succeeds", async () => {

--- a/lib/__tests__/limit-pressure.test.ts
+++ b/lib/__tests__/limit-pressure.test.ts
@@ -6,6 +6,21 @@ import {
 } from "../limit-pressure";
 
 describe("limit pressure helpers", () => {
+  it("classifies free concurrency separately without an upgrade CTA", () => {
+    expect(
+      getLimitPressureContext({
+        subscription: "free",
+        capReason: "free_concurrency",
+      }),
+    ).toMatchObject({
+      limitType: "concurrency",
+      upgradeAvailable: false,
+      addCreditAvailable: false,
+      primaryCta: undefined,
+      eligibleCtas: [],
+    });
+  });
+
   it("routes free limit pressure to upgrade only", () => {
     expect(
       getLimitPressureContext({

--- a/lib/limit-pressure.ts
+++ b/lib/limit-pressure.ts
@@ -7,6 +7,7 @@ export function getPaidDailyFreeAllowanceCtaText(mode?: ChatMode): string {
 }
 
 export type LimitCapReason =
+  | "free_concurrency"
   | "daily_requests_exhausted"
   | "free_monthly_exhausted"
   | "monthly_exhausted"
@@ -24,6 +25,7 @@ export type LimitCapReason =
   | (string & {});
 
 export type LimitType =
+  | "concurrency"
   | "daily_requests"
   | "free_monthly"
   | "monthly"
@@ -70,6 +72,7 @@ export function getLimitTypeForCapReason(
   capReason: LimitCapReason | undefined,
 ): LimitType {
   if (!capReason) return "monthly";
+  if (capReason === "free_concurrency") return "concurrency";
   if (capReason.startsWith("paid_daily_free_allowance")) {
     return "paid_daily_free_allowance";
   }
@@ -117,7 +120,7 @@ export function shouldShowUpgradeCta(args: {
 }): boolean {
   const { subscription, capReason } = args;
   if (!UPGRADABLE_TIERS.has(subscription)) return false;
-  if (subscription === "free") return true;
+  if (subscription === "free") return capReason !== "free_concurrency";
 
   return !capReason || DIRECT_EXTRA_USAGE_REASONS.has(capReason);
 }

--- a/lib/rate-limit/__tests__/free-concurrency.test.ts
+++ b/lib/rate-limit/__tests__/free-concurrency.test.ts
@@ -60,6 +60,17 @@ describe("acquireFreeRunConcurrencyLock", () => {
       type: "rate_limit",
       surface: "chat",
       cause: expect.stringContaining("already have a free request running"),
+      metadata: {
+        subscription: "free",
+        capReason: "free_concurrency",
+        limitType: "concurrency",
+        costGuardrail: false,
+        paidMonthlyExhaustion: false,
+        upgradeAvailable: false,
+        addCreditAvailable: false,
+        primaryCta: undefined,
+        eligibleCtas: [],
+      },
     });
   });
 

--- a/lib/rate-limit/free-concurrency.ts
+++ b/lib/rate-limit/free-concurrency.ts
@@ -1,4 +1,5 @@
 import { ChatSDKError } from "@/lib/errors";
+import { getLimitPressureContext } from "@/lib/limit-pressure";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "./free-config";
 import { createRedisClient } from "./redis";
 
@@ -47,9 +48,18 @@ export async function acquireFreeRunConcurrencyLock(
   });
 
   if (acquired !== "OK") {
+    const capReason = "free_concurrency";
     throw new ChatSDKError(
       "rate_limit:chat",
       "You already have a free request running. Please wait for it to finish before starting another one.",
+      {
+        subscription: "free",
+        capReason,
+        ...getLimitPressureContext({
+          subscription: "free",
+          capReason,
+        }),
+      },
     );
   }
 

--- a/trigger/__tests__/agent-long-post-wait-authorization.test.ts
+++ b/trigger/__tests__/agent-long-post-wait-authorization.test.ts
@@ -188,6 +188,32 @@ describe("agent-long post-wait authorization contract", () => {
     expect(reacquire).toBeGreaterThan(monthlyCost);
   });
 
+  it("releases the free concurrency lock from the outer task cleanup", () => {
+    const cleanupAnchor = taskSource.indexOf(
+      "runtimeSettlementWatchdog?.dispose()",
+    );
+    const outerFinally = taskSource.lastIndexOf("} finally {", cleanupAnchor);
+    const cleanupEnd = taskSource.indexOf(
+      "runCleanupMap.delete(ctx.run.id)",
+      cleanupAnchor,
+    );
+    const outerCleanupSource = taskSource.slice(outerFinally, cleanupEnd);
+
+    expect(outerFinally).toBeGreaterThan(-1);
+    expect(cleanupEnd).toBeGreaterThan(cleanupAnchor);
+    expect(outerCleanupSource).toContain("await releaseFreeRunLockOnce()");
+  });
+
+  it("releases the free concurrency lock from Trigger cancellation cleanup", () => {
+    const onCancelStart = taskSource.indexOf("onCancel: async");
+    const runStart = taskSource.indexOf("run: async", onCancelStart);
+    const onCancelSource = taskSource.slice(onCancelStart, runStart);
+
+    expect(onCancelStart).toBeGreaterThan(-1);
+    expect(runStart).toBeGreaterThan(onCancelStart);
+    expect(onCancelSource).toContain("await cleanup.releaseFreeRunLock()");
+  });
+
   it("checks fresh suspension, ownership, model, and billing state", () => {
     expect(taskSource).toMatch(
       /verifyAgentToolApprovalInputAuthorization\([\s\S]*assertUserCanMakeCostIncurringRequest\(userId\)/,

--- a/trigger/__tests__/agent-long-post-wait-authorization.test.ts
+++ b/trigger/__tests__/agent-long-post-wait-authorization.test.ts
@@ -201,7 +201,18 @@ describe("agent-long post-wait authorization contract", () => {
 
     expect(outerFinally).toBeGreaterThan(-1);
     expect(cleanupEnd).toBeGreaterThan(cleanupAnchor);
-    expect(outerCleanupSource).toContain("await releaseFreeRunLockOnce()");
+    expect(outerCleanupSource).toContain(
+      'await releaseFreeRunLockBestEffort("outer_finally")',
+    );
+  });
+
+  it("keeps failed lock releases retryable without replacing run errors", () => {
+    expect(taskSource).toMatch(
+      /releaseFreeRunLockPromise = release\(\)[\s\S]*releaseFreeRunLock = undefined[\s\S]*\.finally\(\(\) => \{[\s\S]*releaseFreeRunLockPromise = undefined/,
+    );
+    expect(taskSource).toContain(
+      'await releaseFreeRunLockBestEffort("outer_catch")',
+    );
   });
 
   it("releases the free concurrency lock from Trigger cancellation cleanup", () => {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2406,11 +2406,33 @@ export const agentLongTask = task({
     const usageRefundTracker = new UsageRefundTracker();
     usageRefundTracker.setUser(userId, subscription, organizationId);
     let releaseFreeRunLock: (() => Promise<void>) | undefined;
+    let releaseFreeRunLockPromise: Promise<void> | undefined;
     const releaseFreeRunLockOnce = async () => {
+      if (releaseFreeRunLockPromise) return releaseFreeRunLockPromise;
       const release = releaseFreeRunLock;
       if (!release) return;
-      releaseFreeRunLock = undefined;
-      await release();
+      releaseFreeRunLockPromise = release()
+        .then(() => {
+          if (releaseFreeRunLock === release) {
+            releaseFreeRunLock = undefined;
+          }
+        })
+        .finally(() => {
+          releaseFreeRunLockPromise = undefined;
+        });
+      await releaseFreeRunLockPromise;
+    };
+    const releaseFreeRunLockBestEffort = async (cleanupSource: string) => {
+      await releaseFreeRunLockOnce().catch((error) => {
+        triggerLogger.warn("[agent-long] free run lock release failed", {
+          event: "agent_free_run_lock_release_failed",
+          user_id: userId,
+          chat_id: chatId,
+          trigger_run_id: ctx.run.id,
+          cleanup_source: cleanupSource,
+          error: stringifyRedactedError(error),
+        });
+      });
     };
 
     let chatLogger: ChatLogger | undefined = createChatLogger({
@@ -5332,7 +5354,7 @@ export const agentLongTask = task({
       metadata.set("status", "done");
       await phLogger.flush().catch(() => {});
     } catch (error) {
-      await releaseFreeRunLockOnce();
+      await releaseFreeRunLockBestEffort("outer_catch");
       memoryTelemetry.checkpoint({ phase: "run_failed", force: true });
       const chatMissingAfterStream =
         streamPiped &&
@@ -5421,15 +5443,7 @@ export const agentLongTask = task({
 
       throw error;
     } finally {
-      await releaseFreeRunLockOnce().catch((error) => {
-        triggerLogger.warn("[agent-long] free run lock release failed", {
-          event: "agent_free_run_lock_release_failed",
-          user_id: userId,
-          chat_id: chatId,
-          trigger_run_id: ctx.run.id,
-          error: stringifyRedactedError(error),
-        });
-      });
+      await releaseFreeRunLockBestEffort("outer_finally");
       runtimeSettlementWatchdog?.dispose();
       memoryTelemetry.dispose();
       activeRuntimeBudget?.dispose();

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2077,6 +2077,7 @@ const withAgentLongStreamHeartbeat = (
 type RunCleanupState = {
   usageRefundTracker: UsageRefundTracker;
   hasObservedUsage: () => boolean;
+  releaseFreeRunLock: () => Promise<void>;
   chatLogger: ChatLogger | undefined;
   chatId: string;
   userId: string;
@@ -2246,6 +2247,16 @@ export const agentLongTask = task({
     if (!cleanup.hasObservedUsage()) {
       await cleanup.usageRefundTracker.refund().catch(() => {});
     }
+    await cleanup.releaseFreeRunLock().catch((error) => {
+      triggerLogger.warn("[agent-long] canceled run lock release failed", {
+        event: "agent_free_run_lock_release_failed",
+        user_id: cleanup.userId,
+        chat_id: cleanup.chatId,
+        trigger_run_id: ctx.run.id,
+        cleanup_source: "on_cancel",
+        error: stringifyRedactedError(error),
+      });
+    });
     if (cleanup.subagentsEnabled) {
       await settleSubagentsForParentRun(
         ctx.run.id,
@@ -2436,6 +2447,7 @@ export const agentLongTask = task({
     runCleanupMap.set(ctx.run.id, {
       usageRefundTracker,
       hasObservedUsage,
+      releaseFreeRunLock: releaseFreeRunLockOnce,
       chatLogger,
       chatId,
       userId,
@@ -5409,6 +5421,15 @@ export const agentLongTask = task({
 
       throw error;
     } finally {
+      await releaseFreeRunLockOnce().catch((error) => {
+        triggerLogger.warn("[agent-long] free run lock release failed", {
+          event: "agent_free_run_lock_release_failed",
+          user_id: userId,
+          chat_id: chatId,
+          trigger_run_id: ctx.run.id,
+          error: stringifyRedactedError(error),
+        });
+      });
       runtimeSettlementWatchdog?.dispose();
       memoryTelemetry.dispose();
       activeRuntimeBudget?.dispose();


### PR DESCRIPTION
## Summary

- release free Agent concurrency locks from both Trigger cancellation cleanup and the task's outer finalizer
- classify concurrent free runs explicitly so the UI shows the real message and retry action without a misleading monthly-limit upgrade CTA
- show desktop bridge connections as active in Remote Control settings instead of reporting no active connections

## Root cause

A canceled durable Agent run could bypass the inner stream cleanup and leave its Redis concurrency lock until the 65-minute TTL. The lock error also had no structured cap reason, so limit-pressure helpers fell back to a monthly limit and offered an upgrade. Desktop bridge connections were separately filtered out of the Remote Control connection list.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm test --runInBand` (408 suites, 4,298 tests)
- focused formatting check for every changed source and test file
- local app browser smoke test

The repository-wide formatting check still reports pre-existing formatting issues in 11 unrelated files.

## Manual verification

1. In Preview, sign in with a free account in the desktop app, start an Agent run, cancel it, and immediately start another run. The second run should start without waiting for the old lock TTL.
2. While a free Agent run is genuinely active, attempt another request. The error should say another free request is running and show **Try Again**, without **View Usage** or **Upgrade Plan**.
3. Open Settings → Remote Control with only the desktop bridge connected. The machine should appear with **Desktop app connected**, not **No active connections**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved concurrency limit messaging for free-tier accounts, with clearer retry options and no misleading usage or upgrade prompts.
  * Enhanced rate-limit details to better identify concurrency restrictions.
  * Remote Control now displays desktop and remote connections with their type, hostname, and status.

* **Bug Fixes**
  * Canceled or completed agent runs now reliably release concurrency capacity, preventing stale connection limits.
  * Improved cleanup reliability when agent runs are canceled or encounter errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->