### PR TITLE
Add regional user file storage with legacy fallback

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -52,6 +52,13 @@ AWS_S3_SECRET_ACCESS_KEY=
 AWS_S3_REGION=us-east-1
 AWS_S3_BUCKET_NAME=
 
+# Regional storage rollout. Keep false until the matching bucket names and IAM
+# access are configured in both Convex and Trigger.dev for this environment.
+S3_REGIONAL_STORAGE_ENABLED=false
+AWS_S3_BUCKET_NAME_EU_CENTRAL_1=
+AWS_S3_BUCKET_NAME_US_EAST_1=
+AWS_S3_BUCKET_NAME_US_WEST_2=
+
 # Optional S3 configuration (defaults shown, uncomment to override)
 # S3_URL_LIFETIME_SECONDS=3600
 # S3_URL_EXPIRATION_BUFFER_SECONDS=300

--- a/app/api/file-storage/region/route.ts
+++ b/app/api/file-storage/region/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getTriggerRegionForVercelRequest } from "@/lib/api/trigger-region";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(request: NextRequest) {
+  const region = getTriggerRegionForVercelRequest(request) ?? "us-east-1";
+
+  return NextResponse.json(
+    { region },
+    {
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    },
+  );
+}

--- a/app/components/tools/FileHandler.tsx
+++ b/app/components/tools/FileHandler.tsx
@@ -16,6 +16,7 @@ import {
   ToolApprovalControls,
   useAgentAutoReviewLifecycleDisplay,
 } from "./ToolApprovalControls";
+import { getFileToolDisplayTarget } from "./file-tool-display";
 
 interface FileInput {
   action: "view" | "read" | "write" | "append" | "edit";
@@ -116,7 +117,7 @@ export const FileHandler = memo(function FileHandler({
   const briefLabel = (fallback: string) =>
     useBriefOnly ? briefText : fallback;
   const briefTarget = (fallback: string | undefined) =>
-    useBriefOnly ? undefined : fallback;
+    useBriefOnly ? undefined : getFileToolDisplayTarget(fallback);
   const errorLabel = (failed: string, stopped: string) =>
     isStoppedByUser ? stopped : failed;
 
@@ -325,7 +326,7 @@ export const FileHandler = memo(function FileHandler({
         FILE_APPROVAL_TITLES[action ?? "write"] ??
         "Allow HackerAI to change this file?"
       }
-      target={target}
+      target={getFileToolDisplayTarget(target)}
       detail="Approve to continue, or deny to stop this file change."
       kind="file"
       autoReview={autoReview}
@@ -346,7 +347,10 @@ export const FileHandler = memo(function FileHandler({
           <ToolBlock
             icon={icon}
             action={display.action}
-            target={getToolApprovalDisplayTarget({ sendState, target })}
+            target={getToolApprovalDisplayTarget({
+              sendState,
+              target: getFileToolDisplayTarget(target),
+            })}
             isShimmer={display.isShimmer}
             isClickable={isClickable}
             onClick={isClickable ? handleOpenInSidebar : undefined}
@@ -414,7 +418,9 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FileText />}
               action="Stopped reading"
-              target={`${input.path}${getFileRange()}`}
+              target={getFileToolDisplayTarget(
+                `${input.path}${getFileRange()}`,
+              )}
             />
           );
         }
@@ -433,7 +439,9 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FileText />}
               action="Stopped reading"
-              target={`${input.path}${getFileRange()}`}
+              target={getFileToolDisplayTarget(
+                `${input.path}${getFileRange()}`,
+              )}
             />
           );
         }
@@ -488,7 +496,7 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FilePlus />}
               action="Stopped writing"
-              target={input.path}
+              target={getFileToolDisplayTarget(input.path)}
               isClickable={isClickable}
               onClick={isClickable ? handleOpenInSidebar : undefined}
               onKeyDown={isClickable ? handleKeyDown : undefined}
@@ -517,7 +525,7 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FilePlus />}
               action="Stopped writing"
-              target={input.path}
+              target={getFileToolDisplayTarget(input.path)}
               isClickable={isClickable}
               onClick={isClickable ? handleOpenInSidebar : undefined}
               onKeyDown={isClickable ? handleKeyDown : undefined}
@@ -582,7 +590,7 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FileOutput />}
               action="Stopped appending to"
-              target={input.path}
+              target={getFileToolDisplayTarget(input.path)}
               isClickable={isClickable}
               onClick={isClickable ? handleOpenInSidebar : undefined}
               onKeyDown={isClickable ? handleKeyDown : undefined}
@@ -611,7 +619,7 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FileOutput />}
               action="Stopped appending to"
-              target={input.path}
+              target={getFileToolDisplayTarget(input.path)}
               isClickable={isClickable}
               onClick={isClickable ? handleOpenInSidebar : undefined}
               onKeyDown={isClickable ? handleKeyDown : undefined}
@@ -672,7 +680,7 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FilePen />}
               action="Stopped editing"
-              target={input.path}
+              target={getFileToolDisplayTarget(input.path)}
             />
           );
         }
