### PR TITLE
Fix completed chat scroll position after switching

### DIFF
--- a/app/components/__tests__/message-timeline-rows.test.ts
+++ b/app/components/__tests__/message-timeline-rows.test.ts
@@ -1,6 +1,7 @@
 import {
   createStableChatTimelineRowsState,
   deriveChatTimelineRows,
+  findActiveTimelineAnchorMessageId,
   findLatestTimelineAnchorMessageId,
   findMessageTimelineAnchorIndex,
   stabilizeChatTimelineRows,
@@ -47,6 +48,30 @@ describe("deriveChatTimelineRows", () => {
 
     expect(findLatestTimelineAnchorMessageId(messages)).toBe("user-1");
     expect(findLatestTimelineAnchorMessageId([])).toBeNull();
+  });
+
+  it("anchors only while the latest response is active", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Question" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Answer" }],
+      },
+    ] as ChatMessage[];
+
+    expect(findActiveTimelineAnchorMessageId(messages, "submitted")).toBe(
+      "user-1",
+    );
+    expect(findActiveTimelineAnchorMessageId(messages, "streaming")).toBe(
+      "user-1",
+    );
+    expect(findActiveTimelineAnchorMessageId(messages, "ready")).toBeNull();
+    expect(findActiveTimelineAnchorMessageId(messages, "error")).toBeNull();
   });
 
   it("finds the sent message row used to anchor a new turn", () => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -98,7 +98,7 @@ import { useParams, useRouter } from "next/navigation";
 import { ConvexErrorBoundary } from "./ConvexErrorBoundary";
 import { useAutoResume } from "../hooks/useAutoResume";
 import { useAutoContinue } from "../hooks/useAutoContinue";
-import { findLatestTimelineAnchorMessageId } from "./message-timeline-rows";
+import { findActiveTimelineAnchorMessageId } from "./message-timeline-rows";
 import { useLatestRef } from "../hooks/useLatestRef";
 import { useDataStreamDispatch } from "./DataStreamProvider";
 import {
@@ -1805,8 +1805,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // Auto-continue prompts are hidden from the timeline and must not replace
   // the user-visible anchor.
   const timelineAnchorMessageId = useMemo(
-    () => findLatestTimelineAnchorMessageId(messages),
-    [messages],
+    () => findActiveTimelineAnchorMessageId(messages, status),
+    [messages, status],
   );
   const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
     useMessageScroll(timelineAnchorMessageId);

--- a/app/components/message-timeline-rows.ts
+++ b/app/components/message-timeline-rows.ts
@@ -83,6 +83,19 @@ export function findLatestTimelineAnchorMessageId(
   return null;
 }
 
+export function findActiveTimelineAnchorMessageId(
+  messages: readonly ChatMessage[],
+  status: ChatStatus,
+): string | null {
+  // Settled histories rely on initialScrollAtEnd. Retaining the turn anchor
+  // lets delayed row measurements overwrite that completed-chat position.
+  if (status !== "submitted" && status !== "streaming") {
+    return null;
+  }
+
+  return findLatestTimelineAnchorMessageId(messages);
+}
+
 export function findMessageTimelineAnchorIndex(
   rows: readonly ChatTimelineRow[],
   messageId: string | null,


### PR DESCRIPTION
## Summary
- limit latest-turn anchoring to submitted and streaming responses
- let completed, stopped, and errored chats retain LegendList end positioning
- cover active versus settled chat statuses with a regression test

## Validation
- 409 Jest suites passed (4,311 tests)
- TypeScript typecheck passed
- Targeted ESLint passed with only pre-existing chat.tsx warnings
- Prettier check passed
- Local browser verification switched between two completed long chats in both directions with bottomGap 0, anchoredEndSpace false, no console errors, and no Next.js overlay

## Manual verification
1. Open a completed or stopped task with a long final response, image, or collapsed tool content.
2. Switch to another task, then switch back.
3. Confirm the timeline settles at the final response and composer, not at the latest user prompt.
4. Start a new response and confirm the active user turn remains anchored while it streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat timeline positioning while messages are being submitted or streamed.
  * Prevented settled or errored conversations from retaining an unnecessary active timeline anchor.

* **Tests**
  * Added coverage for timeline behavior across submitted, streaming, ready, and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->