### PR TITLE
Route paid vision through GLM 5.3 Flash

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -1,7 +1,7 @@
 import {
-  AUXILIARY_VISION_FALLBACK_SLUG,
-  AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG,
   AUXILIARY_VISION_SLUG,
+  DEEPSEEK_V4_FLASH_VISION_SLUG,
+  GLM_5_3_FLASH_SLUG,
   createOpenRouterPatchFetch,
   enrichOpenRouterStreamError,
   getModelCutoffDate,
@@ -124,10 +124,23 @@ describe("provider registry", () => {
           modelId: string;
         }
       ).modelId,
-    ).toBe("deepseek/deepseek-v4-flash-vision-exp");
-    expect(AUXILIARY_VISION_SLUG).toBe("deepseek/deepseek-v4-flash-vision-exp");
-    expect(AUXILIARY_VISION_FALLBACK_SLUG).toBe("z-ai/glm-5.3-flash");
-    expect(AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG).toBe("minimax/minimax-m3");
+    ).toBe("minimax/minimax-m3");
+    expect(AUXILIARY_VISION_SLUG).toBe("minimax/minimax-m3");
+    expect(GLM_5_3_FLASH_SLUG).toBe("z-ai/glm-5.3-flash");
+    expect(DEEPSEEK_V4_FLASH_VISION_SLUG).toBe(
+      "deepseek/deepseek-v4-flash-vision-exp",
+    );
+    expect(
+      (myProvider.languageModel("model-glm-5.3-flash") as { modelId: string })
+        .modelId,
+    ).toBe(GLM_5_3_FLASH_SLUG);
+    expect(
+      (
+        myProvider.languageModel("model-deepseek-v4-flash-vision") as {
+          modelId: string;
+        }
+      ).modelId,
+    ).toBe(DEEPSEEK_V4_FLASH_VISION_SLUG);
     expect(getModelCutoffDate("auxiliary-vision-model")).toBe("July 2026");
     expect(
       (myProvider.languageModel("model-grok-4.6") as { modelId: string })
@@ -1184,6 +1197,15 @@ describe("supportsMultimodalToolResults", () => {
   });
 
   it("allows active multimodal keys and slugs used after image tool results", () => {
+    expect(supportsMultimodalToolResults("model-glm-5.3-flash")).toBe(true);
+    expect(supportsMultimodalToolResults("model-glm-5.3-flash-pro")).toBe(true);
+    expect(
+      supportsMultimodalToolResults("model-deepseek-v4-flash-vision"),
+    ).toBe(true);
+    expect(supportsMultimodalToolResults(GLM_5_3_FLASH_SLUG)).toBe(true);
+    expect(supportsMultimodalToolResults(DEEPSEEK_V4_FLASH_VISION_SLUG)).toBe(
+      true,
+    );
     expect(supportsMultimodalToolResults("model-grok-4.5")).toBe(true);
     expect(supportsMultimodalToolResults("model-grok-4.5-pro")).toBe(true);
     expect(supportsMultimodalToolResults("model-grok-4.6-pro")).toBe(true);

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -974,13 +974,16 @@ type OpenRouterInstance = typeof openrouter;
 export const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const GLM_5_3_SLUG = "z-ai/glm-5.3";
+export const GLM_5_3_FLASH_SLUG = "z-ai/glm-5.3-flash";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
 export const GROK_4_6_SLUG = "x-ai/grok-4.6";
-// Prefer DeepSeek's purpose-built vision model for auxiliary image analysis,
-// then fall back to GLM Flash and MiniMax M3 in that order.
-export const AUXILIARY_VISION_SLUG = "deepseek/deepseek-v4-flash-vision-exp";
-export const AUXILIARY_VISION_FALLBACK_SLUG = "z-ai/glm-5.3-flash";
-export const AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG = "minimax/minimax-m3";
+export const DEEPSEEK_V4_FLASH_VISION_SLUG =
+  "deepseek/deepseek-v4-flash-vision-exp";
+export const MINIMAX_M3_SLUG = "minimax/minimax-m3";
+// MiniMax is deliberately isolated to the final text-summary recovery. Normal
+// image turns route the original pixels through GLM Flash and then DeepSeek
+// Vision, so the lossy description hop is paid only when both direct routes fail.
+export const AUXILIARY_VISION_SLUG = MINIMAX_M3_SLUG;
 export const DEEPSEEK_V4_PRO_SLUG = "deepseek/deepseek-v4-pro";
 export const DEEPSEEK_V4_PRO_0813_SLUG = "deepseek/deepseek-v4-pro-0813";
 export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
@@ -989,10 +992,18 @@ const TITLE_GENERATOR_DEEPSEEK_SLUG = "deepseek/deepseek-v4-flash";
 
 export const getOpenRouterProviderRoutingForModel = (
   modelSlug: string,
-): { ignore: string[] } | undefined =>
-  modelSlug === DEEPSEEK_V4_FLASH_PREVIOUS_SLUG
-    ? { ignore: ["novita"] }
-    : undefined;
+):
+  | { ignore: string[] }
+  | { sort: "latency"; data_collection: "deny" }
+  | undefined => {
+  if (modelSlug === DEEPSEEK_V4_FLASH_PREVIOUS_SLUG) {
+    return { ignore: ["novita"] };
+  }
+  if (modelSlug === GLM_5_3_FLASH_SLUG) {
+    return { sort: "latency", data_collection: "deny" };
+  }
+  return undefined;
+};
 
 const buildProviderMap = (
   or: OpenRouterInstance,
@@ -1018,6 +1029,9 @@ const buildProviderMap = (
     "model-opus-4.6": or(KIMI_K3_SLUG),
     "model-glm-5.2": or(GLM_5_2_SLUG),
     "model-glm-5.3": or(GLM_5_3_SLUG),
+    "model-glm-5.3-flash": or(GLM_5_3_FLASH_SLUG),
+    "model-glm-5.3-flash-pro": or(GLM_5_3_FLASH_SLUG),
+    "model-deepseek-v4-flash-vision": or(DEEPSEEK_V4_FLASH_VISION_SLUG),
     "model-kimi-k3": or(KIMI_K3_SLUG),
     "fallback-agent-model": or(GROK_4_6_SLUG),
     "fallback-ask-model": or(GROK_4_6_SLUG),
@@ -1046,6 +1060,9 @@ export const modelCutoffDates: Partial<Record<ModelName, string>> &
   "model-deepseek-v4-pro-0813": "August 2026",
   "model-opus-4.6": "July 2026",
   "model-glm-5.2": "June 2026",
+  "model-glm-5.3-flash": "August 2026",
+  "model-glm-5.3-flash-pro": "August 2026",
+  "model-deepseek-v4-flash-vision": "August 2026",
   "fallback-agent-model": "August 2026",
   "fallback-ask-model": "August 2026",
   "title-generator-model": "May 2025",
@@ -1069,6 +1086,9 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-opus-4.6": "Moonshot Kimi K3",
   "model-glm-5.2": "Z.ai GLM 5.2",
   "model-glm-5.3": "Z.ai GLM 5.3",
+  "model-glm-5.3-flash": "Z.ai GLM 5.3 Flash",
+  "model-glm-5.3-flash-pro": "Z.ai GLM 5.3 Flash",
+  "model-deepseek-v4-flash-vision": "DeepSeek V4 Flash Vision",
   "model-kimi-k3": "Moonshot Kimi K3",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
@@ -1136,6 +1156,11 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
   const normalized = modelName.toLowerCase();
 
   return (
+    normalized === "model-glm-5.3-flash" ||
+    normalized === "model-glm-5.3-flash-pro" ||
+    normalized === "model-deepseek-v4-flash-vision" ||
+    normalized.includes("z-ai/glm-5.3-flash") ||
+    normalized.includes("deepseek-v4-flash-vision") ||
     isKimiModel(normalized) ||
     isGrokModel(normalized) ||
     isAnthropicModel(normalized) ||

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -225,6 +225,12 @@ describe("direct vision and summary recovery contracts", () => {
         /describeImageAttachmentsWithAuxiliaryVision\(\{[\s\S]*?cacheDescription:\s*cacheAuxiliaryVisionDescription/,
       );
       expect(source).toMatch(
+        /messages:\s*omitImageViewToolResultsForProviderRetry\(\s*state\.finalMessages,?\s*\)\.messages/,
+      );
+      expect(source).toMatch(
+        /catch \(summaryError\) \{[\s\S]*?event:\s*"vision_summary_recovery_failed"/,
+      );
+      expect(source).toMatch(
         /get auxiliaryVisionEnabled\(\) \{\s*return visionSummaryRecovery\.isEnabled\(\);\s*\}/,
       );
       expect(source).not.toContain("AUXILIARY_VISION_UNAVAILABLE_MESSAGE");

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -224,11 +224,13 @@ describe("direct vision and summary recovery contracts", () => {
       expect(source).toMatch(
         /describeImageAttachmentsWithAuxiliaryVision\(\{[\s\S]*?cacheDescription:\s*cacheAuxiliaryVisionDescription/,
       );
+      expect(
+        source.match(
+          /omitImageViewToolResultsForProviderRetry\(\s*state\.finalMessages,?\s*\)\.messages/g,
+        ),
+      ).toHaveLength(2);
       expect(source).toMatch(
-        /messages:\s*omitImageViewToolResultsForProviderRetry\(\s*state\.finalMessages,?\s*\)\.messages/,
-      );
-      expect(source).toMatch(
-        /catch \(summaryError\) \{[\s\S]*?event:\s*"vision_summary_recovery_failed"/,
+        /catch \(summaryError\) \{[^}]*?event:\s*"vision_summary_recovery_failed"/,
       );
       expect(source).toMatch(
         /get auxiliaryVisionEnabled\(\) \{\s*return visionSummaryRecovery\.isEnabled\(\);\s*\}/,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -206,26 +206,30 @@ const toolExecutionSources = [
   },
 ];
 
-describe("auxiliary vision failover contracts", () => {
+describe("direct vision and summary recovery contracts", () => {
   test.each([
     ["agent-long", taskSrc],
     ["chat handler", chatHandlerSrc],
-  ])("%s switches attachment failures to direct vision", (_name, source) => {
-    expect(source).toContain("createAuxiliaryVisionFailoverController");
-    expect(source).toMatch(
-      /auxiliaryVisionFailover\.activate\(\{\s*error,\s*source: "attachment",\s*\}\);/,
-    );
-    expect(source).toMatch(
-      /selectedModel = [\s\S]*?resolveAgentModelForImageToolResults\([\s\S]*?selectedModel[\s\S]*?true[\s\S]*?false[\s\S]*?\);/,
-    );
-    expect(source).toMatch(
-      /activeDeepSeekV4Pro0813Experiment =\s*getActiveDeepSeekV4Pro0813ExperimentAssignment\([\s\S]*?selectedModel[\s\S]*?\);/,
-    );
-    expect(source).toMatch(
-      /get auxiliaryVisionEnabled\(\) \{\s*return auxiliaryVisionFailover\.isEnabled\(\);\s*\}/,
-    );
-    expect(source).not.toContain("AUXILIARY_VISION_UNAVAILABLE_MESSAGE");
-  });
+  ])(
+    "%s activates MiniMax summaries only after direct vision fails",
+    (_name, source) => {
+      expect(source).toContain("createVisionSummaryRecoveryController");
+      expect(source).toMatch(/available: directGlmVisionEnabled/);
+      expect(source).toMatch(
+        /const shouldRetryWithVisionSummary =[\s\S]*?directGlmVisionEnabled[\s\S]*?hasTerminalProviderStreamError/,
+      );
+      expect(source).toMatch(
+        /visionSummaryRecovery\.activate\(\{[\s\S]*?source: hasImageAttachmentForRecovery/,
+      );
+      expect(source).toMatch(
+        /describeImageAttachmentsWithAuxiliaryVision\(\{[\s\S]*?cacheDescription:\s*cacheAuxiliaryVisionDescription/,
+      );
+      expect(source).toMatch(
+        /get auxiliaryVisionEnabled\(\) \{\s*return visionSummaryRecovery\.isEnabled\(\);\s*\}/,
+      );
+      expect(source).not.toContain("AUXILIARY_VISION_UNAVAILABLE_MESSAGE");
+    },
+  );
 });
 
 describe("agent tool schemas — Head Start bundle boundary", () => {
@@ -1588,7 +1592,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       retryDecisionIdx,
     );
     const retryModelIdx = taskSrc.indexOf(
-      "const retryModel = shouldRetryWithoutImageToolResults",
+      "const retryModel = shouldRetryWithVisionSummary",
       terminalProviderErrorIdx,
     );
     const fallbackIdx = taskSrc.indexOf(
@@ -1621,7 +1625,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       retryDecisionIdx,
     );
     const retryModelIdx = chatHandlerSrc.indexOf(
-      "const retryModel = shouldRetryWithoutImageToolResults",
+      "const retryModel = shouldRetryWithVisionSummary",
       terminalProviderErrorIdx,
     );
     const fallbackIdx = chatHandlerSrc.indexOf(
@@ -1686,7 +1690,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       );
       const catchResetIdx = source.indexOf(resetCall, catchModelSwitchIdx);
       const catchRetryStreamIdx = source.indexOf(
-        "createStream(fallbackModel)",
+        "createStream(apiRetryModel)",
         catchResetIdx,
       );
 
@@ -1695,7 +1699,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       expect(catchRetryStreamIdx).toBeGreaterThan(catchResetIdx);
 
       const retryModelIdx = source.indexOf(
-        "const retryModel = shouldRetryWithoutImageToolResults",
+        "const retryModel = shouldRetryWithVisionSummary",
       );
       const modelSwitchIdx = source.indexOf(
         "retryUsedFallbackModel =",

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -211,6 +211,45 @@ describe("resolveAgentModelForImageToolResults", () => {
     ).toBe("model-grok-4.5-pro");
   });
 
+  it("uses direct GLM Flash for Standard image tool results", () => {
+    expect(
+      resolveAgentModelForImageToolResults(
+        "model-deepseek-v4-flash-0731",
+        "agent",
+        true,
+        "hackerai-standard",
+        false,
+        true,
+      ),
+    ).toBe("model-glm-5.3-flash");
+  });
+
+  it("uses direct GLM Flash Pro for Pro image tool results", () => {
+    expect(
+      resolveAgentModelForImageToolResults(
+        "model-deepseek-v4-pro-0813",
+        "agent",
+        true,
+        "hackerai-pro",
+        false,
+        true,
+      ),
+    ).toBe("model-glm-5.3-flash-pro");
+  });
+
+  it("keeps the DeepSeek text model during MiniMax summary recovery", () => {
+    expect(
+      resolveAgentModelForImageToolResults(
+        "model-deepseek-v4-pro-0813",
+        "agent",
+        true,
+        "hackerai-pro",
+        true,
+        true,
+      ),
+    ).toBe("model-deepseek-v4-pro-0813");
+  });
+
   it.each(["model-deepseek-v4-flash-0731", "model-deepseek-v4-pro-0813"])(
     "keeps %s active when image tool results have auxiliary descriptions",
     (modelName) => {
@@ -273,6 +312,20 @@ describe("resolveAgentModelAfterSummarization", () => {
     ).toBe("model-deepseek-v4-flash-0731");
     expect(
       resolveAgentModelAfterSummarization("model-grok-4.5-pro", "agent", false),
+    ).toBe("model-deepseek-v4-pro-0813");
+    expect(
+      resolveAgentModelAfterSummarization(
+        "model-glm-5.3-flash",
+        "agent",
+        false,
+      ),
+    ).toBe("model-deepseek-v4-flash-0731");
+    expect(
+      resolveAgentModelAfterSummarization(
+        "model-glm-5.3-flash-pro",
+        "agent",
+        false,
+      ),
     ).toBe("model-deepseek-v4-pro-0813");
   });
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -31,6 +31,7 @@ const GROK_SLUG = "x-ai/grok-4.6";
 const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 const GLM_5_2_SLUG = "z-ai/glm-5.2";
 const GLM_SLUG = "z-ai/glm-5.3";
+const DEEPSEEK_VISION_SLUG = "deepseek/deepseek-v4-flash-vision-exp";
 const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
 const DEEPSEEK_FLASH_CANONICAL_SLUG = "deepseek/deepseek-v4-flash-20260731";
 const DEEPSEEK_FLASH_PREVIOUS_SLUG = "deepseek/deepseek-v4-flash";
@@ -171,6 +172,22 @@ describe("buildProviderOptions fallback chain", () => {
       user: "user-1",
     });
   });
+
+  it.each([
+    ["model-glm-5.3-flash", "low"],
+    ["model-glm-5.3-flash-pro", "high"],
+  ] as const)(
+    "routes %s directly with %s reasoning and DeepSeek Vision fallback",
+    (modelName, effort) => {
+      const opts = buildProviderOptions(true, "user-1", modelName, "agent");
+      expect(opts.openrouter).toMatchObject({
+        reasoning: { enabled: true, effort },
+        models: [DEEPSEEK_VISION_SLUG],
+        provider: { sort: "latency", data_collection: "deny" },
+        user: "user-1",
+      });
+    },
+  );
 
   it("resolves Kimi K3 fallback through the active Grok route", () => {
     const opts = buildProviderOptions(
@@ -783,6 +800,14 @@ describe("isExplicitDeepSeekProSelectionForRetry", () => {
 });
 
 describe("getRetryFallbackModel", () => {
+  it.each(["model-glm-5.3-flash", "model-glm-5.3-flash-pro"] as const)(
+    "keeps DeepSeek Vision as the direct provider fallback for %s",
+    (modelName) => {
+      expect(getRetryFallbackModel(modelName, "agent")).toBe(
+        "model-deepseek-v4-flash-vision",
+      );
+    },
+  );
   it("uses DeepSeek Flash 0731 for app-side retry after free Ask DeepSeek fails", () => {
     expect(getRetryFallbackModel("ask-model-free", "ask")).toBe(
       "model-deepseek-v4-flash-0731",

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -138,6 +138,8 @@ import {
 
 const STANDARD_AGENT_VISION_MODEL = "model-grok-4.5";
 const PRO_AGENT_VISION_MODEL = "model-grok-4.5-pro";
+const STANDARD_AGENT_GLM_VISION_MODEL = "model-glm-5.3-flash";
+const PRO_AGENT_GLM_VISION_MODEL = "model-glm-5.3-flash-pro";
 const FREE_AGENT_VISION_MODEL = "model-grok-4.6";
 const STANDARD_AGENT_TEXT_MODEL = "model-deepseek-v4-flash-0731";
 const PRO_AGENT_TEXT_MODEL = "model-deepseek-v4-pro-0813";
@@ -198,6 +200,12 @@ export const resolveAgentModelAfterSummarization = (
   if (modelName === PRO_AGENT_VISION_MODEL) {
     return PRO_AGENT_TEXT_MODEL;
   }
+  if (modelName === STANDARD_AGENT_GLM_VISION_MODEL) {
+    return STANDARD_AGENT_TEXT_MODEL;
+  }
+  if (modelName === PRO_AGENT_GLM_VISION_MODEL) {
+    return PRO_AGENT_TEXT_MODEL;
+  }
   return modelName;
 };
 
@@ -207,9 +215,22 @@ export const resolveAgentModelForImageToolResults = (
   hasImageToolResults: boolean,
   selectedModelOverride?: SelectedModel,
   auxiliaryVisionEnabled = false,
+  directGlmVisionEnabled = false,
 ): string => {
   if (mode !== "agent" || !hasImageToolResults || auxiliaryVisionEnabled) {
     return modelName;
+  }
+  if (directGlmVisionEnabled) {
+    if (
+      selectedModelOverride === "hackerai-pro" ||
+      (!selectedModelOverride &&
+        (modelName === "model-deepseek-v4-pro" ||
+          modelName === "model-deepseek-v4-pro-0813" ||
+          modelName === PRO_AGENT_GLM_VISION_MODEL))
+    ) {
+      return PRO_AGENT_GLM_VISION_MODEL;
+    }
+    return STANDARD_AGENT_GLM_VISION_MODEL;
   }
   if (modelName === "agent-model-free") {
     return FREE_AGENT_VISION_MODEL;
@@ -611,6 +632,8 @@ export type AgentStreamContext = {
   platformAuthorized: boolean;
   /** Images are represented as auxiliary descriptions; never promote the active model. */
   auxiliaryVisionEnabled?: boolean;
+  /** Eligible paid image turns promote directly to GLM Flash before summary recovery. */
+  directGlmVisionEnabled?: boolean;
   providerReasoningOverride?: {
     modelName: string;
     reasoning: ProviderReasoningOverride;
@@ -945,6 +968,7 @@ export async function createAgentStream(
       streamHasImageViewResults,
       ctx.selectedModelOverride,
       ctx.auxiliaryVisionEnabled,
+      ctx.directGlmVisionEnabled,
     );
   const getEffectiveModelInfo = () => {
     const effectiveModelName = getEffectiveModelName();

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1527,20 +1527,29 @@ export const createChatHandler = () => {
                         ? "attachment"
                         : "file_view",
                   });
-                  state.finalMessages =
-                    await describeImageAttachmentsWithAuxiliaryVision({
-                      messages: state.finalMessages,
-                      requestId: req.headers.get("x-vercel-id") ?? undefined,
-                      userId,
-                      chatId,
-                      abortSignal: userStopSignal.signal,
-                      onCost: (costDollars) => {
-                        usageTracker.providerCost += costDollars;
-                        usageTracker.nonModelCost += costDollars;
-                        chatLogger?.getBuilder().addToolCost(costDollars);
-                      },
-                      cacheDescription: cacheAuxiliaryVisionDescription,
-                    });
+                  try {
+                    state.finalMessages =
+                      await describeImageAttachmentsWithAuxiliaryVision({
+                        messages: omitImageViewToolResultsForProviderRetry(
+                          state.finalMessages,
+                        ).messages,
+                        requestId: req.headers.get("x-vercel-id") ?? undefined,
+                        userId,
+                        chatId,
+                        abortSignal: userStopSignal.signal,
+                        onCost: (costDollars) => {
+                          usageTracker.providerCost += costDollars;
+                          usageTracker.nonModelCost += costDollars;
+                          chatLogger?.getBuilder().addToolCost(costDollars);
+                        },
+                        cacheDescription: cacheAuxiliaryVisionDescription,
+                      });
+                  } catch (summaryError) {
+                    preemptiveTimeout?.clear();
+                    await usageRefundTracker.refund();
+                    chatLogger?.emitUnexpectedError(summaryError);
+                    throw error;
+                  }
                 }
                 result = await createStream(apiRetryModel);
               } else {
@@ -1571,6 +1580,7 @@ export const createChatHandler = () => {
                 },
                 onFinish: async ({ messages, isAborted }) => {
                   let retryScheduled = false;
+                  let visionSummaryRecoveryFailure: unknown;
                   try {
                     const lastAssistantMessage = messages
                       .slice()
@@ -1694,6 +1704,61 @@ export const createChatHandler = () => {
                             : fallbackModel;
                       const retryModelSlug =
                         trackedProvider.languageModel(retryModel).modelId;
+                      const shouldAttemptProviderRetry =
+                        (!isAborted || stoppedDueToAssistantContentLoop) &&
+                        (isAutoModel ||
+                          shouldRetryWithVisionSummary ||
+                          providerContentBlocked ||
+                          shouldRetryWithoutImageToolResults ||
+                          loopTriggeredRetry ||
+                          shouldRetryInterruptedToolInput ||
+                          shouldRetryExplicitDeepSeekProReasoning);
+                      let recoveredVisionMessages:
+                        typeof state.finalMessages | undefined;
+                      if (
+                        shouldAttemptProviderRetry &&
+                        shouldRetryWithVisionSummary
+                      ) {
+                        visionSummaryRecovery.activate({
+                          error: visionSummaryRecoveryError,
+                          source: hasImageAttachmentForRecovery
+                            ? "attachment"
+                            : "file_view",
+                        });
+                        try {
+                          recoveredVisionMessages =
+                            await describeImageAttachmentsWithAuxiliaryVision({
+                              messages:
+                                omitImageViewToolResultsForProviderRetry(
+                                  state.finalMessages,
+                                ).messages,
+                              requestId:
+                                req.headers.get("x-vercel-id") ?? undefined,
+                              userId,
+                              chatId,
+                              abortSignal: userStopSignal.signal,
+                              onCost: (costDollars) => {
+                                usageTracker.providerCost += costDollars;
+                                usageTracker.nonModelCost += costDollars;
+                                chatLogger
+                                  ?.getBuilder()
+                                  .addToolCost(costDollars);
+                              },
+                              cacheDescription: cacheAuxiliaryVisionDescription,
+                            });
+                        } catch (summaryError) {
+                          visionSummaryRecoveryFailure = summaryError;
+                          phLogger.error("Vision summary recovery failed", {
+                            event: "vision_summary_recovery_failed",
+                            chatId,
+                            endpoint,
+                            mode,
+                            userId,
+                            subscription,
+                            ...extractErrorDetails(summaryError),
+                          });
+                        }
+                      }
                       phLogger.warn(
                         shouldRetryWithVisionSummary
                           ? "Direct vision routes failed - retrying with MiniMax summary"
@@ -1744,14 +1809,8 @@ export const createChatHandler = () => {
                       // For image-tool rejection, retry the same selected model
                       // after replacing image outputs with text placeholders.
                       if (
-                        (!isAborted || stoppedDueToAssistantContentLoop) &&
-                        (isAutoModel ||
-                          shouldRetryWithVisionSummary ||
-                          providerContentBlocked ||
-                          shouldRetryWithoutImageToolResults ||
-                          loopTriggeredRetry ||
-                          shouldRetryInterruptedToolInput ||
-                          shouldRetryExplicitDeepSeekProReasoning)
+                        shouldAttemptProviderRetry &&
+                        !visionSummaryRecoveryFailure
                       ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
@@ -1780,29 +1839,7 @@ export const createChatHandler = () => {
                           providerContentBlocked;
                         resetServedModelTelemetryForRetry(state);
                         if (shouldRetryWithVisionSummary) {
-                          visionSummaryRecovery.activate({
-                            error: visionSummaryRecoveryError,
-                            source: hasImageAttachmentForRecovery
-                              ? "attachment"
-                              : "file_view",
-                          });
-                          state.finalMessages =
-                            await describeImageAttachmentsWithAuxiliaryVision({
-                              messages: state.finalMessages,
-                              requestId:
-                                req.headers.get("x-vercel-id") ?? undefined,
-                              userId,
-                              chatId,
-                              abortSignal: userStopSignal.signal,
-                              onCost: (costDollars) => {
-                                usageTracker.providerCost += costDollars;
-                                usageTracker.nonModelCost += costDollars;
-                                chatLogger
-                                  ?.getBuilder()
-                                  .addToolCost(costDollars);
-                              },
-                              cacheDescription: cacheAuxiliaryVisionDescription,
-                            });
+                          state.finalMessages = recoveredVisionMessages!;
                           usageTracker.resetModelLeg();
                         } else if (shouldRetryWithoutImageToolResults) {
                           state.finalMessages =
@@ -2213,7 +2250,8 @@ export const createChatHandler = () => {
                       );
                     const outcome = isAborted
                       ? "aborted"
-                      : finalProviderContentBlocked
+                      : finalProviderContentBlocked ||
+                          visionSummaryRecoveryFailure
                         ? "error"
                         : "success";
                     captureAgentCompletionAnalytics({
@@ -2254,7 +2292,11 @@ export const createChatHandler = () => {
                         todoRunMetrics: getTodoManager().getRunMetrics(),
                       }),
                     });
-                    if (finalProviderContentBlocked) {
+                    if (visionSummaryRecoveryFailure) {
+                      chatLogger!.emitUnexpectedError(
+                        visionSummaryRecoveryFailure,
+                      );
+                    } else if (finalProviderContentBlocked) {
                       chatLogger!.emitUnexpectedError(
                         state.providerError ??
                           createProviderContentBlockedFinishReasonError(),

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -117,7 +117,7 @@ import { v4 as uuidv4 } from "uuid";
 import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
 import { cacheAuxiliaryVisionDescription } from "@/lib/utils/file-transform-utils";
 import {
-  createAuxiliaryVisionFailoverController,
+  createVisionSummaryRecoveryController,
   describeImageAttachmentsWithAuxiliaryVision,
   describeImageWithAuxiliaryVision,
 } from "@/lib/chat/auxiliary-vision";
@@ -159,7 +159,7 @@ import {
   getActiveDeepSeekV4Pro0813ExperimentAssignment,
   getDeepSeekV4Pro0813ExperimentContext,
 } from "@/lib/experiments/deepseek-v4-pro-0813";
-import { isEligibleForAuxiliaryDeepSeekVision } from "@/lib/chat/auxiliary-vision-eligibility";
+import { isEligibleForDirectGlmVision } from "@/lib/chat/auxiliary-vision-eligibility";
 import {
   capturePaidDailyFreeAllowanceServerEvent,
   createPaidDailyFreeAllowanceBudgetSnapshot,
@@ -187,7 +187,6 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 import {
   createAgentStream,
   initAgentStreamState,
-  resolveAgentModelForImageToolResults,
   resetServedModelTelemetryForRetry,
   retryUsesDifferentModel,
   type AgentStreamContext,
@@ -201,6 +200,7 @@ import {
 import {
   omitImageViewToolResultsForProviderRetry,
   omitTrailingStepStartAssistantMessage,
+  uiMessagesContainImageViewResult,
 } from "@/lib/chat/multimodal-tool-result-recovery";
 import {
   detectAssistantContentLoopFromParts,
@@ -388,9 +388,9 @@ export const createChatHandler = () => {
         subscription,
       );
       const attachmentCounts = countFileAttachments(truncatedMessages);
-      const auxiliaryVisionEnabled =
+      const directGlmVisionEnabled =
         (isAgentMode(mode) || attachmentCounts.imageCount > 0) &&
-        isEligibleForAuxiliaryDeepSeekVision({
+        isEligibleForDirectGlmVision({
           subscription,
           selectedModelOverride,
         });
@@ -438,7 +438,7 @@ export const createChatHandler = () => {
         extraUsageAvailable,
         allowLocalDesktopFiles:
           isAgentMode(mode) && sandboxPreference === "desktop",
-        auxiliaryVisionEnabled,
+        directGlmVisionEnabled,
         chatId,
         requestId: req.headers.get("x-vercel-id") ?? undefined,
       });
@@ -643,8 +643,8 @@ export const createChatHandler = () => {
       });
 
       const summarizationTracker = new SummarizationTracker();
-      const auxiliaryVisionFailover = createAuxiliaryVisionFailoverController({
-        enabled: auxiliaryVisionEnabled,
+      const visionSummaryRecovery = createVisionSummaryRecoveryController({
+        available: directGlmVisionEnabled,
         service: "chat-handler",
         requestId: req.headers.get("x-vercel-id") ?? undefined,
         userId,
@@ -667,9 +667,9 @@ export const createChatHandler = () => {
         execute: async ({ writer }) => {
           try {
             const usageTracker = new UsageTracker();
-            const auxiliaryVision = auxiliaryVisionFailover.isEnabled()
+            const auxiliaryVision = directGlmVisionEnabled
               ? {
-                  isEnabled: auxiliaryVisionFailover.isEnabled,
+                  isEnabled: visionSummaryRecovery.isEnabled,
                   isAborted: () => userStopSignal.signal.aborted,
                   describeImage: async (args: {
                     image: string;
@@ -677,26 +677,18 @@ export const createChatHandler = () => {
                     filename?: string;
                     source: "file_view";
                   }) => {
-                    try {
-                      return await describeImageWithAuxiliaryVision({
-                        ...args,
-                        requestId: req.headers.get("x-vercel-id") ?? undefined,
-                        userId,
-                        chatId,
-                        abortSignal: userStopSignal.signal,
-                        onCost: (costDollars) => {
-                          usageTracker.providerCost += costDollars;
-                          usageTracker.nonModelCost += costDollars;
-                          chatLogger?.getBuilder().addToolCost(costDollars);
-                        },
-                      });
-                    } catch (error) {
-                      auxiliaryVisionFailover.activate({
-                        error,
-                        source: "file_view",
-                      });
-                      throw error;
-                    }
+                    return await describeImageWithAuxiliaryVision({
+                      ...args,
+                      requestId: req.headers.get("x-vercel-id") ?? undefined,
+                      userId,
+                      chatId,
+                      abortSignal: userStopSignal.signal,
+                      onCost: (costDollars) => {
+                        usageTracker.providerCost += costDollars;
+                        usageTracker.nonModelCost += costDollars;
+                        chatLogger?.getBuilder().addToolCost(costDollars);
+                      },
+                    });
                   },
                 }
               : undefined;
@@ -885,57 +877,6 @@ export const createChatHandler = () => {
               }
             }
 
-            if (auxiliaryVisionFailover.isEnabled()) {
-              try {
-                processedMessages =
-                  await describeImageAttachmentsWithAuxiliaryVision({
-                    messages: processedMessages,
-                    requestId: req.headers.get("x-vercel-id") ?? undefined,
-                    userId,
-                    chatId,
-                    abortSignal: userStopSignal.signal,
-                    onCost: (costDollars) => {
-                      usageTracker.providerCost += costDollars;
-                      usageTracker.nonModelCost += costDollars;
-                      chatLogger?.getBuilder().addToolCost(costDollars);
-                    },
-                    cacheDescription: cacheAuxiliaryVisionDescription,
-                  });
-              } catch (error) {
-                if (userStopSignal.signal.aborted) throw error;
-                auxiliaryVisionFailover.activate({
-                  error,
-                  source: "attachment",
-                });
-                selectedModel = isAgentMode(mode)
-                  ? resolveAgentModelForImageToolResults(
-                      selectedModel,
-                      mode,
-                      true,
-                      selectedModelOverride,
-                      false,
-                    )
-                  : selectModel(
-                      mode,
-                      subscription,
-                      selectedModelOverride,
-                      true,
-                      false,
-                      { extraUsageAvailable, auxiliaryVisionEnabled: false },
-                    );
-                activeDeepSeekV4Pro0813Experiment =
-                  getActiveDeepSeekV4Pro0813ExperimentAssignment(
-                    deepSeekV4Pro0813Experiment,
-                    selectedModel,
-                  );
-                routingExperimentContext =
-                  getDeepSeekV4Pro0813ExperimentContext(
-                    activeDeepSeekV4Pro0813Experiment,
-                  );
-                chatLogger?.setChat(chatLogContext, selectedModel);
-              }
-            }
-
             // Generate the title in parallel for new tasks.
             const titlePromise = isNewChat
               ? generateTitleFromUserMessageWithWriter(
@@ -1064,8 +1005,6 @@ export const createChatHandler = () => {
               selectedModelOverride,
             });
             const fallbackModel = getRetryFallbackModel(selectedModel, mode);
-            const fallbackModelId =
-              trackedProvider.languageModel(fallbackModel).modelId;
             let activeModelName = selectedModel;
 
             let hasRecordedUsage = false;
@@ -1447,8 +1386,9 @@ export const createChatHandler = () => {
               isReasoningModel,
               platformAuthorized,
               get auxiliaryVisionEnabled() {
-                return auxiliaryVisionFailover.isEnabled();
+                return visionSummaryRecovery.isEnabled();
               },
+              directGlmVisionEnabled,
               maxDurationMs: AGENT_MAX_STREAM_DURATION_MS,
               writer,
               abortController: userStopSignal,
@@ -1515,12 +1455,27 @@ export const createChatHandler = () => {
               });
               result = await createStream(selectedModel);
             } catch (error) {
+              const shouldRecoverVisionApiError =
+                directGlmVisionEnabled &&
+                !visionSummaryRecovery.isEnabled() &&
+                (countFileAttachments(state.finalMessages).imageCount > 0 ||
+                  uiMessagesContainImageViewResult(state.finalMessages));
               // If provider returns an API error before streaming, retry with fallback.
               if (
                 isProviderApiError(error) &&
                 !isRetryWithFallback &&
-                isAutoModel
+                (isAutoModel || shouldRecoverVisionApiError)
               ) {
+                const apiRetryModel = shouldRecoverVisionApiError
+                  ? selectModel(
+                      mode,
+                      subscription,
+                      selectedModelOverride,
+                      false,
+                      false,
+                      { extraUsageAvailable },
+                    )
+                  : fallbackModel;
                 phLogger.error("Provider API error, retrying with fallback", {
                   error,
                   chatId,
@@ -1528,8 +1483,9 @@ export const createChatHandler = () => {
                   mode,
                   originalModel: selectedModel,
                   requestedModelSlug: configuredModelId,
-                  fallbackModel,
-                  fallbackModelSlug: fallbackModelId,
+                  fallbackModel: apiRetryModel,
+                  fallbackModelSlug:
+                    trackedProvider.languageModel(apiRetryModel).modelId,
                   userId,
                   subscription,
                   preFallbackCacheReadTokens: usageTracker.cacheReadTokens,
@@ -1540,7 +1496,7 @@ export const createChatHandler = () => {
                 isRetryWithFallback = true;
                 retryUsedFallbackModel = retryUsesDifferentModel(
                   selectedModel,
-                  fallbackModel,
+                  apiRetryModel,
                 );
                 resetServedModelTelemetryForRetry(state);
                 state.lastStepInputTokens = 0;
@@ -1563,7 +1519,30 @@ export const createChatHandler = () => {
                 // only billed for the fallback. Non-model spend (sandbox/tools)
                 // is preserved.
                 usageTracker.resetModelLeg();
-                result = await createStream(fallbackModel);
+                if (shouldRecoverVisionApiError) {
+                  visionSummaryRecovery.activate({
+                    error,
+                    source:
+                      countFileAttachments(state.finalMessages).imageCount > 0
+                        ? "attachment"
+                        : "file_view",
+                  });
+                  state.finalMessages =
+                    await describeImageAttachmentsWithAuxiliaryVision({
+                      messages: state.finalMessages,
+                      requestId: req.headers.get("x-vercel-id") ?? undefined,
+                      userId,
+                      chatId,
+                      abortSignal: userStopSignal.signal,
+                      onCost: (costDollars) => {
+                        usageTracker.providerCost += costDollars;
+                        usageTracker.nonModelCost += costDollars;
+                        chatLogger?.getBuilder().addToolCost(costDollars);
+                      },
+                      cacheDescription: cacheAuxiliaryVisionDescription,
+                    });
+                }
+                result = await createStream(apiRetryModel);
               } else {
                 throw error;
               }
@@ -1651,59 +1630,89 @@ export const createChatHandler = () => {
                         : { messages, omittedCount: 0 };
                     const shouldRetryWithoutImageToolResults =
                       imageRecovery.omittedCount > 0 && !isAborted;
+                    const hasImageAttachmentForRecovery =
+                      countFileAttachments(state.finalMessages).imageCount > 0;
+                    const hasImageToolResultForRecovery =
+                      uiMessagesContainImageViewResult(state.finalMessages);
+                    const shouldRetryWithVisionSummary =
+                      directGlmVisionEnabled &&
+                      !visionSummaryRecovery.isEnabled() &&
+                      !providerContentBlocked &&
+                      hasTerminalProviderStreamError &&
+                      (shouldRetryWithFallback ||
+                        shouldRetryWithoutImageToolResults) &&
+                      (hasImageAttachmentForRecovery ||
+                        hasImageToolResultForRecovery);
+                    const visionSummaryRecoveryError =
+                      state.providerError ??
+                      new Error("Direct vision route failed");
 
                     if (
                       (shouldRetryWithFallback ||
-                        shouldRetryWithoutImageToolResults) &&
+                        shouldRetryWithoutImageToolResults ||
+                        shouldRetryWithVisionSummary) &&
                       !isRetryWithFallback
                     ) {
                       const loopTriggeredRetry =
                         stoppedDueToAssistantContentLoop ||
                         state.stoppedDueToDoomLoop;
-                      const retryReason = shouldRetryWithoutImageToolResults
-                        ? "image_tool_result_rejection"
-                        : providerContentBlocked
-                          ? "content_filter"
-                          : stoppedDueToAssistantContentLoop
-                            ? "assistant_content_loop"
-                            : state.stoppedDueToDoomLoop
-                              ? "doom_loop"
-                              : shouldRetryInterruptedToolInput
-                                ? "interrupted_tool_input"
-                                : shouldRetryReasoningOnlyProviderError
-                                  ? "reasoning_only_provider_error"
-                                  : "incomplete_stream";
+                      const retryReason = shouldRetryWithVisionSummary
+                        ? "vision_summary_recovery"
+                        : shouldRetryWithoutImageToolResults
+                          ? "image_tool_result_rejection"
+                          : providerContentBlocked
+                            ? "content_filter"
+                            : stoppedDueToAssistantContentLoop
+                              ? "assistant_content_loop"
+                              : state.stoppedDueToDoomLoop
+                                ? "doom_loop"
+                                : shouldRetryInterruptedToolInput
+                                  ? "interrupted_tool_input"
+                                  : shouldRetryReasoningOnlyProviderError
+                                    ? "reasoning_only_provider_error"
+                                    : "incomplete_stream";
                       const blockedProviderModel = providerContentBlocked
                         ? state.responseModel
                         : undefined;
-                      const retryModel = shouldRetryWithoutImageToolResults
-                        ? selectedModel
-                        : providerContentBlocked
-                          ? getContentFilterRetryModel(
-                              selectedModel,
-                              mode,
-                              blockedProviderModel,
-                            )
-                          : fallbackModel;
+                      const retryModel = shouldRetryWithVisionSummary
+                        ? selectModel(
+                            mode,
+                            subscription,
+                            selectedModelOverride,
+                            false,
+                            false,
+                            { extraUsageAvailable },
+                          )
+                        : shouldRetryWithoutImageToolResults
+                          ? selectedModel
+                          : providerContentBlocked
+                            ? getContentFilterRetryModel(
+                                selectedModel,
+                                mode,
+                                blockedProviderModel,
+                              )
+                            : fallbackModel;
                       const retryModelSlug =
                         trackedProvider.languageModel(retryModel).modelId;
                       phLogger.warn(
-                        shouldRetryWithoutImageToolResults
-                          ? "Provider rejected image tool output - retrying without images"
-                          : retryReason === "content_filter"
-                            ? "Provider content filter triggered fallback model retry"
-                            : retryReason === "assistant_content_loop"
-                              ? "Assistant content loop detected - triggering fallback"
-                              : retryReason === "doom_loop"
-                                ? "Agent doom loop detected - triggering fallback"
-                                : retryReason === "interrupted_tool_input"
-                                  ? "Provider stream errored during tool input - triggering bounded fallback"
-                                  : retryReason ===
-                                      "reasoning_only_provider_error"
-                                    ? "Provider stream errored after reasoning-only output - triggering bounded fallback"
-                                    : hasTerminalProviderStreamError
-                                      ? "Provider stream errored before useful output - triggering fallback"
-                                      : "Stream finished incomplete - triggering fallback",
+                        shouldRetryWithVisionSummary
+                          ? "Direct vision routes failed - retrying with MiniMax summary"
+                          : shouldRetryWithoutImageToolResults
+                            ? "Provider rejected image tool output - retrying without images"
+                            : retryReason === "content_filter"
+                              ? "Provider content filter triggered fallback model retry"
+                              : retryReason === "assistant_content_loop"
+                                ? "Assistant content loop detected - triggering fallback"
+                                : retryReason === "doom_loop"
+                                  ? "Agent doom loop detected - triggering fallback"
+                                  : retryReason === "interrupted_tool_input"
+                                    ? "Provider stream errored during tool input - triggering bounded fallback"
+                                    : retryReason ===
+                                        "reasoning_only_provider_error"
+                                      ? "Provider stream errored after reasoning-only output - triggering bounded fallback"
+                                      : hasTerminalProviderStreamError
+                                        ? "Provider stream errored before useful output - triggering fallback"
+                                        : "Stream finished incomplete - triggering fallback",
                         {
                           chatId,
                           endpoint,
@@ -1726,6 +1735,7 @@ export const createChatHandler = () => {
                               : undefined,
                           shouldRetryInterruptedToolInput,
                           imageToolResultsOmitted: imageRecovery.omittedCount,
+                          visionSummaryRecovery: shouldRetryWithVisionSummary,
                         },
                       );
 
@@ -1736,6 +1746,7 @@ export const createChatHandler = () => {
                       if (
                         (!isAborted || stoppedDueToAssistantContentLoop) &&
                         (isAutoModel ||
+                          shouldRetryWithVisionSummary ||
                           providerContentBlocked ||
                           shouldRetryWithoutImageToolResults ||
                           loopTriggeredRetry ||
@@ -1768,7 +1779,32 @@ export const createChatHandler = () => {
                           retryUsesDifferentModel(selectedModel, retryModel) ||
                           providerContentBlocked;
                         resetServedModelTelemetryForRetry(state);
-                        if (shouldRetryWithoutImageToolResults) {
+                        if (shouldRetryWithVisionSummary) {
+                          visionSummaryRecovery.activate({
+                            error: visionSummaryRecoveryError,
+                            source: hasImageAttachmentForRecovery
+                              ? "attachment"
+                              : "file_view",
+                          });
+                          state.finalMessages =
+                            await describeImageAttachmentsWithAuxiliaryVision({
+                              messages: state.finalMessages,
+                              requestId:
+                                req.headers.get("x-vercel-id") ?? undefined,
+                              userId,
+                              chatId,
+                              abortSignal: userStopSignal.signal,
+                              onCost: (costDollars) => {
+                                usageTracker.providerCost += costDollars;
+                                usageTracker.nonModelCost += costDollars;
+                                chatLogger
+                                  ?.getBuilder()
+                                  .addToolCost(costDollars);
+                              },
+                              cacheDescription: cacheAuxiliaryVisionDescription,
+                            });
+                          usageTracker.resetModelLeg();
+                        } else if (shouldRetryWithoutImageToolResults) {
                           state.finalMessages =
                             omitTrailingStepStartAssistantMessage(
                               imageRecovery.messages,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -23,6 +23,8 @@ import type {
   UserCustomization,
 } from "@/types";
 import {
+  DEEPSEEK_V4_FLASH_VISION_SLUG,
+  GLM_5_3_FLASH_SLUG,
   GLM_5_3_SLUG,
   GROK_4_5_SLUG,
   GROK_4_6_SLUG,
@@ -621,6 +623,8 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "model-opus-4.6": ["model-grok-4.6"],
   "model-glm-5.2": KIMI_K3_THEN_GROK_FALLBACK_CHAIN,
   "model-glm-5.3": ["model-kimi-k3"],
+  "model-glm-5.3-flash": ["model-deepseek-v4-flash-vision"],
+  "model-glm-5.3-flash-pro": ["model-deepseek-v4-flash-vision"],
   "fallback-agent-model": GROK_4_6_FALLBACK_CHAIN,
   "fallback-ask-model": GROK_4_6_FALLBACK_CHAIN,
   "model-kimi-k3": ["model-grok-4.6"],
@@ -677,6 +681,7 @@ const HIGH_REASONING_MODELS = [
   "model-deepseek-v4-pro-0813",
   "model-glm-5.2",
   "model-glm-5.3",
+  "model-glm-5.3-flash-pro",
   "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
 
@@ -757,6 +762,12 @@ export function getRetryFallbackModel(
   }
   if (modelName === "model-glm-5.3") {
     return "model-kimi-k3";
+  }
+  if (
+    modelName === "model-glm-5.3-flash" ||
+    modelName === "model-glm-5.3-flash-pro"
+  ) {
+    return "model-deepseek-v4-flash-vision";
   }
   return "model-grok-4.6";
 }
@@ -862,6 +873,8 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, string> = {
   "z-ai/glm-5.2-20260616": "model-glm-5.2",
   "z-ai/glm-5.3": "model-glm-5.3",
   "z-ai/glm-5.3-20260816": "model-glm-5.3",
+  [GLM_5_3_FLASH_SLUG]: "model-glm-5.3-flash",
+  [DEEPSEEK_V4_FLASH_VISION_SLUG]: "model-deepseek-v4-flash-vision",
   "moonshotai/kimi-k3": "model-kimi-k3",
   "moonshotai/kimi-k3-20260715": "model-kimi-k3",
 };
@@ -942,9 +955,10 @@ export function buildProviderOptions(
       })
     : fallbackSlugs;
   // OpenRouter applies one reasoning configuration to both the primary model
-  // and every provider fallback. The Standard vision key uses medium while
-  // GLM 5.3, Pro vision, and Grok 4.6 routes remain high.
+  // and every provider fallback. Standard GLM vision uses low, legacy Standard
+  // Grok vision uses medium, and Pro/full reasoning routes remain high.
   const isMediumGrok45Vision = modelName === "model-grok-4.5" && isGrok45;
+  const isStandardGlmFlashVision = modelName === "model-glm-5.3-flash";
   const routesThroughHighReasoningModel =
     isGrok45 ||
     isGrok46 ||
@@ -954,30 +968,35 @@ export function buildProviderOptions(
   const providerRouting = modelId
     ? getOpenRouterProviderRoutingForModel(modelId)
     : undefined;
-  const reasoning = isMediumGrok45Vision
+  const reasoning = isStandardGlmFlashVision
     ? {
         enabled: true,
-        effort: "medium",
+        effort: "low",
       }
-    : routesThroughHighReasoningModel
-      ? isHighOrGreaterReasoningOverride(options.reasoningOverride)
-        ? options.reasoningOverride
-        : {
-            enabled: true,
-            effort: "high",
-          }
-      : (options.reasoningOverride ??
-        (isHighReasoningModel(modelName) || isAgentDeepSeekV4
-          ? {
+    : isMediumGrok45Vision
+      ? {
+          enabled: true,
+          effort: "medium",
+        }
+      : routesThroughHighReasoningModel
+        ? isHighOrGreaterReasoningOverride(options.reasoningOverride)
+          ? options.reasoningOverride
+          : {
               enabled: true,
               effort: "high",
             }
-          : isReasoningModel
+        : (options.reasoningOverride ??
+          (isHighReasoningModel(modelName) || isAgentDeepSeekV4
             ? {
                 enabled: true,
-                ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
+                effort: "high",
               }
-            : { enabled: false }));
+            : isReasoningModel
+              ? {
+                  enabled: true,
+                  ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
+                }
+              : { enabled: false }));
 
   return {
     openrouter: {

--- a/lib/chat/__tests__/auxiliary-vision-eligibility.test.ts
+++ b/lib/chat/__tests__/auxiliary-vision-eligibility.test.ts
@@ -1,18 +1,14 @@
-import { isEligibleForAuxiliaryDeepSeekVision } from "@/lib/chat/auxiliary-vision-eligibility";
+import { isEligibleForDirectGlmVision } from "@/lib/chat/auxiliary-vision-eligibility";
 
-describe("auxiliary DeepSeek vision eligibility", () => {
+describe("direct GLM vision eligibility", () => {
   it("enables paid non-Max routes by default", () => {
-    expect(isEligibleForAuxiliaryDeepSeekVision({ subscription: "pro" })).toBe(
-      true,
-    );
+    expect(isEligibleForDirectGlmVision({ subscription: "pro" })).toBe(true);
     expect(
-      isEligibleForAuxiliaryDeepSeekVision({
+      isEligibleForDirectGlmVision({
         subscription: "pro",
         selectedModelOverride: "hackerai-max",
       }),
     ).toBe(false);
-    expect(isEligibleForAuxiliaryDeepSeekVision({ subscription: "free" })).toBe(
-      false,
-    );
+    expect(isEligibleForDirectGlmVision({ subscription: "free" })).toBe(false);
   });
 });

--- a/lib/chat/__tests__/auxiliary-vision.test.ts
+++ b/lib/chat/__tests__/auxiliary-vision.test.ts
@@ -1,15 +1,15 @@
 jest.mock("server-only", () => ({}));
 
 import {
-  AUXILIARY_VISION_FALLBACK_SLUG,
-  AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG,
   AUXILIARY_VISION_SLUG,
+  DEEPSEEK_V4_FLASH_VISION_SLUG,
+  GLM_5_3_FLASH_SLUG,
 } from "@/lib/ai/providers";
 import {
   AUXILIARY_VISION_MAX_CONCURRENCY,
   AUXILIARY_VISION_MAX_IMAGES_PER_TURN,
   AUXILIARY_VISION_PROVIDER_OPTIONS,
-  createAuxiliaryVisionFailoverController,
+  createVisionSummaryRecoveryController,
   describeImageAttachmentsWithAuxiliaryVision,
   describeImageWithAuxiliaryVision,
   type AuxiliaryVisionModelRunner,
@@ -25,17 +25,14 @@ describe("auxiliary vision", () => {
     jest.restoreAllMocks();
   });
 
-  it("falls back from DeepSeek vision to GLM Flash and then MiniMax", () => {
+  it("uses MiniMax only for the final vision-summary recovery", () => {
     expect(AUXILIARY_VISION_PROVIDER_OPTIONS).toEqual({
       openrouter: {
         reasoning: { enabled: false },
-        models: [
-          AUXILIARY_VISION_FALLBACK_SLUG,
-          AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG,
-        ],
         provider: { sort: "latency", data_collection: "deny" },
       },
     });
+    expect(AUXILIARY_VISION_SLUG).toBe("minimax/minimax-m3");
   });
 
   it("prefixes sandbox base64, records cost, and returns text", async () => {
@@ -75,33 +72,33 @@ describe("auxiliary vision", () => {
     });
   });
 
-  it.each([
-    AUXILIARY_VISION_FALLBACK_SLUG,
-    AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG,
-  ])("records provider fallback model %s", async (fallbackModel) => {
-    const result = await describeImageWithAuxiliaryVision({
-      image: "aW1hZ2U=",
-      mediaType: "image/png",
-      source: "attachment",
-      modelRunner: async () => ({
-        text: "Fallback description",
+  it.each([DEEPSEEK_V4_FLASH_VISION_SLUG, GLM_5_3_FLASH_SLUG])(
+    "records an unexpected summary model %s",
+    async (fallbackModel) => {
+      const result = await describeImageWithAuxiliaryVision({
+        image: "aW1hZ2U=",
+        mediaType: "image/png",
+        source: "attachment",
+        modelRunner: async () => ({
+          text: "Fallback description",
+          model: fallbackModel,
+        }),
+      });
+
+      expect(result.model).toBe(fallbackModel);
+      const payload = JSON.parse(
+        (console.info as jest.Mock).mock.calls[0][0] as string,
+      );
+      expect(payload).toMatchObject({
         model: fallbackModel,
-      }),
-    });
+        fallback_served: true,
+      });
+    },
+  );
 
-    expect(result.model).toBe(fallbackModel);
-    const payload = JSON.parse(
-      (console.info as jest.Mock).mock.calls[0][0] as string,
-    );
-    expect(payload).toMatchObject({
-      model: fallbackModel,
-      fallback_served: true,
-    });
-  });
-
-  it("activates direct vision failover once with bounded diagnostics", () => {
-    const controller = createAuxiliaryVisionFailoverController({
-      enabled: true,
+  it("activates MiniMax summary recovery once with bounded diagnostics", () => {
+    const controller = createVisionSummaryRecoveryController({
+      available: true,
       service: "chat-handler",
       requestId: "request-1",
       userId: "user-1",
@@ -113,7 +110,7 @@ describe("auxiliary vision", () => {
     expect(
       controller.activate({ error: providerError, source: "attachment" }),
     ).toBe(true);
-    expect(controller.isEnabled()).toBe(false);
+    expect(controller.isEnabled()).toBe(true);
     expect(
       controller.activate({ error: providerError, source: "file_view" }),
     ).toBe(false);
@@ -123,14 +120,14 @@ describe("auxiliary vision", () => {
       (console.warn as jest.Mock).mock.calls[0][0] as string,
     );
     expect(payload).toMatchObject({
-      event: "auxiliary_vision_failover_activated",
+      event: "vision_summary_recovery_activated",
       service: "chat-handler",
       request_id: "request-1",
       user_id: "user-1",
       chat_id: "chat-1",
       trigger_run_id: "run-1",
       source: "attachment",
-      fallback_route: "direct_vision",
+      fallback_route: "minimax_vision_summary",
       failure_reason: "provider_error",
       error_name: "Error",
       failed_image_count: 1,
@@ -139,8 +136,8 @@ describe("auxiliary vision", () => {
   });
 
   it("does not activate failover for a user cancellation", () => {
-    const controller = createAuxiliaryVisionFailoverController({
-      enabled: true,
+    const controller = createVisionSummaryRecoveryController({
+      available: true,
       service: "agent-long",
       isUserAborted: () => true,
     });
@@ -151,13 +148,13 @@ describe("auxiliary vision", () => {
         source: "attachment",
       }),
     ).toBe(false);
-    expect(controller.isEnabled()).toBe(true);
+    expect(controller.isEnabled()).toBe(false);
     expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("classifies a descriptor timeout without logging its message", () => {
-    const controller = createAuxiliaryVisionFailoverController({
-      enabled: true,
+    const controller = createVisionSummaryRecoveryController({
+      available: true,
       service: "agent-long",
     });
 
@@ -260,10 +257,7 @@ describe("auxiliary vision", () => {
     });
   });
 
-  it.each([
-    AUXILIARY_VISION_FALLBACK_SLUG,
-    AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG,
-  ])(
+  it.each([DEEPSEEK_V4_FLASH_VISION_SLUG, GLM_5_3_FLASH_SLUG])(
     "reuses owned-file descriptions generated by fallback %s",
     async (fallbackModel) => {
       const modelRunner =

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -211,7 +211,7 @@ describe("selectModel", () => {
     ).toBe("model-deepseek-v4-pro-0813");
     expect(
       selectModel("agent", "ultra", "auto", true, false, auxiliaryVision),
-    ).toBe("model-deepseek-v4-flash-0731");
+    ).toBe("model-deepseek-v4-pro-0813");
   });
 
   it("routes HackerAI Pro through DeepSeek V4 Pro 0813", () => {
@@ -242,6 +242,36 @@ describe("selectModel", () => {
         auxiliaryVisionEnabled: true,
       }),
     ).toBe("model-deepseek-v4-flash-0731");
+  });
+
+  it.each(["ask", "agent"] as const)(
+    "routes Standard %s image prompts directly to GLM 5.3 Flash",
+    (mode) => {
+      expect(
+        selectModel(mode, "pro", "hackerai-standard", true, false, {
+          directGlmVisionEnabled: true,
+        }),
+      ).toBe("model-glm-5.3-flash");
+    },
+  );
+
+  it.each(["ask", "agent"] as const)(
+    "routes Pro %s image prompts directly to GLM 5.3 Flash Pro",
+    (mode) => {
+      expect(
+        selectModel(mode, "pro", "hackerai-pro", true, false, {
+          directGlmVisionEnabled: true,
+        }),
+      ).toBe("model-glm-5.3-flash-pro");
+    },
+  );
+
+  it("uses the Pro GLM vision route for Pro Plus Auto images", () => {
+    expect(
+      selectModel("agent", "pro-plus", "auto", true, false, {
+        directGlmVisionEnabled: true,
+      }),
+    ).toBe("model-glm-5.3-flash-pro");
   });
 
   it.each(["pro", "pro-plus", "ultra", "team"] as const)(

--- a/lib/chat/auxiliary-vision-eligibility.ts
+++ b/lib/chat/auxiliary-vision-eligibility.ts
@@ -1,6 +1,6 @@
 import type { SelectedModel, SubscriptionTier } from "@/types";
 
-export function isEligibleForAuxiliaryDeepSeekVision({
+export function isEligibleForDirectGlmVision({
   subscription,
   selectedModelOverride,
 }: {

--- a/lib/chat/auxiliary-vision.ts
+++ b/lib/chat/auxiliary-vision.ts
@@ -3,9 +3,9 @@ import "server-only";
 import { generateText, type UIMessage } from "ai";
 
 import {
-  AUXILIARY_VISION_FALLBACK_SLUG,
-  AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG,
   AUXILIARY_VISION_SLUG,
+  DEEPSEEK_V4_FLASH_VISION_SLUG,
+  GLM_5_3_FLASH_SLUG,
   myProvider,
 } from "@/lib/ai/providers";
 import { getProviderUsageRawModelCost } from "@/lib/provider-usage-cost";
@@ -15,21 +15,20 @@ export const AUXILIARY_VISION_TIMEOUT_MS = 20_000;
 export const AUXILIARY_VISION_MAX_OUTPUT_TOKENS = 1_200;
 export const AUXILIARY_VISION_MAX_IMAGES_PER_TURN = 10;
 export const AUXILIARY_VISION_MAX_CONCURRENCY = 3;
-const AUXILIARY_VISION_FALLBACK_SLUGS = [
-  AUXILIARY_VISION_FALLBACK_SLUG,
-  AUXILIARY_VISION_SECONDARY_FALLBACK_SLUG,
+const LEGACY_AUXILIARY_VISION_SLUGS = [
+  DEEPSEEK_V4_FLASH_VISION_SLUG,
+  GLM_5_3_FLASH_SLUG,
 ] as const;
 export const AUXILIARY_VISION_PROVIDER_OPTIONS = {
   openrouter: {
     reasoning: { enabled: false },
-    models: [...AUXILIARY_VISION_FALLBACK_SLUGS],
     provider: { sort: "latency", data_collection: "deny" },
   },
 };
 
 export type AuxiliaryVisionSource = "attachment" | "file_view";
 
-export type AuxiliaryVisionFailoverController = {
+export type VisionSummaryRecoveryController = {
   activate: (args: {
     error: unknown;
     source: AuxiliaryVisionSource;
@@ -56,8 +55,8 @@ const getAuxiliaryVisionFailureDetails = (
   };
 };
 
-export function createAuxiliaryVisionFailoverController({
-  enabled,
+export function createVisionSummaryRecoveryController({
+  available,
   service,
   requestId,
   userId,
@@ -65,27 +64,27 @@ export function createAuxiliaryVisionFailoverController({
   triggerRunId,
   isUserAborted,
 }: {
-  enabled: boolean;
+  available: boolean;
   service: "agent-long" | "chat-handler";
   requestId?: string;
   userId?: string;
   chatId?: string;
   triggerRunId?: string;
   isUserAborted?: () => boolean;
-}): AuxiliaryVisionFailoverController {
-  let active = enabled;
+}): VisionSummaryRecoveryController {
+  let active = false;
 
   return {
     isEnabled: () => active,
     activate: ({ error, source }) => {
-      if (!active || isUserAborted?.()) return false;
-      active = false;
+      if (!available || active || isUserAborted?.()) return false;
+      active = true;
       const failure = getAuxiliaryVisionFailureDetails(error);
       console.warn(
         JSON.stringify({
           timestamp: new Date().toISOString(),
           level: "warn",
-          event: "auxiliary_vision_failover_activated",
+          event: "vision_summary_recovery_activated",
           service,
           environment:
             process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
@@ -94,7 +93,7 @@ export function createAuxiliaryVisionFailoverController({
           chat_id: chatId,
           trigger_run_id: triggerRunId,
           source,
-          fallback_route: "direct_vision",
+          fallback_route: "minimax_vision_summary",
           failure_reason: failure.reason,
           error_name: failure.errorName,
           failed_image_count: failure.failedImageCount,
@@ -262,9 +261,7 @@ export async function describeImageWithAuxiliaryVision({
         trigger_run_id: triggerRunId,
         source,
         model,
-        fallback_served: AUXILIARY_VISION_FALLBACK_SLUGS.includes(
-          model as (typeof AUXILIARY_VISION_FALLBACK_SLUGS)[number],
-        ),
+        fallback_served: model !== AUXILIARY_VISION_SLUG,
         media_type: mediaType,
         duration_ms: durationMs,
         input_tokens: result.usage?.inputTokens ?? 0,
@@ -381,8 +378,8 @@ export async function describeImageAttachmentsWithAuxiliaryVision({
         fileId &&
         typeof partRecord.auxiliaryVisionDescription === "string" &&
         (partRecord.auxiliaryVisionModel === AUXILIARY_VISION_SLUG ||
-          AUXILIARY_VISION_FALLBACK_SLUGS.includes(
-            partRecord.auxiliaryVisionModel as (typeof AUXILIARY_VISION_FALLBACK_SLUGS)[number],
+          LEGACY_AUXILIARY_VISION_SLUGS.includes(
+            partRecord.auxiliaryVisionModel as (typeof LEGACY_AUXILIARY_VISION_SLUGS)[number],
           ))
           ? partRecord.auxiliaryVisionDescription
           : undefined;

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -51,6 +51,7 @@ export function selectModel(
   options: {
     extraUsageAvailable?: boolean;
     auxiliaryVisionEnabled?: boolean;
+    directGlmVisionEnabled?: boolean;
   } = {},
 ): ModelName {
   const isAgent = isAgentMode(mode);
@@ -59,8 +60,9 @@ export function selectModel(
     subscription,
     options,
   );
-  // In control, DeepSeek image prompts promote to a media-capable route. The
-  // auxiliary treatment replaces images with descriptions before inference.
+  // Paid Standard/Pro image prompts use GLM Flash directly, with DeepSeek
+  // Vision configured as its provider fallback. The auxiliary treatment is
+  // reserved for MiniMax summary recovery after both direct routes fail.
   // PDFs remain on DeepSeek via OpenRouter's file parser in both routes.
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage =
@@ -68,10 +70,22 @@ export function selectModel(
   const hasProviderImage =
     !!hasImageAttachment && !options.auxiliaryVisionEnabled;
   const paidAutoTextModel: ModelName =
-    (subscription === "pro-plus" || subscription === "ultra") &&
-    !hasImageAttachment
+    subscription === "pro-plus" || subscription === "ultra"
       ? "model-deepseek-v4-pro-0813"
       : "model-deepseek-v4-flash-0731";
+  const directVisionModel: ModelName =
+    allowedSelectedModel === "hackerai-pro" ||
+    ((!allowedSelectedModel || allowedSelectedModel === "auto") &&
+      paidAutoTextModel === "model-deepseek-v4-pro-0813")
+      ? "model-glm-5.3-flash-pro"
+      : "model-glm-5.3-flash";
+  if (
+    options.directGlmVisionEnabled &&
+    hasImageAttachment &&
+    allowedSelectedModel !== "hackerai-max"
+  ) {
+    return directVisionModel;
+  }
   const paidAskMediaModel: ModelName = hasAskImage
     ? "model-grok-4.5"
     : paidAutoTextModel;
@@ -648,6 +662,7 @@ export async function processChatMessages({
   extraUsageAvailable = false,
   allowLocalDesktopFiles = false,
   auxiliaryVisionEnabled = false,
+  directGlmVisionEnabled = false,
   chatId,
   triggerRunId,
   requestId,
@@ -661,6 +676,7 @@ export async function processChatMessages({
   extraUsageAvailable?: boolean;
   allowLocalDesktopFiles?: boolean;
   auxiliaryVisionEnabled?: boolean;
+  directGlmVisionEnabled?: boolean;
   chatId?: string;
   triggerRunId?: string;
   requestId?: string;
@@ -744,6 +760,7 @@ export async function processChatMessages({
     {
       extraUsageAvailable,
       auxiliaryVisionEnabled,
+      directGlmVisionEnabled,
     },
   );
 

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -523,6 +523,29 @@ describe("token-bucket", () => {
       },
     );
 
+    it.each([
+      "model-glm-5.3-flash",
+      "model-glm-5.3-flash-pro",
+      "z-ai/glm-5.3-flash",
+    ])(
+      "should use the conservative GLM 5.3 Flash ceiling for %s ($0.15/$0.50)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(2100);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(7000);
+      },
+    );
+
+    it.each([
+      "model-deepseek-v4-flash-vision",
+      "deepseek/deepseek-v4-flash-vision-exp",
+    ])(
+      "should use the DeepSeek vision peak ceiling for %s ($0.44/$1.32)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(6160);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(18480);
+      },
+    );
+
     it.each(["model-kimi-k3", "model-opus-4.6"])(
       "should use Kimi K3 pricing for %s ($3.00/$15.00)",
       (modelName) => {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -93,6 +93,20 @@ const GLM_5_3_PRICING: ModelPricing = {
   cacheRead: 0.26,
   cacheWrite: 1.4,
 };
+// Use the undiscounted OpenRouter ceiling so budget checks remain conservative
+// when the launch promotion or selected upstream provider changes.
+const GLM_5_3_FLASH_PRICING: ModelPricing = {
+  input: 0.15,
+  output: 0.5,
+  cacheRead: 0.03,
+  cacheWrite: 0.15,
+};
+const DEEPSEEK_V4_FLASH_VISION_PRICING: ModelPricing = {
+  input: 0.44,
+  output: 1.32,
+  cacheRead: 0.014,
+  cacheWrite: 0.44,
+};
 const KIMI_K3_PRICING: ModelPricing = {
   input: 3.0,
   output: 15.0,
@@ -120,12 +134,15 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "model-deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "model-deepseek-v4-pro-0813": DEEPSEEK_V4_PRO_PRICING,
+  "model-deepseek-v4-flash-vision": DEEPSEEK_V4_FLASH_VISION_PRICING,
   // Persisted Max compatibility key; the active provider route is Kimi K3.
   "model-opus-4.6": KIMI_K3_PRICING,
   // Baseline OpenRouter rates: $0.76 in / $2.42 out per 1M tokens.
   "model-glm-5.2": GLM_5_2_PRICING,
   // OpenRouter rates: $1.40 in / $4.40 out / $0.26 cached input per 1M tokens.
   "model-glm-5.3": GLM_5_3_PRICING,
+  "model-glm-5.3-flash": GLM_5_3_FLASH_PRICING,
+  "model-glm-5.3-flash-pro": GLM_5_3_FLASH_PRICING,
   // OpenRouter rates: $3.00 in / $15.00 out / $0.30 cached input per 1M tokens.
   "model-kimi-k3": KIMI_K3_PRICING,
   // Provider response ids can reach accounting before local-key normalization.
@@ -139,11 +156,13 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "deepseek/deepseek-v4-flash-20260731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "deepseek/deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "deepseek/deepseek-v4-pro-0813": DEEPSEEK_V4_PRO_PRICING,
+  "deepseek/deepseek-v4-flash-vision-exp": DEEPSEEK_V4_FLASH_VISION_PRICING,
   "anthropic/claude-opus-4.6": OPUS_4_6_PRICING,
   "z-ai/glm-5.2": GLM_5_2_PRICING,
   "z-ai/glm-5.2-20260616": GLM_5_2_PRICING,
   "z-ai/glm-5.3": GLM_5_3_PRICING,
   "z-ai/glm-5.3-20260816": GLM_5_3_PRICING,
+  "z-ai/glm-5.3-flash": GLM_5_3_FLASH_PRICING,
   "moonshotai/kimi-k3": KIMI_K3_PRICING,
   "moonshotai/kimi-k3-20260715": KIMI_K3_PRICING,
 };

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -28,10 +28,10 @@ import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { createTrackedProvider } from "@/lib/ai/providers";
-import { processChatMessages } from "@/lib/chat/chat-processor";
+import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
 import { cacheAuxiliaryVisionDescription } from "@/lib/utils/file-transform-utils";
 import {
-  createAuxiliaryVisionFailoverController,
+  createVisionSummaryRecoveryController,
   describeImageAttachmentsWithAuxiliaryVision,
   describeImageWithAuxiliaryVision,
 } from "@/lib/chat/auxiliary-vision";
@@ -150,7 +150,7 @@ import {
   getActiveDeepSeekV4Pro0813ExperimentAssignment,
   getDeepSeekV4Pro0813ExperimentContext,
 } from "@/lib/experiments/deepseek-v4-pro-0813";
-import { isEligibleForAuxiliaryDeepSeekVision } from "@/lib/chat/auxiliary-vision-eligibility";
+import { isEligibleForDirectGlmVision } from "@/lib/chat/auxiliary-vision-eligibility";
 import type { AgentAutoReviewAssignment } from "@/lib/experiments/agent-auto-review";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import type { AnalyticsRequestContext } from "@/lib/analytics/request-context";
@@ -205,7 +205,6 @@ import {
 import {
   createAgentStream,
   initAgentStreamState,
-  resolveAgentModelForImageToolResults,
   resetServedModelTelemetryForRetry,
   retryUsesDifferentModel,
   type AgentStreamContext,
@@ -262,6 +261,7 @@ import {
 import {
   omitImageViewToolResultsForProviderRetry,
   omitTrailingStepStartAssistantMessage,
+  uiMessagesContainImageViewResult,
 } from "@/lib/chat/multimodal-tool-result-recovery";
 import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 import { isCentrifugoSandbox } from "@/lib/ai/tools/utils/sandbox-types";
@@ -2530,7 +2530,7 @@ export const agentLongTask = task({
         selectedModelOverride,
         subscription,
       );
-      const auxiliaryVisionEnabled = isEligibleForAuxiliaryDeepSeekVision({
+      const directGlmVisionEnabled = isEligibleForDirectGlmVision({
         subscription,
         selectedModelOverride,
       });
@@ -2558,7 +2558,7 @@ export const agentLongTask = task({
         modelOverride: selectedModelOverride,
         extraUsageAvailable,
         allowLocalDesktopFiles: sandboxPreference === "desktop",
-        auxiliaryVisionEnabled,
+        directGlmVisionEnabled,
         chatId,
         triggerRunId: ctx.run.id,
         requestId: ctx.run.id,
@@ -2706,8 +2706,8 @@ export const agentLongTask = task({
         PaidDailyFreeAllowanceReservation | undefined;
 
       let streamError: unknown;
-      const auxiliaryVisionFailover = createAuxiliaryVisionFailoverController({
-        enabled: auxiliaryVisionEnabled,
+      const visionSummaryRecovery = createVisionSummaryRecoveryController({
+        available: directGlmVisionEnabled,
         service: "agent-long",
         requestId: ctx.run.id,
         userId,
@@ -2727,9 +2727,9 @@ export const agentLongTask = task({
           try {
             const usageTracker = new UsageTracker();
             observedUsageTracker = usageTracker;
-            const auxiliaryVision = auxiliaryVisionFailover.isEnabled()
+            const auxiliaryVision = directGlmVisionEnabled
               ? {
-                  isEnabled: auxiliaryVisionFailover.isEnabled,
+                  isEnabled: visionSummaryRecovery.isEnabled,
                   isAborted: () => userStopSignal.signal.aborted,
                   describeImage: async (args: {
                     image: string;
@@ -2737,27 +2737,19 @@ export const agentLongTask = task({
                     filename?: string;
                     source: "file_view";
                   }) => {
-                    try {
-                      return await describeImageWithAuxiliaryVision({
-                        ...args,
-                        requestId: ctx.run.id,
-                        userId,
-                        chatId,
-                        triggerRunId: ctx.run.id,
-                        abortSignal: userStopSignal.signal,
-                        onCost: (costDollars) => {
-                          usageTracker.providerCost += costDollars;
-                          usageTracker.nonModelCost += costDollars;
-                          chatLogger?.getBuilder().addToolCost(costDollars);
-                        },
-                      });
-                    } catch (error) {
-                      auxiliaryVisionFailover.activate({
-                        error,
-                        source: "file_view",
-                      });
-                      throw error;
-                    }
+                    return await describeImageWithAuxiliaryVision({
+                      ...args,
+                      requestId: ctx.run.id,
+                      userId,
+                      chatId,
+                      triggerRunId: ctx.run.id,
+                      abortSignal: userStopSignal.signal,
+                      onCost: (costDollars) => {
+                        usageTracker.providerCost += costDollars;
+                        usageTracker.nonModelCost += costDollars;
+                        chatLogger?.getBuilder().addToolCost(costDollars);
+                      },
+                    });
                   },
                 }
               : undefined;
@@ -3387,49 +3379,6 @@ export const agentLongTask = task({
               }
             }
 
-            if (auxiliaryVisionFailover.isEnabled()) {
-              try {
-                processedMessages =
-                  await describeImageAttachmentsWithAuxiliaryVision({
-                    messages: processedMessages,
-                    requestId: ctx.run.id,
-                    userId,
-                    chatId,
-                    triggerRunId: ctx.run.id,
-                    abortSignal: userStopSignal.signal,
-                    onCost: (costDollars) => {
-                      usageTracker.providerCost += costDollars;
-                      usageTracker.nonModelCost += costDollars;
-                      chatLogger?.getBuilder().addToolCost(costDollars);
-                    },
-                    cacheDescription: cacheAuxiliaryVisionDescription,
-                  });
-              } catch (error) {
-                if (userStopSignal.signal.aborted) throw error;
-                auxiliaryVisionFailover.activate({
-                  error,
-                  source: "attachment",
-                });
-                selectedModel = resolveAgentModelForImageToolResults(
-                  selectedModel,
-                  mode,
-                  true,
-                  selectedModelOverride,
-                  false,
-                );
-                activeDeepSeekV4Pro0813Experiment =
-                  getActiveDeepSeekV4Pro0813ExperimentAssignment(
-                    deepSeekV4Pro0813Experiment,
-                    selectedModel,
-                  );
-                routingExperimentContext =
-                  getDeepSeekV4Pro0813ExperimentContext(
-                    activeDeepSeekV4Pro0813Experiment,
-                  );
-                chatLogger?.setChat(chatLogContext, selectedModel);
-              }
-            }
-
             const titlePromise = isNewChat
               ? generateTitleFromUserMessageWithWriter(
                   messagesForProcessing,
@@ -3554,8 +3503,6 @@ export const agentLongTask = task({
               selectedModelOverride,
             });
             const fallbackModel = getRetryFallbackModel(selectedModel, mode);
-            const fallbackModelId =
-              trackedProvider.languageModel(fallbackModel).modelId;
             let activeModelName = selectedModel;
 
             let hasRecordedUsage = false;
@@ -4095,8 +4042,9 @@ export const agentLongTask = task({
               isReasoningModel: true, // long mode is always agent mode
               platformAuthorized,
               get auxiliaryVisionEnabled() {
-                return auxiliaryVisionFailover.isEnabled();
+                return visionSummaryRecovery.isEnabled();
               },
+              directGlmVisionEnabled,
               maxDurationMs: agentLongMaxDurationMs,
               getActiveElapsedTimeMs: runtimeBudget.getElapsedTimeMs,
               writer,
@@ -4447,12 +4395,27 @@ export const agentLongTask = task({
               });
               result = await createStream(selectedModel);
             } catch (error) {
+              const shouldRecoverVisionApiError =
+                directGlmVisionEnabled &&
+                !visionSummaryRecovery.isEnabled() &&
+                (countFileAttachments(state.finalMessages).imageCount > 0 ||
+                  uiMessagesContainImageViewResult(state.finalMessages));
               if (
                 isProviderApiError(error) &&
                 !isInvalidImageInputError(error) &&
                 !isRetryWithFallback &&
-                isAutoModel
+                (isAutoModel || shouldRecoverVisionApiError)
               ) {
+                const apiRetryModel = shouldRecoverVisionApiError
+                  ? selectModel(
+                      mode,
+                      subscription,
+                      selectedModelOverride,
+                      false,
+                      false,
+                      { extraUsageAvailable },
+                    )
+                  : fallbackModel;
                 phLogger.error(
                   "[agent-long] Provider API error, retrying with fallback",
                   {
@@ -4460,8 +4423,9 @@ export const agentLongTask = task({
                     chatId,
                     originalModel: selectedModel,
                     requestedModelSlug: configuredModelId,
-                    fallbackModel,
-                    fallbackModelSlug: fallbackModelId,
+                    fallbackModel: apiRetryModel,
+                    fallbackModelSlug:
+                      trackedProvider.languageModel(apiRetryModel).modelId,
                     userId,
                     subscription,
                     preFallbackCacheReadTokens: usageTracker.cacheReadTokens,
@@ -4472,14 +4436,38 @@ export const agentLongTask = task({
                 isRetryWithFallback = true;
                 retryUsedFallbackModel = retryUsesDifferentModel(
                   selectedModel,
-                  fallbackModel,
+                  apiRetryModel,
                 );
                 streamError = undefined;
                 resetAgentStreamStateForRetry(state);
                 preFallbackCacheRead = usageTracker.cacheReadTokens;
                 preFallbackCacheWrite = usageTracker.cacheWriteTokens;
                 usageTracker.resetModelLeg();
-                result = await createStream(fallbackModel);
+                if (shouldRecoverVisionApiError) {
+                  visionSummaryRecovery.activate({
+                    error,
+                    source:
+                      countFileAttachments(state.finalMessages).imageCount > 0
+                        ? "attachment"
+                        : "file_view",
+                  });
+                  state.finalMessages =
+                    await describeImageAttachmentsWithAuxiliaryVision({
+                      messages: state.finalMessages,
+                      requestId: ctx.run.id,
+                      userId,
+                      chatId,
+                      triggerRunId: ctx.run.id,
+                      abortSignal: userStopSignal.signal,
+                      onCost: (costDollars) => {
+                        usageTracker.providerCost += costDollars;
+                        usageTracker.nonModelCost += costDollars;
+                        chatLogger?.getBuilder().addToolCost(costDollars);
+                      },
+                      cacheDescription: cacheAuxiliaryVisionDescription,
+                    });
+                }
+                result = await createStream(apiRetryModel);
               } else {
                 throw error;
               }
@@ -4577,6 +4565,24 @@ export const agentLongTask = task({
                           : { messages: finishedMessages, omittedCount: 0 };
                       const shouldRetryWithoutImageToolResults =
                         imageRecovery.omittedCount > 0 && !isAborted;
+                      const hasImageAttachmentForRecovery =
+                        countFileAttachments(state.finalMessages).imageCount >
+                        0;
+                      const hasImageToolResultForRecovery =
+                        uiMessagesContainImageViewResult(state.finalMessages);
+                      const shouldRetryWithVisionSummary =
+                        directGlmVisionEnabled &&
+                        !visionSummaryRecovery.isEnabled() &&
+                        !providerContentBlocked &&
+                        hasTerminalProviderStreamError &&
+                        (shouldRetryWithFallback ||
+                          shouldRetryWithoutImageToolResults) &&
+                        (hasImageAttachmentForRecovery ||
+                          hasImageToolResultForRecovery);
+                      const visionSummaryRecoveryError =
+                        streamError ??
+                        state.providerError ??
+                        new Error("Direct vision route failed");
                       const normalizedFinishedMessages = finishedMessages
                         .map((message) =>
                           message.role === "assistant"
@@ -4606,10 +4612,12 @@ export const agentLongTask = task({
                       if (
                         (shouldRetryWithFallback ||
                           shouldRetryWithoutImageToolResults ||
+                          shouldRetryWithVisionSummary ||
                           shouldContinueAfterProviderDisconnect) &&
                         !isRetryWithFallback &&
                         (!isAborted || stoppedDueToAssistantContentLoop) &&
                         (isAutoModel ||
+                          shouldRetryWithVisionSummary ||
                           providerContentBlocked ||
                           shouldRetryWithoutImageToolResults ||
                           stoppedDueToAssistantContentLoop ||
@@ -4618,33 +4626,44 @@ export const agentLongTask = task({
                           shouldRetryExplicitDeepSeekProReasoning ||
                           shouldContinueAfterProviderDisconnect)
                       ) {
-                        const retryReason = shouldRetryWithoutImageToolResults
-                          ? "image_tool_result_rejection"
-                          : shouldContinueAfterProviderDisconnect
-                            ? "provider_disconnect_continuation"
-                            : providerContentBlocked
-                              ? "content_filter"
-                              : stoppedDueToAssistantContentLoop
-                                ? "assistant_content_loop"
-                                : state.stoppedDueToDoomLoop
-                                  ? "doom_loop"
-                                  : shouldRetryInterruptedToolInput
-                                    ? "interrupted_tool_input"
-                                    : shouldRetryReasoningOnlyProviderError
-                                      ? "reasoning_only_provider_error"
-                                      : "incomplete_stream";
+                        const retryReason = shouldRetryWithVisionSummary
+                          ? "vision_summary_recovery"
+                          : shouldRetryWithoutImageToolResults
+                            ? "image_tool_result_rejection"
+                            : shouldContinueAfterProviderDisconnect
+                              ? "provider_disconnect_continuation"
+                              : providerContentBlocked
+                                ? "content_filter"
+                                : stoppedDueToAssistantContentLoop
+                                  ? "assistant_content_loop"
+                                  : state.stoppedDueToDoomLoop
+                                    ? "doom_loop"
+                                    : shouldRetryInterruptedToolInput
+                                      ? "interrupted_tool_input"
+                                      : shouldRetryReasoningOnlyProviderError
+                                        ? "reasoning_only_provider_error"
+                                        : "incomplete_stream";
                         const blockedProviderModel = providerContentBlocked
                           ? state.responseModel
                           : undefined;
-                        const retryModel = shouldRetryWithoutImageToolResults
-                          ? selectedModel
-                          : providerContentBlocked
-                            ? getContentFilterRetryModel(
-                                selectedModel,
-                                mode,
-                                blockedProviderModel,
-                              )
-                            : fallbackModel;
+                        const retryModel = shouldRetryWithVisionSummary
+                          ? selectModel(
+                              mode,
+                              subscription,
+                              selectedModelOverride,
+                              false,
+                              false,
+                              { extraUsageAvailable },
+                            )
+                          : shouldRetryWithoutImageToolResults
+                            ? selectedModel
+                            : providerContentBlocked
+                              ? getContentFilterRetryModel(
+                                  selectedModel,
+                                  mode,
+                                  blockedProviderModel,
+                                )
+                              : fallbackModel;
                         const retryModelSlug =
                           trackedProvider.languageModel(retryModel).modelId;
                         phLogger.warn(
@@ -4668,6 +4687,7 @@ export const agentLongTask = task({
                                 : undefined,
                             shouldRetryInterruptedToolInput,
                             imageToolResultsOmitted: imageRecovery.omittedCount,
+                            visionSummaryRecovery: shouldRetryWithVisionSummary,
                             disconnectRemovedPartCount:
                               providerDisconnectContinuation?.removedPartCount,
                             disconnectPreservedCompletedToolCount:
@@ -4676,7 +4696,10 @@ export const agentLongTask = task({
                               providerDisconnectContinuation?.preservedTextPartCount,
                           },
                         );
-                        if (providerDisconnectContinuation) {
+                        if (
+                          providerDisconnectContinuation &&
+                          !shouldRetryWithVisionSummary
+                        ) {
                           recordProviderDisconnectRecoveryAttempt({
                             failedModel: selectedModel,
                             retryModel,
@@ -4692,7 +4715,32 @@ export const agentLongTask = task({
                           retryUsesDifferentModel(selectedModel, retryModel) ||
                           providerContentBlocked;
                         resetAgentStreamStateForRetry(state);
-                        if (providerDisconnectContinuation) {
+                        if (shouldRetryWithVisionSummary) {
+                          visionSummaryRecovery.activate({
+                            error: visionSummaryRecoveryError,
+                            source: hasImageAttachmentForRecovery
+                              ? "attachment"
+                              : "file_view",
+                          });
+                          state.finalMessages =
+                            await describeImageAttachmentsWithAuxiliaryVision({
+                              messages: state.finalMessages,
+                              requestId: ctx.run.id,
+                              userId,
+                              chatId,
+                              triggerRunId: ctx.run.id,
+                              abortSignal: userStopSignal.signal,
+                              onCost: (costDollars) => {
+                                usageTracker.providerCost += costDollars;
+                                usageTracker.nonModelCost += costDollars;
+                                chatLogger
+                                  ?.getBuilder()
+                                  .addToolCost(costDollars);
+                              },
+                              cacheDescription: cacheAuxiliaryVisionDescription,
+                            });
+                          usageTracker.resetModelLeg();
+                        } else if (providerDisconnectContinuation) {
                           state.finalMessages = [
                             ...state.finalMessages,
                             ...providerDisconnectContinuation.messages,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -4451,21 +4451,28 @@ export const agentLongTask = task({
                         ? "attachment"
                         : "file_view",
                   });
-                  state.finalMessages =
-                    await describeImageAttachmentsWithAuxiliaryVision({
-                      messages: state.finalMessages,
-                      requestId: ctx.run.id,
-                      userId,
-                      chatId,
-                      triggerRunId: ctx.run.id,
-                      abortSignal: userStopSignal.signal,
-                      onCost: (costDollars) => {
-                        usageTracker.providerCost += costDollars;
-                        usageTracker.nonModelCost += costDollars;
-                        chatLogger?.getBuilder().addToolCost(costDollars);
-                      },
-                      cacheDescription: cacheAuxiliaryVisionDescription,
-                    });
+                  try {
+                    state.finalMessages =
+                      await describeImageAttachmentsWithAuxiliaryVision({
+                        messages: omitImageViewToolResultsForProviderRetry(
+                          state.finalMessages,
+                        ).messages,
+                        requestId: ctx.run.id,
+                        userId,
+                        chatId,
+                        triggerRunId: ctx.run.id,
+                        abortSignal: userStopSignal.signal,
+                        onCost: (costDollars) => {
+                          usageTracker.providerCost += costDollars;
+                          usageTracker.nonModelCost += costDollars;
+                          chatLogger?.getBuilder().addToolCost(costDollars);
+                        },
+                        cacheDescription: cacheAuxiliaryVisionDescription,
+                      });
+                  } catch (summaryError) {
+                    chatLogger?.emitUnexpectedError(summaryError);
+                    throw error;
+                  }
                 }
                 result = await createStream(apiRetryModel);
               } else {
@@ -4608,8 +4615,7 @@ export const agentLongTask = task({
                       const shouldContinueAfterProviderDisconnect = Boolean(
                         providerDisconnectContinuation,
                       );
-
-                      if (
+                      const shouldAttemptProviderRetry =
                         (shouldRetryWithFallback ||
                           shouldRetryWithoutImageToolResults ||
                           shouldRetryWithVisionSummary ||
@@ -4624,7 +4630,58 @@ export const agentLongTask = task({
                           state.stoppedDueToDoomLoop ||
                           shouldRetryInterruptedToolInput ||
                           shouldRetryExplicitDeepSeekProReasoning ||
-                          shouldContinueAfterProviderDisconnect)
+                          shouldContinueAfterProviderDisconnect);
+                      let recoveredVisionMessages:
+                        typeof state.finalMessages | undefined;
+                      let visionSummaryRecoveryFailure: unknown;
+                      if (
+                        shouldAttemptProviderRetry &&
+                        shouldRetryWithVisionSummary
+                      ) {
+                        visionSummaryRecovery.activate({
+                          error: visionSummaryRecoveryError,
+                          source: hasImageAttachmentForRecovery
+                            ? "attachment"
+                            : "file_view",
+                        });
+                        try {
+                          recoveredVisionMessages =
+                            await describeImageAttachmentsWithAuxiliaryVision({
+                              messages:
+                                omitImageViewToolResultsForProviderRetry(
+                                  state.finalMessages,
+                                ).messages,
+                              requestId: ctx.run.id,
+                              userId,
+                              chatId,
+                              triggerRunId: ctx.run.id,
+                              abortSignal: userStopSignal.signal,
+                              onCost: (costDollars) => {
+                                usageTracker.providerCost += costDollars;
+                                usageTracker.nonModelCost += costDollars;
+                                chatLogger
+                                  ?.getBuilder()
+                                  .addToolCost(costDollars);
+                              },
+                              cacheDescription: cacheAuxiliaryVisionDescription,
+                            });
+                        } catch (summaryError) {
+                          visionSummaryRecoveryFailure = summaryError;
+                          phLogger.error("Vision summary recovery failed", {
+                            event: "vision_summary_recovery_failed",
+                            chatId,
+                            mode,
+                            userId,
+                            subscription,
+                            triggerRunId: ctx.run.id,
+                            ...extractErrorDetails(summaryError),
+                          });
+                        }
+                      }
+
+                      if (
+                        shouldAttemptProviderRetry &&
+                        !visionSummaryRecoveryFailure
                       ) {
                         const retryReason = shouldRetryWithVisionSummary
                           ? "vision_summary_recovery"
@@ -4716,29 +4773,7 @@ export const agentLongTask = task({
                           providerContentBlocked;
                         resetAgentStreamStateForRetry(state);
                         if (shouldRetryWithVisionSummary) {
-                          visionSummaryRecovery.activate({
-                            error: visionSummaryRecoveryError,
-                            source: hasImageAttachmentForRecovery
-                              ? "attachment"
-                              : "file_view",
-                          });
-                          state.finalMessages =
-                            await describeImageAttachmentsWithAuxiliaryVision({
-                              messages: state.finalMessages,
-                              requestId: ctx.run.id,
-                              userId,
-                              chatId,
-                              triggerRunId: ctx.run.id,
-                              abortSignal: userStopSignal.signal,
-                              onCost: (costDollars) => {
-                                usageTracker.providerCost += costDollars;
-                                usageTracker.nonModelCost += costDollars;
-                                chatLogger
-                                  ?.getBuilder()
-                                  .addToolCost(costDollars);
-                              },
-                              cacheDescription: cacheAuxiliaryVisionDescription,
-                            });
+                          state.finalMessages = recoveredVisionMessages!;
                           usageTracker.resetModelLeg();
                         } else if (providerDisconnectContinuation) {
                           state.finalMessages = [


### PR DESCRIPTION
## Summary

- route Standard and Pro image turns directly through `z-ai/glm-5.3-flash`, preserving the original image payload
- fall back from GLM to `deepseek/deepseek-v4-flash-vision-exp` for direct vision
- activate `minimax/minimax-m3` vision summaries only after both direct vision models fail, then retry the tier's normal DeepSeek text model
- preserve model selection across tool-produced images and compaction while updating provider routing, cost accounting, and recovery telemetry

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm exec jest --runInBand` — 409 suites, 4,327 tests
- focused post-rebase routing tests — 8 suites, 511 tests
- ESLint and Prettier through the commit hook
- `git diff --check origin/main...HEAD`

## Manual verification

1. In Standard mode, upload an image and confirm the direct response uses GLM 5.3 Flash with the original image.
2. In Pro mode, upload an image and confirm GLM 5.3 Flash is selected with high reasoning effort.
3. Force the GLM request to fail and confirm DeepSeek V4 Flash Vision receives the original image.
4. Force both direct vision requests to fail and confirm `vision_summary_recovery_activated` is emitted, MiniMax produces the summary, and the request retries on the tier's normal DeepSeek text model.

No visual UI files changed; automated verification is sufficient for UI rendering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added direct GLM 5.3 Flash and Flash Pro vision support for image-based requests.
  - Added DeepSeek V4 Flash Vision and MiniMax-powered image-summary recovery.
  - Added model-specific pricing, multimodal support, and improved provider routing.

- **Bug Fixes**
  - Improved recovery after vision-provider failures involving attachments and image tool results.
  - Improved fallback routing, reasoning settings, and usage tracking for vision requests.
  - Preserved appropriate text models after image summarization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->