@@ -691,7 +699,7 @@ export const FileHandler = memo(function FileHandler({
               key={toolCallId}
               icon={<FilePen />}
               action="Stopped editing"
-              target={input.path}
+              target={getFileToolDisplayTarget(input.path)}
             />
           );
         }

--- a/app/components/tools/FileToolsHandler.tsx
+++ b/app/components/tools/FileToolsHandler.tsx
@@ -19,6 +19,7 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
+import { getFileToolDisplayTarget } from "./file-tool-display";
 
 interface DiffDataPart {
   type: "data-diff";
@@ -82,8 +83,7 @@ export const FileToolsHandler = ({
       (state === "input-streaming" || state === "input-available")
     ) {
       const writeInput = input as
-        | { file_path: string; contents: string }
-        | undefined;
+        { file_path: string; contents: string } | undefined;
       if (!writeInput?.file_path) return null;
       if (state === "input-streaming" && !writeInput.contents) return null;
       return {
@@ -100,8 +100,7 @@ export const FileToolsHandler = ({
 
     if (type === "tool-read_file") {
       const readInput = input as
-        | { target_file: string; offset?: number; limit?: number }
-        | undefined;
+        { target_file: string; offset?: number; limit?: number } | undefined;
       if (!readInput) return null;
       const readOutput = output as { result: string };
       const cleanContent = readOutput?.result?.replace(/^\s*\d+\|/gm, "") || "";
@@ -124,8 +123,7 @@ export const FileToolsHandler = ({
 
     if (type === "tool-write_file") {
       const writeInput = input as
-        | { file_path: string; contents: string }
-        | undefined;
+        { file_path: string; contents: string } | undefined;
       if (!writeInput) return null;
       return {
         path: writeInput.file_path,
@@ -206,8 +204,7 @@ export const FileToolsHandler = ({
   const renderReadFileTool = () => {
     const { toolCallId, state, input } = part;
     const readInput = input as
-      | { target_file: string; offset?: number; limit?: number }
-      | undefined;
+      { target_file: string; offset?: number; limit?: number } | undefined;
 
     const getFileRange = () => {
       if (!readInput) return "";
@@ -241,7 +238,9 @@ export const FileToolsHandler = ({
             action="Reading"
             target={
               readInput
-                ? `${readInput.target_file}${getFileRange()}`
+                ? getFileToolDisplayTarget(
+                    `${readInput.target_file}${getFileRange()}`,
+                  )
                 : undefined
             }
             isShimmer={true}
@@ -256,7 +255,9 @@ export const FileToolsHandler = ({
               key={toolCallId}
               icon={<FileText />}
               action="Read"
-              target={`${readInput.target_file}${getFileRange()}`}
+              target={getFileToolDisplayTarget(
+                `${readInput.target_file}${getFileRange()}`,
+              )}
               isClickable={isClickable}
               onClick={handleOpenInSidebar}
               onKeyDown={handleKeyDown}
@@ -272,7 +273,9 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FileText />}
             action={errorLabel("Failed to read", "Stopped reading")}
-            target={`${readInput.target_file}${getFileRange()}`}
+            target={getFileToolDisplayTarget(
+              `${readInput.target_file}${getFileRange()}`,
+            )}
           />
         );
       default:
@@ -283,8 +286,7 @@ export const FileToolsHandler = ({
   const renderWriteFileTool = () => {
     const { toolCallId, state, input } = part;
     const writeInput = input as
-      | { file_path: string; contents: string }
-      | undefined;
+      { file_path: string; contents: string } | undefined;
 
     switch (state) {
       case "input-streaming": {
@@ -298,7 +300,9 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FilePlus />}
             action={hasContent ? "Creating" : "Creating file"}
-            target={hasFilePath ? writeInput.file_path : undefined}
+            target={getFileToolDisplayTarget(
+              hasFilePath ? writeInput.file_path : undefined,
+            )}
             isShimmer={true}
             isClickable={isClickable}
             onClick={isClickable ? handleOpenInSidebar : undefined}
@@ -313,7 +317,7 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FilePlus />}
             action="Writing to"
-            target={writeInput?.file_path}
+            target={getFileToolDisplayTarget(writeInput?.file_path)}
             isShimmer={true}
             isClickable={isClickable}
             onClick={isClickable ? handleOpenInSidebar : undefined}
@@ -328,7 +332,7 @@ export const FileToolsHandler = ({
               key={toolCallId}
               icon={<FilePlus />}
               action="Successfully wrote"
-              target={writeInput.file_path}
+              target={getFileToolDisplayTarget(writeInput.file_path)}
               isClickable={isClickable}
               onClick={handleOpenInSidebar}
               onKeyDown={handleKeyDown}
@@ -343,7 +347,7 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FilePlus />}
             action={errorLabel("Failed to write", "Stopped writing")}
-            target={writeInput.file_path}
+            target={getFileToolDisplayTarget(writeInput.file_path)}
           />
         );
       default:
@@ -354,8 +358,7 @@ export const FileToolsHandler = ({
   const renderDeleteFileTool = () => {
     const { toolCallId, state, input, output } = part;
     const deleteInput = input as
-      | { target_file: string; explanation: string }
-      | undefined;
+      { target_file: string; explanation: string } | undefined;
 
     switch (state) {
       case "input-streaming":
@@ -373,7 +376,7 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FileMinus />}
             action="Deleting"
-            target={deleteInput?.target_file}
+            target={getFileToolDisplayTarget(deleteInput?.target_file)}
             isShimmer={true}
           />
         ) : null;
@@ -387,7 +390,7 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FileMinus />}
             action={isSuccess ? "Successfully deleted" : "Failed to delete"}
-            target={deleteInput.target_file}
+            target={getFileToolDisplayTarget(deleteInput.target_file)}
           />
         );
       }
@@ -398,7 +401,7 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FileMinus />}
             action={errorLabel("Failed to delete", "Stopped deleting")}
-            target={deleteInput.target_file}
+            target={getFileToolDisplayTarget(deleteInput.target_file)}
           />
         );
       default:
@@ -435,7 +438,7 @@ export const FileToolsHandler = ({
             action={
               searchReplaceInput?.replace_all ? "Replacing all in" : "Editing"
             }
-            target={searchReplaceInput?.file_path}
+            target={getFileToolDisplayTarget(searchReplaceInput?.file_path)}
             isShimmer={true}
           />
         ) : null;
@@ -451,7 +454,7 @@ export const FileToolsHandler = ({
               key={toolCallId}
               icon={<FilePen />}
               action={isSuccess ? "Successfully edited" : "Failed to edit"}
-              target={searchReplaceInput.file_path}
+              target={getFileToolDisplayTarget(searchReplaceInput.file_path)}
               isClickable={isClickable}
               onClick={handleOpenInSidebar}
               onKeyDown={handleKeyDown}
@@ -467,7 +470,7 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FilePen />}
             action={errorLabel("Failed to edit", "Stopped editing")}
-            target={searchReplaceInput.file_path}
+            target={getFileToolDisplayTarget(searchReplaceInput.file_path)}
           />
         );
       default:
@@ -508,7 +511,7 @@ export const FileToolsHandler = ({
                 ? `Making ${multiEditInput.edits.length} edits to`
                 : "Making edits"
             }
-            target={multiEditInput?.file_path}
+            target={getFileToolDisplayTarget(multiEditInput?.file_path)}
             isShimmer={true}
           />
         ) : null;
@@ -529,7 +532,7 @@ export const FileToolsHandler = ({
                   ? `Successfully applied ${multiEditInput.edits.length} edits`
                   : "Failed to apply edits"
               }
-              target={multiEditInput.file_path}
+              target={getFileToolDisplayTarget(multiEditInput.file_path)}
             />
             <OpenFileButton filePath={multiEditInput.file_path} />
           </div>
@@ -542,7 +545,7 @@ export const FileToolsHandler = ({
             key={toolCallId}
             icon={<FilePen />}
             action={errorLabel("Failed to apply edits", "Stopped editing")}
-            target={multiEditInput.file_path}
+            target={getFileToolDisplayTarget(multiEditInput.file_path)}
           />
         );
       default:

--- a/app/components/tools/__tests__/file-tool-display.test.ts
+++ b/app/components/tools/__tests__/file-tool-display.test.ts
@@ -1,0 +1,23 @@
+import { getFileToolDisplayTarget } from "../file-tool-display";
+
+describe("getFileToolDisplayTarget", () => {
+  it("hides shortened attachment namespaces", () => {
+    expect(
+      getFileToolDisplayTarget("/home/user/upload/0123456789abcdef/report.pdf"),
+    ).toBe("report.pdf");
+  });
+
+  it("hides full collision-fallback namespaces and preserves line ranges", () => {
+    expect(
+      getFileToolDisplayTarget(
+        `/tmp/hackerai-upload/${"a".repeat(64)}/report.pdf L2-4`,
+      ),
+    ).toBe("report.pdf L2-4");
+  });
+
+  it("preserves ordinary sandbox paths", () => {
+    expect(getFileToolDisplayTarget("/home/user/results/report.pdf")).toBe(
+      "/home/user/results/report.pdf",
+    );
+  });
+});

--- a/app/components/tools/file-tool-display.ts
+++ b/app/components/tools/file-tool-display.ts
@@ -1,0 +1,9 @@
+const SANDBOX_UPLOAD_TARGET =
+  /^(?:\/home\/user\/upload|\/tmp\/hackerai-upload)\/(?:[a-f0-9]{16}|[a-f0-9]{64})\/([^/]+)$/i;
+
+export const getFileToolDisplayTarget = (
+  target: string | undefined,
+): string | undefined => {
+  if (!target) return target;
+  return SANDBOX_UPLOAD_TARGET.exec(target)?.[1] ?? target;
+};

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -31,6 +31,7 @@ import {
   writeGeneratedTextAttachment,
 } from "./useTauri";
 import { PASTED_TEXT_ATTACHMENT_MIN_CHARS } from "@/lib/utils/pasted-text-attachments";
+import { getPreferredFileStorageRegion } from "@/lib/storage/file-storage-region";
 
 // Show warning when remaining uploads are at or below this threshold
 const RATE_LIMIT_WARNING_THRESHOLD = 10;
@@ -160,6 +161,9 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     sandboxPreference,
   } = useGlobalState();
   const uploadedFilesRef = useRef(uploadedFiles);
+  const preferredStorageRegionPromiseRef = useRef<ReturnType<
+    typeof getPreferredFileStorageRegion
+  > | null>(null);
 
   useEffect(() => {
     uploadedFilesRef.current = uploadedFiles;
@@ -356,13 +360,18 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           sandboxPreference,
         });
 
-        // Step 1: Generate presigned S3 upload URL
+        // Step 1: Generate presigned S3 upload URL in the closest configured
+        // storage region. Region lookup failure safely uses legacy storage.
+        preferredStorageRegionPromiseRef.current ??=
+          getPreferredFileStorageRegion();
+        const storageRegion = await preferredStorageRegionPromiseRef.current;
         const { uploadUrl, s3Key, rateLimit } = await generateS3UploadUrlAction(
           {
             fileName: file.name,
             contentType: file.type || "application/octet-stream",
             size: file.size,
             mode,
+            ...(storageRegion ? { storageRegion } : {}),
           },
         );
 

--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -38,6 +38,7 @@ jest.mock("../_generated/api", () => ({
   internal: {
     fileStorage: {
       saveFileToDb: "internal.fileStorage.saveFileToDb",
+      getFileByS3Key: "internal.fileStorage.getFileByS3Key",
     },
     s3Cleanup: {
       deleteS3ObjectAction: "internal.s3Cleanup.deleteS3ObjectAction",
@@ -48,6 +49,7 @@ jest.mock("../_generated/api", () => ({
 jest.mock("../s3Utils", () => ({
   generateS3DownloadUrl: jest.fn(),
   getS3ObjectSizeBytes: jest.fn(),
+  getStoredS3Location: jest.fn(),
 }));
 
 jest.mock("pdfjs-serverless", () => ({
@@ -128,7 +130,7 @@ describe("fileActions saveFile upload policy", () => {
       scheduler: {
         runAfter: jest.fn().mockResolvedValue(undefined),
       },
-      runQuery: jest.fn(),
+      runQuery: jest.fn().mockResolvedValue({ user_id: "user123" }),
       runMutation: jest.fn().mockResolvedValue("file_123"),
     }) as any;
 
@@ -138,8 +140,9 @@ describe("fileActions saveFile upload policy", () => {
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
     global.fetch = jest.fn() as any;
 
-    const { generateS3DownloadUrl, getS3ObjectSizeBytes } =
+    const { generateS3DownloadUrl, getS3ObjectSizeBytes, getStoredS3Location } =
       await import("../s3Utils");
+    (getStoredS3Location as jest.Mock).mockReturnValue(undefined);
     (generateS3DownloadUrl as jest.Mock).mockResolvedValue(
       "https://s3.example/download",
     );
@@ -212,7 +215,10 @@ describe("fileActions saveFile upload policy", () => {
       { s3Key: "users/user123/notes.txt" },
     );
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(ctx.runQuery).not.toHaveBeenCalled();
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      "internal.fileStorage.getFileByS3Key",
+      { s3Key: "users/user123/notes.txt" },
+    );
     expect(ctx.runMutation).toHaveBeenCalledWith(
       "internal.fileStorage.saveFileToDb",
       expect.objectContaining({
@@ -275,7 +281,10 @@ describe("fileActions saveFile upload policy", () => {
       { s3Key: "users/user123/orphan.txt" },
     );
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(ctx.runQuery).not.toHaveBeenCalled();
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      "internal.fileStorage.getFileByS3Key",
+      { s3Key: "users/user123/orphan.txt" },
+    );
     expect(ctx.runMutation).toHaveBeenCalledWith(
       "internal.fileStorage.saveFileToDb",
       expect.objectContaining({ s3Key: "users/user123/orphan.txt" }),

--- a/convex/__tests__/fileStorage.aggregate.test.ts
+++ b/convex/__tests__/fileStorage.aggregate.test.ts
@@ -17,6 +17,7 @@ jest.mock("convex/values", () => ({
     optional: jest.fn(() => "optional"),
     object: jest.fn(() => "object"),
     union: jest.fn(() => "union"),
+    literal: jest.fn(() => "literal"),
     array: jest.fn(() => "array"),
     boolean: jest.fn(() => "boolean"),
   },
@@ -326,6 +327,8 @@ describe("fileStorage - Aggregate Integration", () => {
         name: "test.pdf",
         mediaType: "application/pdf",
         size: 1024,
+        s3Region: "us-west-2",
+        s3Bucket: "test-west-bucket",
         fileTokenSize: 100,
         trustedServiceGenerated: true,
       });
@@ -336,6 +339,8 @@ describe("fileStorage - Aggregate Integration", () => {
         expect.objectContaining({
           user_id: testUserId,
           s3_key: "users/test-user-123/test.pdf",
+          s3_region: "us-west-2",
+          s3_bucket: "test-west-bucket",
           name: "test.pdf",
           is_attached: false,
         }),
@@ -587,6 +592,8 @@ describe("fileStorage - Aggregate Integration", () => {
         name: "file.pdf",
         mediaType: "application/pdf",
         size: 1024,
+        s3Region: "us-west-2",
+        s3Bucket: "test-west-bucket",
       });
 
       expect(result).toBe(testFileId);
@@ -594,6 +601,8 @@ describe("fileStorage - Aggregate Integration", () => {
         "files",
         expect.objectContaining({
           s3_key: "users/test-user-123/file.pdf",
+          s3_region: "us-west-2",
+          s3_bucket: "test-west-bucket",
           user_id: testUserId,
           size: 1024,
           file_token_size: 0,

--- a/convex/__tests__/fileStorage.delete.test.ts
+++ b/convex/__tests__/fileStorage.delete.test.ts
@@ -17,6 +17,7 @@ jest.mock("convex/values", () => ({
     optional: jest.fn(() => "optional"),
     object: jest.fn(() => "object"),
     union: jest.fn(() => "union"),
+    literal: jest.fn(() => "literal"),
     array: jest.fn(() => "array"),
     boolean: jest.fn(() => "boolean"),
   },

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -51,6 +51,11 @@ describe("s3Actions", () => {
       reset: Date.now() + 5 * 60 * 60 * 1000,
     });
 
+    const { getStoredS3Location } = await import("../s3Utils");
+    (
+      getStoredS3Location as jest.MockedFunction<typeof getStoredS3Location>
+    ).mockReturnValue(undefined);
+
     // Setup environment variables
     process.env.AWS_S3_ACCESS_KEY_ID = "test-access-key";
     process.env.AWS_S3_SECRET_ACCESS_KEY = "test-secret-key";
@@ -67,6 +72,7 @@ describe("s3Actions", () => {
       mockGenerateS3UploadUrl.mockResolvedValue({
         uploadUrl: "https://s3.amazonaws.com/test-upload-url",
         s3Key: "users/user123/123-uuid-test.pdf",
+        storageLocation: { region: "us-east-1", bucket: "test-bucket" },
       });
 
       const { generateS3UploadUrlAction } = await import("../s3Actions");
@@ -119,6 +125,8 @@ describe("s3Actions", () => {
           name: "test.pdf",
           mediaType: "application/pdf",
           size: 1024,
+          s3Region: "us-east-1",
+          s3Bucket: "test-bucket",
         },
       );
 
@@ -209,6 +217,50 @@ describe("s3Actions", () => {
           contentType: "application/pdf",
         }),
       ).rejects.toThrow("Unauthenticated");
+    });
+
+    it("uses the persisted bucket and region for regional files", async () => {
+      const { generateS3DownloadUrl, getStoredS3Location } =
+        await import("../s3Utils");
+      const storageLocation = {
+        region: "eu-central-1" as const,
+        bucket: "test-eu-bucket",
+      };
+      (
+        getStoredS3Location as jest.MockedFunction<typeof getStoredS3Location>
+      ).mockReturnValue(storageLocation);
+      (
+        generateS3DownloadUrl as jest.MockedFunction<
+          typeof generateS3DownloadUrl
+        >
+      ).mockResolvedValue("https://s3.example/regional-download");
+      const { getFileUrlAction } = await import("../s3Actions");
+      const mockCtx = {
+        auth: {
+          getUserIdentity: jest.fn().mockResolvedValue({ subject: "user123" }),
+        },
+        runQuery: jest.fn().mockResolvedValue({
+          s3_key: "users/user123/regional.pdf",
+          s3_region: "eu-central-1",
+          s3_bucket: "test-eu-bucket",
+          user_id: "user123",
+          name: "regional.pdf",
+          media_type: "application/pdf",
+          size: 1024,
+        }),
+      } as any;
+
+      await expect(
+        getFileUrlAction.handler(mockCtx, { fileId: "file123" as any }),
+      ).resolves.toBe("https://s3.example/regional-download");
+      expect(getStoredS3Location).toHaveBeenCalledWith(
+        "eu-central-1",
+        "test-eu-bucket",
+      );
+      expect(generateS3DownloadUrl).toHaveBeenCalledWith(
+        "users/user123/regional.pdf",
+        storageLocation,
+      );
     });
 
     it("should throw error for empty fileName", async () => {
@@ -370,6 +422,7 @@ describe("s3Actions", () => {
         mockGenerateS3UploadUrl.mockResolvedValue({
           uploadUrl: "https://s3.amazonaws.com/test-upload-url",
           s3Key: `users/user123/123-uuid-${testCase.fileName}`,
+          storageLocation: { region: "us-east-1", bucket: "test-bucket" },
         });
 
         // Create mock context with runQuery for storage check
@@ -447,6 +500,7 @@ describe("s3Actions", () => {
       mockGenerateS3UploadUrl.mockResolvedValue({
         uploadUrl: "https://s3.amazonaws.com/test-upload-url",
         s3Key: "users/user123/123-uuid-test.pdf",
+        storageLocation: { region: "us-east-1", bucket: "test-bucket" },
       });
 
       // Mock rate limit to return null (Redis not configured)

--- a/convex/__tests__/s3Cleanup.test.ts
+++ b/convex/__tests__/s3Cleanup.test.ts
@@ -17,6 +17,10 @@ jest.mock("convex/values", () => ({
     string: jest.fn(() => "string"),
     array: jest.fn(() => "array"),
     null: jest.fn(() => "null"),
+    optional: jest.fn(() => "optional"),
+    union: jest.fn(() => "union"),
+    literal: jest.fn(() => "literal"),
+    object: jest.fn(() => "object"),
   },
 }));
 
@@ -64,6 +68,10 @@ describe("s3Cleanup", () => {
           string: jest.fn(() => "string"),
           array: jest.fn(() => "array"),
           null: jest.fn(() => "null"),
+          optional: jest.fn(() => "optional"),
+          union: jest.fn(() => "union"),
+          literal: jest.fn(() => "literal"),
+          object: jest.fn(() => "object"),
         },
       }));
 
@@ -122,6 +130,41 @@ describe("s3Cleanup", () => {
       expect(mockDeleteS3Object).toHaveBeenCalledWith(args.s3Keys[0]);
       expect(mockDeleteS3Object).toHaveBeenCalledWith(args.s3Keys[1]);
       expect(mockDeleteS3Object).toHaveBeenCalledWith(args.s3Keys[2]);
+    });
+
+    it("deletes regional objects from their persisted location", async () => {
+      const { deleteS3Object, getStoredS3Location } =
+        await import("../s3Utils");
+      const storageLocation = {
+        region: "us-west-2" as const,
+        bucket: "test-west-bucket",
+      };
+      (
+        getStoredS3Location as jest.MockedFunction<typeof getStoredS3Location>
+      ).mockReturnValue(storageLocation);
+      const { deleteS3ObjectsBatchAction } = await import("../s3Cleanup");
+
+      await deleteS3ObjectsBatchAction.handler(
+        {},
+        {
+          s3Objects: [
+            {
+              s3Key: "users/user123/regional.pdf",
+              s3Region: "us-west-2",
+              s3Bucket: "test-west-bucket",
+            },
+          ],
+        },
+      );
+
+      expect(getStoredS3Location).toHaveBeenCalledWith(
+        "us-west-2",
+        "test-west-bucket",
+      );
+      expect(deleteS3Object).toHaveBeenCalledWith(
+        "users/user123/regional.pdf",
+        storageLocation,
+      );
     });
 
     it("should log error count when some deletions fail", async () => {

--- a/convex/__tests__/s3Cleanup.test.ts
+++ b/convex/__tests__/s3Cleanup.test.ts
@@ -167,6 +167,47 @@ describe("s3Cleanup", () => {
       );
     });
 
+    it("continues after malformed location metadata fails synchronously", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      const { deleteS3Object, getStoredS3Location } =
+        await import("../s3Utils");
+      (
+        getStoredS3Location as jest.MockedFunction<typeof getStoredS3Location>
+      ).mockImplementation((region, bucket) => {
+        if (region && !bucket) {
+          throw new Error("Incomplete S3 storage location metadata");
+        }
+        return undefined;
+      });
+      const { deleteS3ObjectsBatchAction } = await import("../s3Cleanup");
+
+      await expect(
+        deleteS3ObjectsBatchAction.handler(
+          {},
+          {
+            s3Objects: [
+              {
+                s3Key: "users/user123/malformed.pdf",
+                s3Region: "us-west-2",
+              },
+              { s3Key: "users/user123/legacy.pdf" },
+            ],
+          },
+        ),
+      ).resolves.toBeNull();
+
+      expect(deleteS3Object).toHaveBeenCalledTimes(1);
+      expect(deleteS3Object).toHaveBeenCalledWith("users/user123/legacy.pdf");
+      const logged = JSON.parse(
+        (console.error as jest.Mock).mock.calls[0][0] as string,
+      );
+      expect(logged).toMatchObject({
+        event: "s3_object_batch_delete_failed",
+        failedCount: 1,
+        failedKeys: ["users/user123/malformed.pdf"],
+      });
+    });
+
     it("should log error count when some deletions fail", async () => {
       jest.clearAllMocks();
       jest.spyOn(console, "error").mockImplementation(() => {});

--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -12,6 +12,10 @@ describe("s3Utils", () => {
     process.env.AWS_S3_SECRET_ACCESS_KEY = "test-secret-key";
     process.env.AWS_S3_REGION = "us-east-1";
     process.env.AWS_S3_BUCKET_NAME = "test-bucket";
+    delete process.env.S3_REGIONAL_STORAGE_ENABLED;
+    delete process.env.AWS_S3_BUCKET_NAME_EU_CENTRAL_1;
+    delete process.env.AWS_S3_BUCKET_NAME_US_EAST_1;
+    delete process.env.AWS_S3_BUCKET_NAME_US_WEST_2;
   });
 
   describe("generateS3Key", () => {
@@ -96,6 +100,10 @@ describe("s3Utils", () => {
       // UUID is mocked as "test-uuid-{counter}" in tests
       expect(result.s3Key).toMatch(/^users\/user123\/\d+-test-uuid-\d+\.pdf$/);
       expect(mockGetSignedUrl).toHaveBeenCalled();
+      expect(result.storageLocation).toEqual({
+        region: "us-east-1",
+        bucket: "test-bucket",
+      });
     });
 
     it("should bind expected content length into the PutObject command", async () => {
@@ -130,6 +138,71 @@ describe("s3Utils", () => {
 
       const callArgs = mockGetSignedUrl.mock.calls[0];
       expect(callArgs[2]).toEqual(expect.objectContaining({ expiresIn: 3600 }));
+    });
+
+    it("routes enabled uploads to the requested regional bucket", async () => {
+      const { S3Client, PutObjectCommand } = await import("@aws-sdk/client-s3");
+      const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
+      (
+        getSignedUrl as jest.MockedFunction<typeof getSignedUrl>
+      ).mockResolvedValue("https://s3.amazonaws.com/signed-url");
+      process.env.S3_REGIONAL_STORAGE_ENABLED = "true";
+      process.env.AWS_S3_BUCKET_NAME_EU_CENTRAL_1 = "test-eu-bucket";
+
+      const { generateS3UploadUrl } = await import("../s3Utils");
+      const result = await generateS3UploadUrl(
+        "test.pdf",
+        "application/pdf",
+        "user123",
+        1024,
+        "eu-central-1",
+      );
+
+      expect(result.storageLocation).toEqual({
+        region: "eu-central-1",
+        bucket: "test-eu-bucket",
+      });
+      expect(S3Client).toHaveBeenCalledWith(
+        expect.objectContaining({ region: "eu-central-1" }),
+      );
+      expect(PutObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ Bucket: "test-eu-bucket" }),
+      );
+    });
+
+    it("keeps using legacy storage while regional routing is disabled", async () => {
+      process.env.S3_REGIONAL_STORAGE_ENABLED = "false";
+      process.env.AWS_S3_BUCKET_NAME_EU_CENTRAL_1 = "test-eu-bucket";
+
+      const { resolveS3UploadLocation } = await import("../s3Utils");
+
+      expect(resolveS3UploadLocation("eu-central-1")).toEqual({
+        region: "us-east-1",
+        bucket: "test-bucket",
+      });
+    });
+
+    it("fails closed when an enabled regional bucket is missing", async () => {
+      process.env.S3_REGIONAL_STORAGE_ENABLED = "true";
+      const { resolveS3UploadLocation } = await import("../s3Utils");
+
+      expect(() => resolveS3UploadLocation("eu-central-1")).toThrow(
+        "AWS_S3_BUCKET_NAME_EU_CENTRAL_1",
+      );
+    });
+  });
+
+  describe("getStoredS3Location", () => {
+    it("uses legacy fallback only when both locator fields are absent", async () => {
+      const { getStoredS3Location } = await import("../s3Utils");
+
+      expect(getStoredS3Location()).toBeUndefined();
+      expect(getStoredS3Location("us-west-2", "  exact-west-bucket  ")).toEqual(
+        { region: "us-west-2", bucket: "exact-west-bucket" },
+      );
+      expect(() => getStoredS3Location("us-west-2")).toThrow(
+        "Incomplete S3 storage location metadata",
+      );
     });
   });
 

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -258,7 +258,11 @@ async function deleteMessageForChatDeletion(
             await ctx.scheduler.runAfter(
               0,
               internal.s3Cleanup.deleteS3ObjectAction,
-              { s3Key: file.s3_key },
+              {
+                s3Key: file.s3_key,
+                ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+                ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
+              },
             );
           }
           await fileCountAggregate.deleteIfExists(ctx, file);
@@ -1879,7 +1883,11 @@ export const deleteAllChatsForUser = mutation({
                   await ctx.scheduler.runAfter(
                     0,
                     internal.s3Cleanup.deleteS3ObjectAction,
-                    { s3Key: file.s3_key },
+                    {
+                      s3Key: file.s3_key,
+                      ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+                      ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
+                    },
                   );
                 }
                 await fileCountAggregate.deleteIfExists(ctx, file);

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -20,7 +20,11 @@ import mammoth from "mammoth";
 import WordExtractor from "word-extractor";
 import { isBinaryFile } from "isbinaryfile";
 import { internal } from "./_generated/api";
-import { generateS3DownloadUrl, getS3ObjectSizeBytes } from "./s3Utils";
+import {
+  generateS3DownloadUrl,
+  getS3ObjectSizeBytes,
+  getStoredS3Location,
+} from "./s3Utils";
 import { convexLogger } from "./lib/logger";
 import type {
   FileItemChunk,
@@ -746,6 +750,25 @@ export const saveFile = action({
       });
     }
 
+    const reservation = (await ctx.runQuery(
+      internal.fileStorage.getFileByS3Key,
+      { s3Key },
+    )) as {
+      user_id: string;
+      s3_region?: string;
+      s3_bucket?: string;
+    } | null;
+    if (!reservation || reservation.user_id !== actingUserId) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED_UPLOAD_RESERVATION",
+        message: `Failed to upload ${args.name}: Upload reservation was not found`,
+      });
+    }
+    const storageLocation = getStoredS3Location(
+      reservation.s3_region,
+      reservation.s3_bucket,
+    );
+
     const cleanupUploadedObject = async (stage: string) => {
       try {
         await ctx.scheduler.runAfter(
@@ -753,6 +776,8 @@ export const saveFile = action({
           internal.s3Cleanup.deleteS3ObjectAction,
           {
             s3Key,
+            ...(storageLocation ? { s3Region: storageLocation.region } : {}),
+            ...(storageLocation ? { s3Bucket: storageLocation.bucket } : {}),
           },
         );
       } catch (cleanupError) {
@@ -771,7 +796,7 @@ export const saveFile = action({
 
     let verifiedSize = args.size;
     try {
-      verifiedSize = await getS3ObjectSizeBytes(s3Key);
+      verifiedSize = await getS3ObjectSizeBytes(s3Key, storageLocation);
     } catch (error) {
       convexLogger.error("file_upload_s3_metadata_fetch_failed", {
         userId: actingUserId,
@@ -824,7 +849,7 @@ export const saveFile = action({
       });
     }
 
-    const fileUrl = await generateS3DownloadUrl(s3Key);
+    const fileUrl = await generateS3DownloadUrl(s3Key, storageLocation);
 
     if (!fileUrl) {
       throw new ConvexError({
@@ -1025,6 +1050,8 @@ export const saveSandboxGeneratedFile = action({
     size: v.number(),
     serviceKey: v.string(),
     userId: v.string(),
+    s3Region: v.optional(v.string()),
+    s3Bucket: v.optional(v.string()),
   },
   returns: v.object({
     url: v.string(),
@@ -1033,6 +1060,8 @@ export const saveSandboxGeneratedFile = action({
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
+
+    const storageLocation = getStoredS3Location(args.s3Region, args.s3Bucket);
 
     await checkFileUploadRateLimit(args.userId, false);
 
@@ -1043,6 +1072,8 @@ export const saveSandboxGeneratedFile = action({
           internal.s3Cleanup.deleteS3ObjectAction,
           {
             s3Key: args.s3Key,
+            ...(storageLocation ? { s3Region: storageLocation.region } : {}),
+            ...(storageLocation ? { s3Bucket: storageLocation.bucket } : {}),
           },
         );
       } catch (deleteError) {
@@ -1077,7 +1108,7 @@ export const saveSandboxGeneratedFile = action({
     }
 
     try {
-      const fileUrl = await generateS3DownloadUrl(args.s3Key);
+      const fileUrl = await generateS3DownloadUrl(args.s3Key, storageLocation);
       const fileId = (await ctx.runMutation(internal.fileStorage.saveFileToDb, {
         s3Key: args.s3Key,
         userId: args.userId,
@@ -1086,6 +1117,8 @@ export const saveSandboxGeneratedFile = action({
         size: args.size,
         fileTokenSize: 0,
         trustedServiceGenerated: true,
+        s3Region: storageLocation?.region,
+        s3Bucket: storageLocation?.bucket,
       })) as Id<"files">;
 
       return {

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -100,6 +100,8 @@ export const deleteFile = mutation({
     if (file.s3_key) {
       await ctx.scheduler.runAfter(0, internal.s3Cleanup.deleteS3ObjectAction, {
         s3Key: file.s3_key,
+        ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+        ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
       });
     } else {
       console.warn(
@@ -320,7 +322,11 @@ export const purgeExpiredUnattachedFiles = internalMutation({
           await ctx.scheduler.runAfter(
             0,
             internal.s3Cleanup.deleteS3ObjectAction,
-            { s3Key: file.s3_key },
+            {
+              s3Key: file.s3_key,
+              ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+              ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
+            },
           );
         } else {
           console.warn(
@@ -345,6 +351,8 @@ export const purgeExpiredUnattachedFiles = internalMutation({
 const fileForStorageLookupValidator = v.union(
   v.object({
     s3_key: v.optional(v.string()),
+    s3_region: v.optional(v.string()),
+    s3_bucket: v.optional(v.string()),
     user_id: v.string(),
     name: v.string(),
     media_type: v.string(),
@@ -363,6 +371,8 @@ const toFileForStorageLookup = (file: Doc<"files"> | null) => {
   // whose diagnostic values can include user-authored file content.
   return {
     ...(file.s3_key !== undefined ? { s3_key: file.s3_key } : {}),
+    ...(file.s3_region !== undefined ? { s3_region: file.s3_region } : {}),
+    ...(file.s3_bucket !== undefined ? { s3_bucket: file.s3_bucket } : {}),
     user_id: file.user_id,
     name: file.name,
     media_type: file.media_type,
@@ -408,6 +418,21 @@ export const getFilesByIds = internalQuery({
   },
 });
 
+/** Resolve an upload reservation by its opaque S3 key. */
+export const getFileByS3Key = internalQuery({
+  args: {
+    s3Key: v.string(),
+  },
+  returns: fileForStorageLookupValidator,
+  handler: async (ctx, args) => {
+    const file = await ctx.db
+      .query("files")
+      .withIndex("by_s3_key", (q) => q.eq("s3_key", args.s3Key))
+      .unique();
+    return toFileForStorageLookup(file);
+  },
+});
+
 export const createPendingS3File = internalMutation({
   args: {
     s3Key: v.string(),
@@ -415,6 +440,8 @@ export const createPendingS3File = internalMutation({
     name: v.string(),
     mediaType: v.string(),
     size: v.number(),
+    s3Region: v.optional(v.string()),
+    s3Bucket: v.optional(v.string()),
   },
   returns: v.id("files"),
   handler: async (ctx, args) => {
@@ -442,6 +469,8 @@ export const createPendingS3File = internalMutation({
 
     const fileId = await ctx.db.insert("files", {
       s3_key: args.s3Key,
+      s3_region: args.s3Region,
+      s3_bucket: args.s3Bucket,
       user_id: args.userId,
       name: args.name,
       media_type: args.mediaType,
@@ -473,6 +502,8 @@ export const saveFileToDb = internalMutation({
     fileTokenSize: v.number(),
     content: v.optional(v.string()),
     trustedServiceGenerated: v.optional(v.boolean()),
+    s3Region: v.optional(v.string()),
+    s3Bucket: v.optional(v.string()),
   },
   returns: v.id("files"),
   handler: async (ctx, args) => {
@@ -531,6 +562,8 @@ export const saveFileToDb = internalMutation({
 
     const fileId = await ctx.db.insert("files", {
       s3_key: args.s3Key,
+      s3_region: args.s3Region,
+      s3_bucket: args.s3Bucket,
       user_id: args.userId,
       name: args.name,
       media_type: args.mediaType,

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1321,7 +1321,11 @@ export const deleteLastAssistantMessage = mutation({
                     await ctx.scheduler.runAfter(
                       0,
                       internal.s3Cleanup.deleteS3ObjectAction,
-                      { s3Key: file.s3_key },
+                      {
+                        s3Key: file.s3_key,
+                        ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+                        ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
+                      },
                     );
                   }
                   await fileCountAggregate.deleteIfExists(ctx, file);
@@ -2048,7 +2052,11 @@ export const regenerateWithNewContent = mutation({
               await ctx.scheduler.runAfter(
                 0,
                 internal.s3Cleanup.deleteS3ObjectAction,
-                { s3Key: file.s3_key },
+                {
+                  s3Key: file.s3_key,
+                  ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+                  ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
+                },
               );
             }
             // Delete from aggregate
@@ -2103,7 +2111,11 @@ export const regenerateWithNewContent = mutation({
                   await ctx.scheduler.runAfter(
                     0,
                     internal.s3Cleanup.deleteS3ObjectAction,
-                    { s3Key: file.s3_key },
+                    {
+                      s3Key: file.s3_key,
+                      ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+                      ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
+                    },
                   );
                 }
                 // Delete from aggregate

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -2,7 +2,11 @@
 
 import { action } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
-import { generateS3UploadUrl, generateS3DownloadUrl } from "./s3Utils";
+import {
+  generateS3UploadUrl,
+  generateS3DownloadUrl,
+  getStoredS3Location,
+} from "./s3Utils";
 import { internal } from "./_generated/api";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
@@ -19,6 +23,8 @@ type StorageUsage = {
 /** File record returned by internal.fileStorage.getFileById */
 type FileRecord = {
   s3_key?: string;
+  s3_region?: string;
+  s3_bucket?: string;
   user_id: string;
   name: string;
   media_type: string;
@@ -26,6 +32,23 @@ type FileRecord = {
   auxiliary_vision_description?: string;
   auxiliary_vision_model?: string;
 } | null;
+
+const s3StorageRegionValidator = v.union(
+  v.literal("eu-central-1"),
+  v.literal("us-east-1"),
+  v.literal("us-west-2"),
+);
+
+const getFileStorageLocation = (file: NonNullable<FileRecord>) =>
+  getStoredS3Location(file.s3_region, file.s3_bucket);
+
+const generateFileDownloadUrl = (file: NonNullable<FileRecord>) => {
+  if (!file.s3_key) throw new Error("File has no S3 object reference");
+  const storageLocation = getFileStorageLocation(file);
+  return storageLocation
+    ? generateS3DownloadUrl(file.s3_key, storageLocation)
+    : generateS3DownloadUrl(file.s3_key);
+};
 
 const getFileLookupErrorFields = (error: unknown) => {
   const errorMessage = error instanceof Error ? error.message : "";
@@ -92,6 +115,7 @@ export const generateS3UploadUrlAction = action({
     contentType: v.string(),
     size: v.optional(v.number()),
     mode: v.optional(v.union(v.literal("ask"), v.literal("agent"))),
+    storageRegion: v.optional(s3StorageRegionValidator),
   },
   returns: v.object({
     uploadUrl: v.string(),
@@ -187,12 +211,20 @@ export const generateS3UploadUrlAction = action({
 
     try {
       // Generate presigned upload URL with user-scoped S3 key
-      const { uploadUrl, s3Key } = await generateS3UploadUrl(
-        args.fileName,
-        args.contentType,
-        userId,
-        args.size,
-      );
+      const { uploadUrl, s3Key, storageLocation } = args.storageRegion
+        ? await generateS3UploadUrl(
+            args.fileName,
+            args.contentType,
+            userId,
+            args.size,
+            args.storageRegion,
+          )
+        : await generateS3UploadUrl(
+            args.fileName,
+            args.contentType,
+            userId,
+            args.size,
+          );
 
       await ctx.runMutation(internal.fileStorage.createPendingS3File, {
         s3Key,
@@ -200,6 +232,8 @@ export const generateS3UploadUrlAction = action({
         name: args.fileName,
         mediaType: args.contentType,
         size: args.size,
+        s3Region: storageLocation.region,
+        s3Bucket: storageLocation.bucket,
       });
 
       return {
@@ -282,7 +316,7 @@ export const getFileUrlAction = action({
       }
 
       // S3 file: Generate presigned download URL (valid for 1 hour)
-      return await generateS3DownloadUrl(file.s3_key);
+      return await generateFileDownloadUrl(file);
     } catch (error) {
       convexLogger.error("file_get_url_failed", {
         userId: identity.subject,
@@ -357,7 +391,7 @@ export const getFileUrlsByFileIdsAction = action({
           }
 
           if (file.s3_key) {
-            return await generateS3DownloadUrl(file.s3_key);
+            return await generateFileDownloadUrl(file);
           }
 
           return null;
@@ -431,7 +465,7 @@ export const getFileUrlInfosByFileIdsAction = action({
 
             if (file.s3_key) {
               return {
-                url: await generateS3DownloadUrl(file.s3_key),
+                url: await generateFileDownloadUrl(file),
                 sizeBytes: file.size,
                 mediaType: file.media_type,
                 name: file.name,
@@ -535,7 +569,7 @@ export const getFileUrlsBatchAction = action({
           continue;
         }
 
-        const url = await generateS3DownloadUrl(file.s3_key);
+        const url = await generateFileDownloadUrl(file);
         urlMap[fileId] = url;
       } catch (error) {
         // Log error but continue processing other files (partial failure handling)

--- a/convex/s3Cleanup.ts
+++ b/convex/s3Cleanup.ts
@@ -2,8 +2,25 @@
 
 import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
-import { deleteS3Object } from "./s3Utils";
+import { deleteS3Object, getStoredS3Location } from "./s3Utils";
 import { convexLogger } from "./lib/logger";
+
+const s3ObjectValidator = v.object({
+  s3Key: v.string(),
+  s3Region: v.optional(v.string()),
+  s3Bucket: v.optional(v.string()),
+});
+
+const deleteStoredS3Object = (
+  s3Key: string,
+  s3Region?: string,
+  s3Bucket?: string,
+) => {
+  const storageLocation = getStoredS3Location(s3Region, s3Bucket);
+  return storageLocation
+    ? deleteS3Object(s3Key, storageLocation)
+    : deleteS3Object(s3Key);
+};
 
 /**
  * Delete a single S3 object by key
@@ -17,11 +34,13 @@ import { convexLogger } from "./lib/logger";
 export const deleteS3ObjectAction = internalAction({
   args: {
     s3Key: v.string(),
+    s3Region: v.optional(v.string()),
+    s3Bucket: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     try {
-      await deleteS3Object(args.s3Key);
+      await deleteStoredS3Object(args.s3Key, args.s3Region, args.s3Bucket);
       // console.log(`Successfully deleted S3 object: ${args.s3Key}`);
     } catch (error) {
       convexLogger.error("s3_object_delete_failed", {
@@ -48,12 +67,22 @@ export const deleteS3ObjectAction = internalAction({
  */
 export const deleteS3ObjectsBatchAction = internalAction({
   args: {
-    s3Keys: v.array(v.string()),
+    s3Keys: v.optional(v.array(v.string())),
+    s3Objects: v.optional(v.array(s3ObjectValidator)),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    const s3Objects =
+      args.s3Objects ??
+      (args.s3Keys ?? []).map((s3Key) => ({
+        s3Key,
+        s3Region: undefined,
+        s3Bucket: undefined,
+      }));
     const results = await Promise.allSettled(
-      args.s3Keys.map((key) => deleteS3Object(key)),
+      s3Objects.map((object) =>
+        deleteStoredS3Object(object.s3Key, object.s3Region, object.s3Bucket),
+      ),
     );
 
     const failed = results.filter(
@@ -61,11 +90,11 @@ export const deleteS3ObjectsBatchAction = internalAction({
     );
     if (failed.length > 0) {
       convexLogger.error("s3_object_batch_delete_failed", {
-        totalCount: args.s3Keys.length,
+        totalCount: s3Objects.length,
         failedCount: failed.length,
-        failedKeys: args.s3Keys.filter(
-          (_, i) => results[i].status === "rejected",
-        ),
+        failedKeys: s3Objects
+          .map((object) => object.s3Key)
+          .filter((_, i) => results[i].status === "rejected"),
         firstError:
           failed[0].reason instanceof Error
             ? {

--- a/convex/s3Cleanup.ts
+++ b/convex/s3Cleanup.ts
@@ -80,7 +80,7 @@ export const deleteS3ObjectsBatchAction = internalAction({
         s3Bucket: undefined,
       }));
     const results = await Promise.allSettled(
-      s3Objects.map((object) =>
+      s3Objects.map(async (object) =>
         deleteStoredS3Object(object.s3Key, object.s3Region, object.s3Bucket),
       ),
     );

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -9,7 +9,10 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { v4 as uuidv4 } from "uuid";
 import {
   getS3UrlLifetimeSeconds,
+  S3_REGIONAL_BUCKET_ENV_NAMES,
   S3_USER_FILES_PREFIX,
+  type S3StorageLocation,
+  type S3StorageRegion,
 } from "../lib/constants/s3";
 
 /**
@@ -26,10 +29,61 @@ function getRequiredEnvVar(name: string): string {
 /**
  * Get S3 client with credentials from environment variables
  */
-export function getS3Client(): S3Client {
+function getLegacyS3StorageLocation(): S3StorageLocation {
+  const region = getRequiredEnvVar("AWS_S3_REGION");
+  return {
+    region,
+    bucket: getRequiredEnvVar("AWS_S3_BUCKET_NAME"),
+  };
+}
+
+function isRegionalS3StorageEnabled(): boolean {
+  return process.env.S3_REGIONAL_STORAGE_ENABLED === "true";
+}
+
+/** Resolve the exact bucket used for a new upload. */
+export function resolveS3UploadLocation(
+  requestedRegion?: S3StorageRegion,
+): S3StorageLocation {
+  const legacyLocation = getLegacyS3StorageLocation();
+  if (!requestedRegion || !isRegionalS3StorageEnabled()) {
+    return legacyLocation;
+  }
+
+  const bucketEnvName = S3_REGIONAL_BUCKET_ENV_NAMES[requestedRegion];
+  const bucket = process.env[bucketEnvName]?.trim();
+  if (bucket) {
+    return { region: requestedRegion, bucket };
+  }
+
+  if (legacyLocation.region === requestedRegion) {
+    return legacyLocation;
+  }
+
+  throw new Error(
+    `Missing required environment variable for ${requestedRegion}: ${bucketEnvName}`,
+  );
+}
+
+/**
+ * Convert optional database fields into a storage locator. Historical rows
+ * have neither field and intentionally fall back to the legacy bucket.
+ */
+export function getStoredS3Location(
+  region?: string,
+  bucket?: string,
+): S3StorageLocation | undefined {
+  if (region === undefined && bucket === undefined) return undefined;
+  if (region === undefined || !bucket?.trim()) {
+    throw new Error("Incomplete S3 storage location metadata");
+  }
+  return { region, bucket: bucket.trim() };
+}
+
+export function getS3Client(location?: S3StorageLocation): S3Client {
   const accessKeyId = getRequiredEnvVar("AWS_S3_ACCESS_KEY_ID");
   const secretAccessKey = getRequiredEnvVar("AWS_S3_SECRET_ACCESS_KEY");
-  const region = getRequiredEnvVar("AWS_S3_REGION");
+  const region = location?.region ?? getLegacyS3StorageLocation().region;
 
   return new S3Client({
     region,
@@ -68,14 +122,19 @@ export async function generateS3UploadUrl(
   contentType: string,
   userId: string,
   contentLength?: number,
-): Promise<{ uploadUrl: string; s3Key: string }> {
+  requestedRegion?: S3StorageRegion,
+): Promise<{
+  uploadUrl: string;
+  s3Key: string;
+  storageLocation: S3StorageLocation;
+}> {
   try {
-    const s3Client = getS3Client();
-    const bucketName = getRequiredEnvVar("AWS_S3_BUCKET_NAME");
+    const storageLocation = resolveS3UploadLocation(requestedRegion);
+    const s3Client = getS3Client(storageLocation);
     const s3Key = generateS3Key(userId, fileName);
 
     const command = new PutObjectCommand({
-      Bucket: bucketName,
+      Bucket: storageLocation.bucket,
       Key: s3Key,
       ContentType: contentType,
       ContentLength: contentLength,
@@ -85,7 +144,7 @@ export async function generateS3UploadUrl(
       expiresIn: getS3UrlLifetimeSeconds(),
     });
 
-    return { uploadUrl, s3Key };
+    return { uploadUrl, s3Key, storageLocation };
   } catch (error) {
     console.error("Failed to generate S3 upload URL:", error);
     throw new Error(
@@ -98,13 +157,16 @@ export async function generateS3UploadUrl(
 /**
  * Generate presigned URL for file download
  */
-export async function generateS3DownloadUrl(s3Key: string): Promise<string> {
+export async function generateS3DownloadUrl(
+  s3Key: string,
+  storageLocation?: S3StorageLocation,
+): Promise<string> {
   try {
-    const s3Client = getS3Client();
-    const bucketName = getRequiredEnvVar("AWS_S3_BUCKET_NAME");
+    const location = storageLocation ?? getLegacyS3StorageLocation();
+    const s3Client = getS3Client(location);
 
     const command = new GetObjectCommand({
-      Bucket: bucketName,
+      Bucket: location.bucket,
       Key: s3Key,
     });
 
@@ -125,13 +187,16 @@ export async function generateS3DownloadUrl(s3Key: string): Promise<string> {
 /**
  * Delete object from S3
  */
-export async function deleteS3Object(s3Key: string): Promise<void> {
+export async function deleteS3Object(
+  s3Key: string,
+  storageLocation?: S3StorageLocation,
+): Promise<void> {
   try {
-    const s3Client = getS3Client();
-    const bucketName = getRequiredEnvVar("AWS_S3_BUCKET_NAME");
+    const location = storageLocation ?? getLegacyS3StorageLocation();
+    const s3Client = getS3Client(location);
 
     const command = new DeleteObjectCommand({
-      Bucket: bucketName,
+      Bucket: location.bucket,
       Key: s3Key,
     });
 
@@ -148,13 +213,16 @@ export async function deleteS3Object(s3Key: string): Promise<void> {
 /**
  * Get S3 object size in bytes.
  */
-export async function getS3ObjectSizeBytes(s3Key: string): Promise<number> {
+export async function getS3ObjectSizeBytes(
+  s3Key: string,
+  storageLocation?: S3StorageLocation,
+): Promise<number> {
   try {
-    const s3Client = getS3Client();
-    const bucketName = getRequiredEnvVar("AWS_S3_BUCKET_NAME");
+    const location = storageLocation ?? getLegacyS3StorageLocation();
+    const s3Client = getS3Client(location);
 
     const command = new HeadObjectCommand({
-      Bucket: bucketName,
+      Bucket: location.bucket,
       Key: s3Key,
     });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -258,6 +258,8 @@ export default defineSchema({
 
   files: defineTable({
     s3_key: v.optional(v.string()),
+    s3_region: v.optional(v.string()),
+    s3_bucket: v.optional(v.string()),
     user_id: v.string(),
     name: v.string(),
     media_type: v.string(),

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -285,10 +285,18 @@ async function deleteFiles(
   const unique = uniqueDocs(files);
   increment(stats.deleted, "files", unique.length);
 
-  const s3Keys = unique
-    .map((file) => file.s3_key)
-    .filter((key): key is string => typeof key === "string" && key.length > 0);
-  stats.s3ObjectsQueued += s3Keys.length;
+  const s3Objects = unique.flatMap((file) =>
+    file.s3_key
+      ? [
+          {
+            s3Key: file.s3_key,
+            ...(file.s3_region ? { s3Region: file.s3_region } : {}),
+            ...(file.s3_bucket ? { s3Bucket: file.s3_bucket } : {}),
+          },
+        ]
+      : [],
+  );
+  stats.s3ObjectsQueued += s3Objects.length;
 
   if (mode === "dryRun") return;
 
@@ -297,14 +305,19 @@ async function deleteFiles(
     await ctx.db.delete(file._id);
   }
 
-  if (s3Keys.length > 0) {
+  if (s3Objects.length > 0) {
+    const cleanupArgs = s3Objects.some(
+      (object) => object.s3Region || object.s3Bucket,
+    )
+      ? { s3Objects }
+      : { s3Keys: s3Objects.map((object) => object.s3Key) };
     await ctx.scheduler.runAfter(
       0,
       internal.s3Cleanup.deleteS3ObjectsBatchAction,
-      { s3Keys },
+      cleanupArgs,
     );
     console.log(
-      `Scheduled deletion of ${s3Keys.length} S3 objects for deleted user data cleanup`,
+      `Scheduled deletion of ${s3Objects.length} S3 objects for deleted user data cleanup`,
     );
   }
 }

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -1261,6 +1261,7 @@ async function uploadViewPreviewFiles(args: {
     fullPath: sourcePath,
     mediaType: payload.mediaType,
     name: getFilename(sourcePath),
+    storageRegion: context.triggerRegion,
   });
 
   return [

--- a/lib/ai/tools/get-terminal-files.ts
+++ b/lib/ai/tools/get-terminal-files.ts
@@ -74,6 +74,7 @@ export const createGetTerminalFiles = (context: ToolContext) => {
                 sandbox,
                 userId: context.userID,
                 fullPath: filePath,
+                storageRegion: context.triggerRegion,
               });
 
               context.fileAccumulator.add({

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -231,6 +231,7 @@ export const createTools = (
     ptyScopeId: runtimePolicy.ptyScopeId,
     assistantMessageId,
     triggerRunId,
+    triggerRegion: runtimePolicy.triggerRegion,
     fileAccumulator,
     backgroundProcessTracker,
     ptySessionManager,

--- a/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
@@ -65,6 +65,10 @@ describe("uploadSandboxFileToConvex", () => {
     mockGenerateS3UploadUrl.mockResolvedValue({
       uploadUrl: "https://s3.example/upload",
       s3Key: "users/u1/file.txt",
+      storageLocation: {
+        region: "us-west-2",
+        bucket: "test-west-bucket",
+      },
     });
     mockConvexAction = jest.fn(async () => ({
       url: "https://s3.example/download",
@@ -157,6 +161,8 @@ describe("uploadSandboxFileToConvex", () => {
         name: "report.txt",
         size: 1234,
         s3Key: "users/u1/file.txt",
+        s3Region: "us-west-2",
+        s3Bucket: "test-west-bucket",
       }),
     );
     expect(saved).toMatchObject({

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -8,7 +8,11 @@ import { isCentrifugoSandbox, isE2BSandbox } from "./sandbox-types";
 import { buildSandboxCommandOptions } from "./sandbox-command-options";
 import { generateS3UploadUrl } from "@/convex/s3Utils";
 import { getConvexClient } from "@/lib/db/convex-client";
-import { MAX_GENERATED_FILE_SIZE_BYTES } from "@/lib/constants/s3";
+import {
+  MAX_GENERATED_FILE_SIZE_BYTES,
+  type S3StorageLocation,
+  type S3StorageRegion,
+} from "@/lib/constants/s3";
 import { logger } from "@/lib/logger";
 
 const DEFAULT_MEDIA_TYPE = "application/octet-stream";
@@ -393,6 +397,7 @@ export async function uploadSandboxFileToConvex(args: {
   fullPath: string;
   mediaType?: string;
   name?: string;
+  storageRegion?: S3StorageRegion;
 }): Promise<UploadedFileInfo> {
   if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
     throw new Error(
@@ -428,15 +433,20 @@ export async function uploadSandboxFileToConvex(args: {
 
   let uploadUrl: string;
   let s3Key: string;
+  let storageLocation: S3StorageLocation;
   try {
-    const generatedUrl = await generateS3UploadUrl(
-      name,
-      mediaType,
-      userId,
-      fileSize,
-    );
+    const generatedUrl = args.storageRegion
+      ? await generateS3UploadUrl(
+          name,
+          mediaType,
+          userId,
+          fileSize,
+          args.storageRegion,
+        )
+      : await generateS3UploadUrl(name, mediaType, userId, fileSize);
     uploadUrl = generatedUrl.uploadUrl;
     s3Key = generatedUrl.s3Key;
+    storageLocation = generatedUrl.storageLocation;
   } catch (error) {
     logger.error(
       "sandbox_generated_file_upload_url_failed",
@@ -493,6 +503,8 @@ export async function uploadSandboxFileToConvex(args: {
         size: fileSize,
         serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
         userId,
+        s3Region: storageLocation.region,
+        s3Bucket: storageLocation.bucket,
       },
     );
 

--- a/lib/api/trigger-region.ts
+++ b/lib/api/trigger-region.ts
@@ -1,6 +1,7 @@
 import type { Geo } from "@vercel/functions";
+import type { S3StorageRegion } from "@/lib/constants/s3";
 
-export type TriggerRunRegion = "eu-central-1" | "us-east-1" | "us-west-2";
+export type TriggerRunRegion = S3StorageRegion;
 
 type VercelGeoLocation = Pick<
   Geo,

--- a/lib/constants/s3.ts
+++ b/lib/constants/s3.ts
@@ -4,6 +4,35 @@
  * Centralized constants for S3 file storage configuration.
  */
 
+export const S3_STORAGE_REGIONS = [
+  "eu-central-1",
+  "us-east-1",
+  "us-west-2",
+] as const;
+
+export type S3StorageRegion = (typeof S3_STORAGE_REGIONS)[number];
+
+export type S3StorageLocation = {
+  region: string;
+  bucket: string;
+};
+
+export const S3_REGIONAL_BUCKET_ENV_NAMES: Record<
+  S3StorageRegion,
+  | "AWS_S3_BUCKET_NAME_EU_CENTRAL_1"
+  | "AWS_S3_BUCKET_NAME_US_EAST_1"
+  | "AWS_S3_BUCKET_NAME_US_WEST_2"
+> = {
+  "eu-central-1": "AWS_S3_BUCKET_NAME_EU_CENTRAL_1",
+  "us-east-1": "AWS_S3_BUCKET_NAME_US_EAST_1",
+  "us-west-2": "AWS_S3_BUCKET_NAME_US_WEST_2",
+};
+
+export const isS3StorageRegion = (
+  value: string | null | undefined,
+): value is S3StorageRegion =>
+  S3_STORAGE_REGIONS.includes(value as S3StorageRegion);
+
 // S3 presigned URL lifetime (defaults to 1 hour if not set)
 // Use function to read at runtime, not at module load time (avoids Convex caching)
 export const getS3UrlLifetimeSeconds = (): number => {

--- a/lib/storage/__tests__/file-storage-region.test.ts
+++ b/lib/storage/__tests__/file-storage-region.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { getPreferredFileStorageRegion } from "../file-storage-region";
+
+describe("getPreferredFileStorageRegion", () => {
+  it("returns a supported region from the geo endpoint", async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ region: "eu-central-1" }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    await expect(getPreferredFileStorageRegion()).resolves.toBe("eu-central-1");
+    expect(fetchMock).toHaveBeenCalledWith("/api/file-storage/region", {
+      cache: "no-store",
+    });
+    delete (global as { fetch?: typeof fetch }).fetch;
+  });
+
+  it("falls back safely for invalid or unavailable responses", async () => {
+    const fetchMock = jest.fn<typeof fetch>();
+    global.fetch = fetchMock;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ region: "ap-southeast-1" }),
+    } as Response);
+    await expect(getPreferredFileStorageRegion()).resolves.toBeUndefined();
+
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    await expect(getPreferredFileStorageRegion()).resolves.toBeUndefined();
+    delete (global as { fetch?: typeof fetch }).fetch;
+  });
+});

--- a/lib/storage/file-storage-region.ts
+++ b/lib/storage/file-storage-region.ts
@@ -1,0 +1,26 @@
+import { isS3StorageRegion, type S3StorageRegion } from "@/lib/constants/s3";
+
+export async function getPreferredFileStorageRegion(): Promise<
+  S3StorageRegion | undefined
+> {
+  try {
+    const response = await fetch("/api/file-storage/region", {
+      cache: "no-store",
+    });
+    if (!response.ok) return undefined;
+
+    const data: unknown = await response.json();
+    if (!data || typeof data !== "object" || !("region" in data)) {
+      return undefined;
+    }
+
+    const region = (data as { region?: unknown }).region;
+    return typeof region === "string" && isS3StorageRegion(region)
+      ? region
+      : undefined;
+  } catch {
+    // Region selection is an optimization. Convex safely falls back to the
+    // legacy bucket when this request is unavailable.
+    return undefined;
+  }
+}

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -261,6 +261,13 @@ AWS_S3_SECRET_ACCESS_KEY=
 AWS_S3_REGION=us-east-1
 AWS_S3_BUCKET_NAME=
 
+# Regional storage rollout. Keep false until the matching bucket names and IAM
+# access are configured in both Convex and Trigger.dev for this environment.
+S3_REGIONAL_STORAGE_ENABLED=false
+AWS_S3_BUCKET_NAME_EU_CENTRAL_1=
+AWS_S3_BUCKET_NAME_US_EAST_1=
+AWS_S3_BUCKET_NAME_US_WEST_2=
+
 # Optional S3 configuration (defaults shown, uncomment to override)
 # S3_URL_LIFETIME_SECONDS=3600
 # S3_URL_EXPIRATION_BUFFER_SECONDS=300

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -10,6 +10,7 @@ import type { ChatMode, SubscriptionTier } from "./chat";
 import type { CentrifugoSandbox } from "@/lib/ai/tools/utils/centrifugo-sandbox";
 import type { SandboxFallbackInfo } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
 import type { CloudSandboxProvider } from "@/lib/ai/tools/utils/cloud-sandbox-provider";
+import type { S3StorageRegion } from "@/lib/constants/s3";
 
 // Union type for E2B Sandbox and local CentrifugoSandbox
 export type AnySandbox = Sandbox | CentrifugoSandbox;
@@ -691,6 +692,8 @@ export interface ToolContext {
   assistantMessageId?: string;
   /** Trigger.dev run ID when tools execute inside a durable Agent task. */
   triggerRunId?: string;
+  /** Trigger.dev placement region, reused for generated-file storage. */
+  triggerRegion?: S3StorageRegion;
   fileAccumulator: FileAccumulator;
   backgroundProcessTracker: BackgroundProcessTracker;
   /** Manages interactive PTY sessions for `run_terminal_cmd` interactive actions. */


### PR DESCRIPTION
## Summary
- route new browser uploads to the closest configured S3 region using the same three-region placement policy as Trigger.dev
- persist the exact bucket and region on each file so downloads and cleanup remain correct across regions
- keep all existing file records backward compatible through the legacy bucket configuration
- place Trigger-generated artifacts in the Trigger run region
- add a deployment kill switch and region-specific bucket configuration

## Rollout
- keep `S3_REGIONAL_STORAGE_ENABLED=false` until all regional buckets and IAM access exist in the target environment
- configure the three regional bucket variables independently in Convex and Trigger Preview/Production
- enable Preview first, verify browser uploads and Trigger-generated downloads/deletes, then stage Production
- rollback by disabling the flag; already-created regional files remain readable because their location is persisted

## Validation
- `pnpm run typecheck`
- `pnpm run lint` (passes with seven pre-existing warnings)
- `pnpm exec jest --runInBand` (415 suites, 4,428 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added regional file storage support for uploads, downloads, generated files, and cleanup.
  * Files retain storage location details for reliable future access.
  * Added automatic preferred-region detection with a safe fallback to existing storage behavior.
  * Added configuration examples for EU Central, US East, and US West storage buckets.
  * Simplified displayed file-tool targets by showing relevant filenames instead of internal upload paths.

* **Bug Fixes**
  * Improved download and cleanup handling for files stored in regional buckets.

* **Tests**
  * Expanded coverage for regional routing, metadata persistence, downloads, deletion, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->