### PR TITLE
Monitor HAC-80 activation and enforcement guardrails

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2160,9 +2160,12 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(
       /acquireFreeRunConcurrencyLock\(\s*freeUsageSubject/,
     );
+    expect(taskSrc).toMatch(
+      /checkFreeMonthlyCostLimit\(\s*freeUsageSubject,\s*userId,\s*"trigger_agent_long",\s*\)/,
+    );
     expect(
       taskSrc.match(/checkFreeMonthlyCostLimit\(freeUsageSubject, userId\)/g),
-    ).toHaveLength(3);
+    ).toHaveLength(2);
     expect(taskSrc).not.toMatch(
       /checkFreeMonthlyCostLimit\(freeUsageSubject\)/,
     );

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -614,7 +614,11 @@ export const createChatHandler = () => {
 
       const freeMonthlyBudgetSnapshot =
         subscription === "free"
-          ? await checkFreeMonthlyCostLimit(freeUsageSubject, userId)
+          ? await checkFreeMonthlyCostLimit(
+              freeUsageSubject,
+              userId,
+              "api_chat",
+            )
           : null;
 
       usageRefundTracker.recordDeductions(rateLimitInfo);

--- a/lib/rate-limit/__tests__/free-monthly-cost.test.ts
+++ b/lib/rate-limit/__tests__/free-monthly-cost.test.ts
@@ -13,6 +13,7 @@ describe("free monthly cost limit", () => {
   const mockEval = jest.fn();
   const mockSet = jest.fn();
   const mockGetFeatureFlagVariantForUser = jest.fn();
+  const mockPostHogEvent = jest.fn();
   const originalEnv = process.env.FREE_MONTHLY_COST_LIMIT_USD;
 
   beforeEach(() => {
@@ -43,6 +44,7 @@ describe("free monthly cost limit", () => {
       }));
       jest.doMock("@/lib/posthog/server", () => ({
         getPostHogFeatureFlagVariantForUser: mockGetFeatureFlagVariantForUser,
+        phLogger: { event: mockPostHogEvent },
       }));
 
       isolatedModule = require("../free-monthly-cost");
@@ -95,6 +97,40 @@ describe("free monthly cost limit", () => {
       "free_usage_budget_started:v1:free_quota:v1:subject",
       "2026-08",
       { nx: true },
+    );
+  });
+
+  it("captures the applied treatment policy and enforcement surface", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-08-27T12:00:00Z"));
+    mockGetFeatureFlagVariantForUser.mockResolvedValue("test");
+    mockCreateRedisClient.mockReturnValue({
+      get: mockGet,
+      eval: mockEval,
+      set: mockSet,
+    });
+    const { checkFreeMonthlyCostLimit } = getIsolatedModule();
+
+    await checkFreeMonthlyCostLimit(
+      "free_quota:v1:subject",
+      "user-123",
+      "trigger_agent_long",
+    );
+
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "free_usage_budget_enforcement",
+      expect.objectContaining({
+        userId: "user-123",
+        experiment_key: "free_usage_budget_v1",
+        policy_version: 1,
+        enforcement_surface: "trigger_agent_long",
+        enforcement_result: "allowed",
+        variant: "test",
+        budget_phase: "activation",
+        budget_month: "2026-08",
+        monthly_limit_dollars: 0.25,
+        monthly_used_dollars: 0,
+        monthly_remaining_dollars: 0.25,
+      }),
     );
   });
 
@@ -166,6 +202,32 @@ describe("free monthly cost limit", () => {
     expect(mockSet).not.toHaveBeenCalled();
   });
 
+  it("identifies unresolved assignments as safe fallbacks", async () => {
+    mockCreateRedisClient.mockReturnValue({
+      get: mockGet,
+      eval: mockEval,
+      set: mockSet,
+    });
+    const { checkFreeMonthlyCostLimit } = getIsolatedModule();
+
+    await checkFreeMonthlyCostLimit(
+      "free_quota:v1:subject",
+      "user-123",
+      "api_chat",
+    );
+
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "free_usage_budget_enforcement",
+      expect.objectContaining({
+        enforcement_surface: "api_chat",
+        variant: "unresolved",
+        budget_phase: "safe_fallback",
+        fallback_reason: "variant_unresolved",
+        monthly_limit_dollars: 0.25,
+      }),
+    );
+  });
+
   it("throws a rate-limit error when the monthly free cost cap is exhausted", async () => {
     process.env.FREE_MONTHLY_COST_LIMIT_USD = "0.01";
     mockCreateRedisClient.mockReturnValue({
@@ -176,11 +238,21 @@ describe("free monthly cost limit", () => {
     mockGet.mockResolvedValue(100);
     const { checkFreeMonthlyCostLimit } = getIsolatedModule();
 
-    await expect(checkFreeMonthlyCostLimit("user-123")).rejects.toMatchObject({
+    await expect(
+      checkFreeMonthlyCostLimit("user-123", "user-123", "trigger_subagent"),
+    ).rejects.toMatchObject({
       type: "rate_limit",
       surface: "chat",
       cause: expect.stringContaining("free monthly usage"),
     });
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "free_usage_budget_enforcement",
+      expect.objectContaining({
+        enforcement_surface: "trigger_subagent",
+        enforcement_result: "blocked",
+        monthly_remaining_dollars: 0,
+      }),
+    );
   });
 
   it("records actual free usage cost as monthly points", async () => {

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -77,6 +77,7 @@ const freeMonthlyCostKey = (userId: string, bucket: string) =>
 const freeUsageBudgetStartedKey = (userId: string) =>
   `free_usage_budget_started:${FREE_USAGE_BUDGET_MARKER_VERSION}:${userId}`;
 
+/** Resolve the assigned budget phase while preserving the $0.25 safe fallback. */
 async function getFreeMonthlyBudgetDecision({
   redis,
   quotaSubject,
@@ -139,6 +140,7 @@ async function getFreeMonthlyBudgetDecision({
   }
 }
 
+/** Identify the deployed revision used to reconcile API and Trigger workers. */
 const getServiceVersion = () =>
   (
     process.env.VERCEL_GIT_COMMIT_SHA ??
@@ -147,6 +149,7 @@ const getServiceVersion = () =>
     "dev"
   ).slice(0, 64);
 
+/** Emit one privacy-safe policy decision for cross-surface reconciliation. */
 const captureFreeUsageBudgetEnforcement = ({
   userId,
   surface,

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -195,6 +195,10 @@ const getLimitMessage = (reset: number) =>
     timeZone: "UTC",
   })}. Upgrade for higher limits and more features.`;
 
+/**
+ * Enforce the free monthly cost cap and optionally emit one initial-preflight
+ * decision for cross-surface experiment monitoring.
+ */
 export async function checkFreeMonthlyCostLimit(
   quotaSubject: string,
   userId = quotaSubject,

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -1,5 +1,8 @@
 import { ChatSDKError } from "@/lib/errors";
-import { getPostHogFeatureFlagVariantForUser } from "@/lib/posthog/server";
+import {
+  getPostHogFeatureFlagVariantForUser,
+  phLogger,
+} from "@/lib/posthog/server";
 import {
   FREE_RECURRING_COST_LIMIT_USD_EXPERIMENT,
   getFreeMonthlyCostLimitDollars,
@@ -28,6 +31,17 @@ return nextUsed
 export const FREE_USAGE_BUDGET_EXPERIMENT_KEY = "free_usage_budget_v1";
 export const FREE_USAGE_BUDGET_TREATMENT_VARIANT = "test";
 const FREE_USAGE_BUDGET_MARKER_VERSION = "v1";
+const FREE_USAGE_BUDGET_POLICY_VERSION = 1;
+
+export type FreeUsageBudgetEnforcementSurface =
+  "api_chat" | "trigger_agent_long" | "trigger_subagent";
+
+type FreeUsageBudgetDecision = {
+  limitDollars: number;
+  variant: "control" | "test" | "unresolved";
+  phase: "control" | "activation" | "recurring" | "safe_fallback";
+  fallbackReason?: "variant_unresolved" | "marker_unavailable";
+};
 
 export interface FreeMonthlyCostSnapshot {
   monthlyLimitPoints: number;
@@ -63,7 +77,7 @@ const freeMonthlyCostKey = (userId: string, bucket: string) =>
 const freeUsageBudgetStartedKey = (userId: string) =>
   `free_usage_budget_started:${FREE_USAGE_BUDGET_MARKER_VERSION}:${userId}`;
 
-async function getFreeMonthlyLimitDollars({
+async function getFreeMonthlyBudgetDecision({
   redis,
   quotaSubject,
   userId,
@@ -73,14 +87,25 @@ async function getFreeMonthlyLimitDollars({
   quotaSubject: string;
   userId: string;
   bucket: string;
-}): Promise<number> {
+}): Promise<FreeUsageBudgetDecision> {
   const controlLimit = getFreeMonthlyCostLimitDollars();
   const variant = await getPostHogFeatureFlagVariantForUser(
     FREE_USAGE_BUDGET_EXPERIMENT_KEY,
     userId,
   );
   if (variant !== FREE_USAGE_BUDGET_TREATMENT_VARIANT) {
-    return controlLimit;
+    return variant === "control"
+      ? {
+          limitDollars: controlLimit,
+          variant: "control",
+          phase: "control",
+        }
+      : {
+          limitDollars: controlLimit,
+          variant: "unresolved",
+          phase: "safe_fallback",
+          fallbackReason: "variant_unresolved",
+        };
   }
 
   const markerKey = freeUsageBudgetStartedKey(quotaSubject);
@@ -93,13 +118,70 @@ async function getFreeMonthlyLimitDollars({
     }
 
     return startedBucket === bucket
-      ? controlLimit
-      : FREE_RECURRING_COST_LIMIT_USD_EXPERIMENT;
+      ? {
+          limitDollars: controlLimit,
+          variant: "test",
+          phase: "activation",
+        }
+      : {
+          limitDollars: FREE_RECURRING_COST_LIMIT_USD_EXPERIMENT,
+          variant: "test",
+          phase: "recurring",
+        };
   } catch {
     // A marker failure must not unexpectedly tighten an existing user's cap.
-    return controlLimit;
+    return {
+      limitDollars: controlLimit,
+      variant: "test",
+      phase: "safe_fallback",
+      fallbackReason: "marker_unavailable",
+    };
   }
 }
+
+const getServiceVersion = () =>
+  (
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    process.env.GITHUB_SHA ??
+    process.env.TRIGGER_VERSION ??
+    "dev"
+  ).slice(0, 64);
+
+const captureFreeUsageBudgetEnforcement = ({
+  userId,
+  surface,
+  bucket,
+  decision,
+  limitPoints,
+  usedPoints,
+  remainingPoints,
+}: {
+  userId: string;
+  surface: FreeUsageBudgetEnforcementSurface;
+  bucket: string;
+  decision: FreeUsageBudgetDecision;
+  limitPoints: number;
+  usedPoints: number;
+  remainingPoints: number;
+}) => {
+  phLogger.event("free_usage_budget_enforcement", {
+    userId,
+    experiment_key: FREE_USAGE_BUDGET_EXPERIMENT_KEY,
+    policy_version: FREE_USAGE_BUDGET_POLICY_VERSION,
+    service_version: getServiceVersion(),
+    enforcement_surface: surface,
+    enforcement_result: remainingPoints > 0 ? "allowed" : "blocked",
+    variant: decision.variant,
+    budget_phase: decision.phase,
+    budget_month: bucket,
+    monthly_limit_dollars: limitPoints / POINTS_PER_DOLLAR,
+    monthly_used_dollars: usedPoints / POINTS_PER_DOLLAR,
+    monthly_remaining_dollars: remainingPoints / POINTS_PER_DOLLAR,
+    ...(decision.fallbackReason && {
+      fallback_reason: decision.fallbackReason,
+    }),
+  });
+};
 
 const getLimitMessage = (reset: number) =>
   `You've used your free monthly usage. Free usage resets on ${new Date(
@@ -113,6 +195,9 @@ const getLimitMessage = (reset: number) =>
 export async function checkFreeMonthlyCostLimit(
   quotaSubject: string,
   userId = quotaSubject,
+  // Supply a surface only for the initial preflight. Durable rechecks omit it
+  // so this temporary experiment telemetry emits once per worker execution.
+  enforcementSurface?: FreeUsageBudgetEnforcementSurface,
 ): Promise<FreeMonthlyCostSnapshot> {
   const { bucket, reset } = getCurrentUtcMonthWindow();
   const redis = createRedisClient();
@@ -137,20 +222,31 @@ export async function checkFreeMonthlyCostLimit(
     );
   }
 
-  const limitPoints = dollarsToPoints(
-    await getFreeMonthlyLimitDollars({
-      redis,
-      quotaSubject,
-      userId,
-      bucket,
-    }),
-  );
+  const budgetDecision = await getFreeMonthlyBudgetDecision({
+    redis,
+    quotaSubject,
+    userId,
+    bucket,
+  });
+  const limitPoints = dollarsToPoints(budgetDecision.limitDollars);
 
   const usedPoints = Math.max(
     0,
     Number((await redis.get(freeMonthlyCostKey(quotaSubject, bucket))) ?? 0),
   );
   const remainingPoints = Math.max(0, limitPoints - usedPoints);
+
+  if (enforcementSurface) {
+    captureFreeUsageBudgetEnforcement({
+      userId,
+      surface: enforcementSurface,
+      bucket,
+      decision: budgetDecision,
+      limitPoints,
+      usedPoints,
+      remainingPoints,
+    });
+  }
 
   if (remainingPoints <= 0) {
     throw new ChatSDKError("rate_limit:chat", getLimitMessage(reset), {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2874,7 +2874,11 @@ export const agentLongTask = task({
 
             const freeMonthlyBudgetSnapshot =
               subscription === "free"
-                ? await checkFreeMonthlyCostLimit(freeUsageSubject, userId)
+                ? await checkFreeMonthlyCostLimit(
+                    freeUsageSubject,
+                    userId,
+                    "trigger_agent_long",
+                  )
                 : null;
 
             usageRefundTracker.recordDeductions(rateLimitInfo);

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -609,6 +609,7 @@ export const subagentTask = task({
         await checkFreeMonthlyCostLimit(
           row.free_quota_subject ?? row.user_id,
           row.user_id,
+          "trigger_subagent",
         );
       }
 


### PR DESCRIPTION
## Summary
- emit one privacy-safe free_usage_budget_enforcement event at the initial API chat, Trigger long-agent, and Trigger subagent preflight
- record policy and service versions, assignment, budget phase, applied limit, allowed/blocked result, and remaining budget for deployment parity checks
- retain safe fallback behavior when assignment or marker resolution is unavailable
- add the existing successful Agent-run event as the live PostHog activation guardrail for experiment 451847

## Validation
- 412 Jest suites passed (4,367 tests) via the commit hook
- pnpm typecheck
- scoped ESLint
- Prettier check

## Manual verification after deployment
1. Run one eligible free Ask request through the API, one free Agent run, and one free subagent.
2. In HackerAI PostHog, filter free_usage_budget_enforcement by enforcement_surface.
3. Confirm api_chat, trigger_agent_long, and trigger_subagent report the same policy_version, variant-specific budget_phase, and monthly_limit_dollars for equivalent users/months.
4. Confirm unresolved assignments or marker failures use safe_fallback at $0.25 and blocked users report enforcement_result=blocked.

Linear: HAC-80
PostHog experiment: https://us.posthog.com/project/144137/experiments/451847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved free-tier monthly usage enforcement across chat, agent, and subagent workflows.
  * Added safer fallback handling when usage-policy assignments cannot be resolved.
  * Clarified enforcement behavior for different request types and usage limits.

* **Monitoring**
  * Added telemetry for applied policies, fallback decisions, blocked requests, and usage-limit outcomes.
  * Improved visibility into usage-budget decisions and enforcement results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->