### PR TITLE
Suppress exact Firefox removeChild noise

### DIFF
--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -191,6 +191,9 @@ describe("MessageErrorState", () => {
   });
 
   it("opens Checkout directly and marks the stopped task for resume", async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValue(Date.UTC(2026, 7, 22));
     const user = userEvent.setup();
     const error = new ChatSDKError(
       "rate_limit:chat",
@@ -225,6 +228,7 @@ describe("MessageErrorState", () => {
       ),
     );
     expect(openSettingsDialog).not.toHaveBeenCalled();
+    dateNowSpy.mockRestore();
   });
 
   it("opens payment-method recovery directly for auto-reload failures", async () => {

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom";
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -55,6 +62,10 @@ describe("MessageErrorState", () => {
       paymentMethodBrand: "visa",
       url: null,
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("does not offer same-payload retry for provider content blocks", () => {
@@ -191,9 +202,7 @@ describe("MessageErrorState", () => {
   });
 
   it("opens Checkout directly and marks the stopped task for resume", async () => {
-    const dateNowSpy = jest
-      .spyOn(Date, "now")
-      .mockReturnValue(Date.UTC(2026, 7, 22));
+    jest.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 7, 22));
     const user = userEvent.setup();
     const error = new ChatSDKError(
       "rate_limit:chat",
@@ -228,7 +237,6 @@ describe("MessageErrorState", () => {
       ),
     );
     expect(openSettingsDialog).not.toHaveBeenCalled();
-    dateNowSpy.mockRestore();
   });
 
   it("opens payment-method recovery directly for auto-reload failures", async () => {

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -391,6 +391,7 @@ describe("shouldDropExpectedFrontendException", () => {
     for (const value of [
       "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
       "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+      "NotFoundError: Node.removeChild: The node to be removed is not a child of this node",
       "NotFoundError: The object can not be found here.",
     ]) {
       expect(
@@ -403,6 +404,18 @@ describe("shouldDropExpectedFrontendException", () => {
         }),
       ).toBe(true);
     }
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_types: ["DOMException"],
+          $exception_values: [
+            "NotFoundError: Node.removeChild: Application state is unavailable",
+          ],
+        },
+      }),
+    ).toBe(false);
   });
 
   it("drops exact opaque synthetic browser exceptions", () => {

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -32,6 +32,7 @@ const MANUAL_CHAT_STOP_ABORT_MESSAGES = new Set([
 const REACT_DOM_MUTATION_MESSAGES = new Set([
   "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
   "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+  "NotFoundError: Node.removeChild: The node to be removed is not a child of this node",
   "NotFoundError: The object can not be found here.",
 ]);
 


### PR DESCRIPTION
## Summary

- suppress the exact Firefox `Node.removeChild` DOM mutation exception already proven to be harmless React/browser reconciliation noise
- retain near-matching and unknown DOM exceptions for investigation
- freeze a date-sensitive checkout recommendation test so the repository gate is deterministic at month end

## Production evidence

Frozen audit window: `2026-08-30T20:02:18Z` to `2026-08-31T20:02:18Z`.

PostHog recorded four occurrences across three split issues for:

`NotFoundError: Node.removeChild: The node to be removed is not a child of this node`

The representative sample was Firefox chat traffic and matched the semantics of the existing exact React DOM mutation allowlist. No application frames or evidence of state loss were present. The filter is exact-string only; an adversarial near-match remains captured.

The broader audit found no other sufficiently attributable application defect for a safe code change. Provider 4xx/5xx failures, persistence failures, stack overflows, payment/auth failures, and unknown exceptions remain visible.

## Root cause and change

This is a Firefox spelling of the same benign DOM reconciliation race already filtered for Chromium/WebKit messages. Add only the observed exact message to the existing set and cover both the positive match and a near-match negative case.

The unrelated checkout test had embedded a calendar-dependent weekly spend expectation. It deterministically failed on August 31, so the test now freezes `Date.now` to its original fixture date without changing production behavior.

## Validation

- focused Jest: 36/36
- full commit hook: 422 suites, 4,447 tests
- TypeScript typecheck
- ESLint and Prettier
- `git diff --check`
- adversarial review: exact message boundary, all callers, alternate paths, privacy, deployment skew, and non-suppression of near matches

## Manual verification

Automated validation is sufficient. This changes only client-side exception filtering and has exact positive/negative regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from expected React DOM mutation errors in frontend exception reporting.
  * Continued reporting similar errors when they may indicate unavailable application state.

* **Tests**
  * Improved checkout-resume test reliability with a fixed timestamp during execution.
  * Improved test cleanup by automatically restoring mocked timers and other test mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->