### PR TITLE
Add consent-aware analytics controls

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -52,6 +52,7 @@ function createRequest({
   method = "GET",
   headers = {},
   cookieNames = [],
+  cookieValues = {},
 }: {
   pathname: string;
   accept?: string;
@@ -60,6 +61,7 @@ function createRequest({
   method?: string;
   headers?: Record<string, string>;
   cookieNames?: string[];
+  cookieValues?: Record<string, string>;
 }): NextRequest {
   const url = new URL(pathname, "https://hackerai.co");
   return {
@@ -74,7 +76,14 @@ function createRequest({
     cookies: {
       has: jest.fn(
         (name: string) =>
-          (name === "wos-session" && hasSession) || cookieNames.includes(name),
+          (name === "wos-session" && hasSession) ||
+          cookieNames.includes(name) ||
+          Object.hasOwn(cookieValues, name),
+      ),
+      get: jest.fn((name: string) =>
+        Object.hasOwn(cookieValues, name)
+          ? { name, value: cookieValues[name] }
+          : undefined,
       ),
     },
   } as unknown as NextRequest;
@@ -223,6 +232,85 @@ describe("proxy", () => {
       maxAge: 90 * 24 * 60 * 60,
       path: "/",
     });
+  });
+
+  it("does not set optional attribution cookies before EU consent", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://signin.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/?utm_source=github&referral_code=ABCDEF",
+        accept: "text/html",
+        userAgent: "Mozilla/5.0",
+        headers: { "x-vercel-ip-country": "DE" },
+      }),
+    );
+
+    expect(response.cookies.set).not.toHaveBeenCalled();
+    expect(response.cookies.delete).toHaveBeenCalledWith(
+      "hackerai_first_touch_attribution",
+    );
+    expect(response.cookies.delete).toHaveBeenCalledWith("hackerai_ref");
+    expect(response.cookies.delete).toHaveBeenCalledWith("hackerai_ref_at");
+  });
+
+  it("sets optional attribution cookies after EU consent", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://signin.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/?utm_source=github&referral_code=ABCDEF",
+        accept: "text/html",
+        userAgent: "Mozilla/5.0",
+        headers: { "x-vercel-ip-country": "DE" },
+        cookieValues: { hackerai_analytics_consent: "accepted" },
+      }),
+    );
+
+    expect(response.cookies.set).toHaveBeenCalledWith(
+      "hackerai_ref",
+      "ABCDEF",
+      expect.any(Object),
+    );
+    expect(
+      response.cookies.set.mock.calls.some(
+        ([name]: [string]) => name === "hackerai_first_touch_attribution",
+      ),
+    ).toBe(true);
+  });
+
+  it("honors an analytics rejection outside the EU", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://signin.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/?utm_source=github",
+        accept: "text/html",
+        userAgent: "Mozilla/5.0",
+        headers: { "x-vercel-ip-country": "US" },
+        cookieValues: { hackerai_analytics_consent: "declined" },
+      }),
+    );
+
+    expect(response.cookies.set).not.toHaveBeenCalled();
+    expect(response.cookies.delete).toHaveBeenCalledWith(
+      "hackerai_first_touch_attribution",
+    );
   });
 
   it("does not store attribution for likely bot traffic", async () => {

--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -33,6 +33,7 @@ const { useGlobalState } = jest.requireMock<
 >("../contexts/GlobalState");
 const {
   confirmAuthenticatedAnalyticsUserId,
+  getPostHogClient,
   loadPostHogClient,
   setAuthenticatedAnalyticsUserId,
 } = jest.requireMock<typeof import("@/lib/analytics/client")>(
@@ -45,6 +46,7 @@ const mockUseAuth = useAuth as jest.Mock;
 const mockUseGlobalState = useGlobalState as jest.Mock;
 const mockConfirmAuthenticatedAnalyticsUserId =
   confirmAuthenticatedAnalyticsUserId as jest.Mock;
+const mockGetPostHogClient = getPostHogClient as jest.Mock;
 const mockLoadPostHogClient = loadPostHogClient as jest.Mock;
 const mockSetAuthenticatedAnalyticsUserId =
   setAuthenticatedAnalyticsUserId as jest.Mock;
@@ -55,6 +57,7 @@ describe("PostHogProvider", () => {
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
     process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
     window.localStorage.clear();
+    mockGetPostHogClient.mockReturnValue(null);
 
     mockUseGlobalState.mockReturnValue({
       subscription: "pro",
@@ -88,7 +91,7 @@ describe("PostHogProvider", () => {
     mockLoadPostHogClient.mockResolvedValue(posthog);
 
     render(
-      <PostHogProvider>
+      <PostHogProvider analyticsAllowed>
         <div>child</div>
       </PostHogProvider>,
     );
@@ -184,7 +187,7 @@ describe("PostHogProvider", () => {
       mockLoadPostHogClient.mockResolvedValue(posthog);
 
       render(
-        <PostHogProvider>
+        <PostHogProvider analyticsAllowed>
           <div>child</div>
         </PostHogProvider>,
       );
@@ -226,7 +229,7 @@ describe("PostHogProvider", () => {
 
     try {
       render(
-        <PostHogProvider>
+        <PostHogProvider analyticsAllowed>
           <div>child</div>
         </PostHogProvider>,
       );
@@ -244,7 +247,7 @@ describe("PostHogProvider", () => {
     mockUseAuth.mockReturnValue({ user: null });
 
     render(
-      <PostHogProvider>
+      <PostHogProvider analyticsAllowed>
         <div>child</div>
       </PostHogProvider>,
     );
@@ -270,6 +273,26 @@ describe("PostHogProvider", () => {
     expect(
       window.localStorage.getItem(POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY),
     ).toBeNull();
+  });
+
+  it("stops and clears a loaded PostHog client when consent is withdrawn", () => {
+    const posthog = {
+      __loaded: true,
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockGetPostHogClient.mockReturnValue(posthog);
+
+    render(
+      <PostHogProvider analyticsAllowed={false}>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    expect(posthog.stopSessionRecording).toHaveBeenCalledTimes(1);
+    expect(posthog.reset).toHaveBeenCalledTimes(1);
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1);
   });
 
   it("does not resend unchanged person properties across app loads", async () => {
@@ -307,7 +330,7 @@ describe("PostHogProvider", () => {
     mockLoadPostHogClient.mockResolvedValue(posthog);
 
     render(
-      <PostHogProvider>
+      <PostHogProvider analyticsAllowed>
         <div>child</div>
       </PostHogProvider>,
     );
@@ -334,6 +357,7 @@ describe("PostHogProvider", () => {
 
     render(
       <PostHogProvider
+        analyticsAllowed
         firstTouchAttribution={{
           version: 1,
           source: "github",
@@ -389,7 +413,7 @@ describe("PostHogProvider", () => {
     mockLoadPostHogClient.mockResolvedValue(posthog);
 
     render(
-      <PostHogProvider>
+      <PostHogProvider analyticsAllowed>
         <div>child</div>
       </PostHogProvider>,
     );

--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -253,6 +253,25 @@ describe("PostHogProvider", () => {
     expect(mockLoadPostHogClient).not.toHaveBeenCalled();
   });
 
+  it("does not initialize or identify PostHog without analytics permission", () => {
+    window.localStorage.setItem(
+      POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
+      "previous-identity",
+    );
+
+    render(
+      <PostHogProvider analyticsAllowed={false}>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    expect(mockSetAuthenticatedAnalyticsUserId).toHaveBeenCalledWith(null);
+    expect(mockLoadPostHogClient).not.toHaveBeenCalled();
+    expect(
+      window.localStorage.getItem(POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY),
+    ).toBeNull();
+  });
+
   it("does not resend unchanged person properties across app loads", async () => {
     const posthog = {
       __loaded: false,

--- a/app/actions/__tests__/analytics-consent.test.ts
+++ b/app/actions/__tests__/analytics-consent.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockCookieSet = jest.fn();
+const mockCookieDelete = jest.fn();
+const mockCookies = jest.fn(async () => ({
+  set: mockCookieSet,
+  delete: mockCookieDelete,
+}));
+
+jest.mock("next/headers", () => ({ cookies: mockCookies }));
+
+const { saveAnalyticsConsent } =
+  require("../analytics-consent") as typeof import("../analytics-consent");
+
+describe("saveAnalyticsConsent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+  });
+
+  it("stores an HttpOnly consent choice", async () => {
+    await saveAnalyticsConsent("accepted");
+
+    expect(mockCookieSet).toHaveBeenCalledWith(
+      "hackerai_analytics_consent",
+      "accepted",
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: "lax",
+        maxAge: 180 * 24 * 60 * 60,
+        path: "/",
+      }),
+    );
+    expect(mockCookieDelete).not.toHaveBeenCalled();
+  });
+
+  it("removes existing optional analytics and attribution cookies on rejection", async () => {
+    await saveAnalyticsConsent("declined");
+
+    expect(mockCookieDelete.mock.calls.map(([name]) => name)).toEqual([
+      "hackerai_first_touch_attribution",
+      "hackerai_ref",
+      "hackerai_ref_at",
+      "ph_phc_test_posthog",
+    ]);
+  });
+});

--- a/app/actions/analytics-consent.ts
+++ b/app/actions/analytics-consent.ts
@@ -1,0 +1,43 @@
+"use server";
+
+import { cookies } from "next/headers";
+import {
+  ANALYTICS_CONSENT_COOKIE_NAME,
+  ANALYTICS_CONSENT_MAX_AGE_SECONDS,
+  type AnalyticsConsent,
+  parseAnalyticsConsent,
+} from "@/lib/privacy/analytics-consent";
+import { FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME } from "@/lib/analytics/acquisition";
+import {
+  REFERRAL_COOKIE_CREATED_AT_NAME,
+  REFERRAL_COOKIE_NAME,
+} from "@/lib/referrals/config";
+
+export async function saveAnalyticsConsent(
+  requestedConsent: AnalyticsConsent,
+): Promise<void> {
+  const consent = parseAnalyticsConsent(requestedConsent);
+  if (!consent) {
+    throw new Error("Invalid analytics consent choice");
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set(ANALYTICS_CONSENT_COOKIE_NAME, consent, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: ANALYTICS_CONSENT_MAX_AGE_SECONDS,
+    path: "/",
+  });
+
+  if (consent === "accepted") return;
+
+  cookieStore.delete(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME);
+  cookieStore.delete(REFERRAL_COOKIE_NAME);
+  cookieStore.delete(REFERRAL_COOKIE_CREATED_AT_NAME);
+
+  const postHogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+  if (postHogKey) {
+    cookieStore.delete(`ph_${postHogKey}_posthog`);
+  }
+}

--- a/app/components/AnalyticsConsentManager.tsx
+++ b/app/components/AnalyticsConsentManager.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import Link from "next/link";
+import { ShieldCheck } from "lucide-react";
+import { useState } from "react";
+import { saveAnalyticsConsent } from "@/app/actions/analytics-consent";
+import { PostHogProvider } from "@/app/providers";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { FirstTouchAttribution } from "@/lib/analytics/acquisition";
+import {
+  type AnalyticsConsent,
+  isAnalyticsAllowed,
+} from "@/lib/privacy/analytics-consent";
+
+type AnalyticsConsentManagerProps = {
+  children: React.ReactNode;
+  consentRequired: boolean;
+  firstTouchAttribution?: FirstTouchAttribution | null;
+  initialConsent: AnalyticsConsent | null;
+};
+
+type ChoiceButtonsProps = {
+  currentChoice?: AnalyticsConsent | null;
+  disabled: boolean;
+  onChoose: (choice: AnalyticsConsent) => void;
+};
+
+function ChoiceButtons({
+  currentChoice = null,
+  disabled,
+  onChoose,
+}: ChoiceButtonsProps) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row">
+      <Button
+        type="button"
+        variant={currentChoice === "declined" ? "secondary" : "outline"}
+        className="min-w-36 flex-1"
+        disabled={disabled}
+        aria-pressed={currentChoice === "declined"}
+        onClick={() => onChoose("declined")}
+      >
+        Reject analytics
+      </Button>
+      <Button
+        type="button"
+        variant={currentChoice === "accepted" ? "secondary" : "outline"}
+        className="min-w-36 flex-1"
+        disabled={disabled}
+        aria-pressed={currentChoice === "accepted"}
+        onClick={() => onChoose("accepted")}
+      >
+        Allow analytics
+      </Button>
+    </div>
+  );
+}
+
+function ConsentExplanation() {
+  return (
+    <p className="text-muted-foreground text-sm leading-6">
+      HackerAI uses optional browser storage for PostHog product analytics,
+      diagnostics, and—on eligible paid accounts—session replay. Rejecting
+      analytics will not affect the service. Read our{" "}
+      <Link
+        href="/privacy-policy"
+        target="_blank"
+        className="text-foreground underline underline-offset-4"
+      >
+        Privacy Policy
+      </Link>
+      .
+    </p>
+  );
+}
+
+export function AnalyticsConsentManager({
+  children,
+  consentRequired,
+  firstTouchAttribution = null,
+  initialConsent,
+}: AnalyticsConsentManagerProps) {
+  const [consent, setConsent] = useState(initialConsent);
+  const [isSaving, setIsSaving] = useState(false);
+  const [preferencesOpen, setPreferencesOpen] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const analyticsAllowed = isAnalyticsAllowed({
+    consent,
+    consentRequired,
+  });
+  const needsInitialChoice = consentRequired && consent === null;
+
+  const chooseConsent = async (choice: AnalyticsConsent) => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await saveAnalyticsConsent(choice);
+      setConsent(choice);
+      setPreferencesOpen(false);
+    } catch {
+      setSaveError("We couldn't save your privacy choice. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <PostHogProvider
+      analyticsAllowed={analyticsAllowed}
+      firstTouchAttribution={firstTouchAttribution}
+    >
+      {children}
+
+      {needsInitialChoice ? (
+        <section
+          aria-label="Analytics privacy choices"
+          className="fixed inset-x-3 bottom-3 z-[70] mx-auto max-w-3xl rounded-2xl border border-border bg-background/95 p-4 shadow-2xl backdrop-blur sm:bottom-5 sm:p-5"
+        >
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+            <div className="flex min-w-0 flex-1 gap-3">
+              <span className="mt-0.5 rounded-full border border-border bg-muted p-2 text-foreground">
+                <ShieldCheck aria-hidden="true" className="size-4" />
+              </span>
+              <div className="space-y-2">
+                <h2 className="text-base font-semibold">
+                  Your analytics choice
+                </h2>
+                <ConsentExplanation />
+                {saveError ? (
+                  <p role="alert" className="text-destructive text-sm">
+                    {saveError}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+            <ChoiceButtons
+              disabled={isSaving}
+              onChoose={(choice) => void chooseConsent(choice)}
+            />
+          </div>
+        </section>
+      ) : null}
+
+      {!needsInitialChoice && (consentRequired || consent !== null) ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="fixed bottom-3 left-3 z-50 bg-background/90 text-xs shadow-md backdrop-blur"
+          onClick={() => setPreferencesOpen(true)}
+        >
+          Privacy choices
+        </Button>
+      ) : null}
+
+      <Dialog open={preferencesOpen} onOpenChange={setPreferencesOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Analytics privacy choices</DialogTitle>
+            <DialogDescription asChild>
+              <ConsentExplanation />
+            </DialogDescription>
+          </DialogHeader>
+          {saveError ? (
+            <p role="alert" className="text-destructive text-sm">
+              {saveError}
+            </p>
+          ) : null}
+          <ChoiceButtons
+            currentChoice={consent}
+            disabled={isSaving}
+            onChoose={(choice) => void chooseConsent(choice)}
+          />
+        </DialogContent>
+      </Dialog>
+    </PostHogProvider>
+  );
+}

--- a/app/components/AnalyticsConsentManager.tsx
+++ b/app/components/AnalyticsConsentManager.tsx
@@ -86,9 +86,8 @@ function ChoiceButtons({
 function ConsentExplanation() {
   return (
     <p className="text-muted-foreground text-pretty text-sm leading-5">
-      We use optional cookies to understand product usage, diagnose errors, and
-      replay sessions on eligible paid accounts. HackerAI works the same if you
-      decline. Read our{" "}
+      We use optional cookies to understand product usage and diagnose errors.
+      HackerAI works the same if you decline. Read our{" "}
       <Link
         href="/privacy-policy"
         target="_blank"

--- a/app/components/AnalyticsConsentManager.tsx
+++ b/app/components/AnalyticsConsentManager.tsx
@@ -200,13 +200,13 @@ export function AnalyticsConsentManager({
 
   const preferences = useMemo(
     () => ({
-      available: !needsInitialChoice,
+      available: consent !== null,
       consent,
       isSaving,
       saveError,
       chooseConsent,
     }),
-    [consent, isSaving, needsInitialChoice, saveError, chooseConsent],
+    [consent, isSaving, saveError, chooseConsent],
   );
 
   return (

--- a/app/components/AnalyticsConsentManager.tsx
+++ b/app/components/AnalyticsConsentManager.tsx
@@ -1,18 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { ShieldCheck } from "lucide-react";
-import { useState } from "react";
+import { XIcon } from "lucide-react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import { saveAnalyticsConsent } from "@/app/actions/analytics-consent";
 import { PostHogProvider } from "@/app/providers";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import type { FirstTouchAttribution } from "@/lib/analytics/acquisition";
 import {
   type AnalyticsConsent,
@@ -32,27 +37,42 @@ type ChoiceButtonsProps = {
   onChoose: (choice: AnalyticsConsent) => void;
 };
 
+type AnalyticsConsentPreferencesContextValue = {
+  available: boolean;
+  consent: AnalyticsConsent | null;
+  isSaving: boolean;
+  saveError: string | null;
+  chooseConsent: (choice: AnalyticsConsent) => Promise<boolean>;
+};
+
+const AnalyticsConsentPreferencesContext =
+  createContext<AnalyticsConsentPreferencesContextValue | null>(null);
+
+export function useAnalyticsConsentPreferencesAvailable() {
+  return useContext(AnalyticsConsentPreferencesContext)?.available ?? false;
+}
+
 function ChoiceButtons({
   currentChoice = null,
   disabled,
   onChoose,
 }: ChoiceButtonsProps) {
   return (
-    <div className="flex flex-col gap-2 sm:flex-row">
+    <div className="grid grid-cols-2 gap-2">
       <Button
         type="button"
+        size="sm"
         variant={currentChoice === "declined" ? "secondary" : "outline"}
-        className="min-w-36 flex-1"
         disabled={disabled}
         aria-pressed={currentChoice === "declined"}
         onClick={() => onChoose("declined")}
       >
-        Reject analytics
+        Decline
       </Button>
       <Button
         type="button"
+        size="sm"
         variant={currentChoice === "accepted" ? "secondary" : "outline"}
-        className="min-w-36 flex-1"
         disabled={disabled}
         aria-pressed={currentChoice === "accepted"}
         onClick={() => onChoose("accepted")}
@@ -65,19 +85,88 @@ function ChoiceButtons({
 
 function ConsentExplanation() {
   return (
-    <p className="text-muted-foreground text-sm leading-6">
-      HackerAI uses optional browser storage for PostHog product analytics,
-      diagnostics, and—on eligible paid accounts—session replay. Rejecting
-      analytics will not affect the service. Read our{" "}
+    <p className="text-muted-foreground text-pretty text-sm leading-5">
+      We use optional cookies to understand product usage, diagnose errors, and
+      replay sessions on eligible paid accounts. HackerAI works the same if you
+      decline. Read our{" "}
       <Link
         href="/privacy-policy"
         target="_blank"
+        rel="noreferrer"
         className="text-foreground underline underline-offset-4"
       >
         Privacy Policy
       </Link>
       .
     </p>
+  );
+}
+
+export function AnalyticsConsentPreferences({
+  children,
+}: {
+  children: React.ReactElement;
+}) {
+  const preferences = useContext(AnalyticsConsentPreferencesContext);
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+
+  if (!preferences?.available) return null;
+
+  const chooseConsent = async (choice: AnalyticsConsent) => {
+    if (await preferences.chooseConsent(choice)) {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="top"
+        sideOffset={8}
+        collisionPadding={12}
+        aria-labelledby={titleId}
+        className="w-[calc(100vw-1.5rem)] max-w-sm rounded-xl p-4 shadow-xl"
+      >
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h2 id={titleId} className="text-sm font-semibold">
+              Cookie settings
+            </h2>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              {preferences.consent === "accepted"
+                ? "Analytics allowed"
+                : preferences.consent === "declined"
+                  ? "Analytics declined"
+                  : "No saved preference"}
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close cookie settings"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-ring rounded-md p-1.5 focus-visible:ring-2 focus-visible:outline-none"
+            onClick={() => setOpen(false)}
+          >
+            <XIcon aria-hidden="true" className="size-4" />
+          </button>
+        </div>
+        <ConsentExplanation />
+        {preferences.saveError ? (
+          <p role="alert" className="text-destructive mt-3 text-sm">
+            {preferences.saveError}
+          </p>
+        ) : null}
+        <div className="mt-4">
+          <ChoiceButtons
+            currentChoice={preferences.consent}
+            disabled={preferences.isSaving}
+            onChoose={(choice) => void chooseConsent(choice)}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -89,98 +178,68 @@ export function AnalyticsConsentManager({
 }: AnalyticsConsentManagerProps) {
   const [consent, setConsent] = useState(initialConsent);
   const [isSaving, setIsSaving] = useState(false);
-  const [preferencesOpen, setPreferencesOpen] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  const analyticsAllowed = isAnalyticsAllowed({
-    consent,
-    consentRequired,
-  });
+  const analyticsAllowed = isAnalyticsAllowed({ consent, consentRequired });
   const needsInitialChoice = consentRequired && consent === null;
 
-  const chooseConsent = async (choice: AnalyticsConsent) => {
+  const chooseConsent = useCallback(async (choice: AnalyticsConsent) => {
     setIsSaving(true);
     setSaveError(null);
     try {
       await saveAnalyticsConsent(choice);
       setConsent(choice);
-      setPreferencesOpen(false);
+      return true;
     } catch {
-      setSaveError("We couldn't save your privacy choice. Please try again.");
+      setSaveError("We couldn't save your choice. Please try again.");
+      return false;
     } finally {
       setIsSaving(false);
     }
-  };
+  }, []);
+
+  const preferences = useMemo(
+    () => ({
+      available: !needsInitialChoice,
+      consent,
+      isSaving,
+      saveError,
+      chooseConsent,
+    }),
+    [consent, isSaving, needsInitialChoice, saveError, chooseConsent],
+  );
 
   return (
-    <PostHogProvider
-      analyticsAllowed={analyticsAllowed}
-      firstTouchAttribution={firstTouchAttribution}
-    >
-      {children}
+    <AnalyticsConsentPreferencesContext.Provider value={preferences}>
+      <PostHogProvider
+        analyticsAllowed={analyticsAllowed}
+        firstTouchAttribution={firstTouchAttribution}
+      >
+        {children}
 
-      {needsInitialChoice ? (
-        <section
-          aria-label="Analytics privacy choices"
-          className="fixed inset-x-3 bottom-3 z-[70] mx-auto max-w-3xl rounded-2xl border border-border bg-background/95 p-4 shadow-2xl backdrop-blur sm:bottom-5 sm:p-5"
-        >
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-            <div className="flex min-w-0 flex-1 gap-3">
-              <span className="mt-0.5 rounded-full border border-border bg-muted p-2 text-foreground">
-                <ShieldCheck aria-hidden="true" className="size-4" />
-              </span>
-              <div className="space-y-2">
-                <h2 className="text-base font-semibold">
-                  Your analytics choice
-                </h2>
-                <ConsentExplanation />
-                {saveError ? (
-                  <p role="alert" className="text-destructive text-sm">
-                    {saveError}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-            <ChoiceButtons
-              disabled={isSaving}
-              onChoose={(choice) => void chooseConsent(choice)}
-            />
-          </div>
-        </section>
-      ) : null}
-
-      {!needsInitialChoice ? (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="fixed bottom-3 left-3 z-50 bg-background/90 text-xs shadow-md backdrop-blur"
-          onClick={() => setPreferencesOpen(true)}
-        >
-          Privacy choices
-        </Button>
-      ) : null}
-
-      <Dialog open={preferencesOpen} onOpenChange={setPreferencesOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Analytics privacy choices</DialogTitle>
-            <DialogDescription asChild>
+        {needsInitialChoice ? (
+          <section
+            aria-label="Analytics cookie choices"
+            className="bg-background/95 fixed inset-x-3 bottom-3 z-[70] ml-auto rounded-xl border p-4 shadow-xl backdrop-blur sm:right-5 sm:bottom-5 sm:left-auto sm:w-[24rem]"
+          >
+            <h2 className="text-sm font-semibold">Optional analytics</h2>
+            <div className="mt-2">
               <ConsentExplanation />
-            </DialogDescription>
-          </DialogHeader>
-          {saveError ? (
-            <p role="alert" className="text-destructive text-sm">
-              {saveError}
-            </p>
-          ) : null}
-          <ChoiceButtons
-            currentChoice={consent}
-            disabled={isSaving}
-            onChoose={(choice) => void chooseConsent(choice)}
-          />
-        </DialogContent>
-      </Dialog>
-    </PostHogProvider>
+            </div>
+            {saveError ? (
+              <p role="alert" className="text-destructive mt-3 text-sm">
+                {saveError}
+              </p>
+            ) : null}
+            <div className="mt-4">
+              <ChoiceButtons
+                disabled={isSaving}
+                onChoose={(choice) => void chooseConsent(choice)}
+              />
+            </div>
+          </section>
+        ) : null}
+      </PostHogProvider>
+    </AnalyticsConsentPreferencesContext.Provider>
   );
 }

--- a/app/components/AnalyticsConsentManager.tsx
+++ b/app/components/AnalyticsConsentManager.tsx
@@ -149,7 +149,7 @@ export function AnalyticsConsentManager({
         </section>
       ) : null}
 
-      {!needsInitialChoice && (consentRequired || consent !== null) ? (
+      {!needsInitialChoice ? (
         <Button
           type="button"
           variant="outline"

--- a/app/components/DataControlsTab.tsx
+++ b/app/components/DataControlsTab.tsx
@@ -155,7 +155,7 @@ const DataControlsTab = () => {
               <div className="min-w-0">
                 <div className="font-medium">Analytics cookies</div>
                 <div className="text-muted-foreground mt-1 text-sm">
-                  Control optional product analytics and session replay
+                  Control optional product analytics
                 </div>
               </div>
               <AnalyticsConsentPreferences>

--- a/app/components/DataControlsTab.tsx
+++ b/app/components/DataControlsTab.tsx
@@ -16,9 +16,15 @@ import { toast } from "sonner";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import { ManageSharedChatsDialog } from "./ManageSharedChatsDialog";
 import { formatTaskUiCopy } from "@/app/utils/task-ui-copy";
+import {
+  AnalyticsConsentPreferences,
+  useAnalyticsConsentPreferencesAvailable,
+} from "@/app/components/AnalyticsConsentManager";
 
 const DataControlsTab = () => {
   const { subscription } = useGlobalState();
+  const analyticsPreferencesAvailable =
+    useAnalyticsConsentPreferencesAvailable();
   const [showDeleteChats, setShowDeleteChats] = useState(false);
   const [isDeletingChats, setIsDeletingChats] = useState(false);
   const [showDeleteSandboxes, setShowDeleteSandboxes] = useState(false);
@@ -137,6 +143,30 @@ const DataControlsTab = () => {
           </div>
         </div>
       )}
+
+      {analyticsPreferencesAvailable ? (
+        <>
+          {/* Divider */}
+          <div className="border-t" />
+
+          {/* Analytics Cookie Section */}
+          <div>
+            <div className="flex items-center justify-between gap-4 py-3">
+              <div className="min-w-0">
+                <div className="font-medium">Analytics cookies</div>
+                <div className="text-muted-foreground mt-1 text-sm">
+                  Control optional product analytics and session replay
+                </div>
+              </div>
+              <AnalyticsConsentPreferences>
+                <Button variant="outline" size="sm">
+                  Manage
+                </Button>
+              </AnalyticsConsentPreferences>
+            </div>
+          </div>
+        </>
+      ) : null}
 
       {/* Divider */}
       <div className="border-t" />

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,9 +2,15 @@
 
 import React from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import {
+  AnalyticsConsentPreferences,
+  useAnalyticsConsentPreferencesAvailable,
+} from "@/app/components/AnalyticsConsentManager";
 
 const Footer: React.FC = () => {
   const { user, loading } = useAuth();
+  const analyticsPreferencesAvailable =
+    useAnalyticsConsentPreferencesAvailable();
 
   if (loading || user) {
     return null;
@@ -40,6 +46,20 @@ const Footer: React.FC = () => {
         >
           Security &amp; Trust
         </a>
+        {analyticsPreferencesAvailable ? (
+          <>
+            {" "}
+            <span className="text-muted-foreground">&middot;</span>{" "}
+            <AnalyticsConsentPreferences>
+              <button
+                type="button"
+                className="text-foreground decoration-foreground focus-visible:ring-ring rounded-sm underline focus-visible:ring-2 focus-visible:outline-none"
+              >
+                Cookie settings
+              </button>
+            </AnalyticsConsentPreferences>
+          </>
+        ) : null}
       </span>
     </div>
   );

--- a/app/components/__tests__/AnalyticsConsentManager.test.tsx
+++ b/app/components/__tests__/AnalyticsConsentManager.test.tsx
@@ -25,8 +25,19 @@ jest.mock("@/app/providers", () => ({
   ),
 }));
 
-const { AnalyticsConsentManager } =
+const { AnalyticsConsentManager, AnalyticsConsentPreferences } =
   require("../AnalyticsConsentManager") as typeof import("../AnalyticsConsentManager");
+
+function TestContent() {
+  return (
+    <>
+      <div>App content</div>
+      <AnalyticsConsentPreferences>
+        <button type="button">Cookie settings</button>
+      </AnalyticsConsentPreferences>
+    </>
+  );
+}
 
 describe("AnalyticsConsentManager", () => {
   beforeEach(() => {
@@ -37,15 +48,18 @@ describe("AnalyticsConsentManager", () => {
   it("blocks analytics and asks covered visitors for a choice", () => {
     render(
       <AnalyticsConsentManager consentRequired initialConsent={null}>
-        <div>App content</div>
+        <TestContent />
       </AnalyticsConsentManager>,
     );
 
-    expect(screen.getByText("Your analytics choice")).toBeInTheDocument();
+    expect(screen.getByText("Optional analytics")).toBeInTheDocument();
     expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
       "data-analytics-allowed",
       "false",
     );
+    expect(
+      screen.queryByRole("button", { name: "Cookie settings" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("App content")).toBeInTheDocument();
   });
 
@@ -53,11 +67,11 @@ describe("AnalyticsConsentManager", () => {
     const user = userEvent.setup();
     render(
       <AnalyticsConsentManager consentRequired initialConsent={null}>
-        <div>App content</div>
+        <TestContent />
       </AnalyticsConsentManager>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Reject analytics" }));
+    await user.click(screen.getByRole("button", { name: "Decline" }));
 
     await waitFor(() =>
       expect(mockSaveAnalyticsConsent).toHaveBeenCalledWith("declined"),
@@ -67,13 +81,14 @@ describe("AnalyticsConsentManager", () => {
       "false",
     );
     expect(
-      screen.getByRole("button", { name: "Privacy choices" }),
+      screen.getByRole("button", { name: "Cookie settings" }),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Privacy choices" }));
-    expect(
-      screen.getByRole("button", { name: "Reject analytics" }),
-    ).toHaveAttribute("aria-pressed", "true");
+    await user.click(screen.getByRole("button", { name: "Cookie settings" }));
+    expect(screen.getByRole("button", { name: "Decline" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(
       screen.getByRole("button", { name: "Allow analytics" }),
     ).toHaveAttribute("aria-pressed", "false");
@@ -90,7 +105,7 @@ describe("AnalyticsConsentManager", () => {
     const user = userEvent.setup();
     render(
       <AnalyticsConsentManager consentRequired initialConsent={null}>
-        <div>App content</div>
+        <TestContent />
       </AnalyticsConsentManager>,
     );
 
@@ -108,7 +123,7 @@ describe("AnalyticsConsentManager", () => {
       ),
     );
 
-    await user.click(screen.getByRole("button", { name: "Privacy choices" }));
+    await user.click(screen.getByRole("button", { name: "Cookie settings" }));
     expect(
       screen.getByRole("button", { name: "Allow analytics" }),
     ).toHaveAttribute("aria-pressed", "true");
@@ -119,7 +134,7 @@ describe("AnalyticsConsentManager", () => {
     const user = userEvent.setup();
     render(
       <AnalyticsConsentManager consentRequired initialConsent={null}>
-        <div>App content</div>
+        <TestContent />
       </AnalyticsConsentManager>,
     );
 
@@ -135,14 +150,17 @@ describe("AnalyticsConsentManager", () => {
   it("does not interrupt an unregulated visitor without a saved choice", () => {
     render(
       <AnalyticsConsentManager consentRequired={false} initialConsent={null}>
-        <div>App content</div>
+        <TestContent />
       </AnalyticsConsentManager>,
     );
 
-    expect(screen.queryByText("Your analytics choice")).not.toBeInTheDocument();
+    expect(screen.queryByText("Optional analytics")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Privacy choices" }),
+      screen.getByRole("button", { name: "Cookie settings" }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Privacy choices" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
       "data-analytics-allowed",
       "true",

--- a/app/components/__tests__/AnalyticsConsentManager.test.tsx
+++ b/app/components/__tests__/AnalyticsConsentManager.test.tsx
@@ -53,6 +53,7 @@ describe("AnalyticsConsentManager", () => {
     );
 
     expect(screen.getByText("Optional analytics")).toBeInTheDocument();
+    expect(screen.queryByText(/session replay/i)).not.toBeInTheDocument();
     expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
       "data-analytics-allowed",
       "false",

--- a/app/components/__tests__/AnalyticsConsentManager.test.tsx
+++ b/app/components/__tests__/AnalyticsConsentManager.test.tsx
@@ -114,6 +114,24 @@ describe("AnalyticsConsentManager", () => {
     ).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("keeps analytics blocked and reports a failed save", async () => {
+    mockSaveAnalyticsConsent.mockRejectedValue(new Error("network"));
+    const user = userEvent.setup();
+    render(
+      <AnalyticsConsentManager consentRequired initialConsent={null}>
+        <div>App content</div>
+      </AnalyticsConsentManager>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Allow analytics" }));
+
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
+    );
+  });
+
   it("does not interrupt an unregulated visitor without a saved choice", () => {
     render(
       <AnalyticsConsentManager consentRequired={false} initialConsent={null}>
@@ -122,7 +140,9 @@ describe("AnalyticsConsentManager", () => {
     );
 
     expect(screen.queryByText("Your analytics choice")).not.toBeInTheDocument();
-    expect(screen.queryByText("Privacy choices")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Privacy choices" }),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
       "data-analytics-allowed",
       "true",

--- a/app/components/__tests__/AnalyticsConsentManager.test.tsx
+++ b/app/components/__tests__/AnalyticsConsentManager.test.tsx
@@ -156,14 +156,34 @@ describe("AnalyticsConsentManager", () => {
 
     expect(screen.queryByText("Optional analytics")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Cookie settings" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Cookie settings" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Privacy choices" }),
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
       "data-analytics-allowed",
       "true",
+    );
+  });
+
+  it("keeps preferences available when an unregulated visitor has a saved choice", () => {
+    render(
+      <AnalyticsConsentManager
+        consentRequired={false}
+        initialConsent="declined"
+      >
+        <TestContent />
+      </AnalyticsConsentManager>,
+    );
+
+    expect(screen.queryByText("Optional analytics")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cookie settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
     );
   });
 });

--- a/app/components/__tests__/AnalyticsConsentManager.test.tsx
+++ b/app/components/__tests__/AnalyticsConsentManager.test.tsx
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockSaveAnalyticsConsent = jest.fn<() => Promise<void>>();
+
+jest.mock("@/app/actions/analytics-consent", () => ({
+  saveAnalyticsConsent: mockSaveAnalyticsConsent,
+}));
+
+jest.mock("@/app/providers", () => ({
+  PostHogProvider: ({
+    analyticsAllowed,
+    children,
+  }: {
+    analyticsAllowed: boolean;
+    children: React.ReactNode;
+  }) => (
+    <div
+      data-testid="posthog-provider"
+      data-analytics-allowed={analyticsAllowed}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+const { AnalyticsConsentManager } =
+  require("../AnalyticsConsentManager") as typeof import("../AnalyticsConsentManager");
+
+describe("AnalyticsConsentManager", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveAnalyticsConsent.mockResolvedValue(undefined);
+  });
+
+  it("blocks analytics and asks covered visitors for a choice", () => {
+    render(
+      <AnalyticsConsentManager consentRequired initialConsent={null}>
+        <div>App content</div>
+      </AnalyticsConsentManager>,
+    );
+
+    expect(screen.getByText("Your analytics choice")).toBeInTheDocument();
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
+    );
+    expect(screen.getByText("App content")).toBeInTheDocument();
+  });
+
+  it("keeps rejection reversible without enabling analytics", async () => {
+    const user = userEvent.setup();
+    render(
+      <AnalyticsConsentManager consentRequired initialConsent={null}>
+        <div>App content</div>
+      </AnalyticsConsentManager>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reject analytics" }));
+
+    await waitFor(() =>
+      expect(mockSaveAnalyticsConsent).toHaveBeenCalledWith("declined"),
+    );
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
+    );
+    expect(
+      screen.getByRole("button", { name: "Privacy choices" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Privacy choices" }));
+    expect(
+      screen.getByRole("button", { name: "Reject analytics" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "Allow analytics" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("enables analytics only after the consent write succeeds", async () => {
+    let finishSave: (() => void) | undefined;
+    mockSaveAnalyticsConsent.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSave = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    render(
+      <AnalyticsConsentManager consentRequired initialConsent={null}>
+        <div>App content</div>
+      </AnalyticsConsentManager>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Allow analytics" }));
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
+    );
+
+    finishSave?.();
+    await waitFor(() =>
+      expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+        "data-analytics-allowed",
+        "true",
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Privacy choices" }));
+    expect(
+      screen.getByRole("button", { name: "Allow analytics" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("does not interrupt an unregulated visitor without a saved choice", () => {
+    render(
+      <AnalyticsConsentManager consentRequired={false} initialConsent={null}>
+        <div>App content</div>
+      </AnalyticsConsentManager>,
+    );
+
+    expect(screen.queryByText("Your analytics choice")).not.toBeInTheDocument();
+    expect(screen.queryByText("Privacy choices")).not.toBeInTheDocument();
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "true",
+    );
+  });
+});

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom";
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -55,6 +62,10 @@ describe("MessageErrorState", () => {
       paymentMethodBrand: "visa",
       url: null,
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("does not offer same-payload retry for provider content blocks", () => {
@@ -191,6 +202,7 @@ describe("MessageErrorState", () => {
   });
 
   it("opens Checkout directly and marks the stopped task for resume", async () => {
+    jest.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 7, 20));
     const user = userEvent.setup();
     const error = new ChatSDKError(
       "rate_limit:chat",

--- a/app/invite/[code]/__tests__/route.test.ts
+++ b/app/invite/[code]/__tests__/route.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+function createRedirectResponse(url: URL) {
+  const values = new Map<string, string>();
+  return {
+    cookies: {
+      get: (name: string) => {
+        const value = values.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+      set: (name: string, value: string) => values.set(name, value),
+    },
+    headers: new Headers({ location: url.toString() }),
+  };
+}
+
+jest.mock("next/server", () => ({
+  NextResponse: { redirect: jest.fn(createRedirectResponse) },
+}));
+
+const { GET } = require("../route") as typeof import("../route");
+
+function request({
+  countryCode,
+  consent,
+}: {
+  countryCode: string;
+  consent?: "accepted" | "declined";
+}) {
+  return {
+    url: "https://hackerai.co/invite/ABCDEF",
+    headers: new Headers({ "x-vercel-ip-country": countryCode }),
+    cookies: {
+      get: (name: string) =>
+        name === "hackerai_analytics_consent" && consent
+          ? { name, value: consent }
+          : undefined,
+    },
+  } as never;
+}
+
+const context = { params: Promise.resolve({ code: "ABCDEF" }) };
+
+describe("GET /invite/[code]", () => {
+  it("does not set referral attribution before EU consent", async () => {
+    const response = await GET(request({ countryCode: "DE" }), context);
+
+    expect(response.cookies.get("hackerai_ref")).toBeUndefined();
+    expect(response.headers.get("location")).toBe(
+      "https://hackerai.co/signup?referral_code=ABCDEF",
+    );
+  });
+
+  it("sets referral attribution after EU consent", async () => {
+    const response = await GET(
+      request({ countryCode: "DE", consent: "accepted" }),
+      context,
+    );
+
+    expect(response.cookies.get("hackerai_ref")?.value).toBe("ABCDEF");
+    expect(response.cookies.get("hackerai_ref_at")?.value).toMatch(/^\d+$/);
+  });
+
+  it("honors rejection outside the EU", async () => {
+    const response = await GET(
+      request({ countryCode: "US", consent: "declined" }),
+      context,
+    );
+
+    expect(response.cookies.get("hackerai_ref")).toBeUndefined();
+  });
+});

--- a/app/invite/[code]/route.ts
+++ b/app/invite/[code]/route.ts
@@ -5,6 +5,11 @@ import {
   getReferralRewardConfig,
   isValidReferralCode,
 } from "@/lib/referrals/config";
+import {
+  ANALYTICS_CONSENT_COOKIE_NAME,
+  countryCodeFromHeaders,
+  getAnalyticsConsentDecision,
+} from "@/lib/privacy/analytics-consent";
 
 export const runtime = "nodejs";
 
@@ -23,6 +28,15 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 
   const config = getReferralRewardConfig();
   if (!config.enabled || !isValidReferralCode(referralCode)) {
+    return response;
+  }
+
+  const analyticsConsent = getAnalyticsConsentDecision({
+    cookieValue: request.cookies.get(ANALYTICS_CONSENT_COOKIE_NAME)?.value,
+    countryCode: countryCodeFromHeaders(request.headers),
+    failClosed: process.env.NODE_ENV === "production",
+  });
+  if (!analyticsConsent.analyticsAllowed) {
     return response;
   }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,12 +11,17 @@ import { AgentAutoReviewAvailabilityProvider } from "./contexts/AgentAutoReviewA
 import { ConvexClientProvider } from "@/components/ConvexClientProvider";
 import { TodoBlockProvider } from "./contexts/TodoBlockContext";
 import { AgentApprovalProvider } from "./contexts/AgentApprovalContext";
-import { PostHogProvider } from "./providers";
+import { AnalyticsConsentManager } from "./components/AnalyticsConsentManager";
 import { DataStreamProvider } from "./components/DataStreamProvider";
 import { ChunkLoadRecovery } from "./components/ChunkLoadRecovery";
 import { resolveClientInitialAuth } from "@/lib/auth/initial-auth";
 import { FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME } from "@/lib/analytics/acquisition";
 import { parseFirstTouchAttributionCookie } from "@/lib/analytics/acquisition-cookie";
+import {
+  ANALYTICS_CONSENT_COOKIE_NAME,
+  countryCodeFromHeaders,
+  getAnalyticsConsentDecision,
+} from "@/lib/privacy/analytics-consent";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -117,18 +122,30 @@ export default async function RootLayout({
 }>) {
   // Supplying server-resolved auth prevents AuthKitProvider from invoking its
   // getAuth Server Action on every mount.
-  const [initialAuth, cookieStore] = await Promise.all([
+  const [initialAuth, cookieStore, requestHeaders] = await Promise.all([
     getInitialAuth(),
     cookies(),
+    headers(),
   ]);
   const firstTouchAttribution = parseFirstTouchAttributionCookie(
     cookieStore.get(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME)?.value,
   );
+  const analyticsConsent = getAnalyticsConsentDecision({
+    cookieValue: cookieStore.get(ANALYTICS_CONSENT_COOKIE_NAME)?.value,
+    countryCode: countryCodeFromHeaders(requestHeaders),
+    // If a production proxy ever stops providing country data, ask rather
+    // than silently placing optional analytics storage on a covered visitor.
+    failClosed: process.env.NODE_ENV === "production",
+  });
 
   const content = (
     <GlobalStateProvider>
-      <AgentAutoReviewAvailabilityProvider>
-        <PostHogProvider firstTouchAttribution={firstTouchAttribution}>
+      <AnalyticsConsentManager
+        consentRequired={analyticsConsent.consentRequired}
+        firstTouchAttribution={firstTouchAttribution}
+        initialConsent={analyticsConsent.consent}
+      >
+        <AgentAutoReviewAvailabilityProvider>
           <ChunkLoadRecovery />
           <DataStreamProvider>
             <TodoBlockProvider>
@@ -140,8 +157,8 @@ export default async function RootLayout({
               </AgentApprovalProvider>
             </TodoBlockProvider>
           </DataStreamProvider>
-        </PostHogProvider>
-      </AgentAutoReviewAvailabilityProvider>
+        </AgentAutoReviewAvailabilityProvider>
+      </AnalyticsConsentManager>
     </GlobalStateProvider>
   );
 

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -72,11 +72,12 @@ export default function PrivacyPolicyPage() {
               events, and diagnostic information. Where consent is required,
               optional browser analytics and attribution storage remain off
               until you allow them. Rejecting optional analytics does not limit
-              the Service. You can change or withdraw your choice at any time
-              using the <strong>Cookie settings</strong> control in the Service.
-              Limited server-side operational logs and analytics may still be
-              processed as necessary to secure, operate, bill for, and improve
-              the Service in accordance with applicable law.
+              the Service. When we ask for consent, you can later change or
+              withdraw that saved choice using the{" "}
+              <strong>Cookie settings</strong> control in the Service. Limited
+              server-side operational logs and analytics may still be processed
+              as necessary to secure, operate, bill for, and improve the Service
+              in accordance with applicable law.
             </li>
             <li className="mb-3">
               <strong>How We Use Your Information:</strong> The information we

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -73,7 +73,7 @@ export default function PrivacyPolicyPage() {
               optional browser analytics and attribution storage remain off
               until you allow them. Rejecting optional analytics does not limit
               the Service. You can change or withdraw your choice at any time
-              using the <strong>Privacy choices</strong> control in the Service.
+              using the <strong>Cookie settings</strong> control in the Service.
               Limited server-side operational logs and analytics may still be
               processed as necessary to secure, operate, bill for, and improve
               the Service in accordance with applicable law.

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -28,6 +28,10 @@ export default function PrivacyPolicyPage() {
           HackerAI Privacy Policy
         </h1>
 
+        <p className="text-center text-sm text-muted-foreground">
+          Last updated August 31, 2026
+        </p>
+
         <div className="mt-4 text-lg leading-relaxed text-card-foreground">
           <p className="mb-6">
             Welcome to HackerAI. This Privacy Policy explains how HackerAI LLC
@@ -55,6 +59,24 @@ export default function PrivacyPolicyPage() {
               or content you create, upload, or share through the Service,
               including but not limited to penetration testing results,
               vulnerability reports, and security assessments.
+            </li>
+            <li className="mb-3">
+              <strong>Cookies and Browser Storage:</strong> We use essential
+              cookies to provide authentication, account security, requested
+              redirects, and other core Service functionality. We also use
+              optional cookies and browser storage for first-touch and referral
+              attribution and for PostHog product analytics, browser error
+              diagnostics, and, for eligible paid accounts, session replay.
+              PostHog analytics can include an account identifier, email, name,
+              subscription, device and session identifiers, product usage
+              events, and diagnostic information. Where consent is required,
+              optional browser analytics and attribution storage remain off
+              until you allow them. Rejecting optional analytics does not limit
+              the Service. You can change or withdraw your choice at any time
+              using the <strong>Privacy choices</strong> control in the Service.
+              Limited server-side operational logs and analytics may still be
+              processed as necessary to secure, operate, bill for, and improve
+              the Service in accordance with applicable law.
             </li>
             <li className="mb-3">
               <strong>How We Use Your Information:</strong> The information we
@@ -119,7 +141,7 @@ export default function PrivacyPolicyPage() {
 
           <p className="mt-6">
             By accessing or using our Service, you acknowledge that you have
-            read, understood, and agreed to be bound by this Privacy Policy.
+            read and understood this Privacy Policy.
           </p>
         </div>
       </div>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -38,9 +38,11 @@ function isEnglishLocale(locale: string | null | undefined) {
 }
 
 export function PostHogProvider({
+  analyticsAllowed = true,
   children,
   firstTouchAttribution = null,
 }: {
+  analyticsAllowed?: boolean;
   children: React.ReactNode;
   firstTouchAttribution?: FirstTouchAttribution | null;
 }) {
@@ -56,11 +58,16 @@ export function PostHogProvider({
     const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
     if (!posthogKey) return;
 
-    const shouldTrack = Boolean(userId);
-    setAuthenticatedAnalyticsUserId(userId ?? null);
+    const shouldTrack = Boolean(userId) && analyticsAllowed;
+    setAuthenticatedAnalyticsUserId(shouldTrack ? userId! : null);
 
     if (!shouldTrack) {
       lastIdentifiedSignature = null;
+      try {
+        window.localStorage.removeItem(POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY);
+      } catch {
+        // Storage can be unavailable in privacy-restricted browsers.
+      }
       const posthog = getPostHogClient();
       if (posthog?.__loaded) {
         posthog.stopSessionRecording();
@@ -189,6 +196,7 @@ export function PostHogProvider({
       cancelled = true;
     };
   }, [
+    analyticsAllowed,
     firstTouchAttribution,
     subscription,
     userEmail,

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -38,11 +38,11 @@ function isEnglishLocale(locale: string | null | undefined) {
 }
 
 export function PostHogProvider({
-  analyticsAllowed = true,
+  analyticsAllowed,
   children,
   firstTouchAttribution = null,
 }: {
-  analyticsAllowed?: boolean;
+  analyticsAllowed: boolean;
   children: React.ReactNode;
   firstTouchAttribution?: FirstTouchAttribution | null;
 }) {

--- a/lib/privacy/__tests__/analytics-consent.test.ts
+++ b/lib/privacy/__tests__/analytics-consent.test.ts
@@ -39,6 +39,9 @@ describe("analytics consent", () => {
     expect(countryCodeFromHeaders(new Headers({ "cf-ipcountry": "fr" }))).toBe(
       "FR",
     );
+    expect(countryCodeFromHeaders(new Headers({ "cf-ipcountry": "XX" }))).toBe(
+      null,
+    );
   });
 
   it("rejects unknown consent cookie values", () => {

--- a/lib/privacy/__tests__/analytics-consent.test.ts
+++ b/lib/privacy/__tests__/analytics-consent.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  countryCodeFromHeaders,
+  getAnalyticsConsentDecision,
+  isAnalyticsAllowed,
+  parseAnalyticsConsent,
+  requiresAnalyticsConsent,
+} from "@/lib/privacy/analytics-consent";
+
+describe("analytics consent", () => {
+  it.each(["DE", "fr", "IE", "NO", "GB"])(
+    "requires consent for %s",
+    (countryCode) => {
+      expect(requiresAnalyticsConsent({ countryCode })).toBe(true);
+    },
+  );
+
+  it.each(["US", "CA", "AU", "CH"])(
+    "does not require consent for %s by default",
+    (countryCode) => {
+      expect(requiresAnalyticsConsent({ countryCode })).toBe(false);
+    },
+  );
+
+  it("can fail closed when country data is unavailable", () => {
+    expect(
+      requiresAnalyticsConsent({ countryCode: null, failClosed: true }),
+    ).toBe(true);
+    expect(requiresAnalyticsConsent({ countryCode: null })).toBe(false);
+  });
+
+  it("reads normalized Vercel and Cloudflare country headers", () => {
+    expect(
+      countryCodeFromHeaders(new Headers({ "x-vercel-ip-country": " de " })),
+    ).toBe("DE");
+    expect(countryCodeFromHeaders(new Headers({ cfipcountry: "FR" }))).toBe(
+      null,
+    );
+    expect(countryCodeFromHeaders(new Headers({ "cf-ipcountry": "fr" }))).toBe(
+      "FR",
+    );
+  });
+
+  it("rejects unknown consent cookie values", () => {
+    expect(parseAnalyticsConsent("accepted")).toBe("accepted");
+    expect(parseAnalyticsConsent("declined")).toBe("declined");
+    expect(parseAnalyticsConsent("yes")).toBeNull();
+  });
+
+  it("requires an explicit opt-in in covered countries", () => {
+    expect(
+      getAnalyticsConsentDecision({
+        cookieValue: undefined,
+        countryCode: "DE",
+      }),
+    ).toEqual({
+      consent: null,
+      consentRequired: true,
+      analyticsAllowed: false,
+    });
+    expect(
+      getAnalyticsConsentDecision({
+        cookieValue: "accepted",
+        countryCode: "DE",
+      }).analyticsAllowed,
+    ).toBe(true);
+  });
+
+  it("honors a rejection even where prior opt-in is not required", () => {
+    expect(
+      isAnalyticsAllowed({ consent: "declined", consentRequired: false }),
+    ).toBe(false);
+  });
+});

--- a/lib/privacy/analytics-consent.ts
+++ b/lib/privacy/analytics-consent.ts
@@ -49,7 +49,9 @@ export function countryCodeFromHeaders(headers: Headers): string | null {
   const rawCountryCode =
     headers.get("x-vercel-ip-country") ?? headers.get("cf-ipcountry");
   const countryCode = rawCountryCode?.trim().toUpperCase();
-  return countryCode && /^[A-Z]{2}$/.test(countryCode) ? countryCode : null;
+  return countryCode && countryCode !== "XX" && /^[A-Z]{2}$/.test(countryCode)
+    ? countryCode
+    : null;
 }
 
 export function requiresAnalyticsConsent({

--- a/lib/privacy/analytics-consent.ts
+++ b/lib/privacy/analytics-consent.ts
@@ -1,0 +1,97 @@
+export const ANALYTICS_CONSENT_COOKIE_NAME = "hackerai_analytics_consent";
+export const ANALYTICS_CONSENT_MAX_AGE_SECONDS = 180 * 24 * 60 * 60;
+
+export type AnalyticsConsent = "accepted" | "declined";
+
+const CONSENT_REQUIRED_COUNTRY_CODES = new Set([
+  // European Union
+  "AT",
+  "BE",
+  "BG",
+  "HR",
+  "CY",
+  "CZ",
+  "DE",
+  "DK",
+  "EE",
+  "ES",
+  "FI",
+  "FR",
+  "GR",
+  "HU",
+  "IE",
+  "IT",
+  "LT",
+  "LU",
+  "LV",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SE",
+  "SI",
+  "SK",
+  // Additional EEA countries and the United Kingdom
+  "IS",
+  "LI",
+  "NO",
+  "GB",
+]);
+
+export function parseAnalyticsConsent(
+  value: string | null | undefined,
+): AnalyticsConsent | null {
+  return value === "accepted" || value === "declined" ? value : null;
+}
+
+export function countryCodeFromHeaders(headers: Headers): string | null {
+  const rawCountryCode =
+    headers.get("x-vercel-ip-country") ?? headers.get("cf-ipcountry");
+  const countryCode = rawCountryCode?.trim().toUpperCase();
+  return countryCode && /^[A-Z]{2}$/.test(countryCode) ? countryCode : null;
+}
+
+export function requiresAnalyticsConsent({
+  countryCode,
+  failClosed = false,
+}: {
+  countryCode: string | null;
+  failClosed?: boolean;
+}): boolean {
+  if (!countryCode) return failClosed;
+  return CONSENT_REQUIRED_COUNTRY_CODES.has(countryCode.toUpperCase());
+}
+
+export function isAnalyticsAllowed({
+  consent,
+  consentRequired,
+}: {
+  consent: AnalyticsConsent | null;
+  consentRequired: boolean;
+}): boolean {
+  if (consent === "declined") return false;
+  return consent === "accepted" || !consentRequired;
+}
+
+export function getAnalyticsConsentDecision({
+  cookieValue,
+  countryCode,
+  failClosed = false,
+}: {
+  cookieValue: string | null | undefined;
+  countryCode: string | null;
+  failClosed?: boolean;
+}) {
+  const consent = parseAnalyticsConsent(cookieValue);
+  const consentRequired = requiresAnalyticsConsent({
+    countryCode,
+    failClosed,
+  });
+
+  return {
+    consent,
+    consentRequired,
+    analyticsAllowed: isAnalyticsAllowed({ consent, consentRequired }),
+  } as const;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -14,6 +14,11 @@ import {
   createFirstTouchAttribution,
 } from "@/lib/analytics/acquisition";
 import { serializeSignedFirstTouchAttribution } from "@/lib/analytics/acquisition-cookie";
+import {
+  ANALYTICS_CONSENT_COOKIE_NAME,
+  countryCodeFromHeaders,
+  getAnalyticsConsentDecision,
+} from "@/lib/privacy/analytics-consent";
 
 const AUTHKIT_BYPASS_PATHS = new Set([
   "/api/health/connectivity",
@@ -135,6 +140,22 @@ function withAttributionCookies(
   request: NextRequest,
   response: NextResponse,
 ): NextResponse {
+  const analyticsConsent = getAnalyticsConsentDecision({
+    cookieValue: request.cookies.get(ANALYTICS_CONSENT_COOKIE_NAME)?.value,
+    countryCode: countryCodeFromHeaders(request.headers),
+    failClosed: process.env.NODE_ENV === "production",
+  });
+  if (!analyticsConsent.analyticsAllowed) {
+    response.cookies.delete(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME);
+    response.cookies.delete(REFERRAL_COOKIE_NAME);
+    response.cookies.delete(REFERRAL_COOKIE_CREATED_AT_NAME);
+    const postHogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+    if (postHogKey) {
+      response.cookies.delete(`ph_${postHogKey}_posthog`);
+    }
+    return response;
+  }
+
   const pathname = request.nextUrl.pathname;
   const shouldCaptureFirstTouch =
     (request.method === "GET" || request.method === "HEAD") &&


### PR DESCRIPTION
## Summary

- require explicit analytics consent for EEA and UK visitors, with a production fail-closed path when geolocation is unavailable
- gate PostHog, paid-account session replay, first-touch attribution, and referral storage behind the saved choice
- replace the blocking modal and floating main-screen button with a compact consent card
- expose persistent cookie settings only after a browser has saved a choice: in the signed-out footer or signed-in Settings → Data controls
- keep both the consent prompt and Cookie settings hidden for non-covered visitors with no saved choice
- update the privacy-policy disclosure and treat unknown geolocation sentinels as unavailable

No feature flag is used because this is a privacy/correctness control that should not leave an intentionally non-compliant cohort.

## Validation

- `pnpm typecheck`
- `pnpm test` (426 suites, 4,477 tests)
- `pnpm build`
- focused ESLint and consent tests
- local production-mode browser verification at desktop and 390×844: initial notice, decline, footer settings, signed-in Data controls, preference updates, and no console errors
- deployed Vercel Preview verification for a US visitor with no saved choice: no consent prompt, no Cookie settings footer control, and no console errors
- all CI checks and CodeRabbit review passing

## Manual verification

On the Vercel Preview deployment:

1. From an EEA/UK location in a fresh browser, confirm the compact analytics notice appears without dimming or blocking the app.
2. Decline or allow analytics and confirm the notice closes while the app remains usable.
3. Confirm the saved choice remains manageable from the signed-out footer or **Settings → Data controls → Analytics cookies → Manage** while signed in.
4. From a non-covered location in a fresh browser, confirm neither the consent notice nor Cookie settings control appears.

Closes HAC-14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added analytics consent controls for accepting, declining, and changing cookie preferences.
  - Added “Cookie settings” access in the footer and data controls.
  - Added country-aware consent handling and privacy-policy disclosures.

- **Bug Fixes**
  - Analytics tracking and session recording now stop when consent is withdrawn.
  - Attribution and referral cookies are withheld or removed when analytics consent is unavailable.
  - Invite links continue redirecting without storing disallowed referral data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->