### PR TITLE
Protect usage when automatic Agent recovery cannot finish

### DIFF
--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -21,8 +21,11 @@ export const FinishReasonNotice = ({
   finishReason,
   onContinue,
 }: FinishReasonNoticeProps) => {
-  const { isAutoResuming, isAutoContinuing } = useDataStreamState();
+  const { dataStream, isAutoResuming, isAutoContinuing } = useDataStreamState();
   const [hasContinued, setHasContinued] = useState(false);
+  const usageProtected = dataStream.some(
+    (part) => part.type === "data-auto-continue-usage-protected",
+  );
 
   if (!finishReason) return null;
 
@@ -90,7 +93,15 @@ export const FinishReasonNotice = ({
   return (
     <div className="mt-2 w-full">
       <div className="bg-muted text-muted-foreground rounded-lg px-3 py-2 border border-border flex items-center justify-between gap-3 flex-wrap">
-        <span>{content}</span>
+        <div className="flex flex-col gap-1">
+          <span>{content}</span>
+          {usageProtected ? (
+            <span className="text-foreground">
+              This automatic recovery attempt didn&apos;t finish, so its usage
+              was restored.
+            </span>
+          ) : null}
+        </div>
         {showContinue && (
           <Button
             type="button"

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -8,30 +8,40 @@ import { DataStreamProvider, useDataStream } from "../DataStreamProvider";
 import { MAX_AUTO_CONTINUES } from "@/app/hooks/useAutoContinue";
 import { POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON } from "@/lib/chat/stop-conditions";
 import type { ChatMode, SelectedModel } from "@/types/chat";
+import type { ScopedDataUIPart } from "../DataStreamProvider";
 
 function DataStreamSetter({
   isAutoResuming,
   isAutoContinuing,
   autoContinueCount,
+  dataStream,
   children,
 }: {
   isAutoResuming?: boolean;
   isAutoContinuing?: boolean;
   autoContinueCount?: number;
+  dataStream?: ScopedDataUIPart[];
   children: React.ReactNode;
 }) {
-  const { setIsAutoResuming, setIsAutoContinuing, setAutoContinueCount } =
-    useDataStream();
+  const {
+    setDataStream,
+    setIsAutoResuming,
+    setIsAutoContinuing,
+    setAutoContinueCount,
+  } = useDataStream();
 
   React.useEffect(() => {
     if (isAutoResuming !== undefined) setIsAutoResuming(isAutoResuming);
     if (isAutoContinuing !== undefined) setIsAutoContinuing(isAutoContinuing);
     if (autoContinueCount !== undefined)
       setAutoContinueCount(autoContinueCount);
+    if (dataStream !== undefined) setDataStream(dataStream);
   }, [
     isAutoResuming,
     isAutoContinuing,
     autoContinueCount,
+    dataStream,
+    setDataStream,
     setIsAutoResuming,
     setIsAutoContinuing,
     setAutoContinueCount,
@@ -53,6 +63,7 @@ function renderNotice(
     isAutoResuming?: boolean;
     isAutoContinuing?: boolean;
     autoContinueCount?: number;
+    dataStream?: ScopedDataUIPart[];
   },
 ) {
   return render(
@@ -160,6 +171,28 @@ describe("FinishReasonNotice", () => {
       expect(
         screen.getByText(
           /The response reached its output limit before finishing.*Continue to resume where it stopped/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("confirms when an incomplete automatic recovery had its usage restored", () => {
+      renderNotice(
+        { finishReason: "tool-calls", mode: "agent" },
+        {
+          isAutoResuming: false,
+          autoContinueCount: MAX_AUTO_CONTINUES,
+          dataStream: [
+            {
+              type: "data-auto-continue-usage-protected",
+              data: { status: "restored" },
+            },
+          ],
+        },
+      );
+
+      expect(
+        screen.getByText(
+          /This automatic recovery attempt didn't finish, so its usage was restored/i,
         ),
       ).toBeInTheDocument();
     });

--- a/app/components/worked-for-parts.ts
+++ b/app/components/worked-for-parts.ts
@@ -9,6 +9,7 @@ const TRAILING_METADATA_PART_TYPES = new Set([
   "data-agent-auto-review-lifecycle",
   "data-appendMessage",
   "data-auto-continue",
+  "data-auto-continue-usage-protected",
   "data-context-usage",
   "data-diff",
   "data-file-metadata",

--- a/lib/api/__tests__/agent-auto-continue-usage-protection.test.ts
+++ b/lib/api/__tests__/agent-auto-continue-usage-protection.test.ts
@@ -1,0 +1,103 @@
+import { protectIncompleteAutomaticContinuation } from "../agent-auto-continue-usage-protection";
+
+describe("protectIncompleteAutomaticContinuation", () => {
+  const refundWithResult = jest.fn();
+  const write = jest.fn();
+  const capture = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    refundWithResult.mockResolvedValue({
+      status: "refunded",
+      includedPointsRefunded: 1_000,
+      extraUsagePointsRefunded: 200,
+      includedPointsRemaining: 0,
+      extraUsagePointsRemaining: 0,
+    });
+  });
+
+  const run = (
+    overrides: Partial<
+      Parameters<typeof protectIncompleteAutomaticContinuation>[0]
+    > = {},
+  ) =>
+    protectIncompleteAutomaticContinuation({
+      assignment: "test",
+      stopSource: "tool_calls_finish_reason",
+      usageRefundTracker: { refundWithResult } as never,
+      writer: { write } as never,
+      posthog: { capture } as never,
+      userId: "user-123",
+      subscription: "pro",
+      endpoint: "/api/agent-long",
+      ...overrides,
+    });
+
+  it("restores and confirms the bounded recovery run for treatment", async () => {
+    await run();
+
+    expect(refundWithResult).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith({
+      type: "data-auto-continue-usage-protected",
+      data: { status: "restored" },
+    });
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: "user-123",
+        event: "agent_auto_continue_recovery_finished",
+        properties: expect.objectContaining({
+          experiment_variant: "test",
+          refund_status: "refunded",
+          included_points_refunded: 1_000,
+          extra_usage_points_refunded: 200,
+        }),
+      }),
+    );
+  });
+
+  it("records control exposure without refunding or showing protection", async () => {
+    await run({ assignment: "control" });
+
+    expect(refundWithResult).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          experiment_variant: "control",
+          refund_status: "not_attempted",
+        }),
+      }),
+    );
+  });
+
+  it("does not claim full protection after a partial refund", async () => {
+    refundWithResult.mockResolvedValueOnce({
+      status: "partial",
+      includedPointsRefunded: 1_000,
+      extraUsagePointsRefunded: 0,
+      includedPointsRemaining: 0,
+      extraUsagePointsRemaining: 200,
+    });
+
+    await run();
+
+    expect(write).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          refund_status: "partial",
+          extra_usage_points_remaining: 200,
+        }),
+      }),
+    );
+  });
+
+  it("does nothing when the flag is unavailable or the recovery completed", async () => {
+    await run({ assignment: undefined });
+    await run({ stopSource: null });
+
+    expect(refundWithResult).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1430,13 +1430,47 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       expect(source).toMatch(
         /assignment:\s*autoContinueUsageProtectionAssignment/,
       );
-      expect(source).toMatch(/stopSource:\s*autoContinueStopSource/);
+      expect(source).toMatch(/stopSource,/);
     }
     expect(routeSrc).toMatch(/AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG/);
     expect(routeSrc).toMatch(/autoContinueUsageProtectionAssignment,/);
     expect(taskSrc).toMatch(
       /autoContinueUsageProtectionAssignment\?:\s*AgentAutoContinueUsageProtectionAssignment/,
     );
+  });
+
+  test("fallback and final retry completion paths preserve automatic recovery protection", () => {
+    const directRetryDeductionIdx = chatHandlerSrc.indexOf(
+      "await deductAccumulatedUsage(retryMessageId)",
+    );
+    const directRetryProtectionIdx = chatHandlerSrc.indexOf(
+      "await protectTerminalAutomaticContinuation()",
+      directRetryDeductionIdx,
+    );
+    expect(directRetryDeductionIdx).toBeGreaterThan(-1);
+    expect(directRetryProtectionIdx).toBeGreaterThan(directRetryDeductionIdx);
+
+    const triggerFinalizerIdx = taskSrc.indexOf(
+      "const finalizeRetryStream = async",
+    );
+    const triggerRetryDeductionIdx = taskSrc.indexOf(
+      "await deductAccumulatedUsage()",
+      triggerFinalizerIdx,
+    );
+    const triggerRetryProtectionIdx = taskSrc.indexOf(
+      "await protectTerminalAutomaticContinuation()",
+      triggerRetryDeductionIdx,
+    );
+    expect(triggerFinalizerIdx).toBeGreaterThan(-1);
+    expect(triggerRetryProtectionIdx).toBeGreaterThan(triggerRetryDeductionIdx);
+
+    const finalRetryFinishIdx = taskSrc.indexOf("messages: finalRetryMessages");
+    const finalRetryFinalizeIdx = taskSrc.indexOf(
+      "await finalizeRetryStream({",
+      finalRetryFinishIdx,
+    );
+    expect(finalRetryFinishIdx).toBeGreaterThan(-1);
+    expect(finalRetryFinalizeIdx).toBeGreaterThan(finalRetryFinishIdx);
   });
 
   test("the direct chat boundary strictly normalizes automatic continuation flags", () => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1198,7 +1198,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       /const genericDelegationFlagPromise\s*=\s*agentPermissionMode === "full_access"/,
     );
     expect(routeSrc).toMatch(
-      /existingChat, userCustomization, genericDelegationEnabled[\s\S]*Promise\.all/,
+      /existingChat,[\s\S]{0,200}userCustomization,[\s\S]{0,200}genericDelegationEnabled,[\s\S]{0,200}Promise\.all/,
     );
     expect(routeSrc).toContain('"agent-generic-delegation-v1"');
     expect(routeSrc).not.toContain("securityValidationSubagentsEnabled");
@@ -1415,11 +1415,28 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       expect(source).toMatch(/getAgentAutoContinueStopSource\(\{/);
       expect(source).toMatch(/finishReason:\s*state\.streamFinishReason/);
       expect(source).toMatch(
-        /if \(\s*autoContinueStopSource[\s\S]{0,100}!isAutomaticContinuation\s*\) \{\s*writeAutoContinue/,
+        /if \(\s*autoContinueStopSource\s*&&[\s\S]{0,100}!isAutomaticContinuation\s*\)/,
       );
       expect(source).toMatch(/writeAutoContinue\(writer\)/);
       expect(source).toMatch(/agent_auto_continue_suppressed/);
     }
+  });
+
+  test("both Agent backends protect only a bounded automatic recovery that stops incomplete", () => {
+    for (const source of [chatHandlerSrc, taskSrc]) {
+      expect(source).toMatch(
+        /if \(isAutomaticContinuation\) \{\s*await protectIncompleteAutomaticContinuation\(\{/,
+      );
+      expect(source).toMatch(
+        /assignment:\s*autoContinueUsageProtectionAssignment/,
+      );
+      expect(source).toMatch(/stopSource:\s*autoContinueStopSource/);
+    }
+    expect(routeSrc).toMatch(/AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG/);
+    expect(routeSrc).toMatch(/autoContinueUsageProtectionAssignment,/);
+    expect(taskSrc).toMatch(
+      /autoContinueUsageProtectionAssignment\?:\s*AgentAutoContinueUsageProtectionAssignment/,
+    );
   });
 
   test("the direct chat boundary strictly normalizes automatic continuation flags", () => {
@@ -1629,7 +1646,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       expect(source).toMatch(/getAgentAutoContinueStopSource\(\{/);
       expect(source).toMatch(/autoContinueStopSource/);
       expect(source).toMatch(
-        /if \(\s*autoContinueStopSource[\s\S]{0,100}!isAutomaticContinuation\s*\) \{\s*writeAutoContinue/,
+        /if \(\s*autoContinueStopSource\s*&&[\s\S]{0,100}!isAutomaticContinuation\s*\)/,
       );
       expect(source).toMatch(/agent_auto_continue_signaled/);
     }

--- a/lib/api/__tests__/provider-content-blocked-refund.test.ts
+++ b/lib/api/__tests__/provider-content-blocked-refund.test.ts
@@ -7,7 +7,12 @@ describe("provider content-blocked refund lifecycle", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
-    refundUsage.mockResolvedValue(undefined);
+    refundUsage.mockResolvedValue({
+      includedPointsRefunded: 100,
+      extraUsagePointsRefunded: 0,
+      includedRefundFailed: false,
+      extraUsageRefundFailed: false,
+    });
   });
 
   const createLifecycle = (hasUsage: () => boolean) => {
@@ -53,10 +58,17 @@ describe("provider content-blocked refund lifecycle", () => {
   });
 
   it("serializes concurrent settled callbacks into one external refund", async () => {
-    let completeRefund: (() => void) | undefined;
+    let completeRefund:
+      | ((value: {
+          includedPointsRefunded: number;
+          extraUsagePointsRefunded: number;
+          includedRefundFailed: boolean;
+          extraUsageRefundFailed: boolean;
+        }) => void)
+      | undefined;
     refundUsage.mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise((resolve) => {
           completeRefund = resolve;
         }),
     );
@@ -71,7 +83,12 @@ describe("provider content-blocked refund lifecycle", () => {
     const abortRefund = lifecycle({ error, settled: true });
 
     expect(refundUsage).toHaveBeenCalledTimes(1);
-    completeRefund?.();
+    completeRefund?.({
+      includedPointsRefunded: 100,
+      extraUsagePointsRefunded: 0,
+      includedRefundFailed: false,
+      extraUsageRefundFailed: false,
+    });
     await Promise.all([finishRefund, abortRefund]);
     expect(refundUsage).toHaveBeenCalledTimes(1);
   });

--- a/lib/api/agent-auto-continue-usage-protection.ts
+++ b/lib/api/agent-auto-continue-usage-protection.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import type { PostHog } from "posthog-node";
+import type { UIMessageStreamWriter } from "ai";
+import type { AgentAutoContinueStopSource } from "@/lib/chat/stop-conditions";
+import {
+  captureAgentAutoContinueRecoveryFinished,
+  type AgentAutoContinueUsageProtectionAssignment,
+} from "@/lib/experiments/agent-auto-continue-usage-protection";
+import type { UsageRefundTracker } from "@/lib/rate-limit/refund";
+import { writeAutoContinueUsageProtected } from "@/lib/utils/stream-writer-utils";
+import type { SubscriptionTier } from "@/types";
+
+export const protectIncompleteAutomaticContinuation = async ({
+  assignment,
+  stopSource,
+  usageRefundTracker,
+  writer,
+  posthog,
+  userId,
+  subscription,
+  endpoint,
+}: {
+  assignment?: AgentAutoContinueUsageProtectionAssignment;
+  stopSource: AgentAutoContinueStopSource | null;
+  usageRefundTracker: UsageRefundTracker;
+  writer: UIMessageStreamWriter;
+  posthog: Pick<PostHog, "capture"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  endpoint: string;
+}): Promise<void> => {
+  if (!assignment || !stopSource) return;
+
+  const refund =
+    assignment === "test"
+      ? await usageRefundTracker.refundWithResult()
+      : undefined;
+
+  if (refund?.status === "refunded") {
+    writeAutoContinueUsageProtected(writer);
+  }
+
+  captureAgentAutoContinueRecoveryFinished({
+    posthog,
+    userId,
+    subscription,
+    endpoint,
+    assignment,
+    stopSource,
+    refund,
+  });
+};

--- a/lib/api/agent-auto-continue-usage-protection.ts
+++ b/lib/api/agent-auto-continue-usage-protection.ts
@@ -11,6 +11,7 @@ import type { UsageRefundTracker } from "@/lib/rate-limit/refund";
 import { writeAutoContinueUsageProtected } from "@/lib/utils/stream-writer-utils";
 import type { SubscriptionTier } from "@/types";
 
+/** Restore a treatment recovery's usage only after it ends incomplete again. */
 export const protectIncompleteAutomaticContinuation = async ({
   assignment,
   stopSource,

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -78,7 +78,17 @@ import {
   getBaselineAgentTriggerMachine,
   resolveAgentMachineRouting,
 } from "@/lib/experiments/agent-machine-routing";
-import { getPostHogFeatureFlagForUser, phLogger } from "@/lib/posthog/server";
+import {
+  getPostHogFeatureFlagForUser,
+  getPostHogFeatureFlagValueForUser,
+  phLogger,
+} from "@/lib/posthog/server";
+import {
+  AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG,
+  isAgentAutoContinueUsageProtectionEligible,
+  resolveAgentAutoContinueUsageProtectionAssignment,
+  type AgentAutoContinueUsageProtectionAssignment,
+} from "@/lib/experiments/agent-auto-continue-usage-protection";
 
 const AGENT_TRIGGER_PRIORITY_BY_SUBSCRIPTION: Record<SubscriptionTier, number> =
   {
@@ -465,6 +475,18 @@ export const createAgentTriggerPost =
         agentPermissionMode === "full_access"
           ? getPostHogFeatureFlagForUser("agent-generic-delegation-v1", userId)
           : Promise.resolve(false);
+      const autoContinueUsageProtectionAssignmentPromise =
+        isAgentAutoContinueUsageProtectionEligible({
+          subscription,
+          isAutomaticContinuation: isAutomaticContinuation === true,
+        })
+          ? getPostHogFeatureFlagValueForUser(
+              AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG,
+              userId,
+            ).then(resolveAgentAutoContinueUsageProtectionAssignment)
+          : Promise.resolve<
+              AgentAutoContinueUsageProtectionAssignment | undefined
+            >(undefined);
 
       assertFreeAgentGates({
         mode: "agent",
@@ -499,12 +521,17 @@ export const createAgentTriggerPost =
       // These independent authorization/config reads used to run serially
       // before Trigger was called. Overlap them so the worker starts booting as
       // soon as possible after the suspension check succeeds.
-      const [existingChat, userCustomization, genericDelegationEnabled] =
-        await Promise.all([
-          getChatById({ id: chatId }),
-          getUserCustomization({ userId }),
-          genericDelegationFlagPromise,
-        ]);
+      const [
+        existingChat,
+        userCustomization,
+        genericDelegationEnabled,
+        autoContinueUsageProtectionAssignment,
+      ] = await Promise.all([
+        getChatById({ id: chatId }),
+        getUserCustomization({ userId }),
+        genericDelegationFlagPromise,
+        autoContinueUsageProtectionAssignmentPromise,
+      ]);
 
       // Fetch existing chat to: (a) detect isNewChat for title generation,
       // (b) pass to handleInitialChatAndUserMessage so it skips saveChat on
@@ -733,6 +760,7 @@ export const createAgentTriggerPost =
         triggerRegion,
         isAutoContinue,
         isAutomaticContinuation,
+        autoContinueUsageProtectionAssignment,
         regenerate,
         limitRescue,
         isNewChat,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -149,7 +149,10 @@ import {
   writeAutoContinue,
 } from "@/lib/utils/stream-writer-utils";
 import { Id } from "@/convex/_generated/dataModel";
-import { phLogger } from "@/lib/posthog/server";
+import {
+  getPostHogFeatureFlagValueForUser,
+  phLogger,
+} from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import { readAnalyticsRequestContext } from "@/lib/analytics/request-context";
 import { buildAgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
@@ -210,6 +213,12 @@ import {
   shouldRetryProviderStreamWithFallback,
 } from "@/lib/chat/agent-long-provider-retry";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
+import { protectIncompleteAutomaticContinuation } from "@/lib/api/agent-auto-continue-usage-protection";
+import {
+  AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG,
+  isAgentAutoContinueUsageProtectionEligible,
+  resolveAgentAutoContinueUsageProtectionAssignment,
+} from "@/lib/experiments/agent-auto-continue-usage-protection";
 
 function getStreamContext() {
   try {
@@ -299,6 +308,16 @@ export const createChatHandler = () => {
 
       const { userId, subscription, organizationId, freeQuotaSubject } =
         await getUserIDAndPro(req);
+      const autoContinueUsageProtectionAssignmentPromise =
+        isAgentAutoContinueUsageProtectionEligible({
+          subscription,
+          isAutomaticContinuation,
+        })
+          ? getPostHogFeatureFlagValueForUser(
+              AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG,
+              userId,
+            ).then(resolveAgentAutoContinueUsageProtectionAssignment)
+          : Promise.resolve(undefined);
       const freeUsageSubject = freeQuotaSubject ?? userId;
       let selectedModelOverride: SelectedModel | undefined =
         normalizeSelectedModelOverrideForSubscription(
@@ -483,6 +502,8 @@ export const createChatHandler = () => {
 
       // PostHog client for analytics.
       posthog ??= PostHogClient();
+      const autoContinueUsageProtectionAssignment =
+        await autoContinueUsageProtectionAssignmentPromise;
 
       const fileCounts = countFileAttachments(truncatedMessages);
       const chatLogContext = {
@@ -2603,6 +2624,18 @@ export const createChatHandler = () => {
                         stoppedDueToPostSummarizationIncomplete:
                           state.stoppedDueToPostSummarizationIncomplete,
                       });
+                    if (isAutomaticContinuation) {
+                      await protectIncompleteAutomaticContinuation({
+                        assignment: autoContinueUsageProtectionAssignment,
+                        stopSource: autoContinueStopSource,
+                        usageRefundTracker,
+                        writer,
+                        posthog,
+                        userId,
+                        subscription,
+                        endpoint,
+                      });
+                    }
                     if (
                       autoContinueStopSource &&
                       isAgentMode(mode) &&

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -982,6 +982,28 @@ export const createChatHandler = () => {
                   )
                 : { usedTokens: 0, maxTokens: 0 },
             );
+            const protectTerminalAutomaticContinuation = async () => {
+              const stopSource = getAgentAutoContinueStopSource({
+                finishReason: state.streamFinishReason,
+                stoppedDueToTokenExhaustion: state.stoppedDueToTokenExhaustion,
+                stoppedDueToElapsedTimeout: state.stoppedDueToElapsedTimeout,
+                stoppedDueToPostSummarizationIncomplete:
+                  state.stoppedDueToPostSummarizationIncomplete,
+              });
+              if (isAutomaticContinuation) {
+                await protectIncompleteAutomaticContinuation({
+                  assignment: autoContinueUsageProtectionAssignment,
+                  stopSource,
+                  usageRefundTracker,
+                  writer,
+                  posthog,
+                  userId,
+                  subscription,
+                  endpoint,
+                });
+              }
+              return stopSource;
+            };
 
             // Mid-stream budget enforcement. Paid users use their subscription
             // bucket; free users use an internal monthly cost cap.
@@ -1961,6 +1983,7 @@ export const createChatHandler = () => {
                                 // reason to budget-exhausted; do it before
                                 // analytics and persistence consume state.
                                 await deductAccumulatedUsage(retryMessageId);
+                                await protectTerminalAutomaticContinuation();
                                 const providerContentBlocked =
                                   isProviderContentFilterFinishReason(
                                     state.streamFinishReason,
@@ -2615,27 +2638,7 @@ export const createChatHandler = () => {
                     }
 
                     const autoContinueStopSource =
-                      getAgentAutoContinueStopSource({
-                        finishReason: state.streamFinishReason,
-                        stoppedDueToTokenExhaustion:
-                          state.stoppedDueToTokenExhaustion,
-                        stoppedDueToElapsedTimeout:
-                          state.stoppedDueToElapsedTimeout,
-                        stoppedDueToPostSummarizationIncomplete:
-                          state.stoppedDueToPostSummarizationIncomplete,
-                      });
-                    if (isAutomaticContinuation) {
-                      await protectIncompleteAutomaticContinuation({
-                        assignment: autoContinueUsageProtectionAssignment,
-                        stopSource: autoContinueStopSource,
-                        usageRefundTracker,
-                        writer,
-                        posthog,
-                        userId,
-                        subscription,
-                        endpoint,
-                      });
-                    }
+                      await protectTerminalAutomaticContinuation();
                     if (
                       autoContinueStopSource &&
                       isAgentMode(mode) &&

--- a/lib/experiments/__tests__/agent-auto-continue-usage-protection.test.ts
+++ b/lib/experiments/__tests__/agent-auto-continue-usage-protection.test.ts
@@ -1,0 +1,39 @@
+import {
+  isAgentAutoContinueUsageProtectionEligible,
+  resolveAgentAutoContinueUsageProtectionAssignment,
+} from "../agent-auto-continue-usage-protection";
+
+describe("agent auto-continue usage protection", () => {
+  it("limits eligibility to paid automatic continuations", () => {
+    expect(
+      isAgentAutoContinueUsageProtectionEligible({
+        subscription: "pro",
+        isAutomaticContinuation: true,
+      }),
+    ).toBe(true);
+    expect(
+      isAgentAutoContinueUsageProtectionEligible({
+        subscription: "free",
+        isAutomaticContinuation: true,
+      }),
+    ).toBe(false);
+    expect(
+      isAgentAutoContinueUsageProtectionEligible({
+        subscription: "ultra",
+        isAutomaticContinuation: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves unavailable flag evaluations instead of treating them as control", () => {
+    expect(resolveAgentAutoContinueUsageProtectionAssignment(true)).toBe(
+      "test",
+    );
+    expect(resolveAgentAutoContinueUsageProtectionAssignment(false)).toBe(
+      "control",
+    );
+    expect(resolveAgentAutoContinueUsageProtectionAssignment(null)).toBe(
+      undefined,
+    );
+  });
+});

--- a/lib/experiments/agent-auto-continue-usage-protection.ts
+++ b/lib/experiments/agent-auto-continue-usage-protection.ts
@@ -1,0 +1,67 @@
+import type { PostHog } from "posthog-node";
+import type { AgentAutoContinueStopSource } from "@/lib/chat/stop-conditions";
+import type { UsageRefundOutcome } from "@/lib/rate-limit/refund";
+import type { SubscriptionTier } from "@/types";
+
+export const AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG =
+  "agent_auto_continue_usage_protection_v1";
+export const AGENT_AUTO_CONTINUE_RECOVERY_FINISHED_EVENT =
+  "agent_auto_continue_recovery_finished";
+
+export type AgentAutoContinueUsageProtectionAssignment = "control" | "test";
+
+export const isAgentAutoContinueUsageProtectionEligible = ({
+  subscription,
+  isAutomaticContinuation,
+}: {
+  subscription: SubscriptionTier;
+  isAutomaticContinuation: boolean;
+}): boolean => subscription !== "free" && isAutomaticContinuation;
+
+export const resolveAgentAutoContinueUsageProtectionAssignment = (
+  flagValue: boolean | null,
+): AgentAutoContinueUsageProtectionAssignment | undefined => {
+  if (flagValue === null) return undefined;
+  return flagValue ? "test" : "control";
+};
+
+export const captureAgentAutoContinueRecoveryFinished = ({
+  posthog,
+  userId,
+  subscription,
+  endpoint,
+  assignment,
+  stopSource,
+  refund,
+}: {
+  posthog: Pick<PostHog, "capture"> | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  endpoint: string;
+  assignment: AgentAutoContinueUsageProtectionAssignment;
+  stopSource: AgentAutoContinueStopSource;
+  refund?: UsageRefundOutcome;
+}): void => {
+  if (!posthog) return;
+  posthog.capture({
+    distinctId: userId,
+    event: AGENT_AUTO_CONTINUE_RECOVERY_FINISHED_EVENT,
+    properties: {
+      experiment_key: AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG,
+      experiment_variant: assignment,
+      [`$feature/${AGENT_AUTO_CONTINUE_USAGE_PROTECTION_FLAG}`]:
+        assignment === "test",
+      subscription,
+      subscription_tier: subscription,
+      endpoint,
+      stop_source: stopSource,
+      refund_status: refund?.status ?? "not_attempted",
+      included_points_refunded: refund?.includedPointsRefunded ?? 0,
+      extra_usage_points_refunded: refund?.extraUsagePointsRefunded ?? 0,
+      included_points_remaining: refund?.includedPointsRemaining ?? 0,
+      extra_usage_points_remaining: refund?.extraUsagePointsRemaining ?? 0,
+      exposure_surface: "incomplete_automatic_recovery",
+      $process_person_profile: false,
+    },
+  });
+};

--- a/lib/experiments/agent-auto-continue-usage-protection.ts
+++ b/lib/experiments/agent-auto-continue-usage-protection.ts
@@ -10,6 +10,7 @@ export const AGENT_AUTO_CONTINUE_RECOVERY_FINISHED_EVENT =
 
 export type AgentAutoContinueUsageProtectionAssignment = "control" | "test";
 
+/** Restrict the experiment to paid, system-started recovery runs. */
 export const isAgentAutoContinueUsageProtectionEligible = ({
   subscription,
   isAutomaticContinuation,
@@ -18,6 +19,7 @@ export const isAgentAutoContinueUsageProtectionEligible = ({
   isAutomaticContinuation: boolean;
 }): boolean => subscription !== "free" && isAutomaticContinuation;
 
+/** Preserve flag unavailability while mapping boolean evaluations to cohorts. */
 export const resolveAgentAutoContinueUsageProtectionAssignment = (
   flagValue: boolean | null,
 ): AgentAutoContinueUsageProtectionAssignment | undefined => {
@@ -25,6 +27,7 @@ export const resolveAgentAutoContinueUsageProtectionAssignment = (
   return flagValue ? "test" : "control";
 };
 
+/** Record a privacy-safe terminal exposure and confirmed refund outcome. */
 export const captureAgentAutoContinueRecoveryFinished = ({
   posthog,
   userId,

--- a/lib/rate-limit/__tests__/refund.test.ts
+++ b/lib/rate-limit/__tests__/refund.test.ts
@@ -93,6 +93,7 @@ describe("UsageRefundTracker", () => {
       125,
       125,
       undefined,
+      expect.any(String),
     );
   });
 
@@ -161,6 +162,9 @@ describe("UsageRefundTracker", () => {
     await tracker.refund();
 
     expect(refundUsage).toHaveBeenCalledTimes(2);
+    expect(refundUsage.mock.calls[0]?.[5]).toEqual(
+      refundUsage.mock.calls[1]?.[5],
+    );
     consoleError.mockRestore();
   });
 
@@ -202,6 +206,7 @@ describe("UsageRefundTracker", () => {
       100,
       50,
       undefined,
+      expect.any(String),
     );
     expect(refundUsage).toHaveBeenNthCalledWith(
       2,
@@ -209,6 +214,7 @@ describe("UsageRefundTracker", () => {
       "pro",
       0,
       50,
+      undefined,
       undefined,
     );
   });

--- a/lib/rate-limit/__tests__/refund.test.ts
+++ b/lib/rate-limit/__tests__/refund.test.ts
@@ -1,259 +1,249 @@
-/**
- * Tests for UsageRefundTracker class.
- *
- * Uses jest.isolateModules() to mock the refundUsage dependency.
- */
-import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import type { RateLimitInfo } from "@/types";
 
 describe("UsageRefundTracker", () => {
-  const mockRefundUsage = jest.fn();
+  const refundUsage = jest.fn(
+    async (
+      _userId: string,
+      _subscription: string,
+      includedPoints: number,
+      extraUsagePoints: number,
+    ) => ({
+      includedPointsRefunded: includedPoints,
+      extraUsagePointsRefunded: extraUsagePoints,
+      includedRefundFailed: false,
+      extraUsageRefundFailed: false,
+    }),
+  );
 
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
-    mockRefundUsage.mockResolvedValue(undefined);
+    refundUsage.mockImplementation(
+      async (
+        _userId: string,
+        _subscription: string,
+        includedPoints: number,
+        extraUsagePoints: number,
+      ) => ({
+        includedPointsRefunded: includedPoints,
+        extraUsagePointsRefunded: extraUsagePoints,
+        includedRefundFailed: false,
+        extraUsageRefundFailed: false,
+      }),
+    );
   });
 
-  const getIsolatedModule = () => {
-    let isolatedModule: typeof import("../refund");
-
+  const createTracker = () => {
+    let RefundTracker: typeof import("../refund").UsageRefundTracker;
     jest.isolateModules(() => {
-      jest.doMock("../token-bucket", () => ({
-        refundUsage: mockRefundUsage,
-      }));
-
-      isolatedModule = require("../refund");
+      jest.doMock("../token-bucket", () => ({ refundUsage }));
+      RefundTracker = require("../refund").UsageRefundTracker;
     });
-
-    return isolatedModule!;
+    const tracker = new RefundTracker!();
+    tracker.setUser("user-123", "pro");
+    tracker.recordDeductions({
+      remaining: 900,
+      resetTime: new Date(),
+      limit: 1_000,
+      pointsDeducted: 100,
+      extraUsagePointsDeducted: 50,
+    });
+    return tracker;
   };
 
-  describe("setUser", () => {
-    it("should store user context", () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      tracker.setUser("user-123", "pro");
-
-      // User context is stored internally, verified by refund behavior
-      expect(tracker).toBeDefined();
+  const createEmptyTracker = () => {
+    let RefundTracker: typeof import("../refund").UsageRefundTracker;
+    jest.isolateModules(() => {
+      jest.doMock("../token-bucket", () => ({ refundUsage }));
+      RefundTracker = require("../refund").UsageRefundTracker;
     });
+    return new RefundTracker!();
+  };
+
+  it("records deductions and handles missing deduction fields", () => {
+    const tracker = createEmptyTracker();
+    const emptyRateLimitInfo: RateLimitInfo = {
+      remaining: 1_000,
+      resetTime: new Date(),
+      limit: 1_000,
+    };
+
+    tracker.recordDeductions(emptyRateLimitInfo);
+    expect(tracker.hasDeductions()).toBe(false);
+
+    tracker.recordDeductions({
+      ...emptyRateLimitInfo,
+      pointsDeducted: 100,
+    });
+    expect(tracker.hasDeductions()).toBe(true);
   });
 
-  describe("recordDeductions", () => {
-    it("should record points deducted from rate limit info", () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      const rateLimitInfo: RateLimitInfo = {
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 100,
-        extraUsagePointsDeducted: 50,
-      };
-
-      tracker.recordDeductions(rateLimitInfo);
-
-      expect(tracker.hasDeductions()).toBe(true);
+  it("adds mid-run deductions to the refundable totals", async () => {
+    const tracker = createTracker();
+    tracker.addDeductions({
+      includedPointsDeducted: 25,
+      extraUsagePointsDeducted: 75,
     });
 
-    it("should handle missing deduction fields", () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
+    await tracker.refund();
 
-      const rateLimitInfo: RateLimitInfo = {
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-      };
-
-      tracker.recordDeductions(rateLimitInfo);
-
-      expect(tracker.hasDeductions()).toBe(false);
-    });
+    expect(refundUsage).toHaveBeenCalledWith(
+      "user-123",
+      "pro",
+      125,
+      125,
+      undefined,
+    );
   });
 
-  describe("addDeductions", () => {
-    it("adds mid-run deductions to existing refund totals", async () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
+  it("does not refund without deductions or user context", async () => {
+    const noDeductions = createEmptyTracker();
+    noDeductions.setUser("user-123", "pro");
+    await expect(noDeductions.refundWithResult()).resolves.toMatchObject({
+      status: "skipped",
+    });
 
-      tracker.setUser("user-123", "pro");
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 100,
-        extraUsagePointsDeducted: 50,
-      });
-      tracker.addDeductions({
-        includedPointsDeducted: 25,
-        extraUsagePointsDeducted: 75,
-      });
+    const noUser = createEmptyTracker();
+    noUser.recordDeductions({
+      remaining: 900,
+      resetTime: new Date(),
+      limit: 1_000,
+      pointsDeducted: 100,
+    });
+    await expect(noUser.refundWithResult()).resolves.toMatchObject({
+      status: "skipped",
+      includedPointsRemaining: 100,
+    });
 
-      await tracker.refund();
+    expect(refundUsage).not.toHaveBeenCalled();
+  });
 
-      expect(mockRefundUsage).toHaveBeenCalledWith(
-        "user-123",
-        "pro",
-        125,
-        125,
-        undefined,
+  it("is idempotent after a confirmed refund", async () => {
+    const tracker = createTracker();
+
+    await tracker.refund();
+    await tracker.refund();
+    await tracker.refund();
+
+    expect(refundUsage).toHaveBeenCalledTimes(1);
+    expect(tracker.hasDeductions()).toBe(false);
+  });
+
+  it("keeps deductions retryable when the refund call rejects", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    refundUsage
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockImplementationOnce(
+        async (
+          _userId: string,
+          _subscription: string,
+          includedPoints: number,
+          extraUsagePoints: number,
+        ) => ({
+          includedPointsRefunded: includedPoints,
+          extraUsagePointsRefunded: extraUsagePoints,
+          includedRefundFailed: false,
+          extraUsageRefundFailed: false,
+        }),
       );
+    const tracker = createTracker();
+
+    await expect(tracker.refundWithResult()).resolves.toMatchObject({
+      status: "failed",
+      includedPointsRemaining: 100,
+      extraUsagePointsRemaining: 50,
     });
+    await expect(tracker.refundWithResult()).resolves.toMatchObject({
+      status: "refunded",
+    });
+    await tracker.refund();
+
+    expect(refundUsage).toHaveBeenCalledTimes(2);
+    consoleError.mockRestore();
   });
 
-  describe("hasDeductions", () => {
-    it("should return false when no deductions recorded", () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      expect(tracker.hasDeductions()).toBe(false);
-    });
-
-    it("should return true when points deducted", () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 100,
+  it("retries only the component that failed to refund", async () => {
+    refundUsage
+      .mockResolvedValueOnce({
+        includedPointsRefunded: 100,
+        extraUsagePointsRefunded: 0,
+        includedRefundFailed: false,
+        extraUsageRefundFailed: true,
+      })
+      .mockResolvedValueOnce({
+        includedPointsRefunded: 0,
+        extraUsagePointsRefunded: 50,
+        includedRefundFailed: false,
+        extraUsageRefundFailed: false,
       });
+    const tracker = createTracker();
 
-      expect(tracker.hasDeductions()).toBe(true);
+    await expect(tracker.refundWithResult()).resolves.toMatchObject({
+      status: "partial",
+      includedPointsRefunded: 100,
+      extraUsagePointsRemaining: 50,
+    });
+    await expect(tracker.refundWithResult()).resolves.toMatchObject({
+      status: "refunded",
+      extraUsagePointsRefunded: 50,
+      includedPointsRemaining: 0,
+      extraUsagePointsRemaining: 0,
+    });
+    await expect(tracker.refundWithResult()).resolves.toMatchObject({
+      status: "skipped",
     });
 
-    it("should return true when extra usage points deducted", () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        extraUsagePointsDeducted: 50,
-      });
-
-      expect(tracker.hasDeductions()).toBe(true);
-    });
-
-    it("should return false when both deductions are 0", () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 0,
-        extraUsagePointsDeducted: 0,
-      });
-
-      expect(tracker.hasDeductions()).toBe(false);
-    });
+    expect(refundUsage).toHaveBeenNthCalledWith(
+      1,
+      "user-123",
+      "pro",
+      100,
+      50,
+      undefined,
+    );
+    expect(refundUsage).toHaveBeenNthCalledWith(
+      2,
+      "user-123",
+      "pro",
+      0,
+      50,
+      undefined,
+    );
   });
 
-  describe("refund", () => {
-    it("should call refundUsage with recorded deductions", async () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
+  it("serializes concurrent refund calls", async () => {
+    let resolveRefund:
+      | ((value: {
+          includedPointsRefunded: number;
+          extraUsagePointsRefunded: number;
+          includedRefundFailed: boolean;
+          extraUsageRefundFailed: boolean;
+        }) => void)
+      | undefined;
+    refundUsage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRefund = resolve;
+        }),
+    );
+    const tracker = createTracker();
 
-      tracker.setUser("user-123", "pro");
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 100,
-        extraUsagePointsDeducted: 50,
-      });
-
-      await tracker.refund();
-
-      expect(mockRefundUsage).toHaveBeenCalledWith(
-        "user-123",
-        "pro",
-        100,
-        50,
-        undefined,
-      );
+    const first = tracker.refundWithResult();
+    const second = tracker.refundWithResult();
+    expect(refundUsage).toHaveBeenCalledTimes(1);
+    resolveRefund?.({
+      includedPointsRefunded: 100,
+      extraUsagePointsRefunded: 50,
+      includedRefundFailed: false,
+      extraUsageRefundFailed: false,
     });
 
-    it("should be idempotent - only refund once", async () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      tracker.setUser("user-123", "pro");
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 100,
-      });
-
-      await tracker.refund();
-      await tracker.refund();
-      await tracker.refund();
-
-      expect(mockRefundUsage).toHaveBeenCalledTimes(1);
-    });
-
-    it("should not refund if no deductions", async () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      tracker.setUser("user-123", "pro");
-
-      await tracker.refund();
-
-      expect(mockRefundUsage).not.toHaveBeenCalled();
-    });
-
-    it("should not refund if no user set", async () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 100,
-      });
-
-      await tracker.refund();
-
-      expect(mockRefundUsage).not.toHaveBeenCalled();
-    });
-
-    it("should not mark as refunded on error (allows retry)", async () => {
-      const { UsageRefundTracker } = getIsolatedModule();
-      const tracker = new UsageRefundTracker();
-
-      mockRefundUsage.mockRejectedValueOnce(new Error("Network error"));
-      mockRefundUsage.mockResolvedValueOnce(undefined);
-
-      tracker.setUser("user-123", "pro");
-      tracker.recordDeductions({
-        remaining: 5000,
-        resetTime: new Date(),
-        limit: 10000,
-        pointsDeducted: 100,
-      });
-
-      // First attempt fails
-      await tracker.refund();
-      expect(mockRefundUsage).toHaveBeenCalledTimes(1);
-
-      // Second attempt succeeds (retry allowed)
-      await tracker.refund();
-      expect(mockRefundUsage).toHaveBeenCalledTimes(2);
-
-      // Third attempt blocked (already refunded)
-      await tracker.refund();
-      expect(mockRefundUsage).toHaveBeenCalledTimes(2);
-    });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ status: "refunded" }),
+      expect.objectContaining({ status: "refunded" }),
+    ]);
+    expect(refundUsage).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -1064,13 +1064,19 @@ describe("token-bucket async functions", () => {
     it("should refund bucket tokens via Redis hincrby", async () => {
       const { refundUsage } = getIsolatedModule();
 
-      await refundUsage("user-123", "pro", 1000, 0);
+      const result = await refundUsage("user-123", "pro", 1000, 0);
 
       expect(mockHincrbyFn).toHaveBeenCalledWith(
         expect.stringContaining("usage:monthly"),
         "tokens",
         1000,
       );
+      expect(result).toEqual({
+        includedPointsRefunded: 1000,
+        extraUsagePointsRefunded: 0,
+        includedRefundFailed: false,
+        extraUsageRefundFailed: false,
+      });
     });
 
     it("should refund extra usage balance when provided", async () => {
@@ -1084,10 +1090,33 @@ describe("token-bucket async functions", () => {
     it("should not refund if no points deducted", async () => {
       const { refundUsage } = getIsolatedModule();
 
-      await refundUsage("user-123", "pro", 0, 0);
+      const result = await refundUsage("user-123", "pro", 0, 0);
 
       expect(mockHincrbyFn).not.toHaveBeenCalled();
       expect(mockRefundToBalance).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        includedPointsRefunded: 0,
+        extraUsagePointsRefunded: 0,
+        includedRefundFailed: false,
+        extraUsageRefundFailed: false,
+      });
+    });
+
+    it("reports a failed extra-usage refund without hiding the included refund", async () => {
+      const { refundUsage } = getIsolatedModule();
+      mockRefundToBalance.mockResolvedValueOnce({
+        success: false,
+        newBalanceDollars: 0,
+      });
+
+      const result = await refundUsage("user-123", "pro", 1000, 500);
+
+      expect(result).toEqual({
+        includedPointsRefunded: 1000,
+        extraUsagePointsRefunded: 0,
+        includedRefundFailed: false,
+        extraUsageRefundFailed: true,
+      });
     });
 
     it("should cap refunded tokens at bucket limit", async () => {

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -774,10 +774,10 @@ describe("token-bucket async functions", () => {
       // Should refund the difference (70 - 28 = 42 points)
       const expectedRefund =
         estimatedCost - billableCostDollarsToPoints(providerCostDollars);
-      expect(mockHincrbyFn).toHaveBeenCalledWith(
-        expect.stringContaining("usage:monthly"),
-        "tokens",
-        expectedRefund,
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("HSET", bucketKey'),
+        ["usage:monthly:user-123:pro"],
+        [expect.stringMatching(/^usage-refund:/), expectedRefund, 250_000],
       );
       // Should NOT call limiter to deduct more
       expect(mockLimitFn).not.toHaveBeenCalled();
@@ -884,10 +884,10 @@ describe("token-bucket async functions", () => {
 
       // Should refund the difference (70 - 35 = 35 points)
       const expectedRefund = estimatedCost - actualCost;
-      expect(mockHincrbyFn).toHaveBeenCalledWith(
-        expect.stringContaining("usage:monthly"),
-        "tokens",
-        expectedRefund,
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("HSET", bucketKey'),
+        ["usage:monthly:user-123:pro"],
+        [expect.stringMatching(/^usage-refund:/), expectedRefund, 250_000],
       );
     });
 
@@ -1061,15 +1061,22 @@ describe("token-bucket async functions", () => {
   });
 
   describe("refundUsage", () => {
-    it("should refund bucket tokens via Redis hincrby", async () => {
+    it("atomically refunds bucket tokens with a stable idempotency marker", async () => {
       const { refundUsage } = getIsolatedModule();
 
-      const result = await refundUsage("user-123", "pro", 1000, 0);
-
-      expect(mockHincrbyFn).toHaveBeenCalledWith(
-        expect.stringContaining("usage:monthly"),
-        "tokens",
+      const result = await refundUsage(
+        "user-123",
+        "pro",
         1000,
+        0,
+        undefined,
+        "refund-123",
+      );
+
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("HSET", bucketKey'),
+        ["usage:monthly:user-123:pro"],
+        ["usage-refund:refund-123", 1000, 250_000],
       );
       expect(result).toEqual({
         includedPointsRefunded: 1000,
@@ -1123,23 +1130,65 @@ describe("token-bucket async functions", () => {
       const { refundUsage, getBudgetLimits } = getIsolatedModule();
       const { monthly: monthlyLimit } = getBudgetLimits("pro");
 
-      mockHincrbyFn.mockResolvedValue(monthlyLimit + 10000);
+      await refundUsage("user-123", "pro", 50000, 0, undefined, "refund-cap");
 
-      await refundUsage("user-123", "pro", 50000, 0);
-
-      expect(mockHsetFn).toHaveBeenCalled();
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining("math.min(currentTokens + pointsToRefund"),
+        ["usage:monthly:user-123:pro"],
+        ["usage-refund:refund-cap", 50_000, monthlyLimit],
+      );
     });
 
     it("caps refunds at the stored cycle allocation", async () => {
       const { refundUsage } = getIsolatedModule();
-      mockHgetFn.mockResolvedValue(200_000);
-      mockHincrbyFn.mockResolvedValue(210_000);
 
-      await refundUsage("user-123", "pro", 50_000, 0);
+      await refundUsage(
+        "user-123",
+        "pro",
+        50_000,
+        0,
+        undefined,
+        "refund-cycle",
+      );
 
-      expect(mockHsetFn).toHaveBeenCalledWith("usage:monthly:user-123:pro", {
-        tokens: 200_000,
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'redis.call("HGET", bucketKey, "cycleAllocation")',
+        ),
+        ["usage:monthly:user-123:pro"],
+        ["usage-refund:refund-cycle", 50_000, 250_000],
+      );
+    });
+
+    it("retries an ambiguous response without applying the bucket refund twice", async () => {
+      const { refundUsage } = getIsolatedModule();
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      mockEvalFn
+        .mockRejectedValueOnce(new Error("response lost after execution"))
+        .mockResolvedValueOnce([0, 51_000]);
+
+      await expect(
+        refundUsage("user-123", "pro", 1_000, 0, undefined, "refund-ambiguous"),
+      ).resolves.toMatchObject({
+        includedPointsRefunded: 0,
+        includedRefundFailed: true,
       });
+      await expect(
+        refundUsage("user-123", "pro", 1_000, 0, undefined, "refund-ambiguous"),
+      ).resolves.toMatchObject({
+        includedPointsRefunded: 1_000,
+        includedRefundFailed: false,
+      });
+
+      expect(mockEvalFn).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        ["usage:monthly:user-123:pro"],
+        ["usage-refund:refund-ambiguous", 1_000, 250_000],
+      );
+      consoleError.mockRestore();
     });
   });
 
@@ -2170,10 +2219,10 @@ describe("token-bucket async functions", () => {
 
       await refundUsage("user-123", "pro", deducted, 0);
 
-      expect(mockHincrbyFn).toHaveBeenCalledWith(
-        expect.any(String),
-        "tokens",
-        deducted,
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("HSET", bucketKey'),
+        ["usage:monthly:user-123:pro"],
+        [expect.stringMatching(/^usage-refund:/), deducted, 250_000],
       );
     });
   });

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -55,6 +55,7 @@ export {
   POINTS_PER_DOLLAR,
   type UsageDeductionFailureReason,
   type UsageDeductionResult,
+  type UsageRefundResult,
   type CycleAllocationCapResult,
   type BillingCreditTransitionIdentity,
   type DelinquencyCreditHoldResult,

--- a/lib/rate-limit/refund.ts
+++ b/lib/rate-limit/refund.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { RateLimitInfo, SubscriptionTier } from "@/types";
 import { refundUsage, type UsageDeductionResult } from "./token-bucket";
 
@@ -20,6 +21,7 @@ export class UsageRefundTracker {
   private subscription: SubscriptionTier | undefined;
   private organizationId: string | undefined;
   private refundInFlight: Promise<UsageRefundOutcome> | undefined;
+  private includedRefundId: string | undefined;
 
   /**
    * Set user context for refunds.
@@ -94,12 +96,17 @@ export class UsageRefundTracker {
 
     let result;
     try {
+      const includedRefundId =
+        this.pointsDeducted > 0
+          ? (this.includedRefundId ??= randomUUID())
+          : undefined;
       result = await refundUsage(
         this.userId,
         this.subscription,
         this.pointsDeducted,
         this.extraUsagePointsDeducted,
         this.organizationId,
+        includedRefundId,
       );
     } catch (error) {
       console.error("Failed to refund usage:", error);
@@ -115,6 +122,7 @@ export class UsageRefundTracker {
       0,
       this.pointsDeducted - result.includedPointsRefunded,
     );
+    if (this.pointsDeducted === 0) this.includedRefundId = undefined;
     this.extraUsagePointsDeducted = Math.max(
       0,
       this.extraUsagePointsDeducted - result.extraUsagePointsRefunded,

--- a/lib/rate-limit/refund.ts
+++ b/lib/rate-limit/refund.ts
@@ -1,9 +1,17 @@
 import type { RateLimitInfo, SubscriptionTier } from "@/types";
 import { refundUsage, type UsageDeductionResult } from "./token-bucket";
 
+export type UsageRefundOutcome = {
+  status: "refunded" | "partial" | "failed" | "skipped";
+  includedPointsRefunded: number;
+  extraUsagePointsRefunded: number;
+  includedPointsRemaining: number;
+  extraUsagePointsRemaining: number;
+};
+
 /**
  * Tracks usage deductions and handles refunds on error.
- * Ensures refunds only happen once, even if multiple error handlers trigger.
+ * Serializes concurrent refunds and keeps only unconfirmed amounts retryable.
  */
 export class UsageRefundTracker {
   private pointsDeducted = 0;
@@ -11,7 +19,7 @@ export class UsageRefundTracker {
   private userId: string | undefined;
   private subscription: SubscriptionTier | undefined;
   private organizationId: string | undefined;
-  private hasRefunded = false;
+  private refundInFlight: Promise<UsageRefundOutcome> | undefined;
 
   /**
    * Set user context for refunds.
@@ -55,30 +63,72 @@ export class UsageRefundTracker {
   }
 
   /**
-   * Refund all deducted credits (idempotent - only refunds once).
+   * Refund all tracked deductions without duplicating confirmed refunds.
    * Call this from error handlers to restore credits on failure.
    */
   async refund(): Promise<void> {
-    if (this.hasRefunded || !this.hasDeductions()) {
-      return;
-    }
+    await this.refundWithResult();
+  }
 
+  /** Refund tracked deductions and report only amounts confirmed restored. */
+  async refundWithResult(): Promise<UsageRefundOutcome> {
+    if (this.refundInFlight) return this.refundInFlight;
+    this.refundInFlight = this.performRefund().finally(() => {
+      this.refundInFlight = undefined;
+    });
+    return this.refundInFlight;
+  }
+
+  private async performRefund(): Promise<UsageRefundOutcome> {
+    const skipped = (): UsageRefundOutcome => ({
+      status: "skipped",
+      includedPointsRefunded: 0,
+      extraUsagePointsRefunded: 0,
+      includedPointsRemaining: this.pointsDeducted,
+      extraUsagePointsRemaining: this.extraUsagePointsDeducted,
+    });
+    if (!this.hasDeductions()) return skipped();
     if (!this.userId || !this.subscription) {
-      return;
+      return skipped();
     }
 
+    let result;
     try {
-      await refundUsage(
+      result = await refundUsage(
         this.userId,
         this.subscription,
         this.pointsDeducted,
         this.extraUsagePointsDeducted,
         this.organizationId,
       );
-      this.hasRefunded = true;
     } catch (error) {
       console.error("Failed to refund usage:", error);
-      // Flag stays false, allowing retry on transient failures
+      return {
+        status: "failed",
+        includedPointsRefunded: 0,
+        extraUsagePointsRefunded: 0,
+        includedPointsRemaining: this.pointsDeducted,
+        extraUsagePointsRemaining: this.extraUsagePointsDeducted,
+      };
     }
+    this.pointsDeducted = Math.max(
+      0,
+      this.pointsDeducted - result.includedPointsRefunded,
+    );
+    this.extraUsagePointsDeducted = Math.max(
+      0,
+      this.extraUsagePointsDeducted - result.extraUsagePointsRefunded,
+    );
+
+    const refundedAny =
+      result.includedPointsRefunded > 0 || result.extraUsagePointsRefunded > 0;
+    const hasRemaining = this.hasDeductions();
+    return {
+      status: hasRemaining ? (refundedAny ? "partial" : "failed") : "refunded",
+      includedPointsRefunded: result.includedPointsRefunded,
+      extraUsagePointsRefunded: result.extraUsagePointsRefunded,
+      includedPointsRemaining: this.pointsDeducted,
+      extraUsagePointsRemaining: this.extraUsagePointsDeducted,
+    };
   }
 }

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -1449,11 +1449,11 @@ const refundBucketTokens = async (
   userId: string,
   subscription: SubscriptionTier,
   pointsToRefund: number,
-): Promise<void> => {
-  if (pointsToRefund <= 0) return;
+): Promise<boolean> => {
+  if (pointsToRefund <= 0) return true;
 
   const redis = createRedisClient();
-  if (!redis) return;
+  if (!redis) return false;
 
   const { monthly: monthlyLimit } = getBudgetLimits(subscription);
   const monthlyKey = getMonthlyBucketKey(userId, subscription);
@@ -1477,8 +1477,10 @@ const refundBucketTokens = async (
     if (monthlyTokens > refundCap) {
       await redis.hset(monthlyKey, { tokens: refundCap });
     }
+    return true;
   } catch (error) {
     console.error("Failed to refund bucket tokens:", error);
+    return false;
   }
 };
 
@@ -2434,39 +2436,46 @@ export const applyTeamSeatDebt = async (
  * Refund usage when a request fails after credits were deducted.
  * Refunds both token bucket credits and extra usage balance.
  */
+export type UsageRefundResult = {
+  includedPointsRefunded: number;
+  extraUsagePointsRefunded: number;
+  includedRefundFailed: boolean;
+  extraUsageRefundFailed: boolean;
+};
+
 export const refundUsage = async (
   userId: string,
   subscription: SubscriptionTier,
   pointsDeducted: number,
   extraUsagePointsDeducted: number,
   organizationId?: string,
-): Promise<void> => {
-  const refundPromises: Promise<void>[] = [];
-
-  if (pointsDeducted > 0) {
-    refundPromises.push(
-      refundBucketTokens(userId, subscription, pointsDeducted),
-    );
-  }
-
-  if (extraUsagePointsDeducted > 0) {
+): Promise<UsageRefundResult> => {
+  const includedRefundPromise =
+    pointsDeducted > 0
+      ? refundBucketTokens(userId, subscription, pointsDeducted)
+      : Promise.resolve(true);
+  const extraUsageRefundPromise = (async () => {
+    if (extraUsagePointsDeducted <= 0) return true;
     const isTeamPool = subscription === "team" && !!organizationId;
-    refundPromises.push(
-      isTeamPool
-        ? refundToTeamBalance(
-            organizationId!,
-            userId,
-            extraUsagePointsDeducted,
-          ).then(() => {})
-        : refundToBalance(userId, extraUsagePointsDeducted).then(() => {}),
-    );
-  }
+    const result = isTeamPool
+      ? await refundToTeamBalance(
+          organizationId!,
+          userId,
+          extraUsagePointsDeducted,
+        )
+      : await refundToBalance(userId, extraUsagePointsDeducted);
+    return result.success;
+  })();
 
-  if (refundPromises.length > 0) {
-    try {
-      await Promise.all(refundPromises);
-    } catch (error) {
-      console.error("Failed to refund usage:", error);
-    }
-  }
+  const [includedRefunded, extraUsageRefunded] = await Promise.all([
+    includedRefundPromise,
+    extraUsageRefundPromise,
+  ]);
+
+  return {
+    includedPointsRefunded: includedRefunded ? pointsDeducted : 0,
+    extraUsagePointsRefunded: extraUsageRefunded ? extraUsagePointsDeducted : 0,
+    includedRefundFailed: pointsDeducted > 0 && !includedRefunded,
+    extraUsageRefundFailed: extraUsagePointsDeducted > 0 && !extraUsageRefunded,
+  };
 };

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { Ratelimit } from "@upstash/ratelimit";
 import { ChatSDKError } from "@/lib/errors";
 import type {
@@ -1401,7 +1402,14 @@ export const deductUsage = async (
         initialIncludedPoints,
       );
       if (includedRefundPoints > 0) {
-        await refundBucketTokens(userId, subscription, includedRefundPoints);
+        await refundBucketTokens(
+          userId,
+          subscription,
+          includedRefundPoints,
+          usageSettlementId
+            ? `${usageSettlementId}:settlement-refund`
+            : randomUUID(),
+        );
         lastKnownDeductionResult = buildDeductionResult(
           0,
           0,
@@ -1443,12 +1451,32 @@ export const deductUsage = async (
 
 /**
  * Refund bucket tokens by adding capacity back to the monthly token bucket.
- * Uses direct Redis operations since Upstash Ratelimit doesn't have a native refund method.
+ * The token update and per-refund marker are written atomically so an
+ * ambiguous network response can be retried without applying credit twice.
  */
+const REFUND_BUCKET_TOKENS_SCRIPT = `
+local bucketKey = KEYS[1]
+local refundField = ARGV[1]
+local pointsToRefund = tonumber(ARGV[2])
+local defaultLimit = tonumber(ARGV[3])
+
+local currentTokens = tonumber(redis.call("HGET", bucketKey, "tokens") or "0")
+if redis.call("HEXISTS", bucketKey, refundField) == 1 then
+  return {0, currentTokens}
+end
+
+local cycleAllocation = tonumber(redis.call("HGET", bucketKey, "cycleAllocation"))
+local refundCap = cycleAllocation or defaultLimit
+local nextTokens = math.min(currentTokens + pointsToRefund, refundCap)
+redis.call("HSET", bucketKey, "tokens", nextTokens, refundField, pointsToRefund)
+return {1, nextTokens}
+`;
+
 const refundBucketTokens = async (
   userId: string,
   subscription: SubscriptionTier,
   pointsToRefund: number,
+  refundId: string,
 ): Promise<boolean> => {
   if (pointsToRefund <= 0) return true;
 
@@ -1459,24 +1487,11 @@ const refundBucketTokens = async (
   const monthlyKey = getMonthlyBucketKey(userId, subscription);
 
   try {
-    const monthlyTokens = await redis.hincrby(
-      monthlyKey,
-      "tokens",
-      pointsToRefund,
+    await redis.eval(
+      REFUND_BUCKET_TOKENS_SCRIPT,
+      [monthlyKey],
+      [`usage-refund:${refundId}`, pointsToRefund, monthlyLimit],
     );
-
-    const cycleAllocation = await getStoredCycleAllocation(
-      redis,
-      monthlyKey,
-      monthlyLimit,
-    );
-    const refundCap = cycleAllocation ?? monthlyLimit;
-
-    // Cap refunds at the current cycle allocation, which may be lower than
-    // the broad subscription tier for grandfathered or prorated users.
-    if (monthlyTokens > refundCap) {
-      await redis.hset(monthlyKey, { tokens: refundCap });
-    }
     return true;
   } catch (error) {
     console.error("Failed to refund bucket tokens:", error);
@@ -2449,10 +2464,16 @@ export const refundUsage = async (
   pointsDeducted: number,
   extraUsagePointsDeducted: number,
   organizationId?: string,
+  includedRefundId: string = randomUUID(),
 ): Promise<UsageRefundResult> => {
   const includedRefundPromise =
     pointsDeducted > 0
-      ? refundBucketTokens(userId, subscription, pointsDeducted)
+      ? refundBucketTokens(
+          userId,
+          subscription,
+          pointsDeducted,
+          includedRefundId,
+        )
       : Promise.resolve(true);
   const extraUsageRefundPromise = (async () => {
     if (extraUsagePointsDeducted <= 0) return true;

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -191,3 +191,12 @@ export const writeAutoContinue = (writer: UIMessageStreamWriter): void => {
     data: { shouldContinue: true },
   });
 };
+
+export const writeAutoContinueUsageProtected = (
+  writer: UIMessageStreamWriter,
+): void => {
+  writer.write({
+    type: "data-auto-continue-usage-protected",
+    data: { status: "restored" },
+  });
+};

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -192,6 +192,7 @@ export const writeAutoContinue = (writer: UIMessageStreamWriter): void => {
   });
 };
 
+/** Confirm that every tracked deduction for an automatic recovery was restored. */
 export const writeAutoContinueUsageProtected = (
   writer: UIMessageStreamWriter,
 ): void => {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -3500,6 +3500,27 @@ export const agentLongTask = task({
             // read back here in toUIMessageStream.onFinish.
             const state = initAgentStreamState(finalMessages, initialCtxUsage);
             terminalAgentState = state;
+            const protectTerminalAutomaticContinuation = async () => {
+              const stopSource = getAgentAutoContinueStopSource({
+                finishReason: state.streamFinishReason,
+                stoppedDueToTokenExhaustion: state.stoppedDueToTokenExhaustion,
+                stoppedDueToPostSummarizationIncomplete:
+                  state.stoppedDueToPostSummarizationIncomplete,
+              });
+              if (isAutomaticContinuation) {
+                await protectIncompleteAutomaticContinuation({
+                  assignment: autoContinueUsageProtectionAssignment,
+                  stopSource,
+                  usageRefundTracker,
+                  writer,
+                  posthog,
+                  userId,
+                  subscription,
+                  endpoint,
+                });
+              }
+              return stopSource;
+            };
 
             const budgetSnapshot = captureBudgetSnapshot({
               rateLimitInfo,
@@ -4281,6 +4302,7 @@ export const agentLongTask = task({
               // Final reconciliation can change the finish reason to
               // budget-exhausted; do it before analytics and persistence.
               await deductAccumulatedUsage();
+              await protectTerminalAutomaticContinuation();
               const outcome = retryAborted
                 ? "aborted"
                 : isTerminalProviderStreamError(state)
@@ -5360,25 +5382,7 @@ export const agentLongTask = task({
                       // their plan cap are large enough that the user should
                       // explicitly decide whether to continue.
                       const autoContinueStopSource =
-                        getAgentAutoContinueStopSource({
-                          finishReason: state.streamFinishReason,
-                          stoppedDueToTokenExhaustion:
-                            state.stoppedDueToTokenExhaustion,
-                          stoppedDueToPostSummarizationIncomplete:
-                            state.stoppedDueToPostSummarizationIncomplete,
-                        });
-                      if (isAutomaticContinuation) {
-                        await protectIncompleteAutomaticContinuation({
-                          assignment: autoContinueUsageProtectionAssignment,
-                          stopSource: autoContinueStopSource,
-                          usageRefundTracker,
-                          writer,
-                          posthog,
-                          userId,
-                          subscription,
-                          endpoint,
-                        });
-                      }
+                        await protectTerminalAutomaticContinuation();
                       if (autoContinueStopSource && !isAutomaticContinuation) {
                         writeAutoContinue(writer);
                         phLogger.info("Agent auto-continue signaled", {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -209,6 +209,8 @@ import {
   type AgentStreamContext,
   type AgentStreamState,
 } from "@/lib/api/agent-stream-runner";
+import { protectIncompleteAutomaticContinuation } from "@/lib/api/agent-auto-continue-usage-protection";
+import type { AgentAutoContinueUsageProtectionAssignment } from "@/lib/experiments/agent-auto-continue-usage-protection";
 import {
   assertLocalSandboxFallbackAllowed,
   getSandboxFallbackPromptReminder,
@@ -2264,6 +2266,7 @@ export type AgentLongPayload = {
   triggerRegion?: TriggerRunRegion;
   isAutoContinue?: boolean;
   isAutomaticContinuation?: boolean;
+  autoContinueUsageProtectionAssignment?: AgentAutoContinueUsageProtectionAssignment;
   regenerate?: boolean;
   isNewChat?: boolean;
   limitRescue?: LimitRescueRequest;
@@ -2353,6 +2356,7 @@ export const agentLongTask = task({
       triggerRegion = "us-east-1",
       isAutoContinue,
       isAutomaticContinuation,
+      autoContinueUsageProtectionAssignment,
       regenerate,
       isNewChat,
       limitRescue,
@@ -5363,6 +5367,18 @@ export const agentLongTask = task({
                           stoppedDueToPostSummarizationIncomplete:
                             state.stoppedDueToPostSummarizationIncomplete,
                         });
+                      if (isAutomaticContinuation) {
+                        await protectIncompleteAutomaticContinuation({
+                          assignment: autoContinueUsageProtectionAssignment,
+                          stopSource: autoContinueStopSource,
+                          usageRefundTracker,
+                          writer,
+                          posthog,
+                          userId,
+                          subscription,
+                          endpoint,
+                        });
+                      }
                       if (autoContinueStopSource && !isAutomaticContinuation) {
                         writeAutoContinue(writer);
                         phLogger.info("Agent auto-continue signaled", {


### PR DESCRIPTION
## Why

Cancellation research found a concentrated failure pattern: paid Agent users reach a system limit, HackerAI launches its one bounded automatic recovery, and that recovery can stop incomplete again after consuming more allowance. OpenCode, T3 Code, and Hermes all pair bounded recovery with explicit checkpoint/retry or rollback affordances; the highest-ROI first step here is protecting the usage spent by HackerAI's own unsuccessful recovery.

Linear: [HAC-86](https://linear.app/hackerai/issue/HAC-86/protect-usage-when-bounded-agent-recovery-still-cannot-finish)

## What changed

- Refund only paid, system-started automatic continuations that again end at an incomplete system stop.
- Exclude manual retries, ordinary model/tool failures, user cancellation, policy blocks, free users, and successful recoveries.
- Preserve partial-refund retry safety and show confirmation only after every deducted component is confirmed restored.
- Make included-usage restoration atomic and idempotent so an ambiguous Redis response cannot double-credit a retry.
- Cover direct, fallback, Trigger, and final provider-retry completion paths.
- Emit a privacy-safe `agent_auto_continue_recovery_finished` exposure/outcome event without prompts, code, targets, or other customer content.
- Show: “This automatic recovery attempt didn't finish, so its usage was restored.”

## Rollout

Flag: `agent_auto_continue_usage_protection_v1`

- Preview PostHog project `401167`: active, 100% rollout; application gate limits exposure to paid automatic recovery runs.
- Production PostHog project `144137`: active, 10% staged rollout with the same application gate.
- Trigger environment verification: Preview resolved 40/40 sampled users to treatment; Production resolved 3/40, consistent with the configured 10% rollout.
- Readout: September 14, 2026 or 200 eligible exposures, whichever comes first. Primary metric and guardrails are documented in HAC-86.

## Validation

- `pnpm run typecheck`
- ESLint on every changed TypeScript/TSX file
- `pnpm exec jest --runInBand` — 420 suites, 4,454 tests
- Built-in Browser visual check in the real Next.js shell; confirmation copy rendered correctly beside the existing Continue action
- Vercel Preview, Trigger Preview, GitHub test/coverage, CodeQL, and CodeRabbit checks all passed
- CodeRabbit's two accounting-path findings were fixed, re-reviewed, and resolved with no new actionable comments

## Manual verification after deployment

1. In Preview, use a paid test account assigned to treatment and run an Agent task that triggers its one automatic continuation.
2. Let that automatic recovery reach another supported incomplete stop (step, context/output, or post-compaction limit).
3. Confirm the final notice says the recovery attempt's usage was restored, the second attempt's included/extra usage is returned, and the manual Continue action remains available.
4. Repeat with a control assignment and confirm no restoration notice or refund occurs.
