### PR TITLE
Simplify local machine connection setup

### DIFF
--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -4,17 +4,15 @@ import { useEffect, useRef, useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Circle,
   Copy,
-  Eye,
-  EyeOff,
   RefreshCw,
   AlertTriangle,
   Terminal,
   Server,
   ExternalLink,
+  LoaderCircle,
 } from "lucide-react";
 import { toast } from "sonner";
 import { runCommand, convexUrlFlag } from "@/lib/utils/sandbox-command";
@@ -38,54 +36,6 @@ interface LocalConnection {
   lastSeen: number;
   isDesktop: boolean;
 }
-
-interface CommandBlockProps {
-  label: string;
-  command: string;
-  onCopy: () => void;
-  warning?: boolean;
-}
-
-const CommandBlock = ({
-  label,
-  command,
-  onCopy,
-  warning,
-}: CommandBlockProps) => (
-  <div className="space-y-1.5">
-    <div
-      className={`text-xs font-medium flex items-center gap-1.5 ${warning ? "text-yellow-700 dark:text-yellow-400" : ""}`}
-    >
-      {label}
-      {warning && <AlertTriangle className="h-3 w-3" />}
-    </div>
-    <div className="flex gap-2">
-      <code
-        className={`flex-1 p-2.5 rounded-lg font-mono text-xs overflow-x-auto ${
-          warning
-            ? "bg-yellow-500/5 border border-yellow-500/20 text-yellow-900 dark:text-yellow-100"
-            : "bg-zinc-900 dark:bg-zinc-950 text-zinc-300 dark:text-zinc-400"
-        }`}
-      >
-        {command}
-      </code>
-      <Button
-        variant="outline"
-        size="icon"
-        className="shrink-0 h-9 w-9"
-        onClick={onCopy}
-        aria-label={`Copy ${label} command`}
-      >
-        <Copy className="h-4 w-4" />
-      </Button>
-    </div>
-    {warning && (
-      <p className="text-xs text-yellow-600 dark:text-yellow-400">
-        Commands run directly on host OS - no isolation
-      </p>
-    )}
-  </div>
-);
 
 interface UseAutoSelectNewRemoteConnectionArgs {
   connections: LocalConnection[] | undefined;
@@ -156,9 +106,8 @@ function useAutoSelectNewRemoteConnection({
 }
 
 const RemoteControlTab = () => {
-  const [showToken, setShowToken] = useState(false);
   const [token, setToken] = useState<string | null>(null);
-  const [isLoadingToken, setIsLoadingToken] = useState(false);
+  const [isPreparingCommand, setIsPreparingCommand] = useState(false);
 
   const {
     chatMode,
@@ -187,16 +136,45 @@ const RemoteControlTab = () => {
 
   const activeConnections = connections ?? [];
 
-  const handleGetToken = async () => {
-    setIsLoadingToken(true);
+  const handleCopyConnectCommand = async () => {
+    setIsPreparingCommand(true);
+
     try {
-      const result = await tokenResult();
-      setToken(result.token);
+      const commandPromise = (async () => {
+        let commandToken = token;
+
+        if (!commandToken) {
+          const result = await tokenResult();
+          commandToken = result.token;
+          setToken(commandToken);
+        }
+
+        return `${runCommand} --token ${commandToken}${convexUrlFlag}`;
+      })();
+
+      // Start the clipboard write during the click gesture. Safari can expire
+      // clipboard permission while waiting for the token request to finish.
+      if (
+        typeof ClipboardItem !== "undefined" &&
+        typeof navigator.clipboard.write === "function"
+      ) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            "text/plain": commandPromise.then(
+              (command) => new Blob([command], { type: "text/plain" }),
+            ),
+          }),
+        ]);
+      } else {
+        await navigator.clipboard.writeText(await commandPromise);
+      }
+
+      toast.success("Connect command copied. Paste it into your terminal.");
     } catch (error) {
-      console.error("Failed to get token:", error);
-      toast.error("Failed to get token");
+      console.error("Failed to prepare connect command:", error);
+      toast.error("Failed to copy connect command");
     } finally {
-      setIsLoadingToken(false);
+      setIsPreparingCommand(false);
     }
   };
 
@@ -204,42 +182,11 @@ const RemoteControlTab = () => {
     try {
       const result = await regenerateToken();
       setToken(result.token);
-      toast.success("Token regenerated successfully");
-      setShowToken(false);
+      toast.success("Access token reset. Existing connections were stopped.");
     } catch (error) {
       console.error("Failed to regenerate token:", error);
-      toast.error("Failed to regenerate token");
+      toast.error("Failed to reset access token");
     }
-  };
-
-  const copyToClipboard = async (
-    text: string,
-    successMessage: string,
-    errorMessage: string,
-  ) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      toast.success(successMessage);
-    } catch {
-      toast.error(errorMessage);
-    }
-  };
-
-  const handleCopyCommand = (command: string) =>
-    copyToClipboard(
-      command,
-      "Command copied to clipboard",
-      "Failed to copy command",
-    );
-
-  const handleCopyToken = () => {
-    if (!token) return;
-
-    return copyToClipboard(
-      token,
-      "Token copied to clipboard",
-      "Failed to copy token",
-    );
   };
 
   return (
@@ -304,89 +251,53 @@ const RemoteControlTab = () => {
         )}
       </div>
 
