### PR TITLE
fix: distinguish local provider size rejections

### DIFF
--- a/lib/api/__tests__/provider-terminal-error.test.ts
+++ b/lib/api/__tests__/provider-terminal-error.test.ts
@@ -46,4 +46,34 @@ describe("wrapProviderTerminalError", () => {
       "Provider terminal error provider=xai model=x-ai_grok-4.5 category=provider_5xx status=502",
     );
   });
+
+  it("distinguishes local aggregate-size rejections from upstream 413s", () => {
+    const localAttempt = Object.assign(new Error("Request too large"), {
+      statusCode: 413,
+      responseHeaders: {
+        "X-HackerAI-OpenRouter-Request-Size-Guard": "rejected",
+      },
+    });
+    const localRejection = wrapProviderTerminalError(
+      Object.assign(new Error("Failed after 3 attempts"), {
+        errors: [localAttempt],
+      }),
+      { model: "deepseek/deepseek-v4-flash-0731" },
+    );
+    const upstreamRejection = wrapProviderTerminalError(
+      Object.assign(new Error("Provider request too large"), {
+        statusCode: 413,
+      }),
+      { model: "deepseek/deepseek-v4-flash-0731" },
+    );
+
+    expect(localRejection.message).toBe(
+      "Provider terminal error provider=deepseek model=deepseek_deepseek-v4-flash-0731 category=provider_4xx origin=local_request_size_guard status=413",
+    );
+    expect(localRejection.origin).toBe("local_request_size_guard");
+    expect(upstreamRejection.message).toBe(
+      "Provider terminal error provider=deepseek model=deepseek_deepseek-v4-flash-0731 category=provider_4xx status=413",
+    );
+    expect(upstreamRejection.origin).toBeUndefined();
+  });
 });

--- a/lib/api/provider-terminal-error.ts
+++ b/lib/api/provider-terminal-error.ts
@@ -3,6 +3,7 @@ import {
   extractErrorDetails,
   getProviderErrorCategory,
   getProviderStatusCode,
+  isLocalOpenRouterRequestSizeGuardError,
   type ProviderErrorCategory,
 } from "@/lib/utils/error-utils";
 
@@ -22,6 +23,7 @@ export class ProviderTerminalError extends Error {
   readonly model: string;
   readonly category: ProviderErrorCategory;
   readonly statusCode?: number;
+  readonly origin?: "local_request_size_guard";
   readonly openrouterGenerationId?: string;
   readonly openrouterRequestId?: string;
   readonly openrouterUpstreamId?: string;
@@ -43,11 +45,15 @@ export class ProviderTerminalError extends Error {
         ? details.providerName
         : providerFromModel(model));
     const statusCode = getProviderStatusCode(details);
+    const origin = isLocalOpenRouterRequestSizeGuardError(cause)
+      ? "local_request_size_guard"
+      : undefined;
     const message = [
       "Provider terminal error",
       `provider=${fingerprintToken(provider)}`,
       `model=${fingerprintToken(model)}`,
       `category=${fingerprintToken(category)}`,
+      origin ? `origin=${origin}` : undefined,
       statusCode ? `status=${statusCode}` : undefined,
     ]
       .filter(Boolean)
@@ -59,6 +65,7 @@ export class ProviderTerminalError extends Error {
     this.model = model ?? "unknown";
     this.category = category;
     this.statusCode = statusCode;
+    this.origin = origin;
     this.openrouterGenerationId =
       context.openRouterMetadata?.openrouter_generation_id;
     this.openrouterRequestId =

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -69,6 +69,21 @@ const collectErrorSources = (
   return sources;
 };
 
+const OPENROUTER_REQUEST_SIZE_GUARD_HEADER =
+  "x-hackerai-openrouter-request-size-guard";
+
+export const isLocalOpenRouterRequestSizeGuardError = (
+  error: unknown,
+): boolean =>
+  collectErrorSources(error).some((source) => {
+    if (!isRecord(source) || !isRecord(source.responseHeaders)) return false;
+    return Object.entries(source.responseHeaders).some(
+      ([name, value]) =>
+        name.toLowerCase() === OPENROUTER_REQUEST_SIZE_GUARD_HEADER &&
+        value === "rejected",
+    );
+  });
+
 const getOpenRouterPayload = (
   source: unknown,
 ): Record<string, unknown> | null => {


### PR DESCRIPTION
## Production evidence

Daily production error triage for the frozen `2026-08-26T20:01:47Z`–`2026-08-27T20:01:47Z` window found 20 Trigger.dev terminal rows labeled as provider HTTP 413 failures across four users and six chats. Representative trace `run_06g49aold3jipomuq2rub0r3c1` showed the request was rejected locally by HackerAI's whole-request 5 MiB guard after safe attachment reduction could not fit. These rows were conflated with 28 actual upstream provider HTTP 400 failures, and PostHog's mixed provider issue grew to 47 occurrences across 14 users.

## Root cause

`ProviderTerminalError` classified both app-generated and upstream 413 responses as `provider_4xx`. The local response already carries the private `x-hackerai-openrouter-request-size-guard: rejected` marker, but the stable Trigger fingerprint did not preserve that origin.

## Change

- Detect the app-owned guard marker through nested retry/cause errors.
- Add the bounded `origin=local_request_size_guard` token to the stable terminal-error fingerprint.
- Preserve the existing `provider_4xx` category, 413 status, 5 MiB aggregate enforcement, fallback, retry, and user-facing behavior.
- Keep upstream 413 fingerprints unchanged.

No prompts, attachments, provider payloads, paths, or raw user content are added to telemetry.

## Validation

- Pre-commit suite: 409 suites / 4,309 tests passed.
- Focused provider/error suites: 93 tests passed.
- TypeScript typecheck passed.
- Changed-file ESLint and Prettier checks passed.
- Local dependency links verified as scoped to this worktree.
- Adversarial review covered nested retries, all `ProviderTerminalError` callers, aggregate request scope, upstream 413 separation, deploy skew, and privacy bounds.

## Manual verification

After the Trigger Production worker containing this change is deployed, inspect the next naturally occurring oversized-request rejection. Its terminal fingerprint should include `origin=local_request_size_guard`; an upstream 413 without the private header should not. Confirm no raw response body or request content is present.

Visual verification is not applicable because this is a backend error-fingerprint-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for requests rejected by the local request-size limit.
  * Local size-limit errors now include a clear origin in their message and metadata.
  * Preserved distinct handling for upstream HTTP 413 responses.
* **Tests**
  * Added coverage to verify that local and upstream request-size errors are reported differently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->