### PR TITLE
Track signup acquisition without anonymous events

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import type { NextRequest } from "next/server";
 
 const mockAuthkit = jest.fn();
@@ -11,6 +18,7 @@ const mockNextResponseJson = jest.fn((body: unknown, init?: unknown) =>
 const mockNextResponseRedirect = jest.fn((url: URL, init?: unknown) =>
   mockCreateResponse("redirect", url, init),
 );
+const originalCookiePassword = process.env.WORKOS_COOKIE_PASSWORD;
 
 function mockCreateResponse(kind: string, body?: unknown, init?: unknown) {
   return {
@@ -73,12 +81,22 @@ function createRequest({
 }
 
 describe("proxy", () => {
+  afterAll(() => {
+    if (originalCookiePassword === undefined) {
+      delete process.env.WORKOS_COOKIE_PASSWORD;
+    } else {
+      process.env.WORKOS_COOKIE_PASSWORD = originalCookiePassword;
+    }
+  });
+
   beforeEach(() => {
     jest.resetModules();
     mockAuthkit.mockReset();
     mockNextResponseNext.mockClear();
     mockNextResponseJson.mockClear();
     mockNextResponseRedirect.mockClear();
+    process.env.WORKOS_COOKIE_PASSWORD =
+      "test-cookie-password-with-32-characters";
   });
 
   it.each([
@@ -186,7 +204,9 @@ describe("proxy", () => {
     );
     expect(firstTouchCookieCall).toBeDefined();
     const [, value, options] = firstTouchCookieCall!;
-    expect(JSON.parse(decodeURIComponent(String(value)))).toMatchObject({
+    const { parseFirstTouchAttributionCookie } =
+      await import("@/lib/analytics/acquisition-cookie");
+    expect(parseFirstTouchAttributionCookie(String(value))).toMatchObject({
       version: 1,
       source: "github",
       medium: "social",
@@ -203,6 +223,29 @@ describe("proxy", () => {
       maxAge: 90 * 24 * 60 * 60,
       path: "/",
     });
+  });
+
+  it("does not store attribution for likely bot traffic", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://signin.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/?utm_source=bot_campaign",
+        accept: "text/html",
+        userAgent: "Googlebot/2.1",
+      }),
+    );
+
+    expect(
+      response.cookies.set.mock.calls.some(
+        ([name]: [string]) => name === "hackerai_first_touch_attribution",
+      ),
+    ).toBe(false);
   });
 
   it("does not overwrite existing first-touch attribution", async () => {

--- a/app/callback/__tests__/acquisition-route.test.ts
+++ b/app/callback/__tests__/acquisition-route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockHandleAuth = jest.fn(() => jest.fn());
+const mockCapture = jest.fn();
+const mockAfter = jest.fn();
+const mockFlush = jest.fn();
+
+jest.mock("@workos-inc/authkit-nextjs", () => ({
+  handleAuth: mockHandleAuth,
+}));
+jest.mock("next/server", () => ({
+  after: mockAfter,
+  NextResponse: {
+    redirect: jest.fn(),
+  },
+}));
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+jest.mock("@/lib/analytics/signup-acquisition", () => ({
+  captureSignupAcquisitionAttribution: mockCapture,
+}));
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: { flush: mockFlush },
+}));
+
+describe("AuthKit callback acquisition handoff", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it("captures and flushes valid signup attribution after authentication", async () => {
+    mockCapture.mockReturnValue(true);
+    await import("../route");
+    const options = mockHandleAuth.mock.calls[0]?.[0] as {
+      onSuccess: (input: {
+        user: { id: string };
+        state: string;
+      }) => Promise<void>;
+    };
+
+    await options.onSuccess({ user: { id: "user_new" }, state: "state" });
+
+    expect(mockCapture).toHaveBeenCalledWith({
+      user: { id: "user_new" },
+      state: "state",
+    });
+    expect(mockAfter).toHaveBeenCalledTimes(1);
+    const flush = mockAfter.mock.calls[0]?.[0] as () => Promise<void>;
+    await flush();
+    expect(mockFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not schedule a flush when no signup attribution was captured", async () => {
+    mockCapture.mockReturnValue(false);
+    await import("../route");
+    const options = mockHandleAuth.mock.calls[0]?.[0] as {
+      onSuccess: (input: {
+        user: { id: string };
+        state?: string;
+      }) => Promise<void>;
+    };
+
+    await options.onSuccess({ user: { id: "user_existing" } });
+
+    expect(mockAfter).not.toHaveBeenCalled();
+  });
+});

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -5,7 +5,9 @@ import {
   withRecoverableAuthkitCallbackErrorSuppressed,
 } from "@/lib/auth/authkit-callback-logging";
 import { cookies } from "next/headers";
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
+import { captureSignupAcquisitionAttribution } from "@/lib/analytics/signup-acquisition";
+import { phLogger } from "@/lib/posthog/server";
 
 const isValidLocalPath = (path: string): boolean => {
   return (
@@ -98,6 +100,11 @@ const buildRecoveryResponse = async (
 };
 
 const authHandler = handleAuth({
+  onSuccess: async ({ user, state }) => {
+    if (captureSignupAcquisitionAttribution({ user, state })) {
+      after(() => phLogger.flush());
+    }
+  },
   onError: async ({ error, request }) => {
     return buildRecoveryResponse(request as NextRequest, error);
   },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,10 +15,8 @@ import { PostHogProvider } from "./providers";
 import { DataStreamProvider } from "./components/DataStreamProvider";
 import { ChunkLoadRecovery } from "./components/ChunkLoadRecovery";
 import { resolveClientInitialAuth } from "@/lib/auth/initial-auth";
-import {
-  FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME,
-  parseFirstTouchAttribution,
-} from "@/lib/analytics/acquisition";
+import { FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME } from "@/lib/analytics/acquisition";
+import { parseFirstTouchAttributionCookie } from "@/lib/analytics/acquisition-cookie";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -123,7 +121,7 @@ export default async function RootLayout({
     getInitialAuth(),
     cookies(),
   ]);
-  const firstTouchAttribution = parseFirstTouchAttribution(
+  const firstTouchAttribution = parseFirstTouchAttributionCookie(
     cookieStore.get(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME)?.value,
   );
 

--- a/app/signup/auth/__tests__/route.test.ts
+++ b/app/signup/auth/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockCookieGet = jest.fn();
+const mockParseCookie = jest.fn();
+const mockCreateState = jest.fn();
+const mockRedirect = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(async () => ({ get: mockCookieGet })),
+}));
+jest.mock("@/lib/analytics/acquisition-cookie", () => ({
+  parseFirstTouchAttributionCookie: mockParseCookie,
+}));
+jest.mock("@/lib/analytics/signup-acquisition-state", () => ({
+  createSignupAttributionState: mockCreateState,
+}));
+jest.mock("@/lib/auth/auth-redirect-intents", () => ({
+  redirectToAuthorizationUrl: mockRedirect,
+}));
+
+import { getSignUpUrl } from "@workos-inc/authkit-nextjs";
+const mockGetSignUpUrl = getSignUpUrl as jest.MockedFunction<
+  typeof getSignUpUrl
+>;
+
+describe("GET /signup/auth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSignUpUrl.mockResolvedValue("https://signin.hackerai.co/signup");
+    mockRedirect.mockReturnValue({ kind: "redirect" });
+    mockCookieGet.mockReturnValue({ value: "signed-cookie" });
+  });
+
+  it("seals valid first-touch attribution into WorkOS custom state", async () => {
+    const { GET } = await import("../route");
+    const firstTouch = {
+      version: 1,
+      source: "github",
+      medium: "social",
+      referringDomain: "github.com",
+      entrySurface: "home",
+      capturedAt: "2026-08-30T12:00:00.000Z",
+    };
+    mockParseCookie.mockReturnValue(firstTouch);
+    mockCreateState.mockReturnValue("signup-state");
+
+    const response = await GET({
+      url: "https://hackerai.co/signup/auth",
+    } as Request);
+
+    expect(mockCreateState).toHaveBeenCalledWith(firstTouch);
+    expect(mockGetSignUpUrl).toHaveBeenCalledWith({ state: "signup-state" });
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "https://signin.hackerai.co/signup",
+      new URL("https://hackerai.co/signup/auth"),
+    );
+    expect(response).toEqual({ kind: "redirect" });
+  });
+
+  it("starts signup without attribution when the cookie is absent or invalid", async () => {
+    const { GET } = await import("../route");
+    mockParseCookie.mockReturnValue(null);
+
+    await GET({ url: "https://hackerai.co/signup/auth" } as Request);
+
+    expect(mockCreateState).not.toHaveBeenCalled();
+    expect(mockGetSignUpUrl).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/app/signup/auth/route.ts
+++ b/app/signup/auth/route.ts
@@ -1,8 +1,20 @@
 import { getSignUpUrl } from "@workos-inc/authkit-nextjs";
+import { cookies } from "next/headers";
 import { redirectToAuthorizationUrl } from "@/lib/auth/auth-redirect-intents";
+import { FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME } from "@/lib/analytics/acquisition";
+import { parseFirstTouchAttributionCookie } from "@/lib/analytics/acquisition-cookie";
+import { createSignupAttributionState } from "@/lib/analytics/signup-acquisition-state";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const authorizationUrl = await getSignUpUrl();
+  const cookieStore = await cookies();
+  const firstTouch = parseFirstTouchAttributionCookie(
+    cookieStore.get(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME)?.value,
+  );
+  const authorizationUrl = await getSignUpUrl(
+    firstTouch
+      ? { state: createSignupAttributionState(firstTouch) }
+      : undefined,
+  );
   return redirectToAuthorizationUrl(authorizationUrl, url);
 }

--- a/lib/analytics/__tests__/acquisition-cookie.test.ts
+++ b/lib/analytics/__tests__/acquisition-cookie.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import {
+  createFirstTouchAttribution,
+  serializeFirstTouchAttribution,
+} from "../acquisition";
+import {
+  parseFirstTouchAttributionCookie,
+  serializeSignedFirstTouchAttribution,
+} from "../acquisition-cookie";
+
+const originalCookiePassword = process.env.WORKOS_COOKIE_PASSWORD;
+
+describe("signed first-touch attribution cookie", () => {
+  const capturedAt = new Date("2026-08-30T12:00:00.000Z");
+  const attribution = createFirstTouchAttribution({
+    url: new URL(
+      "https://hackerai.co/?utm_source=github&utm_medium=social&utm_campaign=launch",
+    ),
+    referer: "https://github.com/hackerai-tech",
+    capturedAt,
+  });
+
+  beforeEach(() => {
+    process.env.WORKOS_COOKIE_PASSWORD =
+      "test-cookie-password-with-32-characters";
+  });
+
+  afterEach(() => {
+    if (originalCookiePassword === undefined) {
+      delete process.env.WORKOS_COOKIE_PASSWORD;
+    } else {
+      process.env.WORKOS_COOKIE_PASSWORD = originalCookiePassword;
+    }
+  });
+
+  it("round-trips a signed allowlisted payload", () => {
+    const value = serializeSignedFirstTouchAttribution(attribution);
+
+    expect(value).toMatch(/^v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(parseFirstTouchAttributionCookie(value ?? undefined)).toEqual(
+      attribution,
+    );
+    expect(value).not.toContain("github.com");
+  });
+
+  it("rejects a tampered payload or signature", () => {
+    const value = serializeSignedFirstTouchAttribution(attribution)!;
+    const [prefix, payload, signature] = value.split(".");
+
+    expect(
+      parseFirstTouchAttributionCookie(`${prefix}.${payload}x.${signature}`),
+    ).toBeNull();
+    expect(
+      parseFirstTouchAttributionCookie(`${prefix}.${payload}.${signature}x`),
+    ).toBeNull();
+  });
+
+  it("does not mint cookies when AuthKit's server secret is unavailable", () => {
+    delete process.env.WORKOS_COOKIE_PASSWORD;
+
+    expect(serializeSignedFirstTouchAttribution(attribution)).toBeNull();
+  });
+
+  it("accepts bounded legacy cookies only during their migration window", () => {
+    const legacy = serializeFirstTouchAttribution(attribution);
+
+    expect(
+      parseFirstTouchAttributionCookie(
+        legacy,
+        new Date("2026-10-01T00:00:00.000Z"),
+      ),
+    ).toEqual(attribution);
+    expect(
+      parseFirstTouchAttributionCookie(
+        legacy,
+        new Date("2026-11-15T00:00:00.000Z"),
+      ),
+    ).toBeNull();
+  });
+});

--- a/lib/analytics/__tests__/signup-acquisition.test.ts
+++ b/lib/analytics/__tests__/signup-acquisition.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import type { User } from "@workos-inc/node";
+import { phLogger } from "@/lib/posthog/server";
+import type { FirstTouchAttribution } from "../acquisition";
+import {
+  acquisitionSourceBucket,
+  captureSignupAcquisitionAttribution,
+} from "../signup-acquisition";
+import { createSignupAttributionState } from "../signup-acquisition-state";
+
+const mockPhEvent = jest
+  .spyOn(phLogger, "event")
+  .mockImplementation(() => undefined);
+
+describe("signup acquisition attribution", () => {
+  const now = new Date("2026-08-30T12:05:00.000Z");
+  const firstTouch: FirstTouchAttribution = {
+    version: 1,
+    source: "github",
+    medium: "social",
+    campaign: "aug_launch",
+    referringDomain: "github.com",
+    entrySurface: "home",
+    capturedAt: "2026-08-29T12:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    mockPhEvent.mockClear();
+  });
+
+  it.each([
+    ["google", "organic", "google.com", "home", "organic_search"],
+    ["user_referral", "referral", "$direct", "invite", "referral_link"],
+    ["github", "social", "github.com", "home", "github"],
+    ["reddit.com", "referral", "reddit.com", "home", "community"],
+    ["chatgpt.com", "referral", "chatgpt.com", "home", "ai_assistant"],
+    ["newsletter", "email", "$direct", "home", "campaign"],
+    ["$direct", "none", "$direct", "home", "direct_or_dark"],
+    ["partner.example", "referral", "partner.example", "home", "unknown"],
+  ] as const)(
+    "buckets %s / %s as %s",
+    (source, medium, referringDomain, entrySurface, expected) => {
+      expect(
+        acquisitionSourceBucket({
+          ...firstTouch,
+          source,
+          medium,
+          referringDomain,
+          entrySurface,
+          campaign: undefined,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("emits one idempotent privacy-safe event for a newly created signup", () => {
+    const state = createSignupAttributionState(
+      firstTouch,
+      new Date("2026-08-30T12:00:00.000Z"),
+    );
+    const captured = captureSignupAcquisitionAttribution({
+      user: {
+        id: "user_new",
+        createdAt: "2026-08-30T12:01:00.000Z",
+      } as User,
+      state,
+      now,
+    });
+
+    expect(captured).toBe(true);
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "signup_acquisition_attributed_v1",
+      {
+        userId: "user_new",
+        acquisition_attribution_version: 1,
+        acquisition_source_bucket: "github",
+        attribution_source: "workos_authkit_callback",
+        referral_link_present: false,
+        signup_started_at: "2026-08-30T12:00:00.000Z",
+        user_created_at: "2026-08-30T12:01:00.000Z",
+        first_touch_attribution_version: 1,
+        first_touch_source: "github",
+        first_touch_medium: "social",
+        first_touch_campaign: "aug_launch",
+        first_touch_referring_domain: "github.com",
+        first_touch_entry_surface: "home",
+        first_touch_captured_at: "2026-08-29T12:00:00.000Z",
+        $insert_id: "signup_acquisition_attributed_v1:user_new",
+        $set_once: {
+          acquisition_source_bucket: "github",
+          referral_link_present: false,
+          first_touch_attribution_version: 1,
+          first_touch_source: "github",
+          first_touch_medium: "social",
+          first_touch_campaign: "aug_launch",
+          first_touch_referring_domain: "github.com",
+          first_touch_entry_surface: "home",
+          first_touch_captured_at: "2026-08-29T12:00:00.000Z",
+        },
+      },
+    );
+    expect(JSON.stringify(mockPhEvent.mock.calls[0])).not.toContain("email");
+    expect(JSON.stringify(mockPhEvent.mock.calls[0])).not.toContain("http");
+  });
+
+  it("does not attribute an existing user who enters through the signup screen", () => {
+    const state = createSignupAttributionState(
+      firstTouch,
+      new Date("2026-08-30T12:00:00.000Z"),
+    );
+
+    expect(
+      captureSignupAcquisitionAttribution({
+        user: {
+          id: "user_existing",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        } as User,
+        state,
+        now,
+      }),
+    ).toBe(false);
+    expect(mockPhEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing state", undefined],
+    ["malformed state", "not-json"],
+    [
+      "expired auth flow",
+      createSignupAttributionState(
+        firstTouch,
+        new Date("2026-08-30T11:00:00.000Z"),
+      ),
+    ],
+    [
+      "expired first touch",
+      createSignupAttributionState(
+        { ...firstTouch, capturedAt: "2026-01-01T00:00:00.000Z" },
+        new Date("2026-08-30T12:00:00.000Z"),
+      ),
+    ],
+  ])("ignores %s", (_label, state) => {
+    expect(
+      captureSignupAcquisitionAttribution({
+        user: {
+          id: "user_new",
+          createdAt: "2026-08-30T12:01:00.000Z",
+        } as User,
+        state,
+        now,
+      }),
+    ).toBe(false);
+    expect(mockPhEvent).not.toHaveBeenCalled();
+  });
+});

--- a/lib/analytics/acquisition-cookie.ts
+++ b/lib/analytics/acquisition-cookie.ts
@@ -1,0 +1,90 @@
+import "server-only";
+
+import { createHmac, hkdfSync, timingSafeEqual } from "node:crypto";
+import {
+  parseFirstTouchAttribution,
+  type FirstTouchAttribution,
+} from "@/lib/analytics/acquisition";
+
+const SIGNED_COOKIE_PREFIX = "v1";
+const SIGNING_CONTEXT = "hackerai:first-touch-attribution-cookie:v1";
+const LEGACY_COOKIE_ACCEPT_UNTIL = Date.parse("2026-11-15T00:00:00.000Z");
+
+function signingKey(): Buffer | null {
+  const secret = process.env.WORKOS_COOKIE_PASSWORD;
+  if (!secret) return null;
+
+  return Buffer.from(
+    hkdfSync("sha256", secret, "hackerai-acquisition", SIGNING_CONTEXT, 32),
+  );
+}
+
+function signatureFor(payload: string, key: Buffer): string {
+  return createHmac("sha256", key).update(payload).digest("base64url");
+}
+
+export function serializeSignedFirstTouchAttribution(
+  attribution: FirstTouchAttribution,
+): string | null {
+  const key = signingKey();
+  if (!key) return null;
+
+  const payload = Buffer.from(JSON.stringify(attribution)).toString(
+    "base64url",
+  );
+  return `${SIGNED_COOKIE_PREFIX}.${payload}.${signatureFor(payload, key)}`;
+}
+
+function parseSignedFirstTouchAttribution(
+  value: string,
+): FirstTouchAttribution | null {
+  const key = signingKey();
+  if (!key) return null;
+
+  const [prefix, payload, suppliedSignature, ...extra] = value.split(".");
+  if (
+    prefix !== SIGNED_COOKIE_PREFIX ||
+    !payload ||
+    !suppliedSignature ||
+    extra.length > 0
+  ) {
+    return null;
+  }
+
+  const expectedSignature = signatureFor(payload, key);
+  const supplied = Buffer.from(suppliedSignature);
+  const expected = Buffer.from(expectedSignature);
+  if (
+    supplied.length !== expected.length ||
+    !timingSafeEqual(supplied, expected)
+  ) {
+    return null;
+  }
+
+  try {
+    return parseFirstTouchAttribution(
+      encodeURIComponent(Buffer.from(payload, "base64url").toString("utf8")),
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function parseFirstTouchAttributionCookie(
+  value: string | undefined,
+  now = new Date(),
+): FirstTouchAttribution | null {
+  if (!value || value.length > 2_048) return null;
+
+  const signed = parseSignedFirstTouchAttribution(value);
+  if (signed) return signed;
+
+  // Cookies written before signed attribution shipped remain useful during
+  // their original 90-day lifetime. Values are still strictly allowlisted by
+  // parseFirstTouchAttribution. Remove this compatibility path after cutoff.
+  if (now.getTime() < LEGACY_COOKIE_ACCEPT_UNTIL) {
+    return parseFirstTouchAttribution(value);
+  }
+
+  return null;
+}

--- a/lib/analytics/signup-acquisition-state.ts
+++ b/lib/analytics/signup-acquisition-state.ts
@@ -1,0 +1,52 @@
+import {
+  parseFirstTouchAttribution,
+  type FirstTouchAttribution,
+} from "@/lib/analytics/acquisition";
+
+const SIGNUP_ATTRIBUTION_STATE_KIND = "hackerai_signup_acquisition_v1";
+
+export type SignupAttributionState = {
+  kind: typeof SIGNUP_ATTRIBUTION_STATE_KIND;
+  signupStartedAt: string;
+  firstTouch: FirstTouchAttribution;
+};
+
+export function createSignupAttributionState(
+  firstTouch: FirstTouchAttribution,
+  signupStartedAt = new Date(),
+): string {
+  return JSON.stringify({
+    kind: SIGNUP_ATTRIBUTION_STATE_KIND,
+    signupStartedAt: signupStartedAt.toISOString(),
+    firstTouch,
+  } satisfies SignupAttributionState);
+}
+
+export function parseSignupAttributionState(
+  value: string | undefined,
+): SignupAttributionState | null {
+  if (!value || value.length > 4_096) return null;
+
+  try {
+    const parsed = JSON.parse(value) as Partial<SignupAttributionState>;
+    const firstTouch = parseFirstTouchAttribution(
+      encodeURIComponent(JSON.stringify(parsed.firstTouch)),
+    );
+    if (
+      parsed.kind !== SIGNUP_ATTRIBUTION_STATE_KIND ||
+      typeof parsed.signupStartedAt !== "string" ||
+      !Number.isFinite(Date.parse(parsed.signupStartedAt)) ||
+      !firstTouch
+    ) {
+      return null;
+    }
+
+    return {
+      kind: SIGNUP_ATTRIBUTION_STATE_KIND,
+      signupStartedAt: parsed.signupStartedAt,
+      firstTouch,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/lib/analytics/signup-acquisition.ts
+++ b/lib/analytics/signup-acquisition.ts
@@ -1,0 +1,173 @@
+import type { User } from "@workos-inc/node";
+import {
+  FIRST_TOUCH_ATTRIBUTION_MAX_AGE_SECONDS,
+  firstTouchPersonProperties,
+  type FirstTouchAttribution,
+} from "@/lib/analytics/acquisition";
+import { phLogger } from "@/lib/posthog/server";
+import { parseSignupAttributionState } from "@/lib/analytics/signup-acquisition-state";
+
+const AUTH_FLOW_MAX_AGE_MS = 15 * 60 * 1_000;
+const CLOCK_SKEW_MS = 60 * 1_000;
+
+export type AcquisitionSourceBucket =
+  | "organic_search"
+  | "referral_link"
+  | "community"
+  | "github"
+  | "ai_assistant"
+  | "campaign"
+  | "direct_or_dark"
+  | "unknown";
+
+const COMMUNITY_DOMAINS = new Set([
+  "discord.com",
+  "facebook.com",
+  "linkedin.com",
+  "reddit.com",
+  "tiktok.com",
+  "twitter.com",
+  "x.com",
+  "youtube.com",
+]);
+
+const AI_ASSISTANT_DOMAINS = new Set([
+  "chatgpt.com",
+  "claude.ai",
+  "copilot.microsoft.com",
+  "gemini.google.com",
+  "grok.com",
+  "openai.com",
+  "perplexity.ai",
+]);
+
+function domainMatches(domain: string, candidates: Set<string>): boolean {
+  for (const candidate of candidates) {
+    if (domain === candidate || domain.endsWith(`.${candidate}`)) return true;
+  }
+  return false;
+}
+
+export function acquisitionSourceBucket(
+  attribution: FirstTouchAttribution,
+): AcquisitionSourceBucket {
+  const source = attribution.source.toLowerCase();
+  const medium = attribution.medium.toLowerCase();
+  const domain = attribution.referringDomain.toLowerCase();
+
+  if (source === "user_referral" || attribution.entrySurface === "invite") {
+    return "referral_link";
+  }
+  if (medium === "organic") return "organic_search";
+  if (
+    source === "github" ||
+    source === "github.com" ||
+    domain === "github.com" ||
+    domain.endsWith(".github.com")
+  ) {
+    return "github";
+  }
+  if (
+    domainMatches(source, AI_ASSISTANT_DOMAINS) ||
+    domainMatches(domain, AI_ASSISTANT_DOMAINS)
+  ) {
+    return "ai_assistant";
+  }
+  if (
+    domainMatches(source, COMMUNITY_DOMAINS) ||
+    domainMatches(domain, COMMUNITY_DOMAINS)
+  ) {
+    return "community";
+  }
+  if (source === "$direct" && domain === "$direct") {
+    return "direct_or_dark";
+  }
+  if (
+    attribution.campaign ||
+    ["campaign", "cpc", "email", "paid", "ppc", "social"].includes(medium)
+  ) {
+    return "campaign";
+  }
+  return "unknown";
+}
+
+function isNewUserFromSignupFlow({
+  userCreatedAt,
+  signupStartedAt,
+  now,
+}: {
+  userCreatedAt: string;
+  signupStartedAt: string;
+  now: Date;
+}): boolean {
+  const createdAtMs = Date.parse(userCreatedAt);
+  const startedAtMs = Date.parse(signupStartedAt);
+  const nowMs = now.getTime();
+  if (!Number.isFinite(createdAtMs) || !Number.isFinite(startedAtMs)) {
+    return false;
+  }
+
+  return (
+    startedAtMs >= nowMs - AUTH_FLOW_MAX_AGE_MS - CLOCK_SKEW_MS &&
+    startedAtMs <= nowMs + CLOCK_SKEW_MS &&
+    createdAtMs >= startedAtMs - CLOCK_SKEW_MS &&
+    createdAtMs <= nowMs + CLOCK_SKEW_MS
+  );
+}
+
+export function captureSignupAcquisitionAttribution({
+  user,
+  state,
+  now = new Date(),
+}: {
+  user: User;
+  state?: string;
+  now?: Date;
+}): boolean {
+  const parsed = parseSignupAttributionState(state);
+  if (
+    !parsed ||
+    !isNewUserFromSignupFlow({
+      userCreatedAt: user.createdAt,
+      signupStartedAt: parsed.signupStartedAt,
+      now,
+    })
+  ) {
+    return false;
+  }
+
+  const capturedAtMs = Date.parse(parsed.firstTouch.capturedAt);
+  if (
+    capturedAtMs <
+      now.getTime() - FIRST_TOUCH_ATTRIBUTION_MAX_AGE_SECONDS * 1_000 ||
+    capturedAtMs > now.getTime() + CLOCK_SKEW_MS
+  ) {
+    return false;
+  }
+
+  const firstTouch = firstTouchPersonProperties(parsed.firstTouch);
+  const sourceBucket = acquisitionSourceBucket(parsed.firstTouch);
+  const sourceContext = {
+    referral_link_present: sourceBucket === "referral_link",
+    ...(sourceBucket === "organic_search"
+      ? { search_engine: parsed.firstTouch.source }
+      : {}),
+  };
+  phLogger.event("signup_acquisition_attributed_v1", {
+    userId: user.id,
+    acquisition_attribution_version: parsed.firstTouch.version,
+    acquisition_source_bucket: sourceBucket,
+    attribution_source: "workos_authkit_callback",
+    signup_started_at: parsed.signupStartedAt,
+    user_created_at: user.createdAt,
+    ...sourceContext,
+    ...firstTouch,
+    $insert_id: `signup_acquisition_attributed_v1:${user.id}`,
+    $set_once: {
+      ...firstTouch,
+      acquisition_source_bucket: sourceBucket,
+      ...sourceContext,
+    },
+  });
+  return true;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -12,8 +12,8 @@ import {
   FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME,
   FIRST_TOUCH_ATTRIBUTION_MAX_AGE_SECONDS,
   createFirstTouchAttribution,
-  serializeFirstTouchAttribution,
 } from "@/lib/analytics/acquisition";
+import { serializeSignedFirstTouchAttribution } from "@/lib/analytics/acquisition-cookie";
 
 const AUTHKIT_BYPASS_PATHS = new Set([
   "/api/health/connectivity",
@@ -122,6 +122,13 @@ function isBrowserRequest(request: NextRequest): boolean {
   return accept.includes("text/html");
 }
 
+function isLikelyBot(request: NextRequest): boolean {
+  const userAgent = request.headers.get("user-agent") ?? "";
+  return /bot|crawler|spider|slurp|headless|facebookexternalhit|preview|uptime|betterstack/i.test(
+    userAgent,
+  );
+}
+
 const SESSION_HEADER = "x-workos-session";
 
 function withAttributionCookies(
@@ -140,26 +147,26 @@ function withAttributionCookies(
       "/desktop-callback",
       "/desktop-login",
     ].includes(pathname) &&
+    !isLikelyBot(request) &&
     !request.cookies.has("wos-session") &&
     !request.cookies.has(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME);
 
   if (shouldCaptureFirstTouch) {
-    response.cookies.set(
-      FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME,
-      serializeFirstTouchAttribution(
-        createFirstTouchAttribution({
-          url: request.nextUrl,
-          referer: request.headers.get("referer"),
-        }),
-      ),
-      {
+    const value = serializeSignedFirstTouchAttribution(
+      createFirstTouchAttribution({
+        url: request.nextUrl,
+        referer: request.headers.get("referer"),
+      }),
+    );
+    if (value) {
+      response.cookies.set(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME, value, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         maxAge: FIRST_TOUCH_ATTRIBUTION_MAX_AGE_SECONDS,
         path: "/",
-      },
-    );
+      });
+    }
   }
 
   const referralCode =


### PR DESCRIPTION
## Summary

- sign the existing privacy-safe first-touch cookie and ignore likely bot traffic
- carry allowlisted attribution through AuthKit custom state on the signup flow
- emit one idempotent `signup_acquisition_attributed_v1` event only for newly created WorkOS users
- preserve the existing browser identify path as a best-effort fallback without enabling anonymous pageviews or autocapture
- map attribution into the HAC-57 source buckets and set the same bounded fields once on the PostHog person

## Event-volume design

This keeps PostHog volume proportional to completed signups, not public traffic. Public visitors only receive a first-party cookie; they do not produce a PostHog event. The only new Product Analytics event is one deduplicated event per newly created WorkOS user with valid attribution state.

The event contains only source bucket, allowlisted source/medium/campaign values, referrer hostname, entry-surface bucket, timestamps, search engine when known, and referral-link presence. It never includes full URLs, query strings, prompts, targets, findings, code, uploaded content, email, IP address, or user agent.

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; existing repository warnings only)
- focused acquisition/auth/provider/proxy suites: 66 tests passed
- commit hook full suite: 419 suites / 4,450 tests passed
- changed files pass Prettier; repository-wide format check still reports 11 pre-existing unrelated files

## Manual verification

1. Open `https://hackerai.co/?utm_source=github&utm_medium=social&utm_campaign=hac57_manual`, then start signup through `/signup/auth`.
2. Complete a genuinely new WorkOS signup and confirm authentication returns normally without callback delay or errors.
3. In production PostHog, confirm one `signup_acquisition_attributed_v1` event exists for that user with `acquisition_source_bucket=github`, the allowlisted first-touch fields, and no full URL/query/user-content properties.
4. Repeat the callback or sign in through the signup screen with an existing user and confirm no additional attribution event is created.

No visual QA is required because this changes server-side attribution and auth routing only; the user-visible signup flow is unchanged.

Linear: https://linear.app/hackerai/issue/HAC-57/measure-where-hackerai-users-come-from-and-why-they-recommend-it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added first-touch attribution tracking throughout signup, preserving acquisition details from initial visit through authentication.
  - Added source categorization and privacy-conscious analytics events for new signups.
- **Bug Fixes**
  - Attribution cookies are now signed and validated to help prevent tampering.
  - Invalid, expired, oversized, or bot-generated attribution data is ignored.
  - Legacy attribution cookies remain supported temporarily during migration.
- **Analytics**
  - Successful signup attribution is flushed reliably after authentication.
  - Existing users and signups without valid attribution are excluded from acquisition events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->