-      {/* Token Management */}
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-            Auth Token
-          </h4>
-          {token && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 text-xs text-muted-foreground hover:text-foreground"
-              onClick={handleRegenerateToken}
-            >
-              <RefreshCw className="h-3 w-3 mr-1" />
-              Regenerate
-            </Button>
-          )}
-        </div>
-
-        {!token ? (
-          <Button
-            onClick={handleGetToken}
-            disabled={isLoadingToken}
-            variant="outline"
-            size="sm"
-            className="w-full sm:w-auto"
-          >
-            <Terminal className="h-3.5 w-3.5 mr-2" />
-            {isLoadingToken ? "Loading..." : "Generate Token"}
-          </Button>
-        ) : (
-          <div className="flex gap-2">
-            <div className="flex-1 relative">
-              <Input
-                type={showToken ? "text" : "password"}
-                value={token}
-                readOnly
-                className="font-mono text-xs pr-20 bg-muted/50 border-0"
-              />
-              <div className="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-7 p-0"
-                  onClick={() => setShowToken(!showToken)}
-                >
-                  {showToken ? (
-                    <EyeOff className="h-3.5 w-3.5" />
-                  ) : (
-                    <Eye className="h-3.5 w-3.5" />
-                  )}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-7 p-0"
-                  onClick={handleCopyToken}
-                  aria-label="Copy auth token"
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Setup Commands */}
+      {/* Quick Connect */}
       <div className="space-y-3">
         <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
           Quick Start
         </h4>
-
-        <CommandBlock
-          label="Connect Machine"
-          warning
-          command={`${runCommand} --token ${showToken && token ? token : "<token>"}${convexUrlFlag}`}
-          onCopy={() =>
-            handleCopyCommand(
-              `${runCommand} --token ${token || "YOUR_TOKEN"}${convexUrlFlag}`,
-            )
-          }
-        />
+        <Button
+          variant="outline"
+          className="h-auto w-full justify-start gap-3 whitespace-normal p-3 text-left"
+          onClick={handleCopyConnectCommand}
+          disabled={isPreparingCommand}
+          aria-label="Copy connect command"
+        >
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+            <Terminal className="h-4 w-4" />
+          </span>
+          <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+            <span className="font-medium">
+              {isPreparingCommand
+                ? "Preparing connect command..."
+                : "Copy connect command"}
+            </span>
+            <span className="text-xs font-normal text-muted-foreground">
+              Secure token included automatically
+            </span>
+          </span>
+          {isPreparingCommand ? (
+            <LoaderCircle className="h-4 w-4 shrink-0 animate-spin" />
+          ) : (
+            <Copy className="h-4 w-4 shrink-0" />
+          )}
+        </Button>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            Paste and run it in your terminal to connect this machine.
+          </p>
+          {token && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
+              onClick={handleRegenerateToken}
+            >
+              <RefreshCw className="mr-1 h-3 w-3" />
+              Reset token
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Security Notice - Compact */}

--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
   Server,
   ExternalLink,
   LoaderCircle,
+  Check,
 } from "lucide-react";
 import { toast } from "sonner";
 import { runCommand, convexUrlFlag } from "@/lib/utils/sandbox-command";
