### PR TITLE
Fix Security settings mobile styles

### DIFF
--- a/app/components/SecurityTab.tsx
+++ b/app/components/SecurityTab.tsx
@@ -54,12 +54,14 @@ const SecurityTab = () => {
     <div className="space-y-6">
       <div data-testid="workos-user-security">
         <WorkOsWidgets
+          className="hackerai-security-widget"
           style={{ blockSize: "auto", minBlockSize: "auto" }}
           theme={{
-            appearance: "dark",
+            appearance: "inherit",
             accentColor: "gray",
-            grayColor: "slate",
+            grayColor: "gray",
             hasBackground: false,
+            panelBackground: "solid",
             fontFamily: "var(--font-geist-sans)",
           }}
         >
@@ -91,7 +93,7 @@ const SecurityTab = () => {
           </Button>
         </div>
 
-        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 p-4">
+        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-4 gap-y-3 p-4 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
           <div
             aria-hidden="true"
             className="flex size-8 items-center justify-center rounded-md border bg-muted/50"
@@ -111,7 +113,7 @@ const SecurityTab = () => {
             variant="destructive"
             size="sm"
             onClick={handleLogoutAll}
-            className="shrink-0 bg-red-600 text-white hover:bg-red-700"
+            className="col-start-2 w-fit shrink-0 bg-red-600 text-white hover:bg-red-700 sm:col-start-3 sm:row-start-1"
           >
             Log out all
           </Button>

--- a/app/components/__tests__/SecurityTab.test.tsx
+++ b/app/components/__tests__/SecurityTab.test.tsx
@@ -12,12 +12,27 @@ jest.mock("@workos-inc/authkit-nextjs/components", () => ({
 jest.mock("@workos-inc/widgets/workos-widgets", () => ({
   WorkOsWidgets: ({
     children,
+    className,
     style,
+    theme,
   }: {
     children: ReactNode;
+    className?: string;
     style?: CSSProperties;
+    theme?: {
+      appearance?: string;
+      grayColor?: string;
+      panelBackground?: string;
+    };
   }) => (
-    <div data-testid="workos-widgets-provider" style={style}>
+    <div
+      className={className}
+      data-appearance={theme?.appearance}
+      data-gray-color={theme?.grayColor}
+      data-panel-background={theme?.panelBackground}
+      data-testid="workos-widgets-provider"
+      style={style}
+    >
       {children}
     </div>
   ),
@@ -44,6 +59,21 @@ describe("SecurityTab", () => {
     expect(screen.getByTestId("workos-widgets-provider")).toBeInTheDocument();
     expect(screen.getByTestId("workos-widgets-provider")).toHaveStyle(
       "block-size: auto; min-block-size: auto",
+    );
+    expect(screen.getByTestId("workos-widgets-provider")).toHaveClass(
+      "hackerai-security-widget",
+    );
+    expect(screen.getByTestId("workos-widgets-provider")).toHaveAttribute(
+      "data-appearance",
+      "inherit",
+    );
+    expect(screen.getByTestId("workos-widgets-provider")).toHaveAttribute(
+      "data-gray-color",
+      "gray",
+    );
+    expect(screen.getByTestId("workos-widgets-provider")).toHaveAttribute(
+      "data-panel-background",
+      "solid",
     );
     expect(
       screen.getByTestId("workos-user-security-widget"),

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,53 @@
   z-index: 60;
 }
 
+/* Keep the embedded WorkOS security card visually aligned with HackerAI. */
+.hackerai-security-widget {
+  container-type: inline-size;
+  --color-panel-solid: var(--card);
+  --color-panel: var(--card);
+  --base-card-surface-box-shadow: 0 0 0 1px var(--border);
+  --gray-2: color-mix(in srgb, var(--muted) 50%, var(--card));
+  --gray-4: var(--border);
+  --gray-11: var(--muted-foreground);
+  --gray-12: var(--foreground);
+}
+
+.hackerai-security-widget .woswidgets-card-list-item:not(:first-child) {
+  border-color: var(--border);
+}
+
+.hackerai-security-widget .woswidgets-button.button--secondary {
+  color: var(--foreground);
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+@media (hover: hover) {
+  .hackerai-security-widget .woswidgets-button.button--secondary:hover {
+    background-color: var(--muted);
+  }
+}
+
+@container (max-width: 26rem) {
+  .hackerai-security-widget .woswidgets-card-list-item .rt-Grid {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .hackerai-security-widget .woswidgets-card-list-item .woswidgets-button {
+    grid-column: 2;
+    justify-self: start;
+    width: fit-content;
+    max-width: 100%;
+    height: auto;
+    min-height: var(--space-6);
+    margin-top: var(--space-1);
+    padding-block: var(--space-1);
+    white-space: normal;
+    text-wrap: balance;
+  }
+}
+
 @custom-variant dark (&:is(.dark *));
 @custom-variant desktop (@media (min-width: 950px));
 @custom-variant touch-device (@media (hover: none));


### PR DESCRIPTION
## Summary
- align the embedded WorkOS Security card with HackerAI theme tokens in light and dark modes
- move WorkOS actions below their copy in narrow containers so the authenticator button remains readable
- prevent the mobile “Log out all” action from squeezing its description
- cover the WorkOS theme configuration in the Security tab tests

## Verification
- `pnpm typecheck`
- `pnpm test` — 421 suites / 4,462 tests passed
- targeted ESLint and Prettier checks
- 390 px visual verification using the compiled HackerAI, Radix, and WorkOS styles

## Manual verification
1. Open Settings → Security on a phone-sized viewport in both light and dark modes.
2. Confirm the WorkOS card uses the same card, border, text, and button colors as the session card.
3. Confirm “Set up authenticator app” appears below the MFA copy without squeezing it, then tap it and verify the WorkOS setup dialog opens.
4. Confirm “Log out all” appears below its description on mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the security widget with a consistent gray theme, solid panel background, and improved visual styling.
  - Added custom card borders, secondary-button states, hover behavior, and responsive compact-layout adjustments.

- **Bug Fixes**
  - Improved the all-devices logout layout so the button wraps beneath the content on smaller screens and aligns appropriately on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->