### PR TITLE
Fix desktop terminal output persistence recovery

### DIFF
--- a/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
+++ b/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
@@ -272,6 +272,12 @@ describe("saveFullOutputToFile", () => {
         scopeId: CHAT_ID,
       }),
     ).resolves.toBe(FULL_OUTPUT_SAVE_FAILED_MESSAGE);
+    expect(FULL_OUTPUT_SAVE_FAILED_MESSAGE).toContain(
+      "Do not rerun the original command unchanged",
+    );
+    expect(FULL_OUTPUT_SAVE_FAILED_MESSAGE).toContain(
+      "use a safe, read-only follow-up",
+    );
     expect(terminalWriter).toHaveBeenCalledWith(
       FULL_OUTPUT_SAVE_FAILED_MESSAGE,
     );

--- a/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
+++ b/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, jest } from "@jest/globals";
 import { phLogger } from "@/lib/posthog/server";
 import {
   classifyTerminalOutputPersistenceFailure,
+  FULL_OUTPUT_SAVE_FAILED_MESSAGE,
   MAX_SAVED_TERMINAL_OUTPUT_FILES,
   saveFullOutputToFile,
+  saveTruncatedOutput,
 } from "../terminal-output-saver";
 
 const CHAT_ID = "chat_123";
@@ -133,6 +135,40 @@ describe("saveFullOutputToFile", () => {
     jest.useRealTimers();
   });
 
