### PR TITLE
feat(miosa): interactive PTY, live resource metrics, agent-browser env

### DIFF
--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -22,6 +22,7 @@ import {
 import {
   isCloudSandbox,
   isE2BSandbox,
+  isMiosaSandbox,
   isCentrifugoSandbox,
 } from "./utils/sandbox-types";
 import {
@@ -381,13 +382,13 @@ export const createRunTerminalCmd = (context: ToolContext) => {
           const isCentrifugo = isCentrifugoSandbox(sandbox);
           const isE2B = isE2BSandbox(sandbox);
 
-          if (!isE2B && !isCentrifugo) {
+          if (!isE2B && !isCentrifugo && !isMiosaSandbox(sandbox)) {
             return {
               result: {
                 output: "",
                 exitCode: 1,
                 error:
-                  "Interactive PTY requires E2B or local (Centrifugo) sandbox.",
+                  "Interactive PTY requires E2B, MIOSA, or local (Centrifugo) sandbox.",
               },
             };
           }
@@ -441,6 +442,17 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   cols,
                   rows,
                   cwd: sandbox.getWorkingDirectory(),
+                });
+              }
+              if (isMiosaSandbox(sandbox)) {
+                const { createMiosaPtyHandle } = await import(
+                  "./utils/miosa-pty-adapter"
+                );
+                return createMiosaPtyHandle(sandbox, {
+                  cols,
+                  rows,
+                  cwd: buildSandboxCommandOptions(sandbox).cwd,
+                  envs: agentBrowserEnv,
                 });
               }
               return createE2BPtyHandle(sandbox, {
@@ -1130,9 +1142,13 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     onStderr: forwardCommandOutput,
                   },
             );
-            const agentBrowserEnv = isE2BSandbox(sandboxInstance)
-              ? getAgentBrowserRuntimeEnv(command)
-              : undefined;
+            // agent-browser is installed in MIOSA sandboxes too, and needs the
+            // same runtime env there. Gating this on E2B alone left Chromium
+            // running without its configured flags on MIOSA.
+            const agentBrowserEnv =
+              isE2BSandbox(sandboxInstance) || isMiosaSandbox(sandboxInstance)
+                ? getAgentBrowserRuntimeEnv(command)
+                : undefined;
             const runOptions = isCentrifugoSandbox(sandboxInstance)
               ? {
                   ...commonOptions,

--- a/lib/ai/tools/utils/__tests__/miosa-metrics.test.ts
+++ b/lib/ai/tools/utils/__tests__/miosa-metrics.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for sampleMiosaMetrics — live CPU/memory/disk sampling inside a MIOSA
+ * sandbox, used by the pre-command health check.
+ */
+
+import { sampleMiosaMetrics } from "../miosa-metrics";
+import type { MiosaSandbox } from "../miosa-sandbox";
+
+type RunResult = { stdout: string; stderr: string; exitCode: number };
+
+function sandboxReturning(result: RunResult | Error): MiosaSandbox {
+  return {
+    commands: {
+      run: async () => {
+        if (result instanceof Error) throw result;
+        return result;
+      },
+    },
+  } as unknown as MiosaSandbox;
+}
+
+/** Two /proc/stat lines whose delta is 100 busy jiffies out of 200 total. */
+const CPU_50_PCT = [
+  "CPU_A:cpu  100 0 100 800 0 0 0 0 0 0",
+  "CPU_B:cpu  150 0 150 900 0 0 0 0 0 0",
+].join("\n");
+
+function probeOutput(overrides: Partial<Record<string, string>> = {}): string {
+  const base: Record<string, string> = {
+    cpu: CPU_50_PCT,
+    memTotal: "MEM_TOTAL:1000000",
+    memAvail: "MEM_AVAIL:250000",
+    diskUsed: "DISK_USED:2000",
+    diskTotal: "DISK_TOTAL:10000",
+  };
+  const merged = { ...base, ...overrides };
+  return [
+    merged.cpu,
+    merged.memTotal,
+    merged.memAvail,
+    merged.diskUsed,
+    merged.diskTotal,
+  ].join("\n");
+}
+
+describe("sampleMiosaMetrics", () => {
+  it("derives cpu, memory and disk percentages from the guest probe", async () => {
+    const sandbox = sandboxReturning({
+      stdout: probeOutput(),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const metrics = await sampleMiosaMetrics(sandbox);
+
+    // busy delta 100 of 200 total jiffies
+    expect(metrics?.cpuPct).toBeCloseTo(50, 5);
+    // 750000 of 1000000 kB in use
+    expect(metrics?.memPct).toBeCloseTo(75, 5);
+    // 2000 of 10000 kB used
+    expect(metrics?.diskPct).toBeCloseTo(20, 5);
+  });
+
+  it("reports 0% CPU for an idle guest rather than NaN", async () => {
+    const idle = [
+      "CPU_A:cpu  100 0 100 800 0 0 0 0 0 0",
+      "CPU_B:cpu  100 0 100 800 0 0 0 0 0 0",
+    ].join("\n");
+
+    const metrics = await sampleMiosaMetrics(
+      sandboxReturning({
+        stdout: probeOutput({ cpu: idle }),
+        stderr: "",
+        exitCode: 0,
+      }),
+    );
+
+    expect(metrics?.cpuPct).toBe(0);
+  });
+
+  it("returns null when the probe exits non-zero", async () => {
+    const metrics = await sampleMiosaMetrics(
+      sandboxReturning({ stdout: "", stderr: "boom", exitCode: 1 }),
+    );
+    expect(metrics).toBeNull();
+  });
+
+  it("returns null instead of throwing when the command itself fails", async () => {
+    const metrics = await sampleMiosaMetrics(
+      sandboxReturning(new Error("sandbox unreachable")),
+    );
+    expect(metrics).toBeNull();
+  });
+
+  it("returns null on unparseable output rather than reporting zeroes", async () => {
+    // A sandbox that answers but without the expected fields must not be
+    // reported as a perfectly idle machine — that would mask real pressure.
+    const metrics = await sampleMiosaMetrics(
+      sandboxReturning({ stdout: "unexpected", stderr: "", exitCode: 0 }),
+    );
+    expect(metrics).toBeNull();
+  });
+
+  it("tolerates a guest that reports no disk figures", async () => {
+    const metrics = await sampleMiosaMetrics(
+      sandboxReturning({
+        stdout: [CPU_50_PCT, "MEM_TOTAL:1000000", "MEM_AVAIL:250000"].join(
+          "\n",
+        ),
+        stderr: "",
+        exitCode: 0,
+      }),
+    );
+
+    expect(metrics).not.toBeNull();
+    expect(metrics?.diskPct).toBe(0);
+    expect(metrics?.memPct).toBeCloseTo(75, 5);
+  });
+
+  it("clamps percentages into 0-100", async () => {
+    // MemAvailable can briefly exceed MemTotal on some kernels; a negative
+    // percentage would render as "-3%" in a warning string.
+    const metrics = await sampleMiosaMetrics(
+      sandboxReturning({
+        stdout: probeOutput({
+          memTotal: "MEM_TOTAL:1000",
+          memAvail: "MEM_AVAIL:1200",
+        }),
+        stderr: "",
+        exitCode: 0,
+      }),
+    );
+
+    expect(metrics?.memPct).toBe(0);
+  });
+});

--- a/lib/ai/tools/utils/miosa-metrics.ts
+++ b/lib/ai/tools/utils/miosa-metrics.ts
@@ -1,0 +1,114 @@
+/**
+ * MIOSA sandbox resource metrics.
+ *
+ * MIOSA's `GET /api/v1/sandboxes/:id/metrics` currently reports the sandbox's
+ * *configured* shape (cpu_count / memory_mb / disk_size_mb) and an empty time
+ * series — it does not yet publish live utilisation. Wiring the health check to
+ * it would return numbers that never move, which is worse than none: the agent
+ * would read "0% CPU" while the box is pegged.
+ *
+ * So sample the guest directly instead. One short exec reads /proc and df, and
+ * the CPU figure comes from two /proc/stat snapshots 200ms apart, because a
+ * single snapshot only gives cumulative jiffies since boot, not current load.
+ *
+ * Swap this for the API once MIOSA publishes a real series.
+ */
+
+import type { SandboxResourceMetrics } from "@/types";
+import type { MiosaSandbox } from "./miosa-sandbox";
+
+/** Gap between the two /proc/stat reads used to derive CPU utilisation. */
+const CPU_SAMPLE_INTERVAL_MS = 200;
+
+/** Keep the probe well under any caller timeout — metrics must never block a command. */
+const PROBE_TIMEOUT_MS = 5_000;
+
+const PROBE = `
+a=$(head -n1 /proc/stat)
+sleep ${CPU_SAMPLE_INTERVAL_MS / 1000}
+b=$(head -n1 /proc/stat)
+echo "CPU_A:$a"
+echo "CPU_B:$b"
+echo "MEM_TOTAL:$(awk '/^MemTotal:/{print $2}' /proc/meminfo)"
+echo "MEM_AVAIL:$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)"
+df -k / | awk 'NR==2{print "DISK_USED:"$3; print "DISK_TOTAL:"($3+$4)}'
+`.trim();
+
+function field(lines: string[], prefix: string): string | null {
+  const hit = lines.find((l) => l.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : null;
+}
+
+/**
+ * CPU utilisation between two `/proc/stat` cpu lines.
+ *
+ * Field 4 is idle and field 5 is iowait; everything else counts as busy.
+ * Returns 0 when the two samples are identical (an idle box), never NaN.
+ */
+function cpuPctFromStat(a: string, b: string): number {
+  const parse = (line: string): number[] =>
+    line
+      .replace(/^cpu\s+/, "")
+      .trim()
+      .split(/\s+/)
+      .map((n) => Number.parseInt(n, 10) || 0);
+
+  const first = parse(a);
+  const second = parse(b);
+  if (first.length < 5 || second.length < 5) return 0;
+
+  const totalOf = (v: number[]) => v.reduce((sum, n) => sum + n, 0);
+  const idleOf = (v: number[]) => (v[3] ?? 0) + (v[4] ?? 0);
+
+  const totalDelta = totalOf(second) - totalOf(first);
+  const idleDelta = idleOf(second) - idleOf(first);
+  if (totalDelta <= 0) return 0;
+
+  const pct = ((totalDelta - idleDelta) / totalDelta) * 100;
+  return Math.min(100, Math.max(0, pct));
+}
+
+/**
+ * Sample live CPU, memory and disk usage from inside a MIOSA sandbox.
+ *
+ * Returns `null` — never throws — when the probe fails or the guest returns
+ * something unparseable. A metrics failure must not fail the health check that
+ * called it, let alone the command behind it.
+ */
+export async function sampleMiosaMetrics(
+  sandbox: MiosaSandbox,
+): Promise<SandboxResourceMetrics | null> {
+  try {
+    const result = await sandbox.commands.run(PROBE, {
+      timeoutMs: PROBE_TIMEOUT_MS,
+    });
+    if (result.exitCode !== 0) return null;
+
+    const lines = result.stdout.split("\n").map((l) => l.trim());
+
+    const cpuA = field(lines, "CPU_A:");
+    const cpuB = field(lines, "CPU_B:");
+    const memTotalKb = Number(field(lines, "MEM_TOTAL:"));
+    const memAvailKb = Number(field(lines, "MEM_AVAIL:"));
+    const diskUsedKb = Number(field(lines, "DISK_USED:"));
+    const diskTotalKb = Number(field(lines, "DISK_TOTAL:"));
+
+    if (!cpuA || !cpuB) return null;
+    if (!Number.isFinite(memTotalKb) || memTotalKb <= 0) return null;
+
+    const cpuPct = cpuPctFromStat(cpuA, cpuB);
+    const memPct = ((memTotalKb - memAvailKb) / memTotalKb) * 100;
+    const diskPct =
+      Number.isFinite(diskTotalKb) && diskTotalKb > 0
+        ? (diskUsedKb / diskTotalKb) * 100
+        : 0;
+
+    return {
+      cpuPct,
+      memPct: Math.min(100, Math.max(0, memPct)),
+      diskPct: Math.min(100, Math.max(0, diskPct)),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/lib/ai/tools/utils/miosa-pty-adapter.ts
+++ b/lib/ai/tools/utils/miosa-pty-adapter.ts
@@ -1,0 +1,194 @@
+/**
+ * MIOSA PTY adapter.
+ *
+ * Creates a PtyHandle backed by MIOSA's sandbox terminal WebSocket, so the
+ * interactive exec branch in run-terminal-cmd.ts can treat MIOSA sandboxes the
+ * same way it treats E2B and Centrifugo ones.
+ *
+ * Message flow:
+ *   POST /api/v1/sandboxes/:id/terminal   →  { session_id, ws_url, ... }
+ *   Client  ──── binary frames ────▶  PTY stdin
+ *   Client  ──── {"type":"resize"} ─▶  PTY resize
+ *   Server  ◀─── binary frames ─────  PTY stdout/stderr
+ *   DELETE /api/v1/sandboxes/:id/terminal/:session_id  →  closes the PTY
+ *
+ * The upgrade authenticates with `Authorization: Bearer <MIOSA_API_KEY>`, the
+ * same credential the SDK client uses. MIOSA also mints a short-lived
+ * `stream_auth` for browser clients that cannot set headers; this adapter runs
+ * server-side and does not need it.
+ */
+
+import WebSocket from "ws";
+import type { CreatePtyOptions, PtyHandle } from "./e2b-pty-adapter";
+import type { MiosaSandbox } from "./miosa-sandbox";
+
+const LOG_PREFIX = "[miosa-pty-adapter]";
+
+/** How long to wait for the WebSocket upgrade before giving up. */
+const CONNECT_TIMEOUT_MS = 15_000;
+
+type TerminalSession = {
+  sessionId: string;
+  wsUrl: string;
+};
+
+/**
+ * MIOSA returns snake_case JSON. The SDK passes it through untyped, so read
+ * both spellings rather than assuming one — a silent `undefined` here would
+ * surface much later as an unexplained WebSocket failure.
+ */
+function readTerminalSession(raw: Record<string, unknown>): TerminalSession {
+  const sessionId = (raw.session_id ?? raw.sessionId) as string | undefined;
+  const wsUrl = (raw.ws_url ?? raw.wsUrl) as string | undefined;
+
+  if (typeof sessionId !== "string" || sessionId === "") {
+    throw new Error(`${LOG_PREFIX} terminal create returned no session_id`);
+  }
+  if (typeof wsUrl !== "string" || wsUrl === "") {
+    throw new Error(`${LOG_PREFIX} terminal create returned no ws_url`);
+  }
+
+  return { sessionId, wsUrl };
+}
+
+function toUint8Array(data: unknown): Uint8Array {
+  if (data instanceof Uint8Array) return data;
+  if (Buffer.isBuffer(data)) return new Uint8Array(data);
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (Array.isArray(data)) return new Uint8Array(Buffer.concat(data));
+  return new TextEncoder().encode(String(data ?? ""));
+}
+
+/**
+ * Create a PtyHandle for a MIOSA sandbox.
+ *
+ * Resolves once the WebSocket is open, so callers can write to the PTY
+ * immediately without racing the upgrade.
+ */
+export async function createMiosaPtyHandle(
+  sandbox: MiosaSandbox,
+  opts: CreatePtyOptions,
+): Promise<PtyHandle> {
+  const apiKey = process.env.MIOSA_API_KEY;
+  if (!apiKey) {
+    throw new Error(`${LOG_PREFIX} MIOSA_API_KEY is not set`);
+  }
+
+  const created = (await sandbox.sdkSandbox.terminal.create({
+    cols: opts.cols,
+    rows: opts.rows,
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    ...(opts.envs ? { env: opts.envs } : {}),
+  })) as Record<string, unknown>;
+
+  const { sessionId, wsUrl } = readTerminalSession(created);
+
+  const ws = new WebSocket(wsUrl, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  const listeners = new Set<(bytes: Uint8Array) => void>();
+  let exitResolved = false;
+  let resolveExited: (value: { exitCode: number | null }) => void = () => {};
+  const exited = new Promise<{ exitCode: number | null }>((resolve) => {
+    resolveExited = resolve;
+  });
+
+  // The PTY is gone once the socket closes, however that happens. Settling
+  // once here means an abnormal close still releases anyone awaiting `exited`
+  // instead of hanging until the session manager's max-lifetime timer fires.
+  const settleExited = (exitCode: number | null) => {
+    if (exitResolved) return;
+    exitResolved = true;
+    resolveExited({ exitCode });
+  };
+
+  ws.on("message", (data) => {
+    const bytes = toUint8Array(data);
+    for (const cb of listeners) {
+      try {
+        cb(bytes);
+      } catch {
+        // A throwing consumer must not tear down the stream for the others.
+      }
+    }
+  });
+
+  ws.on("close", (code) => settleExited(code === 1000 ? 0 : null));
+  ws.on("error", () => settleExited(null));
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try {
+        ws.terminate();
+      } catch {
+        // already gone
+      }
+      reject(
+        new Error(
+          `${LOG_PREFIX} timed out after ${CONNECT_TIMEOUT_MS}ms connecting to the terminal stream`,
+        ),
+      );
+    }, CONNECT_TIMEOUT_MS);
+
+    ws.once("open", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    ws.once("error", (err) => {
+      clearTimeout(timer);
+      reject(
+        err instanceof Error
+          ? err
+          : new Error(`${LOG_PREFIX} terminal stream failed to open`),
+      );
+    });
+  });
+
+  const send = (payload: Uint8Array | string): void => {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    ws.send(payload);
+  };
+
+  return {
+    // MIOSA addresses the PTY by session id, not by host pid. The session
+    // manager only uses `pid` as an opaque handle, so a stable non-zero
+    // placeholder keeps its bookkeeping intact.
+    get pid() {
+      return 1;
+    },
+
+    async sendInput(bytes: Uint8Array): Promise<void> {
+      send(bytes);
+    },
+
+    async resize(cols: number, rows: number): Promise<void> {
+      send(JSON.stringify({ type: "resize", cols, rows }));
+    },
+
+    async kill(): Promise<void> {
+      // Delete the server-side session first: closing only the socket would
+      // leave the PTY running in the sandbox until it idled out.
+      try {
+        await sandbox.sdkSandbox.terminal.delete(sessionId);
+      } catch {
+        // Best effort — the close below still frees the local side.
+      }
+      try {
+        ws.close();
+      } catch {
+        // already closed
+      }
+      settleExited(null);
+    },
+
+    onData(cb: (bytes: Uint8Array) => void): () => void {
+      listeners.add(cb);
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+
+    exited,
+  };
+}

--- a/lib/ai/tools/utils/sandbox-health.ts
+++ b/lib/ai/tools/utils/sandbox-health.ts
@@ -11,7 +11,8 @@ import type {
   TerminalTimeoutRecoveryOutcome,
 } from "@/types";
 import { createRetryLogger } from "@/lib/posthog/worker";
-import { isE2BSandbox } from "./sandbox-types";
+import { isE2BSandbox, isMiosaSandbox } from "./sandbox-types";
+import { sampleMiosaMetrics } from "./miosa-metrics";
 import { retryWithBackoff } from "./retry-with-backoff";
 import {
   AuthenticationError,
@@ -32,12 +33,36 @@ const MEM_WARNING_THRESHOLD = 90; // percentage
 const FAILURE_METRICS_TIMEOUT_MS = 1000;
 
 /**
+ * Human-readable warning for a resource sample, or null when nothing is hot.
+ * Shared so every provider reports pressure with identical wording.
+ */
+function buildResourceWarning(metrics: SandboxResourceMetrics): string | null {
+  const warnings: string[] = [];
+  if (metrics.cpuPct > CPU_WARNING_THRESHOLD) {
+    warnings.push(`CPU at ${metrics.cpuPct.toFixed(0)}%`);
+  }
+  if (metrics.memPct > MEM_WARNING_THRESHOLD) {
+    warnings.push(`Memory at ${metrics.memPct.toFixed(0)}%`);
+  }
+  return warnings.length > 0 ? warnings.join(", ") : null;
+}
+
+/**
  * Check sandbox resource metrics and return a diagnostic summary.
  * Returns null if metrics are unavailable (non-E2B sandbox or API error).
  */
 async function checkSandboxMetrics(
   sandbox: AnySandbox,
 ): Promise<(SandboxResourceMetrics & { warning: string | null }) | null> {
+  // MIOSA has no live-utilisation series yet, so sample the guest directly.
+  // Without this branch the agent runs blind on MIOSA: no CPU or memory
+  // warning ever fires, and a wedged sandbox looks identical to a healthy one.
+  if (isMiosaSandbox(sandbox)) {
+    const sample = await sampleMiosaMetrics(sandbox);
+    if (!sample) return null;
+    return { ...sample, warning: buildResourceWarning(sample) };
+  }
+
   if (!isE2BSandbox(sandbox)) return null;
 
   try {


### PR DESCRIPTION
Stacked on #1185 (targets `codex/miosa-sandbox-rollout`, not `main`) so it builds on your work rather than competing with it.

Three capabilities the agent has on E2B but silently loses on MIOSA. **All three are supported by MIOSA today** — the adapter just was not reaching for them.

## 1. Interactive PTY

`run_terminal_cmd` refused outright:

```
"Interactive PTY requires E2B or local (Centrifugo) sandbox."
```

For a pentest agent that means **no msfconsole, no interactive sqlmap, no ssh session** on MIOSA.

The adapter note said MIOSA exposed terminal creation but no input/resize stream. That is no longer true — `POST /api/v1/sandboxes/:id/terminal` returns a `ws_url`, and the socket carries binary PTY frames both ways plus `{"type":"resize","cols":N,"rows":M}`. Confirmed against the server implementation, and it is the same channel the MIOSA CLI already drives.

`miosa-pty-adapter.ts` implements `PtyHandle` over it, so `PtySessionManager` treats MIOSA exactly like the other providers. Auth is `Authorization: Bearer $MIOSA_API_KEY` on the upgrade — the short-lived `stream_auth` MIOSA also returns is for browsers that cannot set headers, so it is not needed server-side.

## 2. Live resource metrics

`checkSandboxMetrics` opened with `if (!isE2BSandbox(sandbox)) return null`, so on MIOSA every pre-command health check returned nothing — **no CPU or memory warning could ever fire, and a wedged sandbox looked identical to a healthy one.**

One thing worth knowing before anyone "fixes" this by calling the API: MIOSA's `GET /sandboxes/:id/metrics` currently returns the sandbox's **configured** shape (`cpu_count`/`memory_mb`/`disk_size_mb`) with an **empty series**. Wiring to it would report numbers that never move — worse than none, because the agent would read "0% CPU" on a pegged box.

So this samples the guest: one short exec reads `/proc` and `df`, with CPU derived from two `/proc/stat` snapshots 200ms apart (a single snapshot only gives cumulative jiffies since boot). Swap it for the API when a real series ships.

Metrics failures return `null` and never throw — a metrics problem must not fail the health check that called it, let alone the command behind it.

## 3. agent-browser env

`getAgentBrowserRuntimeEnv` was gated on E2B alone, so Chromium ran on MIOSA without its configured flags. agent-browser is installed in MIOSA sandboxes too — verified headless Chromium rendering a page in one.

## Verification

- **418 tests passing** (7 new), 32 suites
- `tsc --noEmit` clean, `eslint` clean
- Independently verified in a live MIOSA sandbox: `nmap -sS` SYN scan with version detection, headless Chromium rendering, and a custom 20 GiB disk on a `small` shape

Happy to split this into three commits or retarget at `main` after #1185 lands — whichever is easier for you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MIOSA sandbox support for interactive terminal sessions.
  * Added MIOSA-compatible CPU, memory, and disk usage monitoring.
  * Improved terminal session handling, including resizing, input, cleanup, and connection errors.

* **Bug Fixes**
  * Improved sandbox health reporting when metrics are unavailable or malformed.
  * Memory warnings now focus on usage percentages for clearer reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->