### PR TITLE
Continue large account deletion cleanup safely

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -151,6 +151,7 @@ const mockTerminateCloudSandboxesForUser =
 const mockLoggerError = logger.error as jest.MockedFunction<
   typeof logger.error
 >;
+const mockLoggerWarn = logger.warn as jest.MockedFunction<typeof logger.warn>;
 
 const request = () => ({
   url: "https://hackerai.test/api/delete-account",
@@ -577,7 +578,7 @@ describe("POST /api/delete-account", () => {
     expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
-  it("logs bounded aggregate progress when the request cleanup limit is exhausted", async () => {
+  it("returns a continuation response with bounded progress when cleanup needs another request", async () => {
     mockListOrganizationMemberships.mockResolvedValueOnce({
       data: [],
     } as never);
@@ -597,14 +598,13 @@ describe("POST /api/delete-account", () => {
     const response = await POST(request() as any);
     const body = await response.json();
 
-    expect(response.status).toBe(500);
-    expect(body.error).toContain("taking longer than expected");
+    expect(response.status).toBe(409);
+    expect(body).toEqual({ code: "account_cleanup_in_progress" });
     expect(mockConvexMutation).toHaveBeenCalledTimes(52);
-    expect(mockLoggerError).toHaveBeenCalledWith(
-      "account_cleanup_batch_limit_exhausted",
-      undefined,
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "account_cleanup_continuation_required",
       {
-        event: "account_cleanup_batch_limit_exhausted",
+        event: "account_cleanup_continuation_required",
         service: "hackerai-web",
         environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
         request_id: "iad1::opaque-request",
@@ -624,6 +624,7 @@ describe("POST /api/delete-account", () => {
     expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
     expect(mockDeleteUserRateLimitKeys).not.toHaveBeenCalled();
     expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
   it("does not delete external identity resources when Convex cleanup returns an unexpected shape", async () => {

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -11,6 +11,7 @@ import { fenceAndGetActiveAgentResourcesForUser } from "@/lib/db/actions";
 import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
 import { cancelSubagentsForUserDeletion } from "@/lib/db/subagents";
 import { terminateCloudSandboxesForUser } from "@/lib/ai/tools/utils/cloud-sandbox";
+import { ACCOUNT_CLEANUP_IN_PROGRESS_CODE } from "@/lib/account-deletion";
 
 type OrganizationMembership = Awaited<
   ReturnType<typeof workos.userManagement.listOrganizationMemberships>
@@ -171,7 +172,7 @@ async function deleteConvexUserData(
   userId: string,
   serviceKey: string,
   requestId: string,
-) {
+): Promise<boolean> {
   const convex = getConvexClient();
   let progressStatsBatches = 0;
   let batchesWithProgress = 0;
@@ -205,12 +206,12 @@ async function deleteConvexUserData(
     }
 
     if (!parsedResult.hasMore) {
-      return;
+      return true;
     }
   }
 
-  logger.error("account_cleanup_batch_limit_exhausted", undefined, {
-    event: "account_cleanup_batch_limit_exhausted",
+  logger.warn("account_cleanup_continuation_required", {
+    event: "account_cleanup_continuation_required",
     service: "hackerai-web",
     environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
     request_id: requestId,
@@ -227,9 +228,7 @@ async function deleteConvexUserData(
     last_batch_s3_objects_queued: lastProgress?.s3ObjectsQueued,
   });
 
-  throw new Error(
-    "Account cleanup is taking longer than expected. Please contact support so we can finish deleting this account.",
-  );
+  return false;
 }
 
 export const POST = async (req: NextRequest) => {
@@ -320,7 +319,17 @@ export const POST = async (req: NextRequest) => {
     // Own app-data cleanup on the server so account deletion does not depend
     // on the browser successfully running a Convex mutation before this route.
     stage = "delete_convex_user_data";
-    await deleteConvexUserData(userId, serviceKey, requestId);
+    const cleanupComplete = await deleteConvexUserData(
+      userId,
+      serviceKey,
+      requestId,
+    );
+    if (!cleanupComplete) {
+      return NextResponse.json(
+        { code: ACCOUNT_CLEANUP_IN_PROGRESS_CODE },
+        { status: 409 },
+      );
+    }
 
     // Process each organization from memberships. Only delete org-level billing
     // and identity resources after proving this user is the sole active admin.

--- a/app/components/DeleteAccountDialog.tsx
+++ b/app/components/DeleteAccountDialog.tsx
@@ -15,11 +15,46 @@ import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2, Lock, TriangleAlert } from "lucide-react";
+import {
+  ACCOUNT_CLEANUP_IN_PROGRESS_CODE,
+  MAX_ACCOUNT_CLEANUP_REQUESTS,
+} from "@/lib/account-deletion";
 
 type DeleteAccountDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
+
+type DeleteAccountResponse = {
+  code?: string;
+  error?: string;
+};
+
+async function requestAccountDeletion() {
+  for (let attempt = 0; attempt < MAX_ACCOUNT_CLEANUP_REQUESTS; attempt++) {
+    const response = await fetch("/api/delete-account", { method: "POST" });
+    const data = (await response
+      .json()
+      .catch(() => ({}))) as DeleteAccountResponse;
+
+    if (
+      response.status === 409 &&
+      data.code === ACCOUNT_CLEANUP_IN_PROGRESS_CODE
+    ) {
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(data.error || "Failed to delete account");
+    }
+
+    return;
+  }
+
+  throw new Error(
+    "Account cleanup is still in progress after the bounded retry window",
+  );
+}
 
 export const DeleteAccountDialog = ({
   open,
@@ -78,11 +113,7 @@ export const DeleteAccountDialog = ({
     try {
       // Delete Convex data, cancel Stripe subs, remove WorkOS org(s), and
       // delete the WorkOS user server-side.
-      const res = await fetch("/api/delete-account", { method: "POST" });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data?.error || "Failed to cancel subscriptions");
-      }
+      await requestAccountDeletion();
       // Clear HttpOnly auth cookies on the server, then redirect home
       try {
         await fetch("/api/clear-auth-cookies", { method: "POST" });

--- a/app/components/__tests__/DeleteAccountDialog.test.tsx
+++ b/app/components/__tests__/DeleteAccountDialog.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import DeleteAccountDialog from "../DeleteAccountDialog";
 
@@ -13,6 +13,10 @@ jest.mock("sonner", () => ({
     error: jest.fn(),
   },
 }));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+jest.spyOn(console, "error").mockImplementation(() => {});
 
 describe("DeleteAccountDialog", () => {
   const mockUser = {
@@ -28,6 +32,8 @@ describe("DeleteAccountDialog", () => {
     render(<DeleteAccountDialog open={open} onOpenChange={jest.fn()} />);
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
     mockUseAuth.mockReturnValue({
       user: {
         ...mockUser,
@@ -35,6 +41,16 @@ describe("DeleteAccountDialog", () => {
       },
     } as ReturnType<typeof useAuth>);
   });
+
+  const confirmDeletion = () => {
+    fireEvent.change(screen.getByTestId("delete-phrase-input"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.change(screen.getByTestId("email-confirmation"), {
+      target: { value: mockUser.email },
+    });
+    fireEvent.click(screen.getByTestId("delete-button"));
+  };
 
   it("keeps the delete button visible but disabled before confirmation", () => {
     renderDialog();
@@ -112,5 +128,89 @@ describe("DeleteAccountDialog", () => {
     expect(
       (screen.getByTestId("delete-phrase-input") as HTMLInputElement).value,
     ).toBe("");
+  });
+
+  it("continues account cleanup across bounded server requests", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({ code: "account_cleanup_in_progress" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({ code: "account_cleanup_in_progress" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "terminal cleanup failure" }),
+      });
+
+    renderDialog();
+    confirmDeletion();
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
+    expect(mockFetch).toHaveBeenNthCalledWith(1, "/api/delete-account", {
+      method: "POST",
+    });
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "/api/delete-account", {
+      method: "POST",
+    });
+    expect(mockFetch).toHaveBeenNthCalledWith(3, "/api/delete-account", {
+      method: "POST",
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("delete-button")).toBeEnabled(),
+    );
+  });
+
+  it("finishes external cleanup only after the continuation completes", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({ code: "account_cleanup_in_progress" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+    renderDialog();
+    confirmDeletion();
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
+    expect(mockFetch).toHaveBeenNthCalledWith(1, "/api/delete-account", {
+      method: "POST",
+    });
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "/api/delete-account", {
+      method: "POST",
+    });
+    expect(mockFetch).toHaveBeenNthCalledWith(3, "/api/clear-auth-cookies", {
+      method: "POST",
+    });
+  });
+
+  it("stops cleanup continuation after the client request bound", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ code: "account_cleanup_in_progress" }),
+    });
+
+    renderDialog();
+    confirmDeletion();
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(10));
+    await waitFor(() =>
+      expect(screen.getByTestId("delete-button")).toBeEnabled(),
+    );
   });
 });

--- a/lib/account-deletion.ts
+++ b/lib/account-deletion.ts
@@ -1,0 +1,6 @@
+export const ACCOUNT_CLEANUP_IN_PROGRESS_CODE = "account_cleanup_in_progress";
+
+// Each server request keeps Convex work below its existing 50-mutation bound.
+// Ten requests fit inside the route's recent-login window even when a batch
+// pass takes roughly the 47-48 seconds observed in production.
+export const MAX_ACCOUNT_CLEANUP_REQUESTS = 10;


### PR DESCRIPTION
## Production evidence

Daily production error triage used the frozen window `2026-08-27T20:02:52Z` through `2026-08-28T20:02:52Z`.

Vercel production recorded two `/api/delete-account` failures for the same user on deployment `dpl_G9619C6JbDgoWGYgiJUxsQSe5Vyu`. Both requests made progress in all 50 permitted Convex cleanup batches, then failed after approximately 48.2s and 47.3s. Combined structured progress reported 5,372 deleted documents, 2,317 anonymized documents, and 426 S3 objects queued. Raising the synchronous request limit is not supported because 50 batches already consumed nearly 48 seconds.

## Root cause

The Convex transaction bound was correct, but the browser treated the server's per-request cleanup cap as a terminal account-deletion failure. Large accounts therefore required repeated manual submissions even though every request advanced cleanup.

## Change

- Keep the existing 100-read Convex mutation budget and 50-mutation server-request limit.
- Return a coded `409 account_cleanup_in_progress` response before memberships, billing, rate-limit keys, or WorkOS identity are deleted.
- Let the deletion dialog continue the idempotent operation for at most ten requests.
- Emit bounded warning-level continuation telemetry with opaque IDs and aggregate counts.
- Fail closed across deploy skew: old clients treat the non-2xx continuation as incomplete rather than clearing auth early.
- No PostHog suppression or unrelated refactor is included.

## Validation

- Focused account-deletion route and dialog tests: 23 passed.
- Typecheck passed.
- Changed-file ESLint and Prettier passed.
- Pre-commit full suite: 412 suites / 4,368 tests passed.
- Adversarial review covered aggregate limits, lookahead/continuation behavior, retry exhaustion, partial progress, external-resource ordering, final completion, and old/new client-server deploy skew.

## Manual verification

On the Vercel Preview deployment:

1. Open the account deletion dialog and verify the confirmation fields and loading state render normally.
2. With a stubbed or disposable account that requires more than 50 cleanup batches, submit deletion.
3. Confirm the UI stays in the deleting state across coded continuation responses and clears auth only after a final `200`.
4. Confirm unexpected `409` responses and ten exhausted continuations restore the button and show the existing failure toast.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account deletion now safely continues when cleanup requires additional processing.
  * The deletion dialog automatically retries in-progress cleanup requests, up to a fixed limit.
  * External account cleanup only proceeds after internal cleanup completes.

* **Bug Fixes**
  * Prevented incomplete cleanup from being reported as a server error.
  * Added clearer handling when the retry limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->