### PR TITLE
Add allowlisted E2B BYO proxy support

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -72,6 +72,12 @@ OPENAI_API_KEY=
 # CLOUD_SANDBOX_PROVIDER=e2b
 E2B_API_KEY=
 E2B_TEMPLATE=terminal-agent-sandbox
+# Optional E2B BYO SOCKS5 proxy. Traffic is enabled only for the comma-separated
+# user IDs below; use `*` only after the internal rollout has been validated.
+E2B_EGRESS_PROXY_ADDRESS=
+E2B_EGRESS_PROXY_USERNAME=
+E2B_EGRESS_PROXY_PASSWORD=
+E2B_EGRESS_PROXY_ALLOWED_USER_IDS=
 # Optional EU cluster. When configured, fresh sandboxes created by Trigger
 # eu-central-1 runs use this separate account and domain. Existing US
 # sandboxes continue to be reused until they are gone.

--- a/infra/aws/e2b-preview-proxy.yaml
+++ b/infra/aws/e2b-preview-proxy.yaml
@@ -1,0 +1,220 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Preview-only authenticated SOCKS5 gateway for E2B BYO proxy testing.
+
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+  AmiId:
+    Type: AWS::EC2::Image::Id
+    Description: Ubuntu 24.04 ARM64 AMI.
+  InstanceType:
+    Type: String
+    Default: t4g.nano
+    AllowedValues:
+      - t4g.nano
+      - t4g.micro
+
+Resources:
+  ProxySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: E2B preview SOCKS5 credentials.
+      GenerateSecretString:
+        SecretStringTemplate: '{"username":"e2b-preview"}'
+        GenerateStringKey: password
+        PasswordLength: 40
+        ExcludePunctuation: true
+      Tags:
+        - Key: Project
+          Value: HackerAI
+        - Key: Purpose
+          Value: E2B-BYOP-preview
+        - Key: LinearIssue
+          Value: HAC-88
+
+  ProxyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Policies:
+        - PolicyName: ReadProxyCredentials
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Ref ProxySecret
+      Tags:
+        - Key: Project
+          Value: HackerAI
+        - Key: Purpose
+          Value: E2B-BYOP-preview
+        - Key: LinearIssue
+          Value: HAC-88
+
+  ProxyInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref ProxyRole
+
+  ProxySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Authenticated SOCKS5 access for E2B preview testing
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - Description: E2B BYO proxy TCP traffic
+          IpProtocol: tcp
+          FromPort: 1080
+          ToPort: 1080
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: hackerai-e2b-preview-proxy
+        - Key: Project
+          Value: HackerAI
+        - Key: Purpose
+          Value: E2B-BYOP-preview
+        - Key: LinearIssue
+          Value: HAC-88
+
+  ProxyInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref ProxyInstanceProfile
+      SubnetId: !Ref SubnetId
+      SecurityGroupIds:
+        - !Ref ProxySecurityGroup
+      MetadataOptions:
+        HttpEndpoint: enabled
+        HttpTokens: required
+        HttpPutResponseHopLimit: 1
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 8
+            VolumeType: gp3
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+
+          apt-get update
+          apt-get install -y ca-certificates curl dante-server jq unzip
+
+          if ! command -v aws >/dev/null 2>&1; then
+            work_dir=$(mktemp -d)
+            curl --fail --silent --show-error --location \
+              https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip \
+              --output "$work_dir/awscliv2.zip"
+            unzip -q "$work_dir/awscliv2.zip" -d "$work_dir"
+            "$work_dir/aws/install"
+            rm -rf "$work_dir"
+          fi
+
+          secret_json=$(aws secretsmanager get-secret-value \
+            --region ${AWS::Region} \
+            --secret-id ${ProxySecret} \
+            --query SecretString \
+            --output text)
+          proxy_username=$(printf '%s' "$secret_json" | jq -r .username)
+          proxy_password=$(printf '%s' "$secret_json" | jq -r .password)
+
+          if ! id "$proxy_username" >/dev/null 2>&1; then
+            useradd --system --no-create-home --shell /usr/sbin/nologin "$proxy_username"
+          fi
+          printf '%s:%s\n' "$proxy_username" "$proxy_password" | chpasswd
+          unset proxy_password secret_json
+
+          external_interface=$(ip route show default | awk 'NR == 1 { print $5 }')
+          cat >/etc/danted.conf <<EOF
+          logoutput: syslog
+          internal: 0.0.0.0 port = 1080
+          external: $external_interface
+          clientmethod: none
+          socksmethod: username
+          # Dante needs root only for shadow-password verification, then drops
+          # connection handling to nobody via user.notprivileged.
+          user.privileged: root
+          user.notprivileged: nobody
+
+          client pass {
+            from: 0.0.0.0/0 to: 0.0.0.0/0
+            log: connect error
+          }
+
+          socks pass {
+            from: 0.0.0.0/0 to: 0.0.0.0/0
+            command: connect
+            protocol: tcp
+            log: connect error
+          }
+
+          socks block {
+            from: 0.0.0.0/0 to: 0.0.0.0/0
+            log: connect error
+          }
+          EOF
+
+          chmod 600 /etc/danted.conf
+          systemctl enable --now danted
+          systemctl enable --now snap.amazon-ssm-agent.amazon-ssm-agent.service || true
+      Tags:
+        - Key: Name
+          Value: hackerai-e2b-preview-proxy
+        - Key: Project
+          Value: HackerAI
+        - Key: Purpose
+          Value: E2B-BYOP-preview
+        - Key: LinearIssue
+          Value: HAC-88
+
+  ProxyElasticIp:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: hackerai-e2b-preview-proxy
+        - Key: Project
+          Value: HackerAI
+        - Key: Purpose
+          Value: E2B-BYOP-preview
+        - Key: LinearIssue
+          Value: HAC-88
+
+  ProxyElasticIpAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      AllocationId: !GetAtt ProxyElasticIp.AllocationId
+      InstanceId: !Ref ProxyInstance
+
+Outputs:
+  ProxyAddress:
+    Description: E2B egress proxy address.
+    Value: !Sub "${ProxyElasticIp}:1080"
+  ProxySecretArn:
+    Description: Secrets Manager ARN containing the SOCKS5 username and password.
+    Value: !Ref ProxySecret
+  ProxyInstanceId:
+    Description: EC2 instance ID for SSM and operational checks.
+    Value: !Ref ProxyInstance

