### PR TITLE
Simplify platform cost sync configuration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -148,12 +148,7 @@ E2B_TEMPLATE=terminal-agent-sandbox
 # CRON_SECRET=
 # Team-scoped Vercel access token with read access to billing charges.
 # VERCEL_BILLING_READ_TOKEN=
-# Vercel team id whose FOCUS billing charges should be reconciled daily.
-# VERCEL_BILLING_TEAM_ID=
-# CONVEX_DEPLOY_KEY and CONVEX_SERVICE_ROLE_KEY are reused to record deployment
-# usage in the existing PostHog warehouse source. Set the canonical deployment
-# URL only when the deploy-key format does not identify a single deployment.
-# CONVEX_DEPLOYMENT_URL=https://your-deployment.convex.cloud
+# Everything else reuses existing app configuration.
 
 # Protects /api/health/core, which checks the WorkOS dependency for uptime monitoring.
 # Add the same value as the x-hackerai-health-token header in the uptime monitor.

--- a/app/api/cron/platform-costs/convex/route.ts
+++ b/app/api/cron/platform-costs/convex/route.ts
@@ -31,8 +31,7 @@ export async function GET(request: Request) {
   try {
     const deployKey = requireEnvironment("CONVEX_DEPLOY_KEY");
     const convexUrl = convexUsageBaseUrl(
-      deployKey,
-      process.env.CONVEX_DEPLOYMENT_URL,
+      requireEnvironment("NEXT_PUBLIC_CONVEX_URL"),
     );
     const usage = await fetchWithRetry(
       `${convexUrl.replace(/\/$/, "")}/api/v1/get_current_usage`,

--- a/app/api/cron/platform-costs/vercel/route.ts
+++ b/app/api/cron/platform-costs/vercel/route.ts
@@ -17,6 +17,9 @@ export const runtime = "nodejs";
 export const maxDuration = 120;
 
 const RECONCILIATION_DAYS = 35;
+// Stable, non-secret identifier for the HackerAI Vercel team. Keeping it here
+// avoids requiring a duplicate production environment variable.
+const HACKERAI_VERCEL_TEAM_ID = "team_hxFubfIkaQ2A55N5nZeTifXH";
 
 export async function GET(request: Request) {
   const requestId = request.headers.get("x-vercel-id") ?? randomUUID();
@@ -31,12 +34,11 @@ export async function GET(request: Request) {
   const startedAt = Date.now();
   try {
     const token = requireEnvironment("VERCEL_BILLING_READ_TOKEN");
-    const teamId = requireEnvironment("VERCEL_BILLING_TEAM_ID");
     const window = completedUtcDayWindow(startedAt, RECONCILIATION_DAYS);
     const url = new URL("https://api.vercel.com/v1/billing/charges");
     url.searchParams.set("from", window.from);
     url.searchParams.set("to", window.to);
-    url.searchParams.set("teamId", teamId);
+    url.searchParams.set("teamId", HACKERAI_VERCEL_TEAM_ID);
 
     const rows = await fetchWithRetry(
       url.toString(),

--- a/docs/platform-cost-sync.md
+++ b/docs/platform-cost-sync.md
@@ -35,19 +35,17 @@ which avoids unnecessary warehouse sync churn.
   economics. The separate table prevents platform overhead from being counted
   in both user-level and organization-level economics.
 
-## Required production environment
+## Production environment
 
-- `CRON_SECRET`
-- `VERCEL_BILLING_READ_TOKEN`
-- `VERCEL_BILLING_TEAM_ID`
-- `CONVEX_DEPLOY_KEY`
-- `NEXT_PUBLIC_CONVEX_URL`
-- `CONVEX_SERVICE_ROLE_KEY`
+The only platform-cost-specific variables are `CRON_SECRET` and
+`VERCEL_BILLING_READ_TOKEN`.
 
-`CONVEX_DEPLOYMENT_URL` is only required when `CONVEX_DEPLOY_KEY` is not a
-deployment-scoped `prod:<deployment>|...` or `dev:<deployment>|...` key. When
-set, it must be the canonical `https://<deployment>.convex.cloud` URL; custom
-domains do not expose the authenticated deployment-usage endpoint.
+The jobs reuse the app's existing `CONVEX_DEPLOY_KEY`,
+`NEXT_PUBLIC_CONVEX_URL`, and `CONVEX_SERVICE_ROLE_KEY` configuration. The
+non-secret HackerAI Vercel team ID is fixed in the Vercel sync route, so it does
+not need to be duplicated in production configuration. `NEXT_PUBLIC_CONVEX_URL`
+must be the canonical `https://<deployment>.convex.cloud` URL; custom domains do
+not expose the authenticated deployment-usage endpoint.
 
 The Vercel token should be scoped to the owning team and used only for this
 billing-read integration. Never log it or expose it to the browser.

--- a/lib/billing/__tests__/platform-costs.test.ts
+++ b/lib/billing/__tests__/platform-costs.test.ts
@@ -161,5 +161,11 @@ describe("platform cost normalization", () => {
     expect(() => convexUsageBaseUrl("https://example.com")).toThrow(
       "canonical https://*.convex.cloud URL",
     );
+    expect(() => convexUsageBaseUrl("https://.convex.cloud")).toThrow(
+      "canonical https://*.convex.cloud URL",
+    );
+    expect(() =>
+      convexUsageBaseUrl("https://careful-otter-456.convex.cloud:8443"),
+    ).toThrow("canonical https://*.convex.cloud URL");
   });
 });

--- a/lib/billing/__tests__/platform-costs.test.ts
+++ b/lib/billing/__tests__/platform-costs.test.ts
@@ -155,23 +155,11 @@ describe("platform cost normalization", () => {
   });
 
   it("uses Convex's canonical deployment URL for admin usage requests", () => {
-    expect(convexUsageBaseUrl("prod:happy-capybara-123|secret-value")).toBe(
-      "https://happy-capybara-123.convex.cloud",
+    expect(convexUsageBaseUrl("https://careful-otter-456.convex.cloud")).toBe(
+      "https://careful-otter-456.convex.cloud",
     );
-    expect(
-      convexUsageBaseUrl(
-        "project:team:project|secret-value",
-        "https://careful-otter-456.convex.cloud",
-      ),
-    ).toBe("https://careful-otter-456.convex.cloud");
-    expect(() =>
-      convexUsageBaseUrl("project:team:project|secret-value"),
-    ).toThrow("CONVEX_DEPLOYMENT_URL is required");
-    expect(() =>
-      convexUsageBaseUrl(
-        "prod:happy-capybara-123|secret-value",
-        "https://example.com",
-      ),
-    ).toThrow("canonical https://*.convex.cloud URL");
+    expect(() => convexUsageBaseUrl("https://example.com")).toThrow(
+      "canonical https://*.convex.cloud URL",
+    );
   });
 });

--- a/lib/billing/platform-costs.ts
+++ b/lib/billing/platform-costs.ts
@@ -317,30 +317,16 @@ export function completedUtcDayWindow(
   };
 }
 
-export function convexUsageBaseUrl(
-  deployKey: string,
-  configuredUrl?: string,
-): string {
-  if (configuredUrl?.trim()) {
-    const url = new URL(configuredUrl);
-    if (
-      url.protocol !== "https:" ||
-      !url.hostname.endsWith(".convex.cloud") ||
-      url.pathname !== "/"
-    ) {
-      throw new Error(
-        "CONVEX_DEPLOYMENT_URL must be a canonical https://*.convex.cloud URL",
-      );
-    }
-    return url.origin;
-  }
-
-  const keyTarget = deployKey.slice(0, deployKey.indexOf("|"));
-  const match = /^(?:prod|dev):([a-z0-9-]+)$/.exec(keyTarget);
-  if (!match) {
+export function convexUsageBaseUrl(configuredUrl: string): string {
+  const url = new URL(configuredUrl);
+  if (
+    url.protocol !== "https:" ||
+    !url.hostname.endsWith(".convex.cloud") ||
+    url.pathname !== "/"
+  ) {
     throw new Error(
-      "CONVEX_DEPLOYMENT_URL is required for this deploy key format",
+      "NEXT_PUBLIC_CONVEX_URL must be a canonical https://*.convex.cloud URL",
     );
   }
-  return `https://${match[1]}.convex.cloud`;
+  return url.origin;
 }

--- a/lib/billing/platform-costs.ts
+++ b/lib/billing/platform-costs.ts
@@ -321,7 +321,9 @@ export function convexUsageBaseUrl(configuredUrl: string): string {
   const url = new URL(configuredUrl);
   if (
     url.protocol !== "https:" ||
+    url.hostname === ".convex.cloud" ||
     !url.hostname.endsWith(".convex.cloud") ||
+    url.port !== "" ||
     url.pathname !== "/"
   ) {
     throw new Error(


### PR DESCRIPTION
## Summary
- reduce platform cost sync to two explicit variables: `CRON_SECRET` and `VERCEL_BILLING_READ_TOKEN`
- reuse the existing canonical Convex URL instead of `CONVEX_DEPLOYMENT_URL`
- keep the stable, non-secret HackerAI Vercel team ID in the sync route instead of `VERCEL_BILLING_TEAM_ID`
- simplify the environment template and operating documentation

## Validation
- `corepack pnpm jest lib/billing/__tests__/platform-costs.test.ts --runInBand`
- `corepack pnpm typecheck`
- targeted ESLint and Prettier checks
- full pre-commit suite: 428 suites / 4,486 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Platform cost synchronization now uses the canonical Convex deployment URL.
  * Vercel billing requests use a fixed team configuration.
  * Removed legacy deployment and billing configuration options.
* **Documentation**
  * Updated setup guidance to reflect streamlined configuration requirements.
* **Bug Fixes**
  * Improved Convex URL validation by rejecting empty hostnames and non-default ports.
* **Tests**
  * Updated coverage for canonical Convex URLs and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->