### PR TITLE
Right-size lightweight paid Agent starts

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1288,6 +1288,10 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(machineRoutingSrc).toMatch(/if \(hasFileAttachment\)/);
     expect(machineRoutingSrc).toMatch(/if \(hasProjectContext\)/);
     expect(machineRoutingSrc).toMatch(/if \(hasTodos\)/);
+    expect(machineRoutingSrc).toMatch(/if \(subagentsEnabled\)/);
+    expect(routeSrc).toMatch(
+      /subagentsEnabled:\s*securityValidationSubagentsEnabled\s*\|\|\s*securityTaskSubagentsEnabled/,
+    );
     expect(machineRoutingSrc).toMatch(
       /machine: lightweightSmall1xEnabled \? "small-1x" : "small-2x"/,
     );

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -62,6 +62,11 @@ const routeSrc = fs.readFileSync(
   "utf8",
 );
 
+const machineRoutingSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../experiments/agent-machine-routing.ts"),
+  "utf8",
+);
+
 const agentRouteSrc = fs.readFileSync(
   path.resolve(__dirname, "../../../app/api/agent/route.ts"),
   "utf8",
@@ -1268,6 +1273,35 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
     expect(routeSrc).toMatch(
       /shouldRequireAgentApprovalWorkerVersion\(\)[\s\S]*!approvalWorkerVersion[\s\S]*temporarily unavailable/,
+    );
+  });
+
+  test("lightweight machine routing stays fail-closed and uses one decision for every trigger path", () => {
+    expect(machineRoutingSrc).toMatch(
+      /subscription !== "pro" && subscription !== "pro-plus"/,
+    );
+    expect(machineRoutingSrc).toMatch(/if \(!isNewChat\)/);
+    expect(machineRoutingSrc).toMatch(/requestMessageCount !== 1/);
+    expect(machineRoutingSrc).toMatch(
+      /requestMessageBytes > AGENT_LIGHTWEIGHT_REQUEST_MAX_BYTES/,
+    );
+    expect(machineRoutingSrc).toMatch(/if \(hasFileAttachment\)/);
+    expect(machineRoutingSrc).toMatch(/if \(hasProjectContext\)/);
+    expect(machineRoutingSrc).toMatch(/if \(hasTodos\)/);
+    expect(machineRoutingSrc).toMatch(
+      /machine: lightweightSmall1xEnabled \? "small-1x" : "small-2x"/,
+    );
+    expect(routeSrc).toMatch(
+      /const machineRoutingFlagPromise = machineRoutingEligibility\.eligible/,
+    );
+    expect(routeSrc).toMatch(
+      /const triggerMachine = machineRoutingDecision\.machine/,
+    );
+    expect(routeSrc).toMatch(
+      /const approvalTriggerConfig\s*=\s*{[\s\S]*?machine:\s*triggerMachine/,
+    );
+    expect(routeSrc).toMatch(
+      /tasks\.trigger<[\s\S]*?triggerOptions[\s\S]*?getAgentMachineRoutingExposure/,
     );
   });
 

--- a/lib/api/__tests__/agent-trigger-route.test.ts
+++ b/lib/api/__tests__/agent-trigger-route.test.ts
@@ -30,6 +30,7 @@ const mockCancelAgentTriggerRun = jest.fn<any>();
 const mockCloseAgentApprovalSession = jest.fn<any>();
 
 jest.mock("next/server", () => ({
+  after: jest.fn(),
   NextRequest: class NextRequest {},
   NextResponse: class NextResponse {},
 }));

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -141,6 +141,7 @@ export const createAgentTriggerPayloadTooLargeResponse = () =>
 const getAgentTriggerPriority = (subscription: SubscriptionTier) =>
   AGENT_TRIGGER_PRIORITY_BY_SUBSCRIPTION[subscription];
 
+/** Return the unchanged subscription baseline outside the routing experiment. */
 export const getAgentTriggerMachine = (subscription: SubscriptionTier) =>
   getBaselineAgentTriggerMachine(subscription);
 

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 import { createHash } from "crypto";
 import { tasks, auth, idempotencyKeys, sessions } from "@trigger.dev/sdk";
 import type { agentLongTask } from "@/trigger/agent-long";
@@ -16,6 +16,7 @@ import {
 import {
   assertFreeAgentGates,
   buildExtraUsageConfig,
+  hasFileAttachments,
 } from "@/lib/api/chat-stream-helpers";
 import {
   AGENT_TRIGGER_TASK_ID,
@@ -69,6 +70,15 @@ import {
   DEFAULT_AGENT_AUTO_REVIEW_ASSIGNMENT,
   type AgentAutoReviewAssignment,
 } from "@/lib/experiments/agent-auto-review";
+import {
+  AGENT_LIGHTWEIGHT_SMALL_1X_FEATURE_FLAG,
+  getAgentLightweightMachineEligibility,
+  getAgentMachineRoutingExposure,
+  getAgentMachineRoutingFlagBeforeDeadline,
+  getBaselineAgentTriggerMachine,
+  resolveAgentMachineRouting,
+} from "@/lib/experiments/agent-machine-routing";
+import { getPostHogFeatureFlagForUser, phLogger } from "@/lib/posthog/server";
 
 const AGENT_TRIGGER_PRIORITY_BY_SUBSCRIPTION: Record<SubscriptionTier, number> =
   {
@@ -131,24 +141,8 @@ export const createAgentTriggerPayloadTooLargeResponse = () =>
 const getAgentTriggerPriority = (subscription: SubscriptionTier) =>
   AGENT_TRIGGER_PRIORITY_BY_SUBSCRIPTION[subscription];
 
-type AgentTriggerMachinePreset = "small-1x" | "small-2x";
-
-const AGENT_TRIGGER_MACHINE_BY_SUBSCRIPTION: Record<
-  SubscriptionTier,
-  AgentTriggerMachinePreset
-> = {
-  free: "small-1x",
-  // Long Pro runs can exceed the 512 MB small-1x ceiling while retaining
-  // provider checkpoints and tool output. Match the other paid tiers so a
-  // recoverable stream does not become an unrecoverable worker OOM.
-  pro: "small-2x",
-  "pro-plus": "small-2x",
-  ultra: "small-2x",
-  team: "small-2x",
-};
-
 export const getAgentTriggerMachine = (subscription: SubscriptionTier) =>
-  AGENT_TRIGGER_MACHINE_BY_SUBSCRIPTION[subscription];
+  getBaselineAgentTriggerMachine(subscription);
 
 type AgentDeploymentEnvironment = {
   NODE_ENV?: string;
@@ -592,14 +586,48 @@ export const createAgentTriggerPost =
         localDesktopAttachmentsPrepared = true;
       }
 
-      await handleInitialChatAndUserMessage({
-        chatId,
-        userId,
-        messages: messagesForPersistence,
-        regenerate,
-        chat: existingChat ?? null,
-        isHidden: isAutoContinue ? true : undefined,
-        projectId: projectContext.projectId,
+      const requestMessageBytes =
+        getAgentTriggerPayloadSizeBytes(requestMessages);
+      const requestHasFileAttachments = hasFileAttachments(requestMessages);
+      const machineRoutingEligibility = getAgentLightweightMachineEligibility({
+        subscription,
+        isNewChat,
+        regenerate: regenerate === true,
+        isAutoContinue: isAutoContinue === true,
+        isAutomaticContinuation: isAutomaticContinuation === true,
+        hasLimitRescue: limitRescue !== undefined,
+        requestMessageCount: requestMessages.length,
+        requestMessageBytes,
+        hasFileAttachment: requestHasFileAttachments,
+        localDesktopAttachmentsPrepared,
+        hasProjectContext: projectContext.projectId !== undefined,
+        hasTodos: Array.isArray(todos) && todos.length > 0,
+      });
+      const machineRoutingFlagPromise = machineRoutingEligibility.eligible
+        ? getAgentMachineRoutingFlagBeforeDeadline(
+            getPostHogFeatureFlagForUser(
+              AGENT_LIGHTWEIGHT_SMALL_1X_FEATURE_FLAG,
+              userId,
+            ),
+          )
+        : Promise.resolve(false);
+
+      const [, lightweightSmall1xEnabled] = await Promise.all([
+        handleInitialChatAndUserMessage({
+          chatId,
+          userId,
+          messages: messagesForPersistence,
+          regenerate,
+          chat: existingChat ?? null,
+          isHidden: isAutoContinue ? true : undefined,
+          projectId: projectContext.projectId,
+        }),
+        machineRoutingFlagPromise,
+      ]);
+      const machineRoutingDecision = resolveAgentMachineRouting({
+        subscription,
+        eligibility: machineRoutingEligibility,
+        lightweightSmall1xEnabled,
       });
 
       // Snapshot permission behavior once for this run. UI changes made while
@@ -609,6 +637,9 @@ export const createAgentTriggerPost =
       const triggerTags = [`user_${userId}`, `chat_${chatId}`];
       if (subscription !== "free") triggerTags.push(`sub_${subscription}`);
       triggerTags.push(permissionSnapshot.triggerTag);
+      if (machineRoutingDecision.eligible) {
+        triggerTags.push(`machine_route_${machineRoutingDecision.variant}`);
+      }
 
       // Persisted chats are rehydrated from Convex inside the task after the
       // route saves the latest user message. Avoid sending the same history
@@ -620,7 +651,7 @@ export const createAgentTriggerPost =
 
       const triggerRequestedAt = Date.now();
       const triggerPriority = getAgentTriggerPriority(subscription);
-      const triggerMachine = getAgentTriggerMachine(subscription);
+      const triggerMachine = machineRoutingDecision.machine;
       // Trigger.dev's atomic Vercel integration pins the app and worker from the
       // same commit. Reuse that pin so Sessions cannot schedule an older worker.
       const approvalWorkerVersion =
@@ -706,6 +737,13 @@ export const createAgentTriggerPost =
         triggerRequestedAt,
         triggerPriority,
         triggerMachine,
+        machineRoutingFlagKey: AGENT_LIGHTWEIGHT_SMALL_1X_FEATURE_FLAG,
+        machineRoutingEligible: machineRoutingDecision.eligible,
+        machineRoutingEligibilityReason: machineRoutingDecision.reason,
+        machineRoutingVariant: machineRoutingDecision.variant,
+        requestMessageCount: requestMessages.length,
+        requestMessageBytes,
+        requestHasFileAttachments,
         triggerPayloadMessageCount: messagesForPayload.length,
         agentPermissionMode: permissionSnapshot.mode,
         securityValidationSubagentsEnabled,
@@ -815,6 +853,24 @@ export const createAgentTriggerPost =
       }
 
       const triggerCompletedAt = Date.now();
+      const machineRoutingExposure = getAgentMachineRoutingExposure({
+        decision: machineRoutingDecision,
+        subscription,
+        endpoint,
+        runId,
+        isNewChat,
+        requestMessageCount: requestMessages.length,
+        requestMessageBytes,
+        requestHasFileAttachments,
+        localDesktopAttachmentsPrepared,
+      });
+      if (machineRoutingExposure) {
+        phLogger.event(machineRoutingExposure.event, {
+          ...machineRoutingExposure.properties,
+          userId,
+        });
+        after(() => phLogger.flush());
+      }
 
       // Access-token creation and durable association are independent, so
       // overlap them while treating every post-start failure as terminal.

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -603,6 +603,8 @@ export const createAgentTriggerPost =
         localDesktopAttachmentsPrepared,
         hasProjectContext: projectContext.projectId !== undefined,
         hasTodos: Array.isArray(todos) && todos.length > 0,
+        subagentsEnabled:
+          securityValidationSubagentsEnabled || securityTaskSubagentsEnabled,
       });
       const machineRoutingFlagPromise = machineRoutingEligibility.eligible
         ? getAgentMachineRoutingFlagBeforeDeadline(

--- a/lib/experiments/__tests__/agent-machine-routing.test.ts
+++ b/lib/experiments/__tests__/agent-machine-routing.test.ts
@@ -145,6 +145,12 @@ describe("Agent machine routing", () => {
     await expect(
       getAgentMachineRoutingFlagBeforeDeadline(Promise.resolve(true), 100),
     ).resolves.toBe(true);
+    await expect(
+      getAgentMachineRoutingFlagBeforeDeadline(
+        Promise.reject(new Error("PostHog unavailable")),
+        100,
+      ),
+    ).resolves.toBe(false);
   });
 
   it("builds a privacy-safe exposure only for eligible scheduled runs", () => {

--- a/lib/experiments/__tests__/agent-machine-routing.test.ts
+++ b/lib/experiments/__tests__/agent-machine-routing.test.ts
@@ -1,0 +1,202 @@
+import {
+  AGENT_LIGHTWEIGHT_REQUEST_MAX_BYTES,
+  getAgentLightweightMachineEligibility,
+  getAgentMachineRoutingExposure,
+  getAgentMachineRoutingFlagBeforeDeadline,
+  getBaselineAgentTriggerMachine,
+  resolveAgentMachineRouting,
+} from "@/lib/experiments/agent-machine-routing";
+import type { SubscriptionTier } from "@/types";
+
+const eligibleInput = {
+  subscription: "pro" as const,
+  isNewChat: true,
+  regenerate: false,
+  isAutoContinue: false,
+  isAutomaticContinuation: false,
+  hasLimitRescue: false,
+  requestMessageCount: 1,
+  requestMessageBytes: 1_024,
+  hasFileAttachment: false,
+  localDesktopAttachmentsPrepared: false,
+  hasProjectContext: false,
+  hasTodos: false,
+};
+
+describe("Agent machine routing", () => {
+  it.each([
+    ["free", "small-1x"],
+    ["pro", "small-2x"],
+    ["pro-plus", "small-2x"],
+    ["ultra", "small-2x"],
+    ["team", "small-2x"],
+  ] as const)("keeps the %s baseline on %s", (subscription, machine) => {
+    expect(getBaselineAgentTriggerMachine(subscription)).toBe(machine);
+  });
+
+  it.each(["pro", "pro-plus"] as const)(
+    "allows a conservative lightweight %s first turn",
+    (subscription) => {
+      expect(
+        getAgentLightweightMachineEligibility({
+          ...eligibleInput,
+          subscription,
+        }),
+      ).toEqual({ eligible: true, reason: "eligible" });
+    },
+  );
+
+  it.each([
+    ["free", { subscription: "free" }, "unsupported_subscription"],
+    ["ultra", { subscription: "ultra" }, "unsupported_subscription"],
+    ["team", { subscription: "team" }, "unsupported_subscription"],
+    ["existing chat", { isNewChat: false }, "existing_chat"],
+    ["regeneration", { regenerate: true }, "regenerate"],
+    ["auto-continue", { isAutoContinue: true }, "auto_continue"],
+    [
+      "automatic continuation",
+      { isAutomaticContinuation: true },
+      "automatic_continuation",
+    ],
+    ["limit rescue", { hasLimitRescue: true }, "limit_rescue"],
+    [
+      "multiple request messages",
+      { requestMessageCount: 2 },
+      "request_message_count",
+    ],
+    [
+      "oversized request",
+      { requestMessageBytes: AGENT_LIGHTWEIGHT_REQUEST_MAX_BYTES + 1 },
+      "request_too_large",
+    ],
+    ["file attachment", { hasFileAttachment: true }, "file_attachment"],
+    [
+      "desktop-local attachment",
+      { localDesktopAttachmentsPrepared: true },
+      "desktop_local_attachment",
+    ],
+    ["project context", { hasProjectContext: true }, "project_context"],
+    ["existing todos", { hasTodos: true }, "existing_todos"],
+  ] as const)("excludes %s", (_name, overrides, reason) => {
+    expect(
+      getAgentLightweightMachineEligibility({
+        ...eligibleInput,
+        ...overrides,
+        subscription:
+          (overrides as { subscription?: SubscriptionTier }).subscription ??
+          eligibleInput.subscription,
+      }),
+    ).toEqual({ eligible: false, reason });
+  });
+
+  it("keeps eligible control users on small-2x", () => {
+    expect(
+      resolveAgentMachineRouting({
+        subscription: "pro",
+        eligibility: { eligible: true, reason: "eligible" },
+        lightweightSmall1xEnabled: false,
+      }),
+    ).toEqual({
+      eligible: true,
+      reason: "eligible",
+      variant: "control",
+      machine: "small-2x",
+    });
+  });
+
+  it("routes only eligible treatment users to small-1x", () => {
+    expect(
+      resolveAgentMachineRouting({
+        subscription: "pro-plus",
+        eligibility: { eligible: true, reason: "eligible" },
+        lightweightSmall1xEnabled: true,
+      }),
+    ).toEqual({
+      eligible: true,
+      reason: "eligible",
+      variant: "test",
+      machine: "small-1x",
+    });
+
+    expect(
+      resolveAgentMachineRouting({
+        subscription: "ultra",
+        eligibility: {
+          eligible: false,
+          reason: "unsupported_subscription",
+        },
+        lightweightSmall1xEnabled: true,
+      }),
+    ).toEqual({
+      eligible: false,
+      reason: "unsupported_subscription",
+      variant: "ineligible",
+      machine: "small-2x",
+    });
+  });
+
+  it("fails closed when PostHog misses the routing deadline", async () => {
+    await expect(
+      getAgentMachineRoutingFlagBeforeDeadline(
+        new Promise<boolean>(() => {}),
+        1,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      getAgentMachineRoutingFlagBeforeDeadline(Promise.resolve(true), 100),
+    ).resolves.toBe(true);
+  });
+
+  it("builds a privacy-safe exposure only for eligible scheduled runs", () => {
+    const exposure = getAgentMachineRoutingExposure({
+      decision: {
+        eligible: true,
+        reason: "eligible",
+        variant: "test",
+        machine: "small-1x",
+      },
+      subscription: "pro",
+      endpoint: "/api/agent",
+      runId: "run_123",
+      isNewChat: true,
+      requestMessageCount: 1,
+      requestMessageBytes: 1_024,
+      requestHasFileAttachments: false,
+      localDesktopAttachmentsPrepared: false,
+    });
+
+    expect(exposure).toEqual({
+      event: "agent_machine_routing_exposed",
+      properties: expect.objectContaining({
+        experiment_key: "agent_lightweight_small_1x_v1",
+        experiment_variant: "test",
+        "$feature/agent_lightweight_small_1x_v1": true,
+        trigger_run_id: "run_123",
+        selected_machine: "small-1x",
+        request_message_bytes: 1_024,
+        $process_person_profile: false,
+      }),
+    });
+    expect(JSON.stringify(exposure)).not.toContain("prompt");
+    expect(JSON.stringify(exposure)).not.toContain("filename");
+
+    expect(
+      getAgentMachineRoutingExposure({
+        decision: {
+          eligible: false,
+          reason: "existing_chat",
+          variant: "ineligible",
+          machine: "small-2x",
+        },
+        subscription: "pro",
+        endpoint: "/api/agent",
+        runId: "run_456",
+        isNewChat: false,
+        requestMessageCount: 1,
+        requestMessageBytes: 1_024,
+        requestHasFileAttachments: false,
+        localDesktopAttachmentsPrepared: false,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/lib/experiments/__tests__/agent-machine-routing.test.ts
+++ b/lib/experiments/__tests__/agent-machine-routing.test.ts
@@ -21,6 +21,7 @@ const eligibleInput = {
   localDesktopAttachmentsPrepared: false,
   hasProjectContext: false,
   hasTodos: false,
+  subagentsEnabled: false,
 };
 
 describe("Agent machine routing", () => {
@@ -77,6 +78,7 @@ describe("Agent machine routing", () => {
     ],
     ["project context", { hasProjectContext: true }, "project_context"],
     ["existing todos", { hasTodos: true }, "existing_todos"],
+    ["enabled subagents", { subagentsEnabled: true }, "subagents_enabled"],
   ] as const)("excludes %s", (_name, overrides, reason) => {
     expect(
       getAgentLightweightMachineEligibility({

--- a/lib/experiments/agent-machine-routing.ts
+++ b/lib/experiments/agent-machine-routing.ts
@@ -1,0 +1,211 @@
+import type { SubscriptionTier } from "@/types";
+
+export const AGENT_LIGHTWEIGHT_SMALL_1X_FEATURE_FLAG =
+  "agent_lightweight_small_1x_v1";
+export const AGENT_MACHINE_ROUTING_EXPOSURE_EVENT =
+  "agent_machine_routing_exposed";
+export const AGENT_LIGHTWEIGHT_REQUEST_MAX_BYTES = 32 * 1024;
+export const AGENT_MACHINE_ROUTING_FLAG_TIMEOUT_MS = 100;
+
+export type AgentTriggerMachinePreset = "small-1x" | "small-2x";
+
+export type AgentLightweightMachineEligibilityReason =
+  | "eligible"
+  | "unsupported_subscription"
+  | "existing_chat"
+  | "regenerate"
+  | "auto_continue"
+  | "automatic_continuation"
+  | "limit_rescue"
+  | "request_message_count"
+  | "request_too_large"
+  | "file_attachment"
+  | "desktop_local_attachment"
+  | "project_context"
+  | "existing_todos";
+
+export type AgentLightweightMachineEligibility = {
+  eligible: boolean;
+  reason: AgentLightweightMachineEligibilityReason;
+};
+
+export type AgentMachineRoutingVariant = "ineligible" | "control" | "test";
+
+export type AgentMachineRoutingDecision = {
+  eligible: boolean;
+  reason: AgentLightweightMachineEligibilityReason;
+  variant: AgentMachineRoutingVariant;
+  machine: AgentTriggerMachinePreset;
+};
+
+const AGENT_TRIGGER_MACHINE_BY_SUBSCRIPTION: Record<
+  SubscriptionTier,
+  AgentTriggerMachinePreset
+> = {
+  free: "small-1x",
+  // Paid baselines stay on the 1 GB worker. Only a flag-enabled request that
+  // passes every conservative first-turn guard below may use small-1x.
+  pro: "small-2x",
+  "pro-plus": "small-2x",
+  ultra: "small-2x",
+  team: "small-2x",
+};
+
+export function getBaselineAgentTriggerMachine(
+  subscription: SubscriptionTier,
+): AgentTriggerMachinePreset {
+  return AGENT_TRIGGER_MACHINE_BY_SUBSCRIPTION[subscription];
+}
+
+export function getAgentLightweightMachineEligibility({
+  subscription,
+  isNewChat,
+  regenerate,
+  isAutoContinue,
+  isAutomaticContinuation,
+  hasLimitRescue,
+  requestMessageCount,
+  requestMessageBytes,
+  hasFileAttachment,
+  localDesktopAttachmentsPrepared,
+  hasProjectContext,
+  hasTodos,
+}: {
+  subscription: SubscriptionTier;
+  isNewChat: boolean;
+  regenerate: boolean;
+  isAutoContinue: boolean;
+  isAutomaticContinuation: boolean;
+  hasLimitRescue: boolean;
+  requestMessageCount: number;
+  requestMessageBytes: number;
+  hasFileAttachment: boolean;
+  localDesktopAttachmentsPrepared: boolean;
+  hasProjectContext: boolean;
+  hasTodos: boolean;
+}): AgentLightweightMachineEligibility {
+  if (subscription !== "pro" && subscription !== "pro-plus") {
+    return { eligible: false, reason: "unsupported_subscription" };
+  }
+  if (regenerate) return { eligible: false, reason: "regenerate" };
+  if (isAutomaticContinuation) {
+    return { eligible: false, reason: "automatic_continuation" };
+  }
+  if (isAutoContinue) return { eligible: false, reason: "auto_continue" };
+  if (hasLimitRescue) return { eligible: false, reason: "limit_rescue" };
+  if (!isNewChat) return { eligible: false, reason: "existing_chat" };
+  if (requestMessageCount !== 1) {
+    return { eligible: false, reason: "request_message_count" };
+  }
+  if (requestMessageBytes > AGENT_LIGHTWEIGHT_REQUEST_MAX_BYTES) {
+    return { eligible: false, reason: "request_too_large" };
+  }
+  if (hasFileAttachment) {
+    return { eligible: false, reason: "file_attachment" };
+  }
+  if (localDesktopAttachmentsPrepared) {
+    return { eligible: false, reason: "desktop_local_attachment" };
+  }
+  if (hasProjectContext) {
+    return { eligible: false, reason: "project_context" };
+  }
+  if (hasTodos) return { eligible: false, reason: "existing_todos" };
+
+  return { eligible: true, reason: "eligible" };
+}
+
+export function resolveAgentMachineRouting({
+  subscription,
+  eligibility,
+  lightweightSmall1xEnabled,
+}: {
+  subscription: SubscriptionTier;
+  eligibility: AgentLightweightMachineEligibility;
+  lightweightSmall1xEnabled: boolean;
+}): AgentMachineRoutingDecision {
+  if (!eligibility.eligible) {
+    return {
+      ...eligibility,
+      variant: "ineligible",
+      machine: getBaselineAgentTriggerMachine(subscription),
+    };
+  }
+
+  return {
+    ...eligibility,
+    variant: lightweightSmall1xEnabled ? "test" : "control",
+    machine: lightweightSmall1xEnabled ? "small-1x" : "small-2x",
+  };
+}
+
+export async function getAgentMachineRoutingFlagBeforeDeadline(
+  evaluation: Promise<boolean>,
+  timeoutMs = AGENT_MACHINE_ROUTING_FLAG_TIMEOUT_MS,
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      evaluation,
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export function getAgentMachineRoutingExposure({
+  decision,
+  subscription,
+  endpoint,
+  runId,
+  isNewChat,
+  requestMessageCount,
+  requestMessageBytes,
+  requestHasFileAttachments,
+  localDesktopAttachmentsPrepared,
+}: {
+  decision: AgentMachineRoutingDecision;
+  subscription: SubscriptionTier;
+  endpoint: string;
+  runId: string;
+  isNewChat: boolean;
+  requestMessageCount: number;
+  requestMessageBytes: number;
+  requestHasFileAttachments: boolean;
+  localDesktopAttachmentsPrepared: boolean;
+}):
+  | {
+      event: typeof AGENT_MACHINE_ROUTING_EXPOSURE_EVENT;
+      properties: Record<string, unknown>;
+    }
+  | undefined {
+  if (!decision.eligible || decision.variant === "ineligible") {
+    return undefined;
+  }
+
+  return {
+    event: AGENT_MACHINE_ROUTING_EXPOSURE_EVENT,
+    properties: {
+      experiment_key: AGENT_LIGHTWEIGHT_SMALL_1X_FEATURE_FLAG,
+      experiment_variant: decision.variant,
+      [`$feature/${AGENT_LIGHTWEIGHT_SMALL_1X_FEATURE_FLAG}`]:
+        decision.variant === "test",
+      subscription,
+      subscription_tier: subscription,
+      endpoint,
+      trigger_run_id: runId,
+      selected_machine: decision.machine,
+      machine_routing_eligible: true,
+      machine_routing_eligibility_reason: decision.reason,
+      is_new_chat: isNewChat,
+      request_message_count: requestMessageCount,
+      request_message_bytes: requestMessageBytes,
+      request_has_file_attachments: requestHasFileAttachments,
+      local_desktop_attachments_prepared: localDesktopAttachmentsPrepared,
+      exposure_surface: "trigger_schedule",
+      $process_person_profile: false,
+    },
+  };
+}

--- a/lib/experiments/agent-machine-routing.ts
+++ b/lib/experiments/agent-machine-routing.ts
@@ -51,12 +51,14 @@ const AGENT_TRIGGER_MACHINE_BY_SUBSCRIPTION: Record<
   team: "small-2x",
 };
 
+/** Return the established subscription machine when no treatment applies. */
 export function getBaselineAgentTriggerMachine(
   subscription: SubscriptionTier,
 ): AgentTriggerMachinePreset {
   return AGENT_TRIGGER_MACHINE_BY_SUBSCRIPTION[subscription];
 }
 
+/** Return the first failed safety guard, or mark the request treatment-eligible. */
 export function getAgentLightweightMachineEligibility({
   subscription,
   isNewChat,
@@ -114,6 +116,7 @@ export function getAgentLightweightMachineEligibility({
   return { eligible: true, reason: "eligible" };
 }
 
+/** Resolve one machine decision shared by direct tasks and approval Sessions. */
 export function resolveAgentMachineRouting({
   subscription,
   eligibility,
@@ -138,6 +141,7 @@ export function resolveAgentMachineRouting({
   };
 }
 
+/** Bound remote flag latency and fail closed to the existing paid baseline. */
 export async function getAgentMachineRoutingFlagBeforeDeadline(
   evaluation: Promise<boolean>,
   timeoutMs = AGENT_MACHINE_ROUTING_FLAG_TIMEOUT_MS,
@@ -150,11 +154,14 @@ export async function getAgentMachineRoutingFlagBeforeDeadline(
         timeout = setTimeout(() => resolve(false), timeoutMs);
       }),
     ]);
+  } catch {
+    return false;
   } finally {
     if (timeout) clearTimeout(timeout);
   }
 }
 
+/** Build content-free exposure properties only after an eligible run is scheduled. */
 export function getAgentMachineRoutingExposure({
   decision,
   subscription,

--- a/lib/experiments/agent-machine-routing.ts
+++ b/lib/experiments/agent-machine-routing.ts
@@ -22,7 +22,8 @@ export type AgentLightweightMachineEligibilityReason =
   | "file_attachment"
   | "desktop_local_attachment"
   | "project_context"
-  | "existing_todos";
+  | "existing_todos"
+  | "subagents_enabled";
 
 export type AgentLightweightMachineEligibility = {
   eligible: boolean;
@@ -72,6 +73,7 @@ export function getAgentLightweightMachineEligibility({
   localDesktopAttachmentsPrepared,
   hasProjectContext,
   hasTodos,
+  subagentsEnabled,
 }: {
   subscription: SubscriptionTier;
   isNewChat: boolean;
@@ -85,6 +87,7 @@ export function getAgentLightweightMachineEligibility({
   localDesktopAttachmentsPrepared: boolean;
   hasProjectContext: boolean;
   hasTodos: boolean;
+  subagentsEnabled: boolean;
 }): AgentLightweightMachineEligibility {
   if (subscription !== "pro" && subscription !== "pro-plus") {
     return { eligible: false, reason: "unsupported_subscription" };
@@ -112,6 +115,9 @@ export function getAgentLightweightMachineEligibility({
     return { eligible: false, reason: "project_context" };
   }
   if (hasTodos) return { eligible: false, reason: "existing_todos" };
+  if (subagentsEnabled) {
+    return { eligible: false, reason: "subagents_enabled" };
+  }
 
   return { eligible: true, reason: "eligible" };
 }


### PR DESCRIPTION
## Summary

- add a conservative machine-routing experiment for lightweight Pro and Pro+ first turns
- keep Ultra, Team, existing chats, continuations, regenerations, files, projects, todos, subagent-enabled runs, and large requests on `small-2x`
- use one routing decision for direct Trigger tasks and approval Sessions
- add Trigger tags/metadata and privacy-safe `agent_machine_routing_exposed` telemetry
- preserve the existing `maxAttempts: 1` streaming contract; there is no transparent OOM retry

## Rollout safety

- PostHog flag: [`agent_lightweight_small_1x_v1`](https://us.posthog.com/project/144137/feature_flags/852938)
- current production rollout: **0%**
- feature evaluation is capped at 100 ms, overlapped with chat persistence, and fails closed to `small-2x`
- follow-up turns remain on `small-2x`, so history growth never remains on the smaller worker
- rollout plan and rollback thresholds: [HAC-82](https://linear.app/hackerai/issue/HAC-82/right-size-lightweight-paid-agent-starts-on-triggerdev)

## Validation

- `corepack pnpm exec jest lib/experiments/__tests__/agent-machine-routing.test.ts lib/api/__tests__/agent-trigger-route.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 148 passed
- `corepack pnpm run typecheck` — passed
- `corepack pnpm run lint` — passed with 7 pre-existing unrelated warnings
- commit hook full Jest suite — 413 suites / 4,392 tests passed
- Prettier and `git diff --check` — passed

## Manual verification after deployment

1. Keep the PostHog flag at 0% and confirm eligible control runs carry `machine_route_control` and use `small-2x`.
2. Allowlist an internal Pro or Pro+ user. Start a new Agent chat with one short text-only message, no project/todos, and Ask for approval or Approve for me; confirm `machine_route_test`, `small-1x`, and one `agent_machine_routing_exposed` event.
3. For the same user, verify an existing chat, file attachment, project chat, auto-continuation, regeneration, Ultra account, Team account, and Full access (subagent-enabled) run all use `small-2x`.
4. Review complete-day OOM/crash/system-failure, completion, startup latency, total duration, and compute-per-eligible-start before expanding the flag.

Visual verification is not applicable because this is backend-only routing and telemetry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intelligent agent machine routing that can select lightweight processing for eligible requests.
  * Routing considers request size, subscription, attachments, projects, todos, conversation state, and enabled subagents.
  * Added feature-flagged control and test routing with safe fallback behavior.
  * Added routing metadata and privacy-safe exposure tracking.

* **Tests**
  * Added comprehensive coverage for eligibility, exclusions, timeouts, routing decisions, and machine propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
