### PR TITLE
Fix remote device overflow in chat input

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -74,6 +74,11 @@ interface ChatInputProps {
   isResolvingInitialState?: boolean;
 }
 
+const COMPACT_AGENT_CONTROLS_BREAKPOINT_PX = 720;
+
+const shouldUseCompactAgentControls = (width: number): boolean =>
+  width > 0 && width < COMPACT_AGENT_CONTROLS_BREAKPOINT_PX;
+
 const ChatInputLoadingState = ({
   showAgentControls,
 }: {
@@ -297,7 +302,30 @@ export const ChatInput = ({
   );
   const [isStoppingAgent, setIsStoppingAgent] = useState(false);
   const [isReconnecting, setIsReconnecting] = useState(false);
+  const [compactAgentControls, setCompactAgentControls] = useState(false);
+  const chatInputContainerRef = useRef<HTMLDivElement>(null);
   const showAgentApprovalPrompt = !!approvalRequest && !isStoppingAgent;
+
+  useLayoutEffect(() => {
+    const container = chatInputContainerRef.current;
+    if (!container) return;
+
+    const updateCompactLayout = (width: number) => {
+      const nextCompact = shouldUseCompactAgentControls(width);
+      setCompactAgentControls((current) =>
+        current === nextCompact ? current : nextCompact,
+      );
+    };
+
+    updateCompactLayout(container.getBoundingClientRect().width);
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) updateCompactLayout(entry.contentRect.width);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (!isGenerating && !activeToolApprovalRequest && !storedApprovalRequest) {
@@ -760,7 +788,11 @@ export const ChatInput = ({
 
   return (
     <div className={`relative px-4 min-w-0 ${isCentered ? "" : "pb-3"}`}>
-      <div className="mx-auto w-full max-w-full min-w-0 sm:max-w-[768px] sm:min-w-[390px] flex flex-col flex-1">
+      <div
+        ref={chatInputContainerRef}
+        className="mx-auto flex w-full min-w-0 max-w-full flex-1 flex-col sm:min-w-[390px] sm:max-w-[768px]"
+        data-testid="chat-input-container"
+      >
         {isOffline && (
           <div
             role="status"
@@ -855,6 +887,7 @@ export const ChatInput = ({
               autoFocus={autoFocus}
             />
             <ChatInputToolbar
+              compactAgentControls={compactAgentControls}
               onAttachClick={handleAttachClick}
               isGenerating={isGenerating}
               hideStop={hideStop}
@@ -871,11 +904,12 @@ export const ChatInput = ({
           </div>
         )}
 
-        {/* Compact mobile Agent controls below the input. Desktop keeps these
-            selectors in the main toolbar where there is room for them. */}
+        {/* Compact Agent controls below the input. The composer switches to
+            this strip whenever its own width is constrained, even on desktop. */}
         {isAgent && !showAgentApprovalPrompt && (
           <div
-            className="chat-input-glass-context relative z-0 order-3 mx-6 -mt-2 flex h-10 min-w-0 items-center gap-2 rounded-b-[18px] border border-t-0 border-black/8 px-3 pt-2 md:hidden dark:border-border/70"
+            className={`chat-input-glass-context relative z-0 order-3 mx-6 -mt-2 flex h-10 min-w-0 items-center gap-2 rounded-b-[18px] border border-t-0 border-black/8 px-3 pt-2 dark:border-border/70 ${compactAgentControls ? "" : "md:hidden"}`}
+            data-compact={compactAgentControls ? "true" : "false"}
             data-testid="chat-input-agent-context"
           >
             <SandboxSelector
@@ -883,7 +917,7 @@ export const ChatInput = ({
               onChange={setSandboxPreference}
             />
             <div
-              className="ml-auto min-w-0 md:hidden"
+              className={`ml-auto min-w-0 ${compactAgentControls ? "" : "md:hidden"}`}
               data-testid="chat-input-mobile-permission"
             >
               <AgentPermissionSelector analyticsSurface="chat_input" />

--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -15,10 +15,12 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { FreeAskComputerActivation } from "./FreeAskComputerActivation";
 
 export interface ChatInputToolbarProps extends SubmitStopButtonProps {
+  compactAgentControls?: boolean;
   onAttachClick: () => void;
 }
 
 export function ChatInputToolbar({
+  compactAgentControls = false,
   onAttachClick,
   chatMode,
   isOnline = true,
@@ -47,7 +49,7 @@ export function ChatInputToolbar({
   return (
     <div className="flex min-w-0 items-center gap-2 px-3">
       <div
-        className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden"
         data-testid="chat-input-toolbar-controls"
       >
         <div className="shrink-0">
@@ -66,13 +68,17 @@ export function ChatInputToolbar({
         {isAgentMode(chatMode) ? (
           <>
             <div
-              className="hidden shrink-0 md:block"
+              className={
+                compactAgentControls ? "hidden" : "hidden shrink-0 md:block"
+              }
               data-testid="chat-input-desktop-permission"
             >
               <AgentPermissionSelector analyticsSurface="chat_input" />
             </div>
             <div
-              className="hidden min-w-0 md:block"
+              className={
+                compactAgentControls ? "hidden" : "hidden min-w-0 md:block"
+              }
               data-testid="chat-input-desktop-sandbox"
             >
               <SandboxSelector

--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -45,38 +45,49 @@ export function ChatInputToolbar({
   );
 
   return (
-    <div className="px-3 flex gap-2 items-center min-w-0">
-      <div className="shrink-0">
-        <AttachmentButton onAttachClick={onAttachClick} disabled={!isOnline} />
+    <div className="flex min-w-0 items-center gap-2 px-3">
+      <div
+        className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        data-testid="chat-input-toolbar-controls"
+      >
+        <div className="shrink-0">
+          <AttachmentButton
+            onAttachClick={onAttachClick}
+            disabled={!isOnline}
+          />
+        </div>
+        {user &&
+        chatModeAccessResolved &&
+        !paidAgentOnlyActive &&
+        !freeDesktopAgentOnlyActive ? (
+          <ChatModeSelector />
+        ) : null}
+        {showFreeAskComputerActivation ? <FreeAskComputerActivation /> : null}
+        {isAgentMode(chatMode) ? (
+          <>
+            <div
+              className="hidden shrink-0 md:block"
+              data-testid="chat-input-desktop-permission"
+            >
+              <AgentPermissionSelector analyticsSurface="chat_input" />
+            </div>
+            <div
+              className="hidden min-w-0 md:block"
+              data-testid="chat-input-desktop-sandbox"
+            >
+              <SandboxSelector
+                value={sandboxPreference}
+                onChange={setSandboxPreference}
+                size="toolbar"
+              />
+            </div>
+          </>
+        ) : null}
       </div>
-      {user &&
-      chatModeAccessResolved &&
-      !paidAgentOnlyActive &&
-      !freeDesktopAgentOnlyActive ? (
-        <ChatModeSelector />
-      ) : null}
-      {showFreeAskComputerActivation ? <FreeAskComputerActivation /> : null}
-      {isAgentMode(chatMode) ? (
-        <>
-          <div
-            className="hidden md:block"
-            data-testid="chat-input-desktop-permission"
-          >
-            <AgentPermissionSelector analyticsSurface="chat_input" />
-          </div>
-          <div
-            className="hidden md:block"
-            data-testid="chat-input-desktop-sandbox"
-          >
-            <SandboxSelector
-              value={sandboxPreference}
-              onChange={setSandboxPreference}
-              size="toolbar"
-            />
-          </div>
-        </>
-      ) : null}
-      <div className="ml-auto shrink-0 flex items-center gap-2.5">
+      <div
+        className="flex shrink-0 items-center gap-2.5"
+        data-testid="chat-input-primary-actions"
+      >
         {user ? (
           <ModelSelector
             value={selectedModel}

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -224,7 +224,7 @@ describe("ChatInputToolbar", () => {
     expect(screen.getByTestId("chat-input-toolbar-controls")).toHaveClass(
       "min-w-0",
       "flex-1",
-      "overflow-x-auto",
+      "overflow-hidden",
     );
     expect(screen.getByTestId("chat-input-primary-actions")).toHaveClass(
       "shrink-0",
@@ -234,6 +234,31 @@ describe("ChatInputToolbar", () => {
     );
     expect(screen.getByTestId("chat-input-primary-actions")).toContainElement(
       screen.getByRole("button", { name: "Send" }),
+    );
+  });
+
+  it("moves Agent controls out of the toolbar in compact layout", () => {
+    mockAuthUser({ id: "user_123" });
+
+    render(
+      <ChatInputToolbar
+        {...defaultProps}
+        chatMode="agent"
+        compactAgentControls
+      />,
+    );
+
+    expect(screen.getByTestId("chat-input-desktop-permission")).toHaveClass(
+      "hidden",
+    );
+    expect(screen.getByTestId("chat-input-desktop-permission")).not.toHaveClass(
+      "md:block",
+    );
+    expect(screen.getByTestId("chat-input-desktop-sandbox")).toHaveClass(
+      "hidden",
+    );
+    expect(screen.getByTestId("chat-input-desktop-sandbox")).not.toHaveClass(
+      "md:block",
     );
   });
 

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -211,7 +211,29 @@ describe("ChatInputToolbar", () => {
     );
     expect(screen.getByTestId("chat-input-desktop-sandbox")).toHaveClass(
       "hidden",
+      "min-w-0",
       "md:block",
+    );
+  });
+
+  it("keeps model and send actions outside the flexible toolbar controls", () => {
+    mockAuthUser({ id: "user_123" });
+
+    render(<ChatInputToolbar {...defaultProps} chatMode="agent" />);
+
+    expect(screen.getByTestId("chat-input-toolbar-controls")).toHaveClass(
+      "min-w-0",
+      "flex-1",
+      "overflow-x-auto",
+    );
+    expect(screen.getByTestId("chat-input-primary-actions")).toHaveClass(
+      "shrink-0",
+    );
+    expect(screen.getByTestId("chat-input-primary-actions")).toContainElement(
+      screen.getByTestId("model-selector"),
+    );
+    expect(screen.getByTestId("chat-input-primary-actions")).toContainElement(
+      screen.getByRole("button", { name: "Send" }),
     );
   });
 

--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useCompactTaskSidebar } from "@/hooks/use-workspace-layout";
 import { useGlobalState } from "../contexts/GlobalState";
 import { useChats } from "../hooks/useChats";
 import { useProjects } from "../hooks/useProjects";
@@ -28,8 +30,12 @@ const SettingsDialog = dynamic(
  */
 export function ChatLayout({ children }: { children: React.ReactNode }) {
   const isMobile = useIsMobile();
-  const { chatSidebarOpen, setChatSidebarOpen } = useGlobalState();
+  const pathname = usePathname();
+  const compactTaskSidebar = useCompactTaskSidebar();
+  const { chatSidebarOpen, setChatSidebarOpen, sidebarOpen } = useGlobalState();
   const panelRef = useRef<HTMLDivElement>(null);
+  const [compactSidebarOverlayOpen, setCompactSidebarOverlayOpen] =
+    useState(false);
   // Keep list subscriptions in the layout so mobile overlay remounts do not refetch.
   const chatListData = useChats();
   const projectListData = useProjects();
@@ -57,9 +63,34 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
     [handleOpenSettings],
   );
 
-  // Escape key handler and focus trap for mobile overlay
+  const forceTaskSidebarRail = Boolean(
+    isMobile === false && sidebarOpen && compactTaskSidebar,
+  );
+  const taskSidebarOverlayOpen =
+    isMobile === true
+      ? chatSidebarOpen
+      : forceTaskSidebarRail && compactSidebarOverlayOpen;
+  const closeTaskSidebarOverlay = useCallback(() => {
+    if (isMobile) {
+      setChatSidebarOpen(false);
+      return;
+    }
+    setCompactSidebarOverlayOpen(false);
+  }, [isMobile, setChatSidebarOpen]);
+
   useEffect(() => {
-    if (!isMobile || !chatSidebarOpen) return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) setCompactSidebarOverlayOpen(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [forceTaskSidebarRail, pathname]);
+
+  // Escape key handler and focus trap for mobile and compact desktop overlays.
+  useEffect(() => {
+    if (!taskSidebarOverlayOpen) return;
 
     // Store the previously focused element
     previousActiveElementRef.current = document.activeElement as HTMLElement;
@@ -79,7 +110,7 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        setChatSidebarOpen(false);
+        closeTaskSidebarOverlay();
         return;
       }
 
@@ -132,7 +163,20 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
         previousActiveElementRef.current.focus();
       }
     };
-  }, [isMobile, chatSidebarOpen, setChatSidebarOpen]);
+  }, [closeTaskSidebarOverlay, taskSidebarOverlayOpen]);
+
+  const handleDesktopSidebarOpenChange = useCallback(
+    (open: boolean) => {
+      if (forceTaskSidebarRail) {
+        setCompactSidebarOverlayOpen(open);
+        return;
+      }
+      setChatSidebarOpen(open);
+    },
+    [forceTaskSidebarRail, setChatSidebarOpen],
+  );
+
+  const desktopSidebarExpanded = chatSidebarOpen && !forceTaskSidebarRail;
 
   return (
     <div className="flex min-h-0 flex-1 w-full overflow-hidden">
@@ -140,13 +184,15 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
       {isMobile === false && (
         <div
           data-testid="sidebar"
+          data-layout={forceTaskSidebarRail ? "compact-rail" : "standard"}
           className={`relative z-10 min-w-0 shrink-0 overflow-hidden bg-sidebar transition-all duration-300 ${
-            chatSidebarOpen ? "w-[300px]" : "w-12"
+            desktopSidebarExpanded ? "w-[300px]" : "w-12"
           }`}
         >
           <SidebarProvider
-            open={chatSidebarOpen}
-            onOpenChange={setChatSidebarOpen}
+            open={desktopSidebarExpanded}
+            onOpenChange={handleDesktopSidebarOpenChange}
+            persistOpenState={!forceTaskSidebarRail}
             defaultOpen={true}
           >
             <MainSidebar
@@ -164,11 +210,12 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
         {children}
       </div>
 
-      {/* Overlay Chat Sidebar - Mobile: only when resolved to mobile */}
-      {isMobile === true && chatSidebarOpen && (
+      {/* Overlay task sidebar for mobile and constrained desktop workspaces. */}
+      {taskSidebarOverlayOpen && (
         <div
-          className="fixed inset-0 z-40 bg-black/50 flex"
-          onClick={() => setChatSidebarOpen(false)}
+          className="fixed inset-0 z-[55] flex bg-black/50"
+          onClick={closeTaskSidebarOverlay}
+          data-testid="task-sidebar-overlay"
         >
           <div
             ref={panelRef}
@@ -176,11 +223,16 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
             aria-modal="true"
             aria-label="Task sidebar"
             tabIndex={-1}
-            className="w-full max-w-80 h-full bg-background shadow-lg transform transition-transform duration-300 ease-in-out"
+            className={`h-full bg-background shadow-lg transform transition-transform duration-300 ease-in-out ${
+              isMobile
+                ? "w-full max-w-80"
+                : "w-[300px] max-w-[calc(100vw-2rem)]"
+            }`}
             onClick={(e) => e.stopPropagation()}
           >
             <MainSidebar
               isMobileOverlay={true}
+              onClose={closeTaskSidebarOverlay}
               chatListData={chatListData}
               projectListData={projectListData}
             />

--- a/app/components/SandboxSelector.tsx
+++ b/app/components/SandboxSelector.tsx
@@ -261,7 +261,7 @@ export function SandboxSelector({
     size === "md"
       ? "h-9 px-3 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
       : size === "toolbar"
-        ? "h-7 px-2 gap-1 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
+        ? "h-7 max-w-44 px-2 gap-1 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
         : "h-7 px-2 gap-1 text-xs font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink";
 
   const iconClassName = size === "md" ? "h-4 w-4 shrink-0" : "h-3 w-3 shrink-0";
@@ -274,9 +274,12 @@ export function SandboxSelector({
           size={size === "md" ? "default" : "sm"}
           disabled={disabled}
           className={buttonClassName}
+          title={selectedOption?.label}
         >
           <Icon className={iconClassName} />
-          <span className="truncate">{selectedOption?.shortLabel}</span>
+          <span className="min-w-0 flex-1 truncate text-left">
+            {selectedOption?.shortLabel}
+          </span>
           <ChevronDown
             className={
               size === "md" ? "h-4 w-4 ml-1 shrink-0" : "h-3 w-3 ml-1 shrink-0"

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -113,12 +113,14 @@ const DesktopSidebarContent: FC<{
 
 const MainSidebar: FC<{
   isMobileOverlay?: boolean;
+  onClose?: () => void;
   /** When provided (e.g. from ChatLayout), avoids refetching when sidebar opens/closes */
   chatListData?: ChatListData;
   /** Keeps the resolved project list alive too, especially the empty state on mobile. */
   projectListData?: ProjectListData;
 }> = ({
   isMobileOverlay = false,
+  onClose,
   chatListData: chatListDataProp,
   projectListData: projectListDataProp,
 }) => {
@@ -134,6 +136,10 @@ const MainSidebar: FC<{
   const projectListData = projectListDataProp ?? projectListDataFromHook;
 
   const handleCloseSidebar = () => {
+    if (onClose) {
+      onClose();
+      return;
+    }
     setChatSidebarOpen(false);
   };
 

--- a/app/components/SidebarHeader.tsx
+++ b/app/components/SidebarHeader.tsx
@@ -117,6 +117,7 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
 
   const handleNewChat = () => {
     startNewChat();
+    if (isMobileOverlay) handleCloseSidebar();
   };
 
   const handleSearchOpen = () => {

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -498,6 +498,101 @@ describe("ChatInput - Integration Tests", () => {
       );
     });
 
+    it("moves Agent controls below the input when the composer becomes narrow", () => {
+      window.localStorage.setItem(CHAT_MODE_STORAGE_KEY, "agent");
+      mockUseQuery.mockReturnValue([
+        {
+          connectionId: "local-sandbox",
+          name: "Local sandbox",
+          isDesktop: false,
+        },
+      ]);
+
+      let resizeCallback: ResizeObserverCallback | null = null;
+      const originalResizeObserverDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "ResizeObserver",
+      );
+
+      class ResizeObserverMock implements ResizeObserver {
+        constructor(private readonly callback: ResizeObserverCallback) {}
+
+        disconnect = jest.fn();
+        observe = (element: Element) => {
+          if (
+            (element as HTMLElement).dataset.testid === "chat-input-container"
+          ) {
+            resizeCallback = this.callback;
+          }
+        };
+        unobserve = jest.fn();
+      }
+
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        configurable: true,
+        value: ResizeObserverMock,
+      });
+
+      try {
+        render(
+          <TestWrapper>
+            <ChatInput
+              onSubmit={mockOnSubmit}
+              onStop={mockOnStop}
+              status="ready"
+              hasMessages
+            />
+          </TestWrapper>,
+        );
+
+        act(() => {
+          (resizeCallback as ResizeObserverCallback)(
+            [{ contentRect: { width: 700 } } as ResizeObserverEntry],
+            {} as ResizeObserver,
+          );
+        });
+
+        expect(screen.getByTestId("chat-input-agent-context")).toHaveAttribute(
+          "data-compact",
+          "true",
+        );
+        expect(screen.getByTestId("chat-input-agent-context")).not.toHaveClass(
+          "md:hidden",
+        );
+        expect(
+          screen.getByTestId("chat-input-desktop-permission"),
+        ).not.toHaveClass("md:block");
+
+        act(() => {
+          (resizeCallback as ResizeObserverCallback)(
+            [{ contentRect: { width: 740 } } as ResizeObserverEntry],
+            {} as ResizeObserver,
+          );
+        });
+
+        expect(screen.getByTestId("chat-input-agent-context")).toHaveAttribute(
+          "data-compact",
+          "false",
+        );
+        expect(screen.getByTestId("chat-input-agent-context")).toHaveClass(
+          "md:hidden",
+        );
+        expect(screen.getByTestId("chat-input-desktop-permission")).toHaveClass(
+          "md:block",
+        );
+      } finally {
+        if (originalResizeObserverDescriptor) {
+          Object.defineProperty(
+            globalThis,
+            "ResizeObserver",
+            originalResizeObserverDescriptor,
+          );
+        } else {
+          Reflect.deleteProperty(globalThis, "ResizeObserver");
+        }
+      }
+    });
+
     it("does not show a late approval after the composer stop button is clicked", async () => {
       let resolveStop: ((stopped: boolean) => void) | undefined;
       const pendingStop = new Promise<boolean>((resolve) => {

--- a/app/components/__tests__/ChatLayout.accessibility.test.tsx
+++ b/app/components/__tests__/ChatLayout.accessibility.test.tsx
@@ -1,19 +1,33 @@
 import "@testing-library/jest-dom";
 import type { ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+let mockIsMobile = true;
+let mockCompactTaskSidebar = false;
+let mockChatSidebarOpen = true;
+let mockComputerSidebarOpen = false;
+let mockPathname = "/c/task-1";
+const mockSetChatSidebarOpen = jest.fn();
 
 jest.mock("next/dynamic", () => ({
   __esModule: true,
   default: () => () => null,
 }));
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
 jest.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => true,
+  useIsMobile: () => mockIsMobile,
+}));
+jest.mock("@/hooks/use-workspace-layout", () => ({
+  useCompactTaskSidebar: () => mockCompactTaskSidebar,
 }));
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
-    chatSidebarOpen: true,
-    setChatSidebarOpen: jest.fn(),
+    chatSidebarOpen: mockChatSidebarOpen,
+    setChatSidebarOpen: mockSetChatSidebarOpen,
+    sidebarOpen: mockComputerSidebarOpen,
   }),
 }));
 jest.mock("@/app/hooks/useChats", () => ({
@@ -31,22 +45,51 @@ jest.mock("@/app/hooks/useProjects", () => ({
   }),
 }));
 jest.mock("@/components/ui/sidebar", () => ({
-  SidebarProvider: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+  SidebarProvider: ({
+    children,
+    onOpenChange,
+    open,
+    persistOpenState,
+  }: {
+    children: ReactNode;
+    onOpenChange?: (open: boolean) => void;
+    open?: boolean;
+    persistOpenState?: boolean;
+  }) => (
+    <div
+      data-testid="sidebar-provider"
+      data-open={open ? "true" : "false"}
+      data-persist={persistOpenState ? "true" : "false"}
+    >
+      <button type="button" onClick={() => onOpenChange?.(true)}>
+        Open task sidebar
+      </button>
+      {children}
+    </div>
   ),
 }));
 jest.mock("../Sidebar", () => ({
   __esModule: true,
   default: ({
+    isMobileOverlay,
+    onClose,
     projectListData,
   }: {
+    isMobileOverlay?: boolean;
+    onClose?: () => void;
     projectListData?: { results?: unknown[] };
   }) => (
     <div
       data-testid="main-sidebar"
       data-project-count={projectListData?.results?.length}
+      data-overlay={isMobileOverlay ? "true" : "false"}
     >
       Task navigation
+      {onClose ? (
+        <button type="button" onClick={onClose}>
+          Close task sidebar
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -57,7 +100,16 @@ jest.mock("@/lib/utils/settings-dialog", () => ({
 const { ChatLayout } =
   require("../ChatLayout") as typeof import("../ChatLayout");
 
-describe("ChatLayout mobile accessibility", () => {
+describe("ChatLayout responsive accessibility", () => {
+  beforeEach(() => {
+    mockIsMobile = true;
+    mockCompactTaskSidebar = false;
+    mockChatSidebarOpen = true;
+    mockComputerSidebarOpen = false;
+    mockPathname = "/c/task-1";
+    mockSetChatSidebarOpen.mockReset();
+  });
+
   it("gives the mobile task sidebar dialog an accessible name", () => {
     render(
       <ChatLayout>
@@ -80,6 +132,68 @@ describe("ChatLayout mobile accessibility", () => {
     expect(screen.getByTestId("main-sidebar")).toHaveAttribute(
       "data-project-count",
       "0",
+    );
+  });
+
+  it("uses a rail and opens the task sidebar as an overlay in a compact workspace", () => {
+    mockIsMobile = false;
+    mockCompactTaskSidebar = true;
+    mockComputerSidebarOpen = true;
+
+    render(
+      <ChatLayout>
+        <main>Task content</main>
+      </ChatLayout>,
+    );
+
+    expect(screen.getByTestId("sidebar")).toHaveAttribute(
+      "data-layout",
+      "compact-rail",
+    );
+    expect(screen.getByTestId("sidebar")).toHaveClass("w-12");
+    expect(screen.getByTestId("sidebar-provider")).toHaveAttribute(
+      "data-open",
+      "false",
+    );
+    expect(screen.getByTestId("sidebar-provider")).toHaveAttribute(
+      "data-persist",
+      "false",
+    );
+    expect(screen.queryByRole("dialog", { name: "Task sidebar" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open task sidebar" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Task sidebar" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId("main-sidebar").at(-1)).toHaveAttribute(
+      "data-overlay",
+      "true",
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Task sidebar" })).toBeNull();
+  });
+
+  it("keeps the preferred expanded sidebar in a wide workspace", () => {
+    mockIsMobile = false;
+    mockCompactTaskSidebar = false;
+    mockComputerSidebarOpen = true;
+
+    render(
+      <ChatLayout>
+        <main>Task content</main>
+      </ChatLayout>,
+    );
+
+    expect(screen.getByTestId("sidebar")).toHaveAttribute(
+      "data-layout",
+      "standard",
+    );
+    expect(screen.getByTestId("sidebar")).toHaveClass("w-[300px]");
+    expect(screen.getByTestId("sidebar-provider")).toHaveAttribute(
+      "data-open",
+      "true",
     );
   });
 });

--- a/app/components/__tests__/SandboxSelector.test.tsx
+++ b/app/components/__tests__/SandboxSelector.test.tsx
@@ -85,6 +85,32 @@ describe("SandboxSelector", () => {
     expect(screen.getByRole("button", { name: /4p3x/i })).toBeInTheDocument();
   });
 
+  it("caps long remote names in the chat toolbar without losing the full name", () => {
+    const hostname = "admin1-HP-EliteDesk-800-G3-SFF-with-a-long-suffix";
+    mockGlobalState.desktopBridgeStatus = "connected";
+    mockGlobalState.localConnections = [
+      {
+        connectionId: "remote-office-pc",
+        isDesktop: false,
+        name: "Office PC",
+        osInfo: { hostname },
+      },
+    ];
+
+    render(<SandboxSelector value="remote-office-pc" size="toolbar" />);
+
+    expect(screen.getByRole("button", { name: hostname })).toHaveClass(
+      "max-w-44",
+      "min-w-0",
+    );
+    expect(screen.getByTitle(hostname)).toBeInTheDocument();
+    expect(screen.getByText(hostname)).toHaveClass(
+      "min-w-0",
+      "flex-1",
+      "truncate",
+    );
+  });
+
   it("selects a healthy remote runner while the embedded bridge reconnects", async () => {
     const onChange = jest.fn();
     mockGlobalState.localConnections = [

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom";
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import {
   fireEvent,
   render,
@@ -24,6 +31,8 @@ const mockStop = jest.fn();
 const mockRegenerate = jest.fn();
 const mockResumeStream = jest.fn();
 let mockRouteParams: Record<string, string> = {};
+let mockComputerOverlayMedia = false;
+const originalMatchMedia = window.matchMedia;
 
 jest.mock("@ai-sdk/react", () => ({
   useChat: jest.fn(() => ({
@@ -40,6 +49,7 @@ jest.mock("@ai-sdk/react", () => ({
 
 jest.mock("next/navigation", () => ({
   useParams: jest.fn(() => mockRouteParams),
+  usePathname: jest.fn(() => "/"),
   useRouter: jest.fn(() => ({
     push: jest.fn(),
     replace: jest.fn(),
@@ -251,8 +261,37 @@ const ChatTitleHandoffHarness = ({
   );
 };
 
+const OpenComputerSidebarHarness = () => {
+  const { openSidebar, sidebarOpen } = useGlobalState();
+
+  return (
+    <>
+      <span data-testid="computer-open-state">
+        {sidebarOpen ? "open" : "closed"}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          openSidebar({
+            command: "echo ready",
+            output: "ready",
+            isExecuting: false,
+            toolCallId: "responsive-layout-test",
+          })
+        }
+      >
+        Open Computer
+      </button>
+    </>
+  );
+};
+
 describe("Chat Component Integration", () => {
   let mockUseChat: jest.Mock;
+
+  afterAll(() => {
+    window.matchMedia = originalMatchMedia;
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -260,6 +299,22 @@ describe("Chat Component Integration", () => {
     convexReact.resetMockConvexAuth?.();
     convexReact.resetMockConvexQueries?.();
     mockRouteParams = {};
+    mockComputerOverlayMedia = false;
+    window.matchMedia = jest.fn(
+      (query: string) =>
+        ({
+          get matches() {
+            return query === "(max-width: 949px)" && mockComputerOverlayMedia;
+          },
+          media: query,
+          onchange: null,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        }) as MediaQueryList,
+    );
     const { useChat } = require("@ai-sdk/react");
     mockUseChat = useChat as jest.Mock;
 
@@ -587,7 +642,54 @@ describe("Chat Component Integration", () => {
       expect(screen.getByTestId("sidebar")).toBeInTheDocument();
     });
 
-    // Mobile layout (sidebar hidden in main layout, shown as overlay) is covered by
-    // ChatLayout structure and useIsMobile; full behavior can be asserted in e2e or ChatLayout unit tests.
+    it("uses a bounded split pane for Computer on wide workspaces", async () => {
+      render(
+        <TestWrapper>
+          <OpenComputerSidebarHarness />
+          <Chat autoResume={false} />
+        </TestWrapper>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Open Computer" }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("computer-sidebar")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("computer-sidebar-container")).toHaveAttribute(
+        "data-layout",
+        "split",
+      );
+      expect(screen.getByTestId("computer-sidebar-container")).toHaveClass(
+        "w-[44%]",
+        "min-w-[400px]",
+        "max-w-[560px]",
+      );
+    });
+
+    it("uses an accessible Computer overlay on narrow workspaces", async () => {
+      mockComputerOverlayMedia = true;
+
+      render(
+        <TestWrapper>
+          <OpenComputerSidebarHarness />
+          <Chat autoResume={false} />
+        </TestWrapper>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Open Computer" }));
+
+      expect(screen.getByTestId("computer-open-state")).toHaveTextContent(
+        "open",
+      );
+      expect(
+        await screen.findByTestId("computer-sidebar-container"),
+      ).toHaveAttribute("data-layout", "overlay");
+      expect(
+        screen.getByRole("dialog", { name: "HackerAI’s Computer" }),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("computer-sidebar")).toBeInTheDocument();
+    });
+
+    // Mobile task navigation is covered by ChatLayout accessibility tests.
   });
 });

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -163,7 +163,13 @@ jest.mock("../ChatInput", () => ({
 }));
 
 jest.mock("../ComputerSidebar", () => ({
-  ComputerSidebar: () => <div data-testid="computer-sidebar">Sidebar</div>,
+  ComputerSidebar: () => (
+    <div data-testid="computer-sidebar">
+      Sidebar
+      <button type="button">First computer action</button>
+      <button type="button">Last computer action</button>
+    </div>
+  ),
 }));
 
 jest.mock("../ChatHeader", () => ({
@@ -676,7 +682,9 @@ describe("Chat Component Integration", () => {
         </TestWrapper>,
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Open Computer" }));
+      const trigger = screen.getByRole("button", { name: "Open Computer" });
+      trigger.focus();
+      fireEvent.click(trigger);
 
       expect(screen.getByTestId("computer-open-state")).toHaveTextContent(
         "open",
@@ -688,6 +696,26 @@ describe("Chat Component Integration", () => {
         screen.getByRole("dialog", { name: "HackerAI’s Computer" }),
       ).toBeInTheDocument();
       expect(screen.getByTestId("computer-sidebar")).toBeInTheDocument();
+
+      const firstAction = screen.getByRole("button", {
+        name: "First computer action",
+      });
+      const lastAction = screen.getByRole("button", {
+        name: "Last computer action",
+      });
+      await waitFor(() => expect(firstAction).toHaveFocus());
+
+      lastAction.focus();
+      fireEvent.keyDown(document, { key: "Tab" });
+      expect(firstAction).toHaveFocus();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("dialog", { name: "HackerAI’s Computer" }),
+        ).not.toBeInTheDocument();
+      });
+      expect(trigger).toHaveFocus();
     });
 
     // Mobile task navigation is covered by ChatLayout accessibility tests.

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -518,6 +518,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const router = useRouter();
   const isMobile = useIsMobile();
   const computerSidebarOverlay = useComputerSidebarOverlay();
+  const computerDialogRef = useRef<HTMLDivElement>(null);
+  const computerDialogPreviousFocusRef = useRef<HTMLElement | null>(null);
   const { setDataStream, setIsAutoResuming } = useDataStreamDispatch();
   const {
     isLoading: isConvexAuthLoading,
@@ -560,6 +562,71 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     useAgentApproval();
   const { hasResolvedInitialPresentation, markInitialPresentationResolved } =
     useChatRoutePresentation();
+
+  useEffect(() => {
+    if (!computerSidebarOverlay || !sidebarOpen) return;
+
+    const dialog = computerDialogRef.current;
+    if (!dialog) return;
+
+    computerDialogPreviousFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    const getFocusableElements = () =>
+      Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          [
+            "a[href]",
+            "button:not([disabled])",
+            "input:not([disabled])",
+            "select:not([disabled])",
+            "textarea:not([disabled])",
+            '[tabindex]:not([tabindex="-1"])',
+          ].join(", "),
+        ),
+      );
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeSidebar();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    const focusTimeout = window.setTimeout(() => {
+      (getFocusableElements()[0] ?? dialog).focus();
+    }, 0);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.clearTimeout(focusTimeout);
+      document.removeEventListener("keydown", handleKeyDown);
+      const previousFocus = computerDialogPreviousFocusRef.current;
+      if (previousFocus?.isConnected) previousFocus.focus();
+    };
+  }, [closeSidebar, computerSidebarOverlay, sidebarOpen]);
 
   // Simple logic: use route chatId if provided, otherwise generate new one
   const [chatId, setChatId] = useState<string>(() => {
@@ -2241,15 +2308,14 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         {/* Computer overlay for mobile and narrow desktop workspaces. */}
         {computerSidebarOverlay && sidebarOpen && (
           <div
+            ref={computerDialogRef}
             className="fixed inset-0 z-50 flex items-center justify-center bg-background p-4"
             role="dialog"
             aria-modal="true"
             aria-label="HackerAI’s Computer"
+            tabIndex={-1}
             data-layout="overlay"
             data-testid="computer-sidebar-container"
-            onKeyDown={(event) => {
-              if (event.key === "Escape") closeSidebar();
-            }}
           >
             <div className="w-full max-w-4xl h-full">
               <ComputerSidebar messages={messages} status={status} />

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -94,6 +94,7 @@ import {
 import { coerceSelectedModel } from "@/types/chat";
 import { v4 as uuidv4 } from "uuid";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useComputerSidebarOverlay } from "@/hooks/use-workspace-layout";
 import { useParams, useRouter } from "next/navigation";
 import { ConvexErrorBoundary } from "./ConvexErrorBoundary";
 import { useAutoResume } from "../hooks/useAutoResume";
@@ -516,6 +517,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const routeChatId = params?.id as string | undefined;
   const router = useRouter();
   const isMobile = useIsMobile();
+  const computerSidebarOverlay = useComputerSidebarOverlay();
   const { setDataStream, setIsAutoResuming } = useDataStreamDispatch();
   const {
     isLoading: isConvexAuthLoading,
@@ -532,6 +534,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     chatMode,
     setChatMode,
     sidebarOpen,
+    closeSidebar,
     chatSidebarOpen,
     initializeChat,
     setTodos,
@@ -2212,11 +2215,15 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           </div>
 
           {/* Desktop Computer Sidebar */}
-          {!isMobile && (
+          {!computerSidebarOverlay && (
             <div
-              className={`transition-[width] duration-300 min-w-0 ${
-                sidebarOpen ? "w-1/2 flex-shrink-0" : "w-0 overflow-hidden"
+              className={`min-w-0 transition-[width] duration-300 ${
+                sidebarOpen
+                  ? "w-[44%] min-w-[400px] max-w-[560px] flex-shrink-0"
+                  : "w-0 overflow-hidden"
               }`}
+              data-layout="split"
+              data-testid="computer-sidebar-container"
             >
               {sidebarOpen && (
                 <ComputerSidebar messages={messages} status={status} />
@@ -2231,9 +2238,19 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           />
         </div>
 
-        {/* Mobile Computer Sidebar */}
-        {isMobile && sidebarOpen && (
-          <div className="flex fixed inset-0 z-50 bg-background items-center justify-center p-4">
+        {/* Computer overlay for mobile and narrow desktop workspaces. */}
+        {computerSidebarOverlay && sidebarOpen && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-background p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label="HackerAI’s Computer"
+            data-layout="overlay"
+            data-testid="computer-sidebar-container"
+            onKeyDown={(event) => {
+              if (event.key === "Escape") closeSidebar();
+            }}
+          >
             <div className="w-full max-w-4xl h-full">
               <ComputerSidebar messages={messages} status={status} />
             </div>

--- a/components/ui/__tests__/sidebar.test.tsx
+++ b/components/ui/__tests__/sidebar.test.tsx
@@ -85,6 +85,27 @@ describe("SidebarProvider", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("does not persist temporary controlled sidebar state", () => {
+    const onOpenChange = jest.fn();
+    const { mainSidebarStorage } = require("@/lib/utils/sidebar-storage");
+    mainSidebarStorage.save.mockClear();
+
+    render(
+      <SidebarProvider
+        open={false}
+        onOpenChange={onOpenChange}
+        persistOpenState={false}
+      >
+        <div>content</div>
+      </SidebarProvider>,
+    );
+
+    fireEvent.keyDown(window, { key: "s", metaKey: true, shiftKey: true });
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(mainSidebarStorage.save).not.toHaveBeenCalled();
+  });
+
   it("does not replace the sidebar shortcut with Cmd/Ctrl+B", () => {
     const onOpenChange = jest.fn();
 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -57,6 +57,7 @@ function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
+  persistOpenState = true,
   className,
   style,
   children,
@@ -65,6 +66,7 @@ function SidebarProvider({
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  persistOpenState?: boolean;
 }) {
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
@@ -85,7 +87,11 @@ function SidebarProvider({
       }
 
       // Persist state on desktop only
-      if (isMobile === false && typeof window !== "undefined") {
+      if (
+        persistOpenState &&
+        isMobile === false &&
+        typeof window !== "undefined"
+      ) {
         mainSidebarStorage.save(openState, false);
         // Keep cookie for backward compatibility
         try {
@@ -95,7 +101,7 @@ function SidebarProvider({
         }
       }
     },
-    [setOpenProp, open, isMobile],
+    [setOpenProp, open, isMobile, persistOpenState],
   );
 
   // Helper to toggle the sidebar.

--- a/hooks/__tests__/use-media-query.test.ts
+++ b/hooks/__tests__/use-media-query.test.ts
@@ -1,0 +1,43 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { useMediaQuery } from "../use-media-query";
+
+describe("useMediaQuery", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("updates when the media query result changes", () => {
+    let matches = false;
+    const listeners = new Set<() => void>();
+    const mediaQueryList = {
+      get matches() {
+        return matches;
+      },
+      media: "(max-width: 949px)",
+      onchange: null,
+      addEventListener: (_type: string, listener: () => void) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: () => void) => {
+        listeners.delete(listener);
+      },
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as MediaQueryList;
+    window.matchMedia = jest.fn(() => mediaQueryList);
+
+    const { result } = renderHook(() => useMediaQuery(mediaQueryList.media));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      matches = true;
+      listeners.forEach((listener) => listener());
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/hooks/use-media-query.ts
+++ b/hooks/use-media-query.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mediaQuery = window.matchMedia(query);
+      mediaQuery.addEventListener("change", onStoreChange);
+      return () => mediaQuery.removeEventListener("change", onStoreChange);
+    },
+    [query],
+  );
+  const getSnapshot = useCallback(
+    () => window.matchMedia(query).matches,
+    [query],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/hooks/use-workspace-layout.ts
+++ b/hooks/use-workspace-layout.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useMediaQuery } from "@/hooks/use-media-query";
+
+const COMPACT_TASK_SIDEBAR_QUERY = "(min-width: 768px) and (max-width: 1239px)";
+const COMPUTER_SIDEBAR_OVERLAY_QUERY = "(max-width: 949px)";
+
+export function useCompactTaskSidebar(): boolean {
+  return useMediaQuery(COMPACT_TASK_SIDEBAR_QUERY);
+}
+
+export function useComputerSidebarOverlay(): boolean {
+  return useMediaQuery(COMPUTER_SIDEBAR_OVERLAY_QUERY);
+}


### PR DESCRIPTION
## Summary
- truncate long remote-device names while keeping model selection and Send visible and clickable
- switch constrained composers to the compact control strip without a horizontal scrollbar
- when Computer is open at medium widths, collapse task navigation to a 48px rail and open it as a modal overlay without squeezing chat or Computer
- keep the normal resizable split on wide screens and make Computer a full-screen accessible overlay below 950px
- preserve the user's saved sidebar preference across temporary responsive states

## Testing
- 412 test suites passed
- 4,335 tests passed
- TypeScript typecheck passed
- targeted ESLint and Prettier checks passed

## Visual verification
- at 973px, verified a 48px task rail, 484px composer, and 407px Computer pane with no document or body horizontal overflow
- verified task navigation opens as a 300px modal overlay while chat and Computer keep their positions
- at 800px, verified Computer becomes a full-viewport modal overlay and can be dismissed
- at 1280px, verified Computer remains a bounded split pane and the composer stays usable

## Manual verification
1. Open the branch preview while signed in and enter Agent mode with Computer open.
2. Resize through wide desktop, approximately 973px, and below 950px.
3. Verify wide split layout, medium 48px task rail with overlay navigation, and narrow full-screen Computer overlay.
4. Select a long remote hostname and confirm model selection and Send remain visible and usable without horizontal scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added responsive compact layouts for task navigation and Computer panels on narrow desktop screens.
  - Computer panels now use split panes on wide screens and accessible overlays on smaller screens, with Escape-to-close support and focus management.
  - Agent controls switch to a compact presentation in constrained chat composers.

- **Improvements**
  - Long sandbox hostnames truncate cleanly with tooltip access.
  - Sidebar state can be temporarily controlled without persistence.
  - Starting a new chat closes the mobile sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