@@ -46,6 +47,7 @@ interface UseAutoSelectNewRemoteConnectionArgs {
   setSandboxPreference: (preference: SandboxPreference) => void;
   selectedModel: SelectedModel;
   setSelectedModel: (model: SelectedModel) => void;
+  onNewConnection?: () => void;
 }
 
 function useAutoSelectNewRemoteConnection({
@@ -57,6 +59,7 @@ function useAutoSelectNewRemoteConnection({
   setSandboxPreference,
   selectedModel,
   setSelectedModel,
+  onNewConnection,
 }: UseAutoSelectNewRemoteConnectionArgs) {
   const previousRemoteConnectionIdsRef = useRef<Set<string> | null>(null);
 
@@ -79,6 +82,8 @@ function useAutoSelectNewRemoteConnection({
     );
     if (!newConnection) return;
 
+    onNewConnection?.();
+
     if (sandboxPreference !== newConnection.connectionId) {
       setSandboxPreference(newConnection.connectionId);
     }
@@ -96,6 +101,7 @@ function useAutoSelectNewRemoteConnection({
   }, [
     chatMode,
     connections,
+    onNewConnection,
     sandboxPreference,
     selectedModel,
     setChatMode,
@@ -108,6 +114,11 @@ function useAutoSelectNewRemoteConnection({
 const RemoteControlTab = () => {
   const [token, setToken] = useState<string | null>(null);
   const [isPreparingCommand, setIsPreparingCommand] = useState(false);
+  const [isCommandCopied, setIsCommandCopied] = useState(false);
+  const [showConnectSetup, setShowConnectSetup] = useState(false);
+  const copiedResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const {
     chatMode,
@@ -122,6 +133,7 @@ const RemoteControlTab = () => {
 
   const tokenResult = useMutation(api.localSandbox.getToken);
   const regenerateToken = useMutation(api.localSandbox.regenerateToken);
+  const hideConnectSetup = useCallback(() => setShowConnectSetup(false), []);
 
   useAutoSelectNewRemoteConnection({
     chatMode,
@@ -132,7 +144,17 @@ const RemoteControlTab = () => {
     setSandboxPreference,
     setSelectedModel,
     subscription,
+    onNewConnection: hideConnectSetup,
   });
+
+  useEffect(
+    () => () => {
+      if (copiedResetTimeoutRef.current) {
+        clearTimeout(copiedResetTimeoutRef.current);
+      }
+    },
+    [],
+  );
 
   const activeConnections = connections ?? [];
 
@@ -169,6 +191,14 @@ const RemoteControlTab = () => {
         await navigator.clipboard.writeText(await commandPromise);
       }
 
+      if (copiedResetTimeoutRef.current) {
+        clearTimeout(copiedResetTimeoutRef.current);
+      }
+      setIsCommandCopied(true);
+      copiedResetTimeoutRef.current = setTimeout(() => {
+        setIsCommandCopied(false);
+        copiedResetTimeoutRef.current = null;
+      }, 2_000);
       toast.success("Connect command copied. Paste it into your terminal.");
     } catch (error) {
       console.error("Failed to prepare connect command:", error);
@@ -182,6 +212,7 @@ const RemoteControlTab = () => {
     try {
       const result = await regenerateToken();
       setToken(result.token);
+      setIsCommandCopied(false);
       toast.success("Access token reset. Existing connections were stopped.");
     } catch (error) {
       console.error("Failed to regenerate token:", error);
@@ -237,6 +268,17 @@ const RemoteControlTab = () => {
                 </div>
               </div>
             ))}
+            {!showConnectSetup ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => setShowConnectSetup(true)}
+              >
+                <Terminal className="mr-2 h-3.5 w-3.5" />
+                Connect another machine
+              </Button>
+            ) : null}
           </div>
         ) : (
           <div className="flex flex-col items-center justify-center py-6 px-4 bg-muted/30 rounded-lg">
@@ -252,56 +294,72 @@ const RemoteControlTab = () => {
       </div>
 
       {/* Quick Connect */}
-      <div className="space-y-3">
-        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Quick Start
-        </h4>
-        <div className="overflow-hidden rounded-lg border bg-muted/30">
-          <div className="flex items-center gap-2 p-2">
-            <Terminal className="ml-1 h-4 w-4 shrink-0 text-muted-foreground" />
-            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap py-2 font-mono text-xs text-foreground">
-              {`${runCommand} --token <token>${convexUrlFlag}`}
-            </code>
-            <Button
-              size="sm"
-              className="shrink-0 gap-1.5"
-              onClick={handleCopyConnectCommand}
-              disabled={isPreparingCommand}
-              aria-label="Copy connect command"
-            >
-              {isPreparingCommand ? (
-                <LoaderCircle className="h-4 w-4 animate-spin" />
-              ) : (
-                <Copy className="h-4 w-4" />
-              )}
-              <span className="hidden sm:inline">
-                {isPreparingCommand ? "Preparing..." : "Copy"}
-              </span>
-            </Button>
+      {activeConnections.length === 0 || showConnectSetup ? (
+        <div className="space-y-3">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            {activeConnections.length > 0
+              ? "Connect Another Machine"
+              : "Quick Start"}
+          </h4>
+          <div className="overflow-hidden rounded-lg border bg-muted/30">
+            <div className="flex items-center gap-2 p-2">
+              <Terminal className="ml-1 h-4 w-4 shrink-0 text-muted-foreground" />
+              <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap py-2 font-mono text-xs text-foreground">
+                {`${runCommand} --token <token>${convexUrlFlag}`}
+              </code>
+              <Button
+                size="sm"
+                className="shrink-0 gap-1.5"
+                onClick={handleCopyConnectCommand}
+                disabled={isPreparingCommand}
+                aria-label={
+                  isPreparingCommand
+                    ? "Preparing connect command"
+                    : isCommandCopied
+                      ? "Connect command copied"
+                      : "Copy connect command"
+                }
+              >
+                {isPreparingCommand ? (
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                ) : isCommandCopied ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+                <span aria-live="polite">
+                  {isPreparingCommand
+                    ? "Preparing..."
+                    : isCommandCopied
+                      ? "Copied"
+                      : "Copy command"}
+                </span>
+              </Button>
+            </div>
+            <p className="border-t px-3 py-2 text-xs text-muted-foreground">
+              {isPreparingCommand
+                ? "Preparing connect command..."
+                : "Secure token included automatically when copied."}
+            </p>
           </div>
-          <p className="border-t px-3 py-2 text-xs text-muted-foreground">
-            {isPreparingCommand
-              ? "Preparing connect command..."
-              : "Secure token included automatically when copied."}
-          </p>
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              Paste and run it in your terminal to connect this machine.
+            </p>
+            {token ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={handleRegenerateToken}
+              >
+                <RefreshCw className="mr-1 h-3 w-3" />
+                Reset token
+              </Button>
+            ) : null}
+          </div>
         </div>
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-xs text-muted-foreground">
-            Paste and run it in your terminal to connect this machine.
-          </p>
-          {token && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
-              onClick={handleRegenerateToken}
-            >
-              <RefreshCw className="mr-1 h-3 w-3" />
-              Reset token
-            </Button>
-          )}
-        </div>
-      </div>
+      ) : null}
 
       {/* Security Notice - Compact */}
       <div className="flex items-start gap-2 p-3 bg-yellow-500/10 rounded-lg text-xs">

--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -256,32 +256,35 @@ const RemoteControlTab = () => {
         <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
           Quick Start
         </h4>
-        <Button
-          variant="outline"
-          className="h-auto w-full justify-start gap-3 whitespace-normal p-3 text-left"
-          onClick={handleCopyConnectCommand}
-          disabled={isPreparingCommand}
-          aria-label="Copy connect command"
-        >
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
-            <Terminal className="h-4 w-4" />
-          </span>
-          <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
-            <span className="font-medium">
-              {isPreparingCommand
-                ? "Preparing connect command..."
-                : "Copy connect command"}
-            </span>
-            <span className="text-xs font-normal text-muted-foreground">
-              Secure token included automatically
-            </span>
-          </span>
-          {isPreparingCommand ? (
-            <LoaderCircle className="h-4 w-4 shrink-0 animate-spin" />
-          ) : (
-            <Copy className="h-4 w-4 shrink-0" />
-          )}
-        </Button>
+        <div className="overflow-hidden rounded-lg border bg-muted/30">
+          <div className="flex items-center gap-2 p-2">
+            <Terminal className="ml-1 h-4 w-4 shrink-0 text-muted-foreground" />
+            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap py-2 font-mono text-xs text-foreground">
+              {`${runCommand} --token <token>${convexUrlFlag}`}
+            </code>
+            <Button
+              size="sm"
+              className="shrink-0 gap-1.5"
+              onClick={handleCopyConnectCommand}
+              disabled={isPreparingCommand}
+              aria-label="Copy connect command"
+            >
+              {isPreparingCommand ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+              <span className="hidden sm:inline">
+                {isPreparingCommand ? "Preparing..." : "Copy"}
+              </span>
+            </Button>
+          </div>
+          <p className="border-t px-3 py-2 text-xs text-muted-foreground">
+            {isPreparingCommand
+              ? "Preparing connect command..."
+              : "Secure token included automatically when copied."}
+          </p>
+        </div>
         <div className="flex items-center justify-between gap-3">
           <p className="text-xs text-muted-foreground">
             Paste and run it in your terminal to connect this machine.

--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -114,6 +114,7 @@ function useAutoSelectNewRemoteConnection({
 const RemoteControlTab = () => {
   const [token, setToken] = useState<string | null>(null);
   const [isPreparingCommand, setIsPreparingCommand] = useState(false);
+  const [isResettingToken, setIsResettingToken] = useState(false);
   const [isCommandCopied, setIsCommandCopied] = useState(false);
   const [showConnectSetup, setShowConnectSetup] = useState(false);
   const copiedResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -209,14 +210,22 @@ const RemoteControlTab = () => {
   };
 
   const handleRegenerateToken = async () => {
+    setIsResettingToken(true);
+
     try {
       const result = await regenerateToken();
       setToken(result.token);
+      if (copiedResetTimeoutRef.current) {
+        clearTimeout(copiedResetTimeoutRef.current);
+        copiedResetTimeoutRef.current = null;
+      }
       setIsCommandCopied(false);
       toast.success("Access token reset. Existing connections were stopped.");
     } catch (error) {
       console.error("Failed to regenerate token:", error);
       toast.error("Failed to reset access token");
+    } finally {
+      setIsResettingToken(false);
     }
   };
 
@@ -311,7 +320,7 @@ const RemoteControlTab = () => {
                 size="sm"
                 className="shrink-0 gap-1.5"
                 onClick={handleCopyConnectCommand}
-                disabled={isPreparingCommand}
+                disabled={isPreparingCommand || isResettingToken}
                 aria-label={
                   isPreparingCommand
                     ? "Preparing connect command"
@@ -352,9 +361,12 @@ const RemoteControlTab = () => {
                 size="sm"
                 className="h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
                 onClick={handleRegenerateToken}
+                disabled={isPreparingCommand || isResettingToken}
               >
-                <RefreshCw className="mr-1 h-3 w-3" />
-                Reset token
+                <RefreshCw
+                  className={`mr-1 h-3 w-3 ${isResettingToken ? "animate-spin" : ""}`}
+                />
+                {isResettingToken ? "Resetting..." : "Reset token"}
               </Button>
             ) : null}
           </div>

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -275,6 +275,49 @@ describe("RemoteControlTab", () => {
     );
   });
 
+  it("keeps command copying and token reset mutually exclusive", async () => {
+    render(<RemoteControlTab />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy connect command" }),
+    );
+    const resetButton = await screen.findByRole("button", {
+      name: "Reset token",
+    });
+
+    let resolveClipboard: (() => void) | undefined;
+    mockWriteText.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveClipboard = resolve;
+        }),
+    );
+    const copyButton = screen.getByRole("button", {
+      name: "Connect command copied",
+    });
+    fireEvent.click(copyButton);
+
+    expect(resetButton).toBeDisabled();
+    await waitFor(() => expect(mockWriteText).toHaveBeenCalledTimes(2));
+    resolveClipboard?.();
+    await waitFor(() => expect(resetButton).toBeEnabled());
+
+    let resolveReset: ((value: { token: string }) => void) | undefined;
+    mockRegenerateToken.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveReset = resolve;
+        }),
+    );
+    fireEvent.click(resetButton);
+
+    expect(copyButton).toBeDisabled();
+    expect(resetButton).toHaveTextContent("Resetting...");
+    await waitFor(() => expect(mockRegenerateToken).toHaveBeenCalledTimes(1));
+    resolveReset?.({ token: "regenerated-token" });
+    await waitFor(() => expect(copyButton).toBeEnabled());
+  });
+
   it("handles a rejected clipboard write without a false success", async () => {
     mockWriteText.mockRejectedValue(
       new DOMException("Document is not focused"),

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -137,6 +137,12 @@ describe("RemoteControlTab", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "Local sandbox connected. Switched to Agent mode.",
     );
+    expect(
+      screen.getByRole("button", { name: "Connect another machine" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy connect command" }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not switch modes when an existing connection appears on initial query load", async () => {
@@ -165,10 +171,30 @@ describe("RemoteControlTab", () => {
     expect(screen.queryByText("No active connections")).not.toBeInTheDocument();
   });
 
+  it("replaces setup with a connect-another action when already connected", () => {
+    mockConnections = [remoteConnection];
+    render(<RemoteControlTab />);
+
+    expect(screen.queryByText("Quick Start")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy connect command" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Connect another machine" }),
+    );
+
+    expect(screen.getByText("Connect Another Machine")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy connect command" }),
+    ).toBeInTheDocument();
+  });
+
   it("generates a token and copies a ready-to-run command in one action", async () => {
     render(<RemoteControlTab />);
 
     expect(screen.getByText(/--token <token>/)).toBeInTheDocument();
+    expect(screen.getByText("Copy command")).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Copy connect command" }),
@@ -183,6 +209,9 @@ describe("RemoteControlTab", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "Connect command copied. Paste it into your terminal.",
     );
+    expect(
+      screen.getByRole("button", { name: "Connect command copied" }),
+    ).toHaveTextContent("Copied");
     expect(screen.queryByText(/test-token/)).not.toBeInTheDocument();
     expect(toast.error).not.toHaveBeenCalled();
   });

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -165,55 +165,75 @@ describe("RemoteControlTab", () => {
     expect(screen.queryByText("No active connections")).not.toBeInTheDocument();
   });
 
-  it("reports command copy success only after the clipboard write succeeds", async () => {
+  it("generates a token and copies a ready-to-run command in one action", async () => {
     render(<RemoteControlTab />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Copy Connect Machine command" }),
+      screen.getByRole("button", { name: "Copy connect command" }),
     );
 
     await waitFor(() => {
       expect(mockWriteText).toHaveBeenCalledWith(
-        expect.stringContaining("--token YOUR_TOKEN"),
+        expect.stringContaining("--token test-token"),
       );
     });
-    expect(toast.success).toHaveBeenCalledWith("Command copied to clipboard");
+    expect(mockGetToken).toHaveBeenCalledTimes(1);
+    expect(toast.success).toHaveBeenCalledWith(
+      "Connect command copied. Paste it into your terminal.",
+    );
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("handles a rejected command clipboard write without a false success", async () => {
+  it("reuses the generated token when the command is copied again", async () => {
+    render(<RemoteControlTab />);
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy connect command",
+    });
+    fireEvent.click(copyButton);
+    await waitFor(() => expect(mockWriteText).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(copyButton);
+    await waitFor(() => expect(mockWriteText).toHaveBeenCalledTimes(2));
+
+    expect(mockGetToken).toHaveBeenCalledTimes(1);
+    expect(mockWriteText).toHaveBeenLastCalledWith(
+      expect.stringContaining("--token test-token"),
+    );
+  });
+
+  it("handles a rejected clipboard write without a false success", async () => {
     mockWriteText.mockRejectedValue(
       new DOMException("Document is not focused"),
     );
     render(<RemoteControlTab />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Copy Connect Machine command" }),
+      screen.getByRole("button", { name: "Copy connect command" }),
     );
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to copy command");
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to copy connect command",
+      );
     });
     expect(toast.success).not.toHaveBeenCalled();
   });
 
-  it("handles a rejected token clipboard write without a false success", async () => {
-    mockWriteText.mockRejectedValue(
-      new DOMException("Clipboard write requires user activation"),
-    );
+  it("does not copy a placeholder command when token generation fails", async () => {
+    mockGetToken.mockRejectedValue(new Error("Token service unavailable"));
     render(<RemoteControlTab />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Generate Token" }));
-    await waitFor(() => {
-      expect(screen.getByDisplayValue("test-token")).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Copy auth token" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy connect command" }),
+    );
 
     await waitFor(() => {
-      expect(mockWriteText).toHaveBeenCalledWith("test-token");
-      expect(toast.error).toHaveBeenCalledWith("Failed to copy token");
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to copy connect command",
+      );
     });
+    expect(mockWriteText).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -202,6 +202,47 @@ describe("RemoteControlTab", () => {
     );
   });
 
+  it("disables the action while the connect command is being prepared", async () => {
+    let resolveToken: ((value: { token: string }) => void) | undefined;
+    mockGetToken.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveToken = resolve;
+        }),
+    );
+    render(<RemoteControlTab />);
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy connect command",
+    });
+    fireEvent.click(copyButton);
+
+    expect(copyButton).toBeDisabled();
+    expect(
+      screen.getByText("Preparing connect command..."),
+    ).toBeInTheDocument();
+
+    resolveToken?.({ token: "test-token" });
+    await waitFor(() => expect(copyButton).toBeEnabled());
+  });
+
+  it("allows the generated token to be reset", async () => {
+    render(<RemoteControlTab />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy connect command" }),
+    );
+    const resetButton = await screen.findByRole("button", {
+      name: "Reset token",
+    });
+    fireEvent.click(resetButton);
+
+    await waitFor(() => expect(mockRegenerateToken).toHaveBeenCalledTimes(1));
+    expect(toast.success).toHaveBeenLastCalledWith(
+      "Access token reset. Existing connections were stopped.",
+    );
+  });
+
   it("handles a rejected clipboard write without a false success", async () => {
     mockWriteText.mockRejectedValue(
       new DOMException("Document is not focused"),

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -168,6 +168,8 @@ describe("RemoteControlTab", () => {
   it("generates a token and copies a ready-to-run command in one action", async () => {
     render(<RemoteControlTab />);
 
+    expect(screen.getByText(/--token <token>/)).toBeInTheDocument();
+
     fireEvent.click(
       screen.getByRole("button", { name: "Copy connect command" }),
     );
@@ -181,6 +183,7 @@ describe("RemoteControlTab", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "Connect command copied. Paste it into your terminal.",
     );
+    expect(screen.queryByText(/test-token/)).not.toBeInTheDocument();
     expect(toast.error).not.toHaveBeenCalled();
   });
 

--- a/packages/local/README.md
+++ b/packages/local/README.md
@@ -32,11 +32,12 @@ Commands run directly on your host OS. The client connects to HackerAI and relay
 | `--convex-url URL` | Override backend URL (for development)                 |
 | `--help, -h`       | Show help message                                      |
 
-## Getting Your Token
+## Connecting From HackerAI
 
 1. Go to [HackerAI Settings](https://hackerai.co/settings)
-2. Navigate to the "Agents" tab
-3. Click "Generate Token" or copy your existing token
+2. Open "Remote Control"
+3. Click "Copy connect command"
+4. Paste and run the command in your terminal
 
 ## Security
 

--- a/packages/local/README.md
+++ b/packages/local/README.md
@@ -2,42 +2,38 @@
 
 HackerAI Local Sandbox Client - Execute commands on your local machine from HackerAI.
 
-## Installation
+## Quick Start
 
-```bash
-npx @hackerai/local@latest --token YOUR_TOKEN
-```
-
-Or install globally:
-
-```bash
-npm install -g @hackerai/local
-hackerai-local --token YOUR_TOKEN
-```
-
-## Usage
-
-```bash
-npx @hackerai/local@latest --token hsb_abc123
-```
-
-Commands run directly on your host OS. The client connects to HackerAI and relays commands in real-time.
-
-## Options
-
-| Option             | Description                                            |
-| ------------------ | ------------------------------------------------------ |
-| `--token TOKEN`    | Authentication token from HackerAI Settings (required) |
-| `--name NAME`      | Optional connection name fallback (default: hostname)  |
-| `--convex-url URL` | Override backend URL (for development)                 |
-| `--help, -h`       | Show help message                                      |
-
-## Connecting From HackerAI
+No installation or manual token handling is required:
 
 1. Go to [HackerAI Settings](https://hackerai.co/settings)
 2. Open "Remote Control"
 3. Click "Copy connect command"
 4. Paste and run the command in your terminal
+
+The copied command runs the latest package with your authentication token
+included automatically.
+
+## Global Installation (Optional)
+
+```bash
+npm install -g @hackerai/local
+```
+
+After installation, copy the connect command from HackerAI Settings and replace
+`npx @hackerai/local@latest` with `hackerai-local`. Leave the generated
+arguments unchanged.
+
+Commands run directly on your host OS. The client connects to HackerAI and relays commands in real-time.
+
+## Options
+
+| Option             | Description                                                    |
+| ------------------ | -------------------------------------------------------------- |
+| `--token TOKEN`    | Authentication token included in the copied command (required) |
+| `--name NAME`      | Optional connection name fallback (default: hostname)          |
+| `--convex-url URL` | Override backend URL included for non-production environments  |
+| `--help, -h`       | Show help message                                              |
 
 ## Security
 


### PR DESCRIPTION
## Summary
- replace the separate token-generation and command-copy steps with one **Copy connect command** action
- generate and embed the authentication token automatically without exposing it in the UI
- preserve token reset as a secondary security action and avoid copying placeholder commands
- update the local client setup documentation

## Verification
- `pnpm exec eslint app/components/RemoteControlTab.tsx app/components/__tests__/RemoteControlTab.test.tsx`
- `pnpm typecheck`
- `pnpm test -- --runInBand app/components/__tests__/RemoteControlTab.test.tsx`
- full pre-commit suite: 409 suites / 4,310 tests passed
- visually checked the real component at desktop and mobile widths in the Codex Browser; no browser warnings or console errors

## Manual verification
1. Open **Settings → Remote Control**.
2. Click **Copy connect command**.
3. Paste and run the command in a terminal.
4. Confirm the command contains a generated token and the machine connects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Quick Start option for preparing and copying remote-control connection commands.
  - Connected machines now show a “Connect another machine” option instead of setup controls.
  - Added clearer “Copy command,” “Copied,” and preparation status feedback.
  - Added token reset support with progress indicators and safeguards against conflicting actions.

- **Bug Fixes**
  - Improved success and error handling during command preparation, copying, and token resets.
  - Prevents copying when token generation fails.

- **Documentation**
  - Updated setup instructions for authenticated connection commands, optional global installation, and custom backend URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->