+  it("retries an unknown desktop relay failure once", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const sandbox = createSandbox({
+      sandboxKind: "centrifugo",
+      nativeFileRelay: true,
+    });
+    sandbox.files.write
+      .mockRejectedValueOnce({ code: "unclassified_desktop_failure" })
+      .mockResolvedValueOnce(undefined);
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+
+    const savePromise = saveFullOutputToFile(
+      sandbox as any,
+      "full output",
+      CHAT_ID,
+    );
+    await jest.advanceTimersByTimeAsync(250);
+
+    await expect(savePromise).resolves.toContain(
+      `/tmp/terminal_full_output/chat-${CHAT_KEY}/`,
+    );
+    expect(sandbox.files.write).toHaveBeenCalledTimes(2);
+    infoSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("classifies inactive desktop connections as relay unavailable", () => {
+    expect(
+      classifyTerminalOutputPersistenceFailure({
+        reason: "connection_inactive",
+      }),
+    ).toBe("relay_unavailable");
+  });
+
   it("does not repeat a completed desktop relay timeout", async () => {
     const sandbox = createSandbox({
       sandboxKind: "centrifugo",
@@ -215,6 +251,31 @@ describe("saveFullOutputToFile", () => {
       { timeoutMs: 5000 },
     );
     jest.useRealTimers();
+  });
+
+  it("tells the agent when truncated output could not be persisted", async () => {
+    const sandbox = createSandbox();
+    sandbox.files.write.mockRejectedValueOnce(new Error("Permission denied"));
+    const terminalWriter = jest.fn(async () => undefined);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = {
+      wasTruncated: () => true,
+      getFullOutput: () => "full output",
+      wasFullOutputCapped: () => false,
+    };
+
+    await expect(
+      saveTruncatedOutput({
+        handler: handler as any,
+        sandbox: sandbox as any,
+        terminalWriter,
+        scopeId: CHAT_ID,
+      }),
+    ).resolves.toBe(FULL_OUTPUT_SAVE_FAILED_MESSAGE);
+    expect(terminalWriter).toHaveBeenCalledWith(
+      FULL_OUTPUT_SAVE_FAILED_MESSAGE,
+    );
+    warnSpy.mockRestore();
   });
 
   it("removes saved outputs beyond the per-chat retention limit", async () => {

--- a/lib/ai/tools/utils/terminal-output-saver.ts
+++ b/lib/ai/tools/utils/terminal-output-saver.ts
@@ -11,6 +11,8 @@ import {
 
 export const MAX_SAVED_TERMINAL_OUTPUT_FILES = 10;
 const DESKTOP_RELAY_RETRY_DELAY_MS = 250;
+export const FULL_OUTPUT_SAVE_FAILED_MESSAGE =
+  "\n[Full terminal output could not be saved. The output below is truncated. Rerun the command with narrower output, filters, or line ranges before relying on omitted content.]";
 
 type TerminalOutputPersistenceProvider = "e2b" | "desktop" | "centrifugo";
 type TerminalOutputPersistenceFailureCategory =
@@ -48,10 +50,20 @@ const getPersistenceProvider = (
 export const classifyTerminalOutputPersistenceFailure = (
   error: unknown,
 ): TerminalOutputPersistenceFailureCategory => {
-  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  const message = (
+    error instanceof Error
+      ? error.message
+      : error && typeof error === "object"
+        ? (["message", "error", "reason", "code"]
+            .map((key) => (error as Record<string, unknown>)[key])
+            .find((value): value is string => typeof value === "string") ?? "")
+        : typeof error === "string"
+          ? error
+          : ""
+  ).toLowerCase();
   if (/timed?\s*out|timeout/.test(message)) return "timeout";
   if (
-    /not subscribed|relay is not available|reconnect the desktop app/.test(
+    /not subscribed|relay is not available|reconnect the desktop app|connection(?: is)? inactive|connection_inactive/.test(
       message,
     )
   ) {
@@ -86,7 +98,9 @@ const canRetryDesktopRelayFailure = (
   category: TerminalOutputPersistenceFailureCategory,
 ): boolean =>
   provider === "desktop" &&
-  (category === "transport" || category === "relay_unavailable");
+  (category === "transport" ||
+    category === "relay_unavailable" ||
+    category === "unknown");
 
 const emitPersistenceFailure = (args: {
   provider: TerminalOutputPersistenceProvider;
@@ -321,7 +335,8 @@ export async function saveTruncatedOutput(opts: {
   );
 
   if (!savedPath) {
-    return "";
+    await terminalWriter(FULL_OUTPUT_SAVE_FAILED_MESSAGE);
+    return FULL_OUTPUT_SAVE_FAILED_MESSAGE;
   }
 
   const saveMsg = FULL_OUTPUT_SAVED_MESSAGE(

--- a/lib/ai/tools/utils/terminal-output-saver.ts
+++ b/lib/ai/tools/utils/terminal-output-saver.ts
@@ -12,7 +12,7 @@ import {
 export const MAX_SAVED_TERMINAL_OUTPUT_FILES = 10;
 const DESKTOP_RELAY_RETRY_DELAY_MS = 250;
 export const FULL_OUTPUT_SAVE_FAILED_MESSAGE =
-  "\n[Full terminal output could not be saved. The output below is truncated. Rerun the command with narrower output, filters, or line ranges before relying on omitted content.]";
+  "\n[Full terminal output could not be saved. The output below is truncated. Do not rerun the original command unchanged. If the omitted content is necessary, use a safe, read-only follow-up with narrower output, filters, or line ranges. Otherwise, explain the limitation and continue.]";
 
 type TerminalOutputPersistenceProvider = "e2b" | "desktop" | "centrifugo";
 type TerminalOutputPersistenceFailureCategory =


### PR DESCRIPTION
## Summary

- classify object-shaped desktop relay failures, including inactive connections
- retry unknown desktop native-file-relay failures once because the output write is idempotent
- expose a clear truncated-output warning to the Agent when full output cannot be persisted, prompting a narrower follow-up command
- cover unknown retry, inactive connection classification, and visible persistence failure behavior

## Why

Production investigation found repeated desktop terminal-output persistence failures strongly correlated with long canceled Agent runs. Previously, object-shaped failures frequently fell into `unknown`, were not retried, and silently returned only truncated terminal output to the Agent.

## Validation

- `pnpm typecheck`
- full Jest suite: 414 suites, 4,405 tests
- staged Prettier and ESLint checks
- focused terminal-output-saver suite: 17 tests
- local dependency links verified as scoped to this worktree

## Manual verification

1. Run Desktop Agent mode with a terminal command whose output exceeds the truncation limit.
2. Interrupt or deactivate the desktop relay during the full-output file write.
3. Confirm transient/unknown relay failures retry once.
4. If persistence still fails, confirm the terminal result visibly states that full output was not saved and instructs the Agent to use narrower output, filters, or line ranges.

No visual browser verification is required: this is a backend Agent/desktop relay recovery change with focused automated coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of desktop relay failures by retrying unknown errors.
  * Correctly identifies inactive connections as unavailable.
  * Recognizes failures reported in multiple error formats.
  * Provides clearer guidance when truncated terminal output cannot be saved, including avoiding unchanged command retries and using a safe, read-only follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->