### PR TITLE
Strengthen privacy disclosures and replay consent

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -199,6 +199,34 @@ describe("PostHogProvider", () => {
     },
   );
 
+  it("does not record sessions where analytics consent is required", async () => {
+    const posthog = {
+      __loaded: false,
+      init: jest.fn(),
+      set_config: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      has_opted_out_capturing: jest.fn(() => false),
+      identify: jest.fn(),
+      sessionRecordingStarted: jest.fn(() => false),
+      startSessionRecording: jest.fn(),
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockLoadPostHogClient.mockResolvedValue(posthog);
+
+    render(
+      <PostHogProvider analyticsAllowed consentRequired>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    await waitFor(() =>
+      expect(posthog.stopSessionRecording).toHaveBeenCalledTimes(1),
+    );
+    expect(posthog.startSessionRecording).not.toHaveBeenCalled();
+  });
+
   it("falls back to the primary browser locale when account locale is missing", async () => {
     const languageSpy = jest
       .spyOn(window.navigator, "language", "get")

--- a/app/components/AnalyticsConsentManager.tsx
+++ b/app/components/AnalyticsConsentManager.tsx
@@ -212,6 +212,7 @@ export function AnalyticsConsentManager({
     <AnalyticsConsentPreferencesContext.Provider value={preferences}>
       <PostHogProvider
         analyticsAllowed={analyticsAllowed}
+        consentRequired={consentRequired}
         firstTouchAttribution={firstTouchAttribution}
       >
         {children}

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Privacy Policy | HackerAI",
@@ -20,132 +21,207 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-static";
 
+const linkClassName =
+  "font-medium text-foreground underline underline-offset-4 hover:text-foreground/80";
+
 export default function PrivacyPolicyPage() {
   return (
     <div className="px-4 py-8 pb-16 md:px-0">
-      <div className="container mx-auto max-w-2xl space-y-6 rounded-md border bg-card px-4 py-8 shadow-lg sm:px-8">
-        <h1 className="mb-5 text-center text-3xl font-semibold text-card-foreground">
+      <main className="container mx-auto max-w-2xl rounded-md border bg-card px-4 py-8 shadow-lg sm:px-8">
+        <h1 className="text-center text-3xl font-semibold text-card-foreground">
           HackerAI Privacy Policy
         </h1>
 
-        <p className="text-center text-sm text-muted-foreground">
+        <p className="mt-3 text-center text-sm text-muted-foreground">
           Last updated August 31, 2026
         </p>
 
-        <div className="mt-4 text-lg leading-relaxed text-card-foreground">
-          <p className="mb-6">
-            Welcome to HackerAI. This Privacy Policy explains how HackerAI LLC
-            (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) collects, uses,
-            shares, and protects information in relation to our website and any
-            associated services, software, and content (collectively, the
-            &quot;Service&quot;). By accessing or using our Service, you
-            (&quot;you&quot; or &quot;User&quot;) understand and agree to the
-            collection and use of information in accordance with this policy.
+        <div className="mt-8 space-y-7 text-base leading-relaxed text-card-foreground sm:text-lg">
+          <p>
+            This Privacy Policy explains how HackerAI LLC (&quot;HackerAI,&quot;
+            &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) handles personal
+            information when you use our websites, applications, and related
+            services (the &quot;Service&quot;).
           </p>
 
-          <ul className="list-inside list-decimal">
-            <li className="mb-3">
-              <strong>Acknowledgement of Beta Service:</strong> You acknowledge
-              that the Service is provided on a beta basis and may contain
-              errors, inaccuracies, or vulnerabilities, including those related
-              to privacy and data security. Your use of the Service signifies
-              your understanding and acceptance of these risks.
-            </li>
-            <li className="mb-3">
-              <strong>Information We Collect:</strong> We may collect and store
-              any information you provide to us or that we collect in connection
-              with your use of the Service. This may include, but is not limited
-              to, personal information such as your email address and any data
-              or content you create, upload, or share through the Service,
-              including but not limited to penetration testing results,
-              vulnerability reports, and security assessments.
-            </li>
-            <li className="mb-3">
-              <strong>Cookies and Browser Storage:</strong> We use essential
-              cookies to provide authentication, account security, requested
-              redirects, and other core Service functionality. We also use
-              optional cookies and browser storage for first-touch and referral
-              attribution and for PostHog product analytics, browser error
-              diagnostics, and, for eligible paid accounts, session replay.
-              PostHog analytics can include an account identifier, email, name,
-              subscription, device and session identifiers, product usage
-              events, and diagnostic information. Where consent is required,
-              optional browser analytics and attribution storage remain off
-              until you allow them. Rejecting optional analytics does not limit
-              the Service. When we ask for consent, you can later change or
-              withdraw that saved choice using the{" "}
-              <strong>Cookie settings</strong> control in the Service. Limited
-              server-side operational logs and analytics may still be processed
-              as necessary to secure, operate, bill for, and improve the Service
-              in accordance with applicable law.
-            </li>
-            <li className="mb-3">
-              <strong>How We Use Your Information:</strong> The information we
-              collect is used to provide, maintain, protect, and improve the
-              Service; to develop new services; and to protect us and our users.
-              We also use this information to offer tailored content and improve
-              our AI-powered penetration testing capabilities.
-            </li>
-            <li className="mb-3">
-              <strong>Information Sharing and Disclosure:</strong> We do not
-              share personal information with companies, organizations, or
-              individuals outside of HackerAI LLC except in the following
-              circumstances:
-              <ul className="ml-6 mt-2 list-disc">
-                <li>With your consent.</li>
-                <li>
-                  For legal reasons, we will share personal information if we
-                  have a good-faith belief that access, use, preservation, or
-                  disclosure of the information is reasonably necessary to meet
-                  any applicable law, regulation, legal process, or enforceable
-                  governmental request.
-                </li>
-              </ul>
-            </li>
-            <li className="mb-3">
-              <strong>Privacy and Beta Service Considerations:</strong> While we
-              implement reasonable privacy protections for your data, you
-              acknowledge that the Service is in beta phase and may have
-              inherent limitations in its privacy and security measures. We are
-              committed to protecting your privacy and continuously improving
-              our security practices, but we cannot guarantee the same level of
-              protection as a production service. By using the Service, you
-              understand these limitations while we work to enhance our privacy
-              and security measures.
-            </li>
-            <li className="mb-3">
-              <strong>Security:</strong> We strive to use commercially
-              acceptable means to protect your information, but we cannot
-              guarantee its absolute security. Your use of the Service signifies
-              your agreement that the risk of any data breaches or security
-              vulnerabilities is borne solely by you.
-            </li>
-            <li className="mb-3">
-              <strong>Changes to This Privacy Policy:</strong> We may modify
-              this Privacy Policy at any time. We will notify you of any changes
-              by posting the new Privacy Policy on this page. You are advised to
-              review this Privacy Policy periodically for any changes.
-            </li>
-            <li className="mb-3">
-              <strong>Contact Us:</strong> If you have any questions about this
-              Privacy Policy, please visit our help center at{" "}
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">
+              Information we collect
+            </h2>
+            <p>
+              Depending on how you use the Service, we collect information you
+              provide, information generated through your use, and limited
+              information from service providers. This may include account and
+              billing information; prompts, messages, files, security findings,
+              and other content you submit; agent, browser, and sandbox
+              activity; device, usage, referral, and diagnostic data; and
+              communications with us. Please avoid submitting personal
+              information that is not needed for your use of the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">
+              How we use information
+            </h2>
+            <p>
+              We use information to provide and personalize the Service, process
+              payments, authenticate accounts, operate AI and security features,
+              respond to requests, maintain safety and reliability, prevent
+              misuse, understand and improve the Service, and comply with legal
+              obligations.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">
+              Cookies and analytics
+            </h2>
+            <p>
+              We use essential cookies and similar technologies for core
+              functions such as authentication, security, and requested
+              redirects. We may also use optional storage and analytics for
+              attribution, product usage, error diagnostics, and, on eligible
+              accounts, session replay. Analytics may include account, device,
+              subscription, session, usage, and diagnostic information.
+            </p>
+            <p className="mt-2">
+              Where consent is required, optional browser analytics and
+              attribution remain off unless you allow them, and session replay
+              remains off. Declining optional analytics does not limit the
+              Service. You can later change a saved choice through{" "}
+              <strong>Cookie settings</strong>. Limited operational logs may
+              still be processed as needed to secure, operate, support, and bill
+              for the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">
+              How we disclose information
+            </h2>
+            <p>
+              We disclose information as reasonably necessary to service
+              providers that support hosting, storage, authentication, billing,
+              analytics, customer support, AI model processing, search, content
+              retrieval, and agent execution. Content sent to an AI feature may
+              be processed by the provider supporting the selected model or
+              tool. We may also disclose information at your direction, to
+              protect users or the Service, in connection with a corporate
+              transaction, or when required by law. We do not sell personal
+              information.
+            </p>
+            <p className="mt-2">
+              Our{" "}
+              <Link href="/trust" className={linkClassName}>
+                Security &amp; Trust page
+              </Link>{" "}
+              provides more information about the services we rely on and the
+              data they process.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">
+              Legal bases for processing
+            </h2>
+            <p>
+              Where applicable law requires a legal basis, we process personal
+              information as needed to provide the Service and perform our
+              agreement with you; for legitimate interests such as securing,
+              supporting, and improving the Service; with your consent; and to
+              comply with legal obligations. We consider the nature of the
+              information and your rights when relying on legitimate interests.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">
+              Retention and international processing
+            </h2>
+            <p>
+              We retain personal information for as long as reasonably needed
+              for the purposes described here, including to provide the Service,
+              maintain security and business records, resolve disputes, and meet
+              legal obligations. Retention varies by the type of information and
+              may continue for a limited period in backups and logs. Information
+              may be processed in the United States and other countries where we
+              or our service providers operate, subject to applicable legal
+              requirements.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">
+              Your choices and rights
+            </h2>
+            <p>
+              Depending on where you live, you may have rights to access,
+              correct, delete, restrict, object to, or receive a copy of certain
+              personal information, withdraw consent, or appeal a decision about
+              a request. You may also have the right to complain to your local
+              data protection authority. Some information can be managed or
+              deleted through your account settings. To make another privacy
+              request, contact us as described below. We may need to verify your
+              identity and may retain information where permitted or required by
+              law.
+            </p>
+            <p className="mt-2">
+              Browser &quot;Do Not Track&quot; signals are not standardized, and
+              the Service does not currently respond to them. You can use
+              available browser controls and HackerAI&apos;s Cookie settings to
+              manage optional browser storage where offered.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">Security</h2>
+            <p>
+              We use reasonable administrative, technical, and organizational
+              measures designed to protect personal information. No system is
+              completely secure, and we cannot guarantee absolute security.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">Children</h2>
+            <p>
+              The Service is not directed to children under 13, and we do not
+              knowingly collect personal information from them. If you believe a
+              child under 13 has provided personal information, please contact
+              us so we can review and address it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">Policy changes</h2>
+            <p>
+              We may update this policy as the Service or applicable
+              requirements change. We will post the updated policy here and
+              revise the date above. When appropriate, we may provide additional
+              notice through the Service or another reasonable channel.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-xl font-semibold">Contact us</h2>
+            <p>
+              HackerAI LLC is responsible for the personal information described
+              in this policy. For privacy questions or requests, contact us
+              through our{" "}
               <a
                 href="https://help.hackerai.co/en/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                className={linkClassName}
               >
-                https://help.hackerai.co/en/
+                help center
               </a>
-            </li>
-          </ul>
-
-          <p className="mt-6">
-            By accessing or using our Service, you acknowledge that you have
-            read and understood this Privacy Policy.
-          </p>
+              .
+            </p>
+          </section>
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -40,10 +40,12 @@ function isEnglishLocale(locale: string | null | undefined) {
 export function PostHogProvider({
   analyticsAllowed,
   children,
+  consentRequired = false,
   firstTouchAttribution = null,
 }: {
   analyticsAllowed: boolean;
   children: React.ReactNode;
+  consentRequired?: boolean;
   firstTouchAttribution?: FirstTouchAttribution | null;
 }) {
   const { subscription } = useGlobalState();
@@ -179,7 +181,9 @@ export function PostHogProvider({
         const replayLocale =
           userLocale == null ? window.navigator.language : userLocale;
         const shouldRecordSession =
-          subscription !== "free" && isEnglishLocale(replayLocale);
+          !consentRequired &&
+          subscription !== "free" &&
+          isEnglishLocale(replayLocale);
 
         if (shouldRecordSession) {
           if (!posthog.sessionRecordingStarted()) {
@@ -197,6 +201,7 @@ export function PostHogProvider({
     };
   }, [
     analyticsAllowed,
+    consentRequired,
     firstTouchAttribution,
     subscription,
     userEmail,


### PR DESCRIPTION
## Summary
- replace the beta-era privacy notice with concise, category-based disclosures covering collection, use, processors, legal bases, retention, rights, security, children, and policy changes
- correct the inaccurate statement that HackerAI does not disclose information outside the company and link the maintained Security & Trust subprocessor page
- keep session replay disabled whenever regional analytics consent is required; a future replay flow must use a separate explicit opt-in
- add regression coverage for the replay region gate

## Validation
- pnpm typecheck
- pnpm test (426 suites, 4,478 tests)
- targeted ESLint and Prettier checks
- visually verified /privacy-policy at desktop and mobile widths in the built-in browser

## Manual verification
1. Open /privacy-policy and confirm every section is readable and the Security & Trust and help center links work.
2. Simulate an EU/UK request, accept optional analytics, and confirm ordinary analytics can initialize while PostHog session recording remains stopped.
3. Simulate a non-consent-required request for an eligible paid English-language account and confirm the existing replay behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Updated the Privacy Policy with clearer sections covering data collection, cookies, analytics, legal bases, retention, user rights, security, and policy changes.
  * Added a link to the Security & Trust page.

* **Analytics**
  * Session recording is now disabled when analytics consent is required, including for eligible paid users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->