### PR TITLE
feat(sandbox): add MIOSA as an optional cloud sandbox provider

### DIFF
--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -74,6 +74,7 @@ export type SandboxSessionUsage = {
 
 const emptySandboxRuntimeMs = (): Record<CloudSandboxProvider, number> => ({
   e2b: 0,
+  miosa: 0,
 });
 
 // Factory function to create tools with context

--- a/lib/ai/tools/utils/MIOSA_PROVIDER.md
+++ b/lib/ai/tools/utils/MIOSA_PROVIDER.md
@@ -1,0 +1,93 @@
+# MIOSA as a cloud sandbox provider
+
+Opt-in. `CLOUD_SANDBOX_PROVIDER` still defaults to `e2b`, and nothing in the
+E2B path changes.
+
+## Why this fits without restructuring the agent
+
+MIOSA is a Firecracker microVM platform, and the sandbox **is** the image - the
+same model as E2B's `Template().fromDockerfile()`, not a container running
+inside a VM. `docker/Dockerfile` is the rootfs on both providers, so the agent's
+tool paths, `/home/user` workdir, and installed binaries are identical.
+
+That is why this integration is three small files rather than a port.
+
+## What is here
+
+| file                                       | role                                                                               |
+| ------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `miosa-sandbox.ts`                         | `MiosaSandbox`, implementing `CommonSandboxInterface` with `sandboxKind = "miosa"` |
+| `cloud-sandbox-provider.ts`                | `CloudSandboxProvider` widened to `"e2b" \| "miosa"`                               |
+| `__tests__/cloud-sandbox-provider.test.ts` | selection + fail-closed coverage for both                                          |
+
+`MiosaSandbox` satisfies the same contract `CentrifugoSandbox` does, so
+`asCommonSandbox()` and every call site that already goes through it work
+unchanged.
+
+## Configuration
+
+```bash
+CLOUD_SANDBOX_PROVIDER=miosa
+MIOSA_API_KEY=msk_...
+MIOSA_TEMPLATE_ID=hackerai-kali   # the rootfs built from docker/Dockerfile
+MIOSA_ENDPOINT=https://api.miosa.ai   # optional
+```
+
+```ts
+import { MiosaSandbox, isMiosaSandbox } from "./miosa-sandbox";
+
+const sandbox = await MiosaSandbox.create({
+  templateId: process.env.MIOSA_TEMPLATE_ID,
+  size: "medium",
+  timeoutSec: 3600,
+});
+
+const { stdout, exitCode } = await sandbox.commands.run("nmap --version", {
+  cwd: "/home/user",
+});
+```
+
+Reattach with `MiosaSandbox.connect(sandboxId)`.
+
+## Two places the contract does not line up, and how each is handled
+
+**1. `getHost(port)` is synchronous; MIOSA resolves a preview URL over the
+network.** The host is resolved once during `create()` and cached, so the
+accessor stays synchronous and the interface is unchanged. For any other port,
+call `await sandbox.prewarmHost(port)` first.
+
+`getHost` on an unwarmed port **throws** rather than returning a constructed
+URL. A fabricated host would fail later, somewhere else, and read as a network
+fault rather than a missing call.
+
+**2. MIOSA has no file-delete endpoint yet**, so `files.remove` shells out to
+`rm -f`. It is marked in the source for replacement when a native call exists,
+and it raises on a non-zero exit rather than resolving as though the file were
+gone.
+
+## Deliberately not done in this PR
+
+`lib/ai/tools/utils/sandbox.ts` is **untouched**. Its lifecycle - E2B clusters,
+leases, 429 retry, auto-pause/auto-resume - is E2B-shaped and load-bearing, and
+rewriting it to be provider-generic is a change that deserves its own review
+rather than riding along with an adapter.
+
+The seam to do that later is `getSandbox()`: branch on
+`getCloudSandboxProvider()` before the cluster lookup, since MIOSA has no
+cluster concept. Happy to follow up with that once the adapter itself is
+agreed.
+
+## Mapping, for review
+
+| `CommonSandboxInterface` | MIOSA SDK                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `commands.run`           | `sandbox.exec.run` / `sandbox.exec.stream` when `onStdout`/`signal` is passed |
+| `files.write`            | `sandbox.files.write`                                                         |
+| `files.read`             | `sandbox.files.readText`                                                      |
+| `files.list`             | `sandbox.files.list`                                                          |
+| `files.remove`           | `exec rm -f` (no native endpoint yet)                                         |
+| `getHost`                | `sandbox.expose(port)`, resolved at create and cached                         |
+| `close`                  | `sandbox.destroy()`                                                           |
+
+`timeoutMs` is converted to MIOSA's seconds and rounded **up** - rounding down
+would cut a command short of the budget the caller asked for.

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-provider.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-provider.test.ts
@@ -21,6 +21,11 @@ describe("cloud sandbox provider selection", () => {
     expect(getCloudSandboxProvider()).toBe("e2b");
   });
 
+  it("honors an explicit MIOSA provider", () => {
+    process.env.CLOUD_SANDBOX_PROVIDER = "miosa";
+    expect(getCloudSandboxProvider()).toBe("miosa");
+  });
+
   it("fails closed for an unsupported provider", () => {
     process.env.CLOUD_SANDBOX_PROVIDER = "unknown-provider";
     expect(() => getCloudSandboxProvider()).toThrow(

--- a/lib/ai/tools/utils/__tests__/miosa-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/miosa-sandbox.test.ts
@@ -1,0 +1,172 @@
+import { MiosaSandbox, isMiosaSandbox } from "../miosa-sandbox";
+
+/**
+ * The adapter's job is to satisfy `CommonSandboxInterface` faithfully. What is
+ * worth asserting is the places the two contracts do NOT line up, because those
+ * are where a wrong answer is silent.
+ */
+
+type ExecResult = { stdout: string; stderr: string; exitCode: number };
+
+function fakeSandbox(overrides: Record<string, any> = {}) {
+  const calls: any[] = [];
+  return {
+    calls,
+    id: "sbx_test",
+    exec: {
+      run: jest.fn(
+        async (command: string, options?: any): Promise<ExecResult> => {
+          calls.push({ command, options });
+          return { stdout: "ok", stderr: "", exitCode: 0, exit_code: 0 } as any;
+        },
+      ),
+      stream: jest.fn(),
+    },
+    files: {
+      write: jest.fn(async () => undefined),
+      readText: jest.fn(async () => "contents"),
+      list: jest.fn(async () => [{ name: "a.txt" }, { name: "b.txt" }]),
+    },
+    expose: jest.fn(async (port: number) => `https://p${port}.miosa.app/`),
+    destroy: jest.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+function build(sandbox: any): MiosaSandbox {
+  // The constructor is private by design; tests build through it directly
+  // rather than reaching the network in create().
+  return new (MiosaSandbox as any)({}, sandbox, sandbox.id);
+}
+
+describe("MiosaSandbox", () => {
+  describe("discriminant", () => {
+    it("identifies itself so call sites can branch like they do for Centrifugo", () => {
+      expect(isMiosaSandbox(build(fakeSandbox()))).toBe(true);
+    });
+
+    it("does not claim unrelated objects", () => {
+      expect(isMiosaSandbox(null)).toBe(false);
+      expect(isMiosaSandbox({})).toBe(false);
+      expect(isMiosaSandbox({ sandboxKind: "centrifugo" })).toBe(false);
+    });
+  });
+
+  describe("commands.run", () => {
+    it("passes cwd and env straight through", async () => {
+      const fake = fakeSandbox();
+      const sandbox = build(fake);
+
+      await sandbox.commands.run("nmap --version", {
+        cwd: "/home/user",
+        envVars: { FOO: "bar" },
+      });
+
+      expect(fake.calls[0].options).toMatchObject({
+        cwd: "/home/user",
+        env: { FOO: "bar" },
+      });
+    });
+
+    it("rounds a millisecond timeout UP to whole seconds", async () => {
+      // Rounding down would cut a command short of the budget the caller asked
+      // for - a 1500ms request must not become a 1s limit.
+      const fake = fakeSandbox();
+      const sandbox = build(fake);
+
+      await sandbox.commands.run("sleep 2", { timeoutMs: 1500 });
+      expect(fake.calls[0].options.timeoutSec).toBe(2);
+    });
+
+    it("never rounds a sub-second timeout down to zero", async () => {
+      const fake = fakeSandbox();
+      const sandbox = build(fake);
+
+      await sandbox.commands.run("true", { timeoutMs: 10 });
+      expect(fake.calls[0].options.timeoutSec).toBe(1);
+    });
+
+    it("normalises exit_code and exitCode to one field", async () => {
+      const fake = fakeSandbox({
+        exec: {
+          run: jest.fn(async () => ({
+            stdout: "",
+            stderr: "boom",
+            exit_code: 3,
+          })),
+          stream: jest.fn(),
+        },
+      });
+
+      const result = await build(fake).commands.run("false");
+      expect(result.exitCode).toBe(3);
+      expect(result.stderr).toBe("boom");
+    });
+  });
+
+  describe("getHost", () => {
+    it("throws for an unresolved port instead of inventing a URL", async () => {
+      // A fabricated host fails later, somewhere else, and reads as a network
+      // fault rather than a missing prewarm.
+      const sandbox = build(fakeSandbox());
+      expect(() => sandbox.getHost(3000)).toThrow("has not been resolved");
+    });
+
+    it("returns a bare host once the port is warmed", async () => {
+      const sandbox = build(fakeSandbox());
+      await sandbox.prewarmHost(8080);
+
+      // No scheme, no trailing slash - E2B's getHost returns a host, not a URL.
+      expect(sandbox.getHost(8080)).toBe("p8080.miosa.app");
+    });
+  });
+
+  describe("files", () => {
+    it("reads text through the SDK's text accessor", async () => {
+      const fake = fakeSandbox();
+      await expect(build(fake).files.read("/tmp/x")).resolves.toBe("contents");
+      expect(fake.files.readText).toHaveBeenCalledWith("/tmp/x");
+    });
+
+    it("normalises listings to { name }", async () => {
+      const entries = await build(fakeSandbox()).files.list("/home/user");
+      expect(entries).toEqual([{ name: "a.txt" }, { name: "b.txt" }]);
+    });
+
+    it("remove raises on a non-zero exit rather than resolving silently", async () => {
+      // Resolving here would report a file as deleted when it is still there.
+      const fake = fakeSandbox({
+        exec: {
+          run: jest.fn(async () => ({
+            stdout: "",
+            stderr: "permission denied",
+            exitCode: 1,
+          })),
+          stream: jest.fn(),
+        },
+      });
+
+      await expect(build(fake).files.remove("/tmp/x")).rejects.toThrow(
+        "permission denied",
+      );
+    });
+
+    it("quotes paths so a space or quote cannot break the shell call", async () => {
+      const fake = fakeSandbox();
+      await build(fake).files.remove("/tmp/a file's name.txt");
+
+      const command: string = fake.calls[0].command;
+      expect(command).toContain("rm -f --");
+      // The embedded quote must be escaped, not terminating the argument.
+      expect(command).toContain(`'\\''`);
+    });
+  });
+
+  describe("close", () => {
+    it("destroys the underlying sandbox", async () => {
+      const fake = fakeSandbox();
+      await build(fake).close();
+      expect(fake.destroy).toHaveBeenCalled();
+    });
+  });
+});

--- a/lib/ai/tools/utils/cloud-sandbox-provider.ts
+++ b/lib/ai/tools/utils/cloud-sandbox-provider.ts
@@ -1,17 +1,25 @@
-export type CloudSandboxProvider = "e2b";
+export type CloudSandboxProvider = "e2b" | "miosa";
+
+const SUPPORTED: readonly CloudSandboxProvider[] = ["e2b", "miosa"] as const;
 
 /**
  * Resolve the configured cloud sandbox provider, defaulting to E2B and
  * rejecting unsupported values instead of silently selecting a provider.
+ *
+ * `miosa` runs the same image on Firecracker microVMs. Both providers build the
+ * sandbox FROM `docker/Dockerfile` - the sandbox is the image, not a container
+ * inside a VM - so the agent's tooling and paths are unchanged between them.
  */
 export function getCloudSandboxProvider(): CloudSandboxProvider {
   const configured = process.env.CLOUD_SANDBOX_PROVIDER?.trim();
-  if (configured === "e2b") {
-    return configured;
+
+  if (configured && (SUPPORTED as readonly string[]).includes(configured)) {
+    return configured as CloudSandboxProvider;
   }
+
   if (configured) {
     throw new Error(
-      `Unsupported CLOUD_SANDBOX_PROVIDER: ${configured}. Expected e2b.`,
+      `Unsupported CLOUD_SANDBOX_PROVIDER: ${configured}. Expected one of ${SUPPORTED.join(", ")}.`,
     );
   }
 

--- a/lib/ai/tools/utils/miosa-sandbox.ts
+++ b/lib/ai/tools/utils/miosa-sandbox.ts
@@ -1,0 +1,266 @@
+import type { CommonSandboxInterface } from "./sandbox-types";
+
+/**
+ * `@miosa/sdk` is an OPTIONAL dependency, loaded only when this provider is
+ * selected. A project running `CLOUD_SANDBOX_PROVIDER=e2b` never installs or
+ * imports it, so adding MIOSA support costs E2B users nothing - not an install,
+ * not a byte of bundle.
+ */
+async function loadMiosaSdk(): Promise<any> {
+  try {
+    return await import("@miosa/sdk");
+  } catch {
+    throw new Error(
+      "CLOUD_SANDBOX_PROVIDER=miosa requires the @miosa/sdk package. " +
+        "Install it with: pnpm add @miosa/sdk",
+    );
+  }
+}
+
+/**
+ * MIOSA sandbox provider.
+ *
+ * Implements the same `CommonSandboxInterface` that E2B and `CentrifugoSandbox`
+ * satisfy, so the rest of the codebase does not learn a third vocabulary. It
+ * carries `sandboxKind = "miosa"` to match the discriminant pattern already
+ * used by `isCentrifugoSandbox`.
+ *
+ * MIOSA is a Firecracker microVM platform. The sandbox IS the image - the same
+ * model as E2B's `Template().fromDockerfile()`, not a container inside a VM -
+ * so `docker/Dockerfile` maps across without restructuring the agent.
+ *
+ * ## Two places the contract does not line up, and how each is handled
+ *
+ * 1. `getHost(port)` is SYNCHRONOUS here but MIOSA resolves a preview URL over
+ *    the network. The host is therefore resolved once during `create()` and
+ *    cached, so the accessor can stay synchronous. `prewarmHost(port)` exists
+ *    for callers that need a port other than the one warmed at construction;
+ *    calling `getHost` for an unwarmed port throws rather than returning a
+ *    plausible-looking guess, because a wrong URL fails later and further away.
+ *
+ * 2. MIOSA has no file-delete endpoint today, so `files.remove` shells out to
+ *    `rm -f`. It is marked below so it can be swapped for a native call when
+ *    one exists, and it fails loudly on a non-zero exit rather than resolving
+ *    as though the file were gone.
+ */
+
+export interface MiosaSandboxOptions {
+  /** MIOSA API key. Defaults to MIOSA_API_KEY. */
+  apiKey?: string;
+  /** API base URL. Defaults to MIOSA_ENDPOINT, then the SDK default. */
+  endpoint?: string;
+  /** Template to boot. Defaults to MIOSA_TEMPLATE_ID. */
+  templateId?: string;
+  /** Shape: xs | small | medium | large | xl. */
+  size?: string;
+  /** Idle timeout in seconds before MIOSA pauses the sandbox. */
+  timeoutSec?: number;
+  /** Environment variables set on the sandbox at create time. */
+  envVars?: Record<string, string>;
+  /** Port to resolve a public host for during create. Defaults to 8080. */
+  hostPort?: number;
+}
+
+type ExecOpts = {
+  envVars?: Record<string, string>;
+  cwd?: string;
+  timeoutMs?: number;
+  background?: boolean;
+  onStdout?: (data: string) => void;
+  onStderr?: (data: string) => void;
+  signal?: AbortSignal;
+};
+
+export class MiosaSandbox implements CommonSandboxInterface {
+  /** Discriminant, mirroring CentrifugoSandbox's `sandboxKind`. */
+  readonly sandboxKind = "miosa" as const;
+
+  private readonly hosts = new Map<number, string>();
+
+  private constructor(
+    private readonly client: any,
+    private readonly sandbox: any,
+    public readonly sandboxId: string,
+  ) {}
+
+  static async create(opts: MiosaSandboxOptions = {}): Promise<MiosaSandbox> {
+    const apiKey = opts.apiKey ?? process.env.MIOSA_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "MIOSA_API_KEY is not set. MiosaSandbox cannot authenticate.",
+      );
+    }
+
+    const { Miosa } = await loadMiosaSdk();
+    const client = new Miosa({
+      apiKey,
+      ...((opts.endpoint ?? process.env.MIOSA_ENDPOINT)
+        ? { baseUrl: opts.endpoint ?? process.env.MIOSA_ENDPOINT }
+        : {}),
+    });
+
+    const sandbox = await client.sandboxes.create({
+      template_id: opts.templateId ?? process.env.MIOSA_TEMPLATE_ID,
+      size: opts.size,
+      timeout_sec: opts.timeoutSec,
+      env: opts.envVars,
+    } as any);
+
+    // Wait for the sandbox to be usable. A create that returns before the guest
+    // agent is up will fail the first exec, which reads as a flaky agent rather
+    // than a race.
+    if (typeof (sandbox as any).waitUntilReady === "function") {
+      await (sandbox as any).waitUntilReady();
+    }
+
+    const instance = new MiosaSandbox(client, sandbox, (sandbox as any).id);
+    await instance.prewarmHost(opts.hostPort ?? 8080);
+    return instance;
+  }
+
+  /** Reattach to an existing sandbox by id. */
+  static async connect(
+    sandboxId: string,
+    opts: MiosaSandboxOptions = {},
+  ): Promise<MiosaSandbox> {
+    const apiKey = opts.apiKey ?? process.env.MIOSA_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "MIOSA_API_KEY is not set. MiosaSandbox cannot authenticate.",
+      );
+    }
+
+    const { Miosa } = await loadMiosaSdk();
+    const client = new Miosa({
+      apiKey,
+      ...((opts.endpoint ?? process.env.MIOSA_ENDPOINT)
+        ? { baseUrl: opts.endpoint ?? process.env.MIOSA_ENDPOINT }
+        : {}),
+    });
+
+    const sandbox = await client.sandboxes.get(sandboxId);
+    return new MiosaSandbox(client, sandbox, sandboxId);
+  }
+
+  readonly commands = {
+    run: async (
+      command: string,
+      opts: ExecOpts = {},
+    ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+      const options: Record<string, unknown> = {};
+      if (opts.cwd) options.cwd = opts.cwd;
+      if (opts.envVars) options.env = opts.envVars;
+      if (typeof opts.timeoutMs === "number") {
+        // MIOSA takes seconds. Round UP: rounding down would cut a command
+        // short of the budget the caller asked for.
+        options.timeoutSec = Math.max(1, Math.ceil(opts.timeoutMs / 1000));
+      }
+
+      // Streaming path, used when the caller wants incremental output or can
+      // abort. Falls through to the buffered call otherwise.
+      if (opts.onStdout || opts.onStderr || opts.signal) {
+        let stdout = "";
+        let stderr = "";
+        let exitCode = 0;
+
+        for await (const event of this.sandbox.exec.stream(command, options)) {
+          if (opts.signal?.aborted) break;
+
+          const e = event as Record<string, any>;
+          if (typeof e.line === "string" && e.type === "stderr") {
+            stderr += e.line;
+            opts.onStderr?.(e.line);
+          } else if (typeof e.line === "string") {
+            stdout += e.line;
+            opts.onStdout?.(e.line);
+          } else if (e.type === "exit") {
+            exitCode = e.exit_code ?? e.exitCode ?? 0;
+          }
+        }
+
+        return { stdout, stderr, exitCode };
+      }
+
+      const result = await this.sandbox.exec.run(command, options);
+      return {
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+        exitCode: result.exitCode ?? result.exit_code ?? 0,
+      };
+    },
+  };
+
+  readonly files = {
+    write: async (path: string, content: string | Buffer): Promise<void> => {
+      const body =
+        typeof content === "string" ? content : new Uint8Array(content);
+      await this.sandbox.files.write(path, body);
+    },
+
+    read: async (path: string): Promise<string> => {
+      return this.sandbox.files.readText(path);
+    },
+
+    // MIOSA has no file-delete endpoint yet. Shelling out is the honest
+    // implementation; swap for a native call when one exists.
+    remove: async (path: string): Promise<void> => {
+      const quoted = `'${path.replace(/'/g, `'\\''`)}'`;
+      const result = await this.commands.run(`rm -f -- ${quoted}`);
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `MiosaSandbox.files.remove(${path}) failed (exit ${result.exitCode}): ${result.stderr}`,
+        );
+      }
+    },
+
+    list: async (path: string): Promise<{ name: string }[]> => {
+      const listing = await this.sandbox.files.list(path);
+      const entries = Array.isArray(listing)
+        ? listing
+        : ((listing as any)?.files ?? (listing as any)?.data ?? []);
+      return entries.map((entry: any) => ({
+        name: typeof entry === "string" ? entry : (entry.name ?? entry.path),
+      }));
+    },
+  };
+
+  /**
+   * Resolve and cache the public host for `port`.
+   *
+   * Called during `create()` so `getHost` can stay synchronous, and available
+   * to callers that later need a different port.
+   */
+  async prewarmHost(port: number): Promise<string> {
+    const url = await this.sandbox.expose(port);
+    const host = url.replace(/^https?:\/\//, "").replace(/\/$/, "");
+    this.hosts.set(port, host);
+    return host;
+  }
+
+  getHost(port: number): string {
+    const host = this.hosts.get(port);
+    if (!host) {
+      // Deliberately throws rather than guessing a URL. A fabricated host fails
+      // later, somewhere else, and reads as a network fault.
+      throw new Error(
+        `MiosaSandbox: host for port ${port} has not been resolved. ` +
+          `Call await sandbox.prewarmHost(${port}) first.`,
+      );
+    }
+    return host;
+  }
+
+  async close(): Promise<void> {
+    await this.sandbox.destroy();
+  }
+}
+
+/** Type guard matching the `isCentrifugoSandbox` / `isE2BSandbox` pattern. */
+export function isMiosaSandbox(sandbox: unknown): sandbox is MiosaSandbox {
+  return (
+    sandbox !== null &&
+    typeof sandbox === "object" &&
+    "sandboxKind" in sandbox &&
+    (sandbox as { sandboxKind?: unknown }).sandboxKind === "miosa"
+  );
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -10,6 +10,7 @@ import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
 import { getProviderUsageRawModelCost } from "@/lib/provider-usage-cost";
 import { redactSensitiveErrorMessage } from "@/lib/utils/error-redaction";
+import type { CloudSandboxProvider } from "@/lib/ai/tools/utils/cloud-sandbox-provider";
 
 export interface ProviderRequestDiagnostics {
   model: string;
@@ -159,7 +160,7 @@ export interface ChatWideEvent {
   sandbox?: {
     type: "e2b" | "desktop" | "remote-connection";
     name?: string;
-    provider?: "e2b";
+    provider?: CloudSandboxProvider;
   };
 
   // Sandbox boot timing — fires once per request, only when actual work is done

--- a/package.json
+++ b/package.json
@@ -265,5 +265,8 @@
       "@workos-inc/authkit-nextjs@4.2.0": "patches/@workos-inc__authkit-nextjs@4.2.0.patch",
       "brace-expansion@5.0.9": "patches/brace-expansion@5.0.9.patch"
     }
+  },
+  "optionalDependencies": {
+    "@miosa/sdk": "^2.0.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,10 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+    optionalDependencies:
+      '@miosa/sdk':
+        specifier: ^2.0.7
+        version: 2.0.7
 
   packages/desktop:
     dependencies:
@@ -2348,6 +2352,10 @@ packages:
 
   '@microsoft/fetch-event-source@2.0.1':
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
+
+  '@miosa/sdk@2.0.7':
+    resolution: {integrity: sha512-X2UKtSkkdGayumr2qEtegxCqg+Qjb7E0z6xKUNv8s2Gtz9iglNUNl2+VLEnn0mo/JX0AALAkHnwmnkEiNFZ+Yw==}
+    engines: {node: '>=18.0.0'}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -7968,6 +7976,10 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -9869,6 +9881,15 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@microsoft/fetch-event-source@2.0.1': {}
+
+  '@miosa/sdk@2.0.7':
+    optionalDependencies:
+      undici: 7.28.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76)':
     dependencies:
@@ -13630,7 +13651,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0)
+      retry-axios: 2.6.0(axios@1.18.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -15816,7 +15837,7 @@ snapshots:
 
   resumable-stream@2.2.12: {}
 
-  retry-axios@2.6.0(axios@1.18.0):
+  retry-axios@2.6.0(axios@1.18.0(debug@4.4.3)):
     dependencies:
       axios: 1.18.0(debug@4.4.3)
 
@@ -16548,6 +16569,9 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.24.6: {}
+
+  undici@7.28.0:
+    optional: true
 
   undici@7.29.0: {}
 


### PR DESCRIPTION
Hi — engineering team at [MIOSA](https://miosa.ai). You've been running on our
sandboxes, and this is the integration work on our side rather than a request
for yours.

**Opt-in and additive.** `CLOUD_SANDBOX_PROVIDER` still defaults to `e2b`.
Nothing in the E2B path changes, and no E2B-only deployment installs or bundles
anything new.

## Why this is small

`getCloudSandboxProvider()` already had the seam — it just had one option. This
widens it to `"e2b" | "miosa"` and adds a `MiosaSandbox` implementing the same
`CommonSandboxInterface` that E2B and `CentrifugoSandbox` already satisfy, with
`sandboxKind = "miosa"` following your existing discriminant pattern.

The reason it isn't a port: MIOSA is a Firecracker microVM platform where **the
sandbox is the image** — the same model as `Template().fromDockerfile()`, not a
container inside a VM. `docker/Dockerfile` becomes the rootfs on both, so tool
paths, the `/home/user` workdir and installed binaries are identical between
providers.

`@miosa/sdk` is an **optional** dependency, imported lazily inside the provider.
Selecting `miosa` without it gives a named error, not a module-resolution stack
trace.

## Two places the contracts don't line up

Both are handled explicitly rather than papered over:

**`getHost(port)` is synchronous; MIOSA resolves a preview URL over the
network.** The host is resolved once during `create()` and cached, so the
accessor stays synchronous and your interface is unchanged. For another port,
`await sandbox.prewarmHost(port)`. `getHost` on an unwarmed port **throws**
rather than returning a constructed URL — a fabricated host fails later and
elsewhere, and reads as a network fault.

**MIOSA has no file-delete endpoint yet**, so `files.remove` shells out to
`rm -f`. It's marked for replacement, quotes its path, and raises on a non-zero
exit instead of resolving as though the file were gone.

## Deliberately not touched

`lib/ai/tools/utils/sandbox.ts`. Its lifecycle — clusters, leases, 429 retry,
auto-pause/auto-resume — is E2B-shaped and load-bearing, and making it
provider-generic deserves its own review rather than riding along with an
adapter. `MIOSA_PROVIDER.md` records exactly where that seam is (`getSandbox()`,
branching before the cluster lookup, since MIOSA has no cluster concept). Happy
to follow up with it if you want this direction.

Two pre-existing types were pinned to the `"e2b"` literal and are widened to the
provider union: `SandboxInfo.provider` in `lib/logger.ts`, and the runtime-ms
`Record` in `lib/ai/tools/index.ts`.

## Verification

```
tsc --noEmit                      0 errors
jest lib/ai/tools/utils/__tests__ 17 suites, 280 tests, all passing
prettier --check                  clean
```

The 13 new adapter tests cover the mismatches above specifically — timeout
rounding (up, never down, never to zero), `exit_code`/`exitCode` normalisation,
`getHost` refusing to guess, `files.remove` raising on failure, and path
quoting.

Happy to adjust naming or structure to whatever fits your conventions — and if
you'd rather not carry a second provider at all, no hard feelings; we can keep
this on our side instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the opt-in MIOSA cloud sandbox provider.
  - MIOSA sandboxes support command execution, file operations, host access, reconnection, and lifecycle management.
  - Provider selection can now be configured through `CLOUD_SANDBOX_PROVIDER`, with E2B remaining the default.
  - Added optional MIOSA SDK support and clearer errors for missing configuration or failed operations.

- **Documentation**
  - Added setup and integration guidance for configuring the MIOSA provider.

- **Tests**
  - Added coverage for provider selection and MIOSA sandbox behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->