### PR TITLE
Handle deleted customers in fraud webhooks

### DIFF
--- a/app/api/fraud/webhook/__tests__/route.test.ts
+++ b/app/api/fraud/webhook/__tests__/route.test.ts
@@ -1,0 +1,252 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const mockConstructEvent = jest.fn();
+const mockListSubscriptions = jest.fn();
+const mockCancelSubscription = jest.fn();
+const mockListPaymentMethods = jest.fn();
+const mockDetachPaymentMethod = jest.fn();
+const mockUpdateCustomer = jest.fn();
+const mockRetrieveCharge = jest.fn();
+const mockUpdateCharge = jest.fn();
+const mockConvexMutation = jest.fn();
+const mockResolveUserIdsFromCustomer = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    webhooks: { constructEvent: mockConstructEvent },
+    subscriptions: {
+      list: mockListSubscriptions,
+      cancel: mockCancelSubscription,
+    },
+    paymentMethods: {
+      list: mockListPaymentMethods,
+      detach: mockDetachPaymentMethod,
+    },
+    customers: { update: mockUpdateCustomer },
+    charges: {
+      retrieve: mockRetrieveCharge,
+      update: mockUpdateCharge,
+    },
+  },
+}));
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: () => ({ mutation: mockConvexMutation }),
+}));
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    extraUsage: {
+      claimWebhookProcessing: "extraUsage.claimWebhookProcessing",
+      finalizeWebhookProcessing: "extraUsage.finalizeWebhookProcessing",
+    },
+    userSuspensions: { upsertActive: "userSuspensions.upsertActive" },
+  },
+}));
+
+jest.mock("@/lib/billing/resolve-customer-users", () => ({
+  resolveUserIdsFromCustomer: mockResolveUserIdsFromCustomer,
+}));
+
+jest.mock("@/lib/billing/stripe-webhook-logging", () => ({
+  logStripeWebhookMissingSignature: jest.fn(),
+  logStripeWebhookSignatureVerificationFailed: jest.fn(),
+}));
+
+const missingCustomerError = {
+  type: "StripeInvalidRequestError",
+  code: "resource_missing",
+  message: "No such customer: 'cus_deleted'",
+};
+
+const transientStripeError = {
+  type: "StripeAPIError",
+  code: "api_error",
+  message: "Stripe is temporarily unavailable",
+};
+
+type CustomerBoundary =
+  "subscriptions.list" | "paymentMethods.list" | "customers.update";
+
+function makeRequest() {
+  return {
+    text: jest.fn().mockResolvedValue("signed-body"),
+    headers: {
+      get: jest.fn((name: string) =>
+        name === "stripe-signature" ? "sig_test" : null,
+      ),
+    },
+  } as any;
+}
+
+function rejectBoundary(boundary: CustomerBoundary, error: unknown) {
+  if (boundary === "subscriptions.list") {
+    mockListSubscriptions.mockRejectedValue(error as never);
+  } else if (boundary === "paymentMethods.list") {
+    mockListPaymentMethods.mockRejectedValue(error as never);
+  } else {
+    mockUpdateCustomer.mockRejectedValue(error as never);
+  }
+}
+
+describe("POST /api/fraud/webhook", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STRIPE_FRAUD_WEBHOOK_SECRET = "whsec_test";
+    process.env.CONVEX_SERVICE_ROLE_KEY = "service_role_test";
+
+    mockConstructEvent.mockReturnValue({
+      id: "evt_dispute",
+      type: "charge.dispute.created",
+      data: {
+        object: {
+          id: "dp_fraudulent",
+          reason: "fraudulent",
+          amount: 4200,
+          charge: "ch_disputed",
+          created: 1_788_000_000,
+        },
+      },
+    });
+    mockRetrieveCharge.mockResolvedValue({
+      id: "ch_disputed",
+      customer: "cus_deleted",
+    } as never);
+    mockResolveUserIdsFromCustomer.mockResolvedValue({
+      userIds: ["user_opaque"],
+      orgId: "org_opaque",
+    } as never);
+    mockListSubscriptions.mockResolvedValue({ data: [] } as never);
+    mockListPaymentMethods.mockResolvedValue({ data: [] } as never);
+    mockUpdateCustomer.mockResolvedValue({ id: "cus_deleted" } as never);
+    mockUpdateCharge.mockResolvedValue({ id: "ch_disputed" } as never);
+    mockConvexMutation.mockImplementation(async (operation: unknown) => {
+      if (operation === "extraUsage.claimWebhookProcessing") {
+        return { state: "acquired" };
+      }
+      return undefined;
+    });
+
+    jest.spyOn(console, "log").mockImplementation(() => undefined);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each<CustomerBoundary>([
+    "subscriptions.list",
+    "paymentMethods.list",
+    "customers.update",
+  ])(
+    "treats a missing customer at %s as terminal and completes the dispute",
+    async (boundary) => {
+      rejectBoundary(boundary, missingCustomerError);
+
+      const { POST } = await import("../route");
+      const response = await POST(makeRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockConvexMutation).toHaveBeenCalledWith(
+        "userSuspensions.upsertActive",
+        expect.objectContaining({
+          userId: "user_opaque",
+          category: "dispute_fraudulent",
+          sourceId: "dp_fraudulent",
+          stripeCustomerId: "cus_deleted",
+        }),
+      );
+      expect(mockUpdateCharge).toHaveBeenCalledWith("ch_disputed", {
+        fraud_details: { user_report: "fraudulent" },
+      });
+      expect(mockConvexMutation).toHaveBeenCalledWith(
+        "extraUsage.finalizeWebhookProcessing",
+        expect.objectContaining({ eventId: "evt_dispute" }),
+      );
+
+      const suspensionCall = mockConvexMutation.mock.calls.findIndex(
+        ([operation]) => operation === "userSuspensions.upsertActive",
+      );
+      expect(suspensionCall).toBeGreaterThanOrEqual(0);
+      expect(
+        mockConvexMutation.mock.invocationCallOrder[suspensionCall],
+      ).toBeLessThan(mockListSubscriptions.mock.invocationCallOrder[0]!);
+    },
+  );
+
+  it.each<CustomerBoundary>([
+    "subscriptions.list",
+    "paymentMethods.list",
+    "customers.update",
+  ])("keeps a transient error at %s retriable", async (boundary) => {
+    rejectBoundary(boundary, transientStripeError);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "userSuspensions.upsertActive",
+      expect.any(Object),
+    );
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "extraUsage.finalizeWebhookProcessing",
+      expect.any(Object),
+    );
+  });
+
+  it("applies a non-fraudulent billing hold before terminal cleanup", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_dispute_non_fraudulent",
+      type: "charge.dispute.created",
+      data: {
+        object: {
+          id: "dp_duplicate",
+          reason: "duplicate",
+          amount: 4200,
+          charge: "ch_disputed",
+          created: 1_788_000_000,
+        },
+      },
+    });
+    mockListSubscriptions.mockRejectedValue(missingCustomerError as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "userSuspensions.upsertActive",
+      expect.objectContaining({
+        category: "dispute_billing_hold",
+        sourceId: "dp_duplicate",
+      }),
+    );
+    expect(mockUpdateCustomer).not.toHaveBeenCalled();
+    expect(mockUpdateCharge).not.toHaveBeenCalled();
+
+    const suspensionCall = mockConvexMutation.mock.calls.findIndex(
+      ([operation]) => operation === "userSuspensions.upsertActive",
+    );
+    expect(
+      mockConvexMutation.mock.invocationCallOrder[suspensionCall],
+    ).toBeLessThan(mockListSubscriptions.mock.invocationCallOrder[0]!);
+  });
+});

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -38,11 +38,22 @@ async function cancelAllSubscriptions(
   customerId: string,
   asOfUnix: number,
 ): Promise<void> {
-  const subs = await stripe.subscriptions.list({
-    customer: customerId,
-    status: "all",
-    limit: 100,
-  });
+  let subs: Stripe.ApiList<Stripe.Subscription>;
+  try {
+    subs = await stripe.subscriptions.list({
+      customer: customerId,
+      status: "all",
+      limit: 100,
+    });
+  } catch (err) {
+    if (isTerminalStripeResourceError(err)) {
+      console.log(
+        `[Fraud Webhook] Subscription cleanup skipped for customer ${customerId}: resource_missing`,
+      );
+      return;
+    }
+    throw err;
+  }
 
   for (const sub of subs.data) {
     if (sub.created > asOfUnix) {
@@ -78,10 +89,21 @@ async function detachAllPaymentMethods(
   customerId: string,
   asOfUnix: number,
 ): Promise<void> {
-  const paymentMethods = await stripe.paymentMethods.list({
-    customer: customerId,
-    limit: 100,
-  });
+  let paymentMethods: Stripe.ApiList<Stripe.PaymentMethod>;
+  try {
+    paymentMethods = await stripe.paymentMethods.list({
+      customer: customerId,
+      limit: 100,
+    });
+  } catch (err) {
+    if (isTerminalStripeResourceError(err)) {
+      console.log(
+        `[Fraud Webhook] Payment method cleanup skipped for customer ${customerId}: resource_missing`,
+      );
+      return;
+    }
+    throw err;
+  }
 
   for (const pm of paymentMethods.data) {
     if (pm.created > asOfUnix) {
@@ -113,13 +135,23 @@ async function markCustomerBlocked(
   customerId: string,
   reason: string,
 ): Promise<void> {
-  await stripe.customers.update(customerId, {
-    metadata: {
-      blocked: "true",
-      blocked_at: new Date().toISOString(),
-      blocked_reason: reason,
-    },
-  });
+  try {
+    await stripe.customers.update(customerId, {
+      metadata: {
+        blocked: "true",
+        blocked_at: new Date().toISOString(),
+        blocked_reason: reason,
+      },
+    });
+  } catch (err) {
+    if (isTerminalStripeResourceError(err)) {
+      console.log(
+        `[Fraud Webhook] Block metadata skipped for customer ${customerId}: resource_missing`,
+      );
+      return;
+    }
+    throw err;
+  }
 }
 
 /** Report a charge as fraudulent — feeds Stripe Radar's ML models. */
@@ -181,6 +213,7 @@ async function suspendCustomerUsers({
 /**
  * Block a fraudulent user without deleting anything.
  *
+ * - Suspend cost-incurring app usage
  * - Cancel all subscriptions (stops billing)
  * - Detach all payment methods (prevents future charges)
  * - Mark customer as blocked (metadata flag)
@@ -202,12 +235,8 @@ async function blockFraudulentUser(
   },
   asOfUnix: number,
 ): Promise<void> {
-  await cancelAllSubscriptions(customerId, asOfUnix);
-  await detachAllPaymentMethods(customerId, asOfUnix);
-  await markCustomerBlocked(customerId, metadataReason);
-  if (chargeId) {
-    await reportChargeFraudulent(chargeId);
-  }
+  // Suspend first so a customer deleted during Stripe cleanup cannot prevent
+  // the local safety control from being applied. The upsert is replay-safe.
   await suspendCustomerUsers({
     customerId,
     category: suspension.category,
@@ -216,9 +245,15 @@ async function blockFraudulentUser(
     chargeId,
     sourceCreatedUnix: asOfUnix,
   });
+  await cancelAllSubscriptions(customerId, asOfUnix);
+  await detachAllPaymentMethods(customerId, asOfUnix);
+  await markCustomerBlocked(customerId, metadataReason);
+  if (chargeId) {
+    await reportChargeFraudulent(chargeId);
+  }
 
   console.log(
-    `[Fraud Webhook] Blocked customer ${customerId}: subscriptions cancelled, payment methods detached, marked as blocked (${metadataReason})`,
+    `[Fraud Webhook] Processed fraud block for customer ${customerId} (${metadataReason})`,
   );
 }
 
@@ -329,8 +364,6 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
     // AND detach payment methods. Don't mark blocked — the customer can
     // still re-subscribe with a different card, while app usage remains paused
     // until support resolves the suspension.
-    await cancelAllSubscriptions(customerId, dispute.created);
-    await detachAllPaymentMethods(customerId, dispute.created);
     await suspendCustomerUsers({
       customerId,
       category: "dispute_billing_hold",
@@ -339,8 +372,10 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
       chargeId,
       sourceCreatedUnix: dispute.created,
     });
+    await cancelAllSubscriptions(customerId, dispute.created);
+    await detachAllPaymentMethods(customerId, dispute.created);
     console.log(
-      `[Fraud Webhook] Cancelled subscriptions and detached payment methods for customer ${customerId} (non-fraudulent dispute ${dispute.id}, reason: ${dispute.reason})`,
+      `[Fraud Webhook] Processed billing hold for customer ${customerId} (non-fraudulent dispute ${dispute.id}, reason: ${dispute.reason})`,
     );
   }
 }


### PR DESCRIPTION
## Production evidence

Daily production error triage for the frozen window `2026-08-29T20:02:30Z`–`2026-08-30T20:02:30Z` found one `/api/fraud/webhook` HTTP 500 while processing `charge.dispute.created`.

The trace showed subscription cleanup reach an idempotent `resource_missing` state, followed by `stripe.paymentMethods.list({ customer })` throwing `StripeInvalidRequestError: No such customer`. The event claim remains pending/reclaimable, so Stripe can retry after this fix is deployed.

## Root cause

Per-resource cancellation/detachment already treated missing resources as terminal, but the customer-scoped `subscriptions.list`, `paymentMethods.list`, and `customers.update` boundaries did not. A customer deleted during cleanup therefore failed the whole webhook and prevented finalization.

## Change

- Treat only Stripe `resource_missing` errors at the three customer-scoped boundaries as terminal idempotent completion.
- Preserve all transient Stripe errors so the webhook returns 500 and remains retryable.
- Apply the replay-safe Convex suspension upsert before Stripe cleanup, preventing a mid-handler deletion from bypassing the local safety control.
- Keep final logs accurate when cleanup is intentionally skipped.
- Cover fraudulent and non-fraudulent disputes, terminal errors at every boundary, ordering, finalization, and transient retry behavior.

## Validation

- Focused Jest: 7/7 tests.
- TypeScript: passed.
- Changed-file ESLint: passed.
- Prettier and `git diff --check`: passed.
- Commit hooks: 415 suites / 4,427 tests, all passing.

## Manual verification

In Stripe test mode or Preview:

1. Deliver a `charge.dispute.created` event for a customer that resolves to a test user.
2. Delete the Stripe customer between user resolution and customer-scoped cleanup, or mock `resource_missing` at each boundary.
3. Confirm the local suspension is active, the webhook returns 200, and the event claim finalizes.
4. Repeat with a transient Stripe API error and confirm the webhook returns 500 without finalizing, allowing retry.

No production retry, webhook replay, deployment, or external mutation was performed by this audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fraud webhook processing when referenced Stripe resources are missing.
  * Prevented cleanup failures from interrupting other fraud-related actions.
  * Suspended affected accounts before completing fraud-related cleanup.
  * Improved handling of non-fraudulent disputes by recording billing holds and completion status.
  * Added safeguards so temporary Stripe errors can be retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->