--- a/lib/ai/tools/utils/__tests__/e2b-egress-proxy.test.ts
+++ b/lib/ai/tools/utils/__tests__/e2b-egress-proxy.test.ts
@@ -1,0 +1,67 @@
+import { getE2BEgressProxyForUser } from "../e2b-egress-proxy";
+
+describe("E2B egress proxy configuration", () => {
+  it("stays disabled without a proxy address", () => {
+    expect(getE2BEgressProxyForUser("user-1", {})).toBeUndefined();
+  });
+
+  it("stays disabled when the user is not explicitly allowlisted", () => {
+    expect(
+      getE2BEgressProxyForUser("user-1", {
+        E2B_EGRESS_PROXY_ADDRESS: "proxy.example.com:1080",
+        E2B_EGRESS_PROXY_ALLOWED_USER_IDS: "user-2",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns credentials only for an allowlisted user", () => {
+    expect(
+      getE2BEgressProxyForUser("user-1", {
+        E2B_EGRESS_PROXY_ADDRESS: " proxy.example.com:1080 ",
+        E2B_EGRESS_PROXY_USERNAME: "proxy-user",
+        E2B_EGRESS_PROXY_PASSWORD: "proxy-password",
+        E2B_EGRESS_PROXY_ALLOWED_USER_IDS: "user-2, user-1",
+      }),
+    ).toEqual({
+      address: "proxy.example.com:1080",
+      username: "proxy-user",
+      password: "proxy-password",
+    });
+  });
+
+  it("supports an explicit all-users rollout", () => {
+    expect(
+      getE2BEgressProxyForUser("user-1", {
+        E2B_EGRESS_PROXY_ADDRESS: "proxy.example.com:1080",
+        E2B_EGRESS_PROXY_ALLOWED_USER_IDS: "*",
+      }),
+    ).toEqual({ address: "proxy.example.com:1080" });
+  });
+
+  it("rejects credentials without an address", () => {
+    expect(() =>
+      getE2BEgressProxyForUser("user-1", {
+        E2B_EGRESS_PROXY_USERNAME: "proxy-user",
+      }),
+    ).toThrow("credentials require E2B_EGRESS_PROXY_ADDRESS");
+  });
+
+  it("rejects a password without a username", () => {
+    expect(() =>
+      getE2BEgressProxyForUser("user-1", {
+        E2B_EGRESS_PROXY_ADDRESS: "proxy.example.com:1080",
+        E2B_EGRESS_PROXY_PASSWORD: "proxy-password",
+      }),
+    ).toThrow("E2B_EGRESS_PROXY_PASSWORD requires E2B_EGRESS_PROXY_USERNAME");
+  });
+
+  it("rejects SOCKS5 credentials longer than 255 UTF-8 bytes", () => {
+    expect(() =>
+      getE2BEgressProxyForUser("user-1", {
+        E2B_EGRESS_PROXY_ADDRESS: "proxy.example.com:1080",
+        E2B_EGRESS_PROXY_USERNAME: "a".repeat(256),
+        E2B_EGRESS_PROXY_ALLOWED_USER_IDS: "user-1",
+      }),
+    ).toThrow("username exceeds 255 bytes");
+  });
+});

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -59,7 +59,13 @@ const listSandbox = (
     sandboxId: string;
     state: "running" | "paused";
     metadata: Record<string, string>;
-    network: { egressProxy?: { address: string; username?: string } };
+    allowInternetAccess: boolean;
+    network: {
+      allowOut?: string[];
+      denyOut?: string[];
+      rules?: Record<string, Array<{ transform?: Record<string, unknown> }>>;
+      egressProxy?: { address: string; username?: string };
+    };
   }> = {},
 ) => {
   sandboxApi.list.mockReturnValue({
@@ -382,13 +388,28 @@ describe("E2B sandbox lease lifecycle", () => {
       sandboxId: "sandbox-1",
       updateNetwork,
     } as unknown as Sandbox;
-    listSandbox();
+    listSandbox({
+      allowInternetAccess: false,
+      network: {
+        allowOut: ["api.example.com"],
+        denyOut: ["0.0.0.0/0"],
+        rules: {
+          "api.example.com": [{ transform: { headers: { "x-test": "1" } } }],
+        },
+      },
+    });
     sandboxApi.connect.mockResolvedValue(connectedSandbox);
     const setSandbox = jest.fn();
 
     await ensureSandboxConnection({ userID: "user-1", setSandbox });
 
     expect(updateNetwork).toHaveBeenCalledWith({
+      allowOut: ["api.example.com"],
+      denyOut: ["0.0.0.0/0"],
+      rules: {
+        "api.example.com": [{ transform: { headers: { "x-test": "1" } } }],
+      },
+      allowInternetAccess: false,
       egressProxy: {
         address: "proxy.example.com:1080",
         username: "proxy-user",
@@ -452,6 +473,39 @@ describe("E2B sandbox lease lifecycle", () => {
       setSandbox.mock.invocationCallOrder[0],
     );
     expect(mockCaptureEvent).not.toHaveBeenCalled();
+  });
+
+  it("preserves network restrictions when clearing an existing proxy", async () => {
+    process.env.E2B_EGRESS_PROXY_ADDRESS = "proxy.example.com:1080";
+    process.env.E2B_EGRESS_PROXY_ALLOWED_USER_IDS = "user-2";
+    const updateNetwork = jest.fn(async () => undefined);
+    const connectedSandbox = {
+      sandboxId: "sandbox-1",
+      updateNetwork,
+    } as unknown as Sandbox;
+    listSandbox({
+      allowInternetAccess: false,
+      network: {
+        allowOut: ["api.example.com"],
+        denyOut: ["0.0.0.0/0"],
+        rules: {
+          "api.example.com": [{ transform: { headers: { "x-test": "1" } } }],
+        },
+        egressProxy: { address: "proxy.example.com:1080" },
+      },
+    });
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+
+    await ensureSandboxConnection({ userID: "user-1", setSandbox: jest.fn() });
+
+    expect(updateNetwork).toHaveBeenCalledWith({
+      allowOut: ["api.example.com"],
+      denyOut: ["0.0.0.0/0"],
+      rules: {
+        "api.example.com": [{ transform: { headers: { "x-test": "1" } } }],
+      },
+      allowInternetAccess: false,
+    });
   });
 
   it("creates new sandboxes with pause and automatic resume enabled", async () => {

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -19,7 +19,18 @@ jest.mock("@e2b/code-interpreter", () => {
   };
 });
 
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    flush: jest.fn(),
+  },
+}));
+
 import { Sandbox } from "@e2b/code-interpreter";
+import { phLogger } from "@/lib/posthog/server";
 import {
   BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
   E2B_SANDBOX_IDLE_RELEASE_TIMEOUT_MS,
@@ -41,6 +52,7 @@ type MockSandboxApi = {
 };
 
 const sandboxApi = Sandbox as unknown as MockSandboxApi;
+const mockCaptureEvent = phLogger.event as jest.Mock;
 
 const listSandbox = (
   overrides: Partial<{
@@ -70,6 +82,10 @@ describe("E2B sandbox lease lifecycle", () => {
     delete process.env.E2B_EU_API_KEY;
     delete process.env.E2B_EU_DOMAIN;
     delete process.env.E2B_EU_TEMPLATE;
+    delete process.env.E2B_EGRESS_PROXY_ADDRESS;
+    delete process.env.E2B_EGRESS_PROXY_USERNAME;
+    delete process.env.E2B_EGRESS_PROXY_PASSWORD;
+    delete process.env.E2B_EGRESS_PROXY_ALLOWED_USER_IDS;
   });
 
   afterEach(() => {
@@ -355,6 +371,65 @@ describe("E2B sandbox lease lifecycle", () => {
     expect(setSandbox).toHaveBeenCalledWith(connectedSandbox);
   });
 
+  it("applies the proxy to a reusable sandbox before exposing it", async () => {
+    process.env.E2B_EGRESS_PROXY_ADDRESS = "proxy.example.com:1080";
+    process.env.E2B_EGRESS_PROXY_USERNAME = "proxy-user";
+    process.env.E2B_EGRESS_PROXY_PASSWORD = "proxy-password";
+    process.env.E2B_EGRESS_PROXY_ALLOWED_USER_IDS = "user-1";
+    const updateNetwork = jest.fn(async () => undefined);
+    const connectedSandbox = {
+      sandboxId: "sandbox-1",
+      updateNetwork,
+    } as unknown as Sandbox;
+    listSandbox();
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+    const setSandbox = jest.fn();
+
+    await ensureSandboxConnection({ userID: "user-1", setSandbox });
+
+    expect(updateNetwork).toHaveBeenCalledWith({
+      egressProxy: {
+        address: "proxy.example.com:1080",
+        username: "proxy-user",
+        password: "proxy-password",
+      },
+    });
+    expect(updateNetwork.mock.invocationCallOrder[0]).toBeLessThan(
+      setSandbox.mock.invocationCallOrder[0],
+    );
+    expect(mockCaptureEvent).toHaveBeenCalledWith("e2b_egress_proxy_exposure", {
+      userId: "user-1",
+      sandbox_id: "sandbox-1",
+      acquisition_path: "reuse_existing",
+    });
+  });
+
+  it("fails closed when E2B cannot apply the proxy to a reusable sandbox", async () => {
+    process.env.E2B_EGRESS_PROXY_ADDRESS = "proxy.example.com:1080";
+    process.env.E2B_EGRESS_PROXY_ALLOWED_USER_IDS = "user-1";
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const connectedSandbox = {
+        sandboxId: "sandbox-1",
+        updateNetwork: jest.fn(async () => {
+          throw new Error("proxy unavailable");
+        }),
+      } as unknown as Sandbox;
+      listSandbox();
+      sandboxApi.connect.mockResolvedValue(connectedSandbox);
+      const setSandbox = jest.fn();
+
+      await expect(
+        ensureSandboxConnection({ userID: "user-1", setSandbox }),
+      ).rejects.toThrow("proxy unavailable");
+
+      expect(setSandbox).not.toHaveBeenCalled();
+      expect(mockCaptureEvent).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("creates new sandboxes with pause and automatic resume enabled", async () => {
     const createdSandbox = { sandboxId: "sandbox-2" } as unknown as Sandbox;
     sandboxApi.list.mockReturnValue({
@@ -377,6 +452,63 @@ describe("E2B sandbox lease lifecycle", () => {
         metadata: expect.objectContaining({ sandboxVersion: "v12" }),
       }),
     );
+  });
+
+  it("passes the proxy to sandbox creation without persisting credentials in metadata", async () => {
+    process.env.E2B_EGRESS_PROXY_ADDRESS = "proxy.example.com:1080";
+    process.env.E2B_EGRESS_PROXY_USERNAME = "proxy-user";
+    process.env.E2B_EGRESS_PROXY_PASSWORD = "proxy-password";
+    process.env.E2B_EGRESS_PROXY_ALLOWED_USER_IDS = "user-1";
+    sandboxApi.list.mockReturnValue({
+      nextItems: jest.fn(async () => []),
+    });
+    const createdSandbox = { sandboxId: "sandbox-2" } as unknown as Sandbox;
+    sandboxApi.create.mockResolvedValue(createdSandbox);
+
+    await ensureSandboxConnection({ userID: "user-1", setSandbox: jest.fn() });
+
+    expect(sandboxApi.create).toHaveBeenCalledWith(
+      "terminal-agent-sandbox",
+      expect.objectContaining({
+        network: {
+          egressProxy: {
+            address: "proxy.example.com:1080",
+            username: "proxy-user",
+            password: "proxy-password",
+          },
+        },
+        metadata: expect.not.objectContaining({
+          address: expect.anything(),
+          username: expect.anything(),
+          password: expect.anything(),
+        }),
+      }),
+    );
+    expect(mockCaptureEvent).toHaveBeenCalledWith(
+      "e2b_egress_proxy_exposure",
+      expect.objectContaining({
+        userId: "user-1",
+        sandbox_id: "sandbox-2",
+        acquisition_path: "create_fresh",
+      }),
+    );
+  });
+
+  it("does not proxy a user outside the rollout allowlist", async () => {
+    process.env.E2B_EGRESS_PROXY_ADDRESS = "proxy.example.com:1080";
+    process.env.E2B_EGRESS_PROXY_ALLOWED_USER_IDS = "user-2";
+    sandboxApi.list.mockReturnValue({
+      nextItems: jest.fn(async () => []),
+    });
+    sandboxApi.create.mockResolvedValue({
+      sandboxId: "sandbox-2",
+    } as unknown as Sandbox);
+
+    await ensureSandboxConnection({ userID: "user-1", setSandbox: jest.fn() });
+
+    const createOptions = sandboxApi.create.mock.calls[0][1];
+    expect(createOptions).not.toHaveProperty("network");
+    expect(mockCaptureEvent).not.toHaveBeenCalled();
   });
 
   it("creates a fresh EU sandbox for an EU Trigger run when EU is configured", async () => {

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -59,6 +59,7 @@ const listSandbox = (
     sandboxId: string;
     state: "running" | "paused";
     metadata: Record<string, string>;
+    network: { egressProxy?: { address: string; username?: string } };
   }> = {},
 ) => {
   sandboxApi.list.mockReturnValue({
@@ -428,6 +429,29 @@ describe("E2B sandbox lease lifecycle", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  it("clears an existing proxy when the user leaves the rollout allowlist", async () => {
+    process.env.E2B_EGRESS_PROXY_ADDRESS = "proxy.example.com:1080";
+    process.env.E2B_EGRESS_PROXY_ALLOWED_USER_IDS = "user-2";
+    const updateNetwork = jest.fn(async () => undefined);
+    const connectedSandbox = {
+      sandboxId: "sandbox-1",
+      updateNetwork,
+    } as unknown as Sandbox;
+    listSandbox({
+      network: { egressProxy: { address: "proxy.example.com:1080" } },
+    });
+    sandboxApi.connect.mockResolvedValue(connectedSandbox);
+    const setSandbox = jest.fn();
+
+    await ensureSandboxConnection({ userID: "user-1", setSandbox });
+
+    expect(updateNetwork).toHaveBeenCalledWith({});
+    expect(updateNetwork.mock.invocationCallOrder[0]).toBeLessThan(
+      setSandbox.mock.invocationCallOrder[0],
+    );
+    expect(mockCaptureEvent).not.toHaveBeenCalled();
   });
 
   it("creates new sandboxes with pause and automatic resume enabled", async () => {

--- a/lib/ai/tools/utils/e2b-egress-proxy.ts
+++ b/lib/ai/tools/utils/e2b-egress-proxy.ts
@@ -1,0 +1,71 @@
+import type { SandboxEgressProxyOpts } from "e2b";
+
+type E2BEgressProxyEnvironment = Readonly<Record<string, string | undefined>>;
+
+const MAX_SOCKS5_CREDENTIAL_BYTES = 255;
+
+const optionalValue = (value: string | undefined): string | undefined =>
+  value !== undefined && value.length > 0 ? value : undefined;
+
+const validateCredentialLength = (
+  name: "username" | "password",
+  value: string | undefined,
+): void => {
+  if (
+    value !== undefined &&
+    Buffer.byteLength(value, "utf8") > MAX_SOCKS5_CREDENTIAL_BYTES
+  ) {
+    throw new Error(
+      `Invalid E2B egress proxy configuration: ${name} exceeds ${MAX_SOCKS5_CREDENTIAL_BYTES} bytes`,
+    );
+  }
+};
+
+/**
+ * Resolves the server-owned E2B SOCKS5 proxy for one user.
+ *
+ * The allowlist is deliberately fail-closed: configuring a gateway without an
+ * explicit user ID (or `*`) does not route any customer traffic through it.
+ */
+export const getE2BEgressProxyForUser = (
+  userID: string,
+  environment: E2BEgressProxyEnvironment = process.env,
+): SandboxEgressProxyOpts | undefined => {
+  const address = optionalValue(environment.E2B_EGRESS_PROXY_ADDRESS?.trim());
+  const username = optionalValue(environment.E2B_EGRESS_PROXY_USERNAME);
+  const password = optionalValue(environment.E2B_EGRESS_PROXY_PASSWORD);
+
+  if (!address) {
+    if (username || password) {
+      throw new Error(
+        "Invalid E2B egress proxy configuration: credentials require E2B_EGRESS_PROXY_ADDRESS",
+      );
+    }
+    return undefined;
+  }
+
+  if (password && !username) {
+    throw new Error(
+      "Invalid E2B egress proxy configuration: E2B_EGRESS_PROXY_PASSWORD requires E2B_EGRESS_PROXY_USERNAME",
+    );
+  }
+
+  validateCredentialLength("username", username);
+  validateCredentialLength("password", password);
+
+  const allowedUserIDs = new Set(
+    (environment.E2B_EGRESS_PROXY_ALLOWED_USER_IDS ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+  if (!allowedUserIDs.has("*") && !allowedUserIDs.has(userID)) {
+    return undefined;
+  }
+
+  return {
+    address,
+    ...(username !== undefined && { username }),
+    ...(password !== undefined && { password }),
+  };
+};

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from "@e2b/code-interpreter";
+import type { SandboxInfo, SandboxNetworkUpdate } from "e2b";
 import type { SandboxBootInfo, SandboxContext } from "@/types";
 import { NotFoundError, getUserFacingE2BErrorMessage } from "./e2b-errors";
 import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
@@ -85,19 +86,33 @@ export const ensureSandboxConnection = async (
   const reconcileEgressProxy = async (
     sandbox: Sandbox,
     path: SandboxReadyPath | "initial_connection",
-    hadEgressProxy = false,
+    existingInfo: Pick<SandboxInfo, "allowInternetAccess" | "network">,
   ): Promise<void> => {
+    const preservedNetwork: SandboxNetworkUpdate = {
+      ...(existingInfo.network?.allowOut !== undefined && {
+        allowOut: existingInfo.network.allowOut,
+      }),
+      ...(existingInfo.network?.denyOut !== undefined && {
+        denyOut: existingInfo.network.denyOut,
+      }),
+      ...(existingInfo.network?.rules !== undefined && {
+        rules: existingInfo.network.rules,
+      }),
+      ...(existingInfo.allowInternetAccess !== undefined && {
+        allowInternetAccess: existingInfo.allowInternetAccess,
+      }),
+    };
+
     if (!egressProxy) {
-      if (hadEgressProxy) {
-        await sandbox.updateNetwork({});
+      if (existingInfo.network?.egressProxy) {
+        await sandbox.updateNetwork(preservedNetwork);
       }
       return;
     }
 
-    // updateNetwork replaces the whole mutable network configuration. This
-    // utility currently owns that state, so always send the complete desired
-    // configuration when attaching the proxy to a reusable sandbox.
-    await sandbox.updateNetwork({ egressProxy });
+    // updateNetwork replaces the whole mutable network configuration, so
+    // preserve restrictions that may have been applied by another caller.
+    await sandbox.updateNetwork({ ...preservedNetwork, egressProxy });
     phLogger.event("e2b_egress_proxy_exposure", {
       userId: userID,
       sandbox_id: sandbox.sandboxId,
@@ -107,7 +122,12 @@ export const ensureSandboxConnection = async (
 
   // Return existing sandbox if already connected
   if (initialSandbox) {
-    await reconcileEgressProxy(initialSandbox, "initial_connection");
+    const initialSandboxInfo = await initialSandbox.getInfo();
+    await reconcileEgressProxy(
+      initialSandbox,
+      "initial_connection",
+      initialSandboxInfo,
+    );
     return { sandbox: initialSandbox };
   }
   const startedAt = performance.now();
@@ -239,7 +259,7 @@ export const ensureSandboxConnection = async (
         await reconcileEgressProxy(
           sandbox,
           "reuse_existing",
-          existingSandboxInfo.network?.egressProxy !== undefined,
+          existingSandboxInfo,
         );
         setSandbox(sandbox);
         reportBoot("reuse_existing", 0);

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -6,6 +6,8 @@ import { retryWithBackoff } from "./retry-with-backoff";
 import { getE2BClusterRouting, type E2BClusterConfig } from "./e2b-cluster";
 import type { TriggerRunRegion } from "@/lib/api/trigger-region";
 import { BASH_SANDBOX_AUTOPAUSE_TIMEOUT } from "./e2b-lease";
+import { phLogger } from "@/lib/posthog/server";
+import { getE2BEgressProxyForUser } from "./e2b-egress-proxy";
 export {
   BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
   E2B_SANDBOX_IDLE_RELEASE_TIMEOUT_MS,
@@ -78,9 +80,28 @@ export const ensureSandboxConnection = async (
 ): Promise<{ sandbox: Sandbox }> => {
   const { userID, setSandbox, onBoot } = context;
   const { initialSandbox, triggerRegion } = options;
+  const egressProxy = getE2BEgressProxyForUser(userID);
+
+  const applyEgressProxy = async (
+    sandbox: Sandbox,
+    path: SandboxReadyPath | "initial_connection",
+  ): Promise<void> => {
+    if (!egressProxy) return;
+
+    // updateNetwork replaces the whole mutable network configuration. This
+    // utility currently owns that state, so always send the complete desired
+    // configuration when attaching the proxy to a reusable sandbox.
+    await sandbox.updateNetwork({ egressProxy });
+    phLogger.event("e2b_egress_proxy_exposure", {
+      userId: userID,
+      sandbox_id: sandbox.sandboxId,
+      acquisition_path: path,
+    });
+  };
 
   // Return existing sandbox if already connected
   if (initialSandbox) {
+    await applyEgressProxy(initialSandbox, "initial_connection");
     return { sandbox: initialSandbox };
   }
   const startedAt = performance.now();
@@ -209,6 +230,7 @@ export const ensureSandboxConnection = async (
             jitterMs: 40,
           },
         );
+        await applyEgressProxy(sandbox, "reuse_existing");
         setSandbox(sandbox);
         reportBoot("reuse_existing", 0);
         return { sandbox };
@@ -253,6 +275,7 @@ export const ensureSandboxConnection = async (
           timeoutMs: BASH_SANDBOX_AUTOPAUSE_TIMEOUT,
           lifecycle: { onTimeout: "pause", autoResume: true },
           secure: true,
+          ...(egressProxy && { network: { egressProxy } }),
           metadata: {
             userID,
             template: createCluster.template,
@@ -262,6 +285,13 @@ export const ensureSandboxConnection = async (
           },
         });
 
+        if (egressProxy) {
+          phLogger.event("e2b_egress_proxy_exposure", {
+            userId: userID,
+            sandbox_id: sandbox.sandboxId,
+            acquisition_path: createPath,
+          });
+        }
         setSandbox(sandbox);
         reportBoot(createPath, attempt + 1);
         return { sandbox };

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -82,11 +82,17 @@ export const ensureSandboxConnection = async (
   const { initialSandbox, triggerRegion } = options;
   const egressProxy = getE2BEgressProxyForUser(userID);
 
-  const applyEgressProxy = async (
+  const reconcileEgressProxy = async (
     sandbox: Sandbox,
     path: SandboxReadyPath | "initial_connection",
+    hadEgressProxy = false,
   ): Promise<void> => {
-    if (!egressProxy) return;
+    if (!egressProxy) {
+      if (hadEgressProxy) {
+        await sandbox.updateNetwork({});
+      }
+      return;
+    }
 
     // updateNetwork replaces the whole mutable network configuration. This
     // utility currently owns that state, so always send the complete desired
@@ -101,7 +107,7 @@ export const ensureSandboxConnection = async (
 
   // Return existing sandbox if already connected
   if (initialSandbox) {
-    await applyEgressProxy(initialSandbox, "initial_connection");
+    await reconcileEgressProxy(initialSandbox, "initial_connection");
     return { sandbox: initialSandbox };
   }
   const startedAt = performance.now();
@@ -230,7 +236,11 @@ export const ensureSandboxConnection = async (
             jitterMs: 40,
           },
         );
-        await applyEgressProxy(sandbox, "reuse_existing");
+        await reconcileEgressProxy(
+          sandbox,
+          "reuse_existing",
+          existingSandboxInfo.network?.egressProxy !== undefined,
+        );
         setSandbox(sandbox);
         reportBoot("reuse_existing", 0);
         return { sandbox };


### PR DESCRIPTION
## Summary

- configure E2B `network.egressProxy` for new and reused cloud sandboxes
- keep the preview rollout fail-closed behind an explicit user-ID allowlist
- validate SOCKS5 credentials and emit a privacy-safe exposure event
- document the preview environment variables

## Validation

- `pnpm typecheck`
- full Jest suite: 422 suites / 4,473 tests passed
- focused E2B proxy and lifecycle suites: 40 tests passed
- scoped ESLint and Prettier
- `git diff --check`

## Manual verification

After the preview SOCKS5 gateway is provisioned:

1. Configure the four `E2B_EGRESS_PROXY_*` preview variables and allowlist one internal user.
2. Start a Cloud Agent sandbox in the PR preview.
3. Confirm known-open and known-closed TCP ports with `nmap -sT`, `nc`, and a connect-mode scanner.
4. Repeat through the US and EU E2B projects and compare against direct egress.
5. Confirm non-allowlisted users receive no `network.egressProxy` configuration.

Linear: [HAC-88](https://linear.app/hackerai/issue/HAC-88/evaluate-e2b-byo-proxy-for-reliable-cloud-agent-tcp-port-scanning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional E2B SOCKS5 proxy support for sandbox network traffic.
  - Proxy access can be limited to specific users or enabled for everyone.
  - Proxy settings apply consistently to new and reused sandboxes.

- **Bug Fixes**
  - Sandboxes fail closed when proxy configuration cannot be applied.
  - Removed stale proxy settings for users no longer eligible.
  - Preserved existing network restrictions during proxy updates or removal.
  - Added safeguards for invalid credentials and oversized usernames.

- **Tests**
  - Added coverage for proxy configuration, access controls, credential handling, and sandbox lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->