### PR TITLE
Guard legacy Agent image sizes before provider calls

### DIFF
--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -765,12 +765,25 @@ describe("processMessageFiles image size guards", () => {
         name: "legacy-large.png",
       },
     ]);
-    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
-      expect(init?.method).toBe("HEAD");
+    const cancelRangeBody = jest.fn(async () => undefined);
+    const fetchSpy = jest.fn(async (_url, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return responseLike({});
+      }
       return responseLike({
-        headers: { "content-length": String(40 * 1024 * 1024) },
+        status: 206,
+        headers: {
+          "content-range": `bytes 0-${5 * 1024 * 1024}/${40 * 1024 * 1024}`,
+        },
+        body: {
+          cancel: cancelRangeBody,
+          getReader: () => {
+            throw new Error("Known range total should avoid reading the body");
+          },
+        },
       });
-    }) as any;
+    });
+    global.fetch = fetchSpy as any;
 
     const result = await processMessageFiles(
       makeMessage({
@@ -785,7 +798,13 @@ describe("processMessageFiles image size guards", () => {
       "pro",
     );
 
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(cancelRangeBody).toHaveBeenCalledTimes(1);
     expect(result.sandboxFiles).toHaveLength(1);
+    const localPath = result.sandboxFiles[0].localPath;
+    expect(localPath).toMatch(
+      /^\/home\/user\/upload\/[a-f0-9]{64}\/legacy-large\.png$/,
+    );
     expect(result.sandboxFiles[0]).toMatchObject({
       kind: "url",
       url: "https://storage.example/legacy-large.png",
@@ -794,7 +813,7 @@ describe("processMessageFiles image size guards", () => {
       { type: "text", text: "what is this?" },
       {
         type: "text",
-        text: `<attachment filename="legacy-large.png" local_path="${result.sandboxFiles[0].localPath}" />`,
+        text: `<attachment filename="legacy-large.png" local_path="${localPath}" />`,
       },
     ]);
   });

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -757,6 +757,48 @@ describe("processMessageFiles image size guards", () => {
     ]);
   });
 
+  it("probes legacy Agent images without trusted size before provider use", async () => {
+    mockConvexAction.mockResolvedValue([
+      {
+        url: "https://storage.example/legacy-large.png",
+        mediaType: "image/png",
+        name: "legacy-large.png",
+      },
+    ]);
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      expect(init?.method).toBe("HEAD");
+      return responseLike({
+        headers: { "content-length": String(40 * 1024 * 1024) },
+      });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        fileId: "file_legacy_large",
+        mediaType: "image/png",
+        name: "legacy-large.png",
+      }),
+      "agent",
+      "user123",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(result.sandboxFiles).toHaveLength(1);
+    expect(result.sandboxFiles[0]).toMatchObject({
+      kind: "url",
+      url: "https://storage.example/legacy-large.png",
+    });
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
+      {
+        type: "text",
+        text: `<attachment filename="legacy-large.png" local_path="${result.sandboxFiles[0].localPath}" />`,
+      },
+    ]);
+  });
+
   it("falls back to legacy file URL action when metadata-aware action is not deployed", async () => {
     mockConvexAction
       .mockRejectedValueOnce(

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -229,12 +229,16 @@ const probeDownloadSize = async (
       signal: controller.signal,
     });
 
-    if (!response.ok) return null;
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      return null;
+    }
 
     const rangeTotal = parseContentRangeTotal(
       response.headers.get("content-range"),
     );
     if (rangeTotal != null) {
+      await response.body?.cancel().catch(() => undefined);
       return { bytes: rangeTotal, source: "content_range" };
     }
 
@@ -242,6 +246,7 @@ const probeDownloadSize = async (
       response.headers.get("content-length"),
     );
     if (contentLength != null && response.status !== 206) {
+      await response.body?.cancel().catch(() => undefined);
       return { bytes: contentLength, source: "content_length" };
     }
 

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -698,8 +698,10 @@ const applyUrlsToFileParts = async (
       typeof file.sizeBytes === "number"
         ? ({ bytes: file.sizeBytes, source: "file_record" } as const)
         : null;
+    // Legacy stored images can lack trusted size metadata in either mode.
+    // Probe Agent images too so oversized files stay sandbox-only.
     const shouldProbeImageSize =
-      isSupportedImage && file.url && mode !== "agent" && !trustedImageSize;
+      isSupportedImage && file.url && !trustedImageSize;
     const probedImageSize = shouldProbeImageSize
       ? await probeImageSize(file.url, MAX_IMAGE_SIZE)
       : null;


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-08-28T20:00:45.346Z` to `2026-08-29T20:00:45.346Z`.

- Trigger.dev: 43 terminal Agent failures across 2 opaque users / 4 chats shared `Provider terminal error category=provider_4xx status=413`. A representative trace from every affected chat resolved to `Downloaded image content cannot exceed 30MB`.
- PostHog: 44 matching oversized downloaded-image events across the same 2-user cohort.
- Existing image-count trimming removed old parts, but the failures persisted because stored legacy images without trusted size metadata skipped the Agent-mode size probe.
- Current production worker at collection was `v20260829.3` (deployment `05rz4nyx`, deployed `2026-08-29T19:32:47Z`). The image failures were on earlier versions through `v20260828.12`; this PR is the supported remediation, not a claim that the current worker already failed it.

## Root cause

Known-size Agent images above the provider-safe per-image limit already become sandbox-only. The shared attachment preparation path probed unknown-size stored images only in Ask mode, so a legacy Agent image with no trusted size could remain provider-visible and reach OpenRouter's download limit.

## Change

Probe owner-checked stored image URLs whenever trusted size metadata is absent, including Agent mode. Oversized Agent images remain available in the sandbox but are removed from the provider payload. Existing file-count and aggregate request-size guards are unchanged.

## Validation

- 157 focused tests across file transformation, image-count processing, and provider error classification
- Full commit hook: 414 suites / 4,403 tests
- TypeScript typecheck
- Changed-file ESLint
- Prettier
- `git diff --check`

## Adversarial review

- Enforces the bound per image, matching the provider limit scope.
- Covers the single shared production preparation entry point for Ask and Agent.
- Preserves owner checking and sandbox staging before provider visibility is removed.
- Keeps known-size, small-image, PDF, local attachment, and count-limit paths unchanged.
- Uses the existing bounded HEAD/range probe and fails provider visibility closed when validation cannot establish safety.
- Worker/Vercel deploy skew remains safe because attachment preparation runs in the pinned Trigger worker for Agent runs.

## Manual verification

1. In the Preview deployment, open a disposable paid Agent chat containing an older stored image larger than 5 MiB whose file record lacks size metadata.
2. Start Agent mode.
3. Confirm the image is staged under the sandbox upload directory, the run completes without the downloaded-image 413, and the provider-visible message contains an attachment path rather than an inline image.
4. Repeat with a small legacy image and confirm it remains visible to the model while also being staged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stored images in Agent mode when reliable size information is unavailable.
  * Images are now checked before processing, and oversized images are safely staged instead of being sent inline.
  * Improved image-size detection when initial server responses are inconclusive.
  * Prevented unnecessary image data from being downloaded when size information is already available or a request fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->