### PR TITLE
Rollback Pro Plus Auto to Standard routing

### DIFF
--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -155,27 +155,37 @@ describe("limitImageParts", () => {
 // ==========================================================================
 describe("selectModel", () => {
   it.each([
-    ["ask", "pro-plus"],
-    ["agent", "pro-plus"],
-    ["ask", "ultra"],
-    ["agent", "ultra"],
+    ["ask", "model-deepseek-v4-flash-0731"],
+    ["agent", "model-glm-5.3-flash-agent"],
   ] as const)(
-    "routes %s %s Auto text to DeepSeek V4 Pro",
-    (mode, subscription) => {
-      expect(selectModel(mode, subscription, "auto", false, false)).toBe(
+    "routes %s Pro Plus Auto text to the Standard model",
+    (mode, expected) => {
+      expect(selectModel(mode, "pro-plus", "auto", false, false)).toBe(
+        expected,
+      );
+    },
+  );
+
+  it.each(["ask", "agent"] as const)(
+    "routes %s Ultra Auto text to DeepSeek V4 Pro",
+    (mode) => {
+      expect(selectModel(mode, "ultra", "auto", false, false)).toBe(
         "model-deepseek-v4-pro-0813",
       );
     },
   );
 
-  it.each(["pro-plus", "ultra"] as const)(
-    "routes %s Auto PDFs to DeepSeek V4 Pro",
-    (subscription) => {
-      expect(selectModel("agent", subscription, "auto", false, true)).toBe(
-        "model-deepseek-v4-pro-0813",
-      );
-    },
-  );
+  it("routes Pro Plus Agent Auto PDFs to GLM 5.3 Flash", () => {
+    expect(selectModel("agent", "pro-plus", "auto", false, true)).toBe(
+      "model-glm-5.3-flash-agent",
+    );
+  });
+
+  it("routes Ultra Auto PDFs to DeepSeek V4 Pro", () => {
+    expect(selectModel("agent", "ultra", "auto", false, true)).toBe(
+      "model-deepseek-v4-pro-0813",
+    );
+  });
 
   it.each(["pro", "team"] as const)(
     "routes %s Agent Auto to GLM 5.3 Flash",
@@ -266,12 +276,12 @@ describe("selectModel", () => {
     },
   );
 
-  it("uses the Pro GLM vision route for Pro Plus Auto images", () => {
+  it("uses the Standard GLM vision route for Pro Plus Auto images", () => {
     expect(
       selectModel("agent", "pro-plus", "auto", true, false, {
         directGlmVisionEnabled: true,
       }),
-    ).toBe("model-glm-5.3-flash-pro");
+    ).toBe("model-glm-5.3-flash");
   });
 
   it.each(["pro", "pro-plus", "ultra", "team"] as const)(
@@ -286,8 +296,8 @@ describe("selectModel", () => {
     },
   );
 
-  it.each(["pro", "team"] as const)(
-    "routes paid %s Auto text to the mode-specific Flash model",
+  it.each(["pro", "pro-plus", "team"] as const)(
+    "routes paid %s Auto text to the mode-specific Standard model",
     (subscription) => {
       expect(selectModel("ask", subscription, "auto")).toBe(
         "model-deepseek-v4-flash-0731",
@@ -300,7 +310,7 @@ describe("selectModel", () => {
 
   // Default model selection by mode
   describe("default models (no override)", () => {
-    it.each(["pro", "team"] as const)(
+    it.each(["pro", "pro-plus", "team"] as const)(
       "should return GLM 5.3 Flash for paid agent text on %s",
       (subscription) => {
         expect(selectModel("agent", subscription)).toBe(
@@ -309,14 +319,9 @@ describe("selectModel", () => {
       },
     );
 
-    it.each(["pro-plus", "ultra"] as const)(
-      "should return DeepSeek V4 Pro 0813 for paid agent text on %s",
-      (subscription) => {
-        expect(selectModel("agent", subscription)).toBe(
-          "model-deepseek-v4-pro-0813",
-        );
-      },
-    );
+    it("should return DeepSeek V4 Pro 0813 for paid agent text on Ultra", () => {
+      expect(selectModel("agent", "ultra")).toBe("model-deepseek-v4-pro-0813");
+    });
 
     it("should return Grok 4.5 medium for paid Agent Auto with an image", () => {
       expect(selectModel("agent", "pro", undefined, true, false)).toBe(

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -37,10 +37,10 @@ export const getMaxStepsForUser = (mode: ChatMode): number => {
  * @param mode - Chat mode (ask or agent)
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
- *   Pro Plus/Ultra Auto uses DeepSeek V4 Pro 0813 for text/PDF prompts.
- *   Paid Agent Standard uses GLM 5.3 Flash, Ask Standard stays on DeepSeek
- *   V4 Flash 0731, Pro uses Pro 0813, and Max uses Grok 4.6. Images retain
- *   their existing direct or auxiliary vision behavior.
+ *   Pro Plus Auto mirrors the mode-specific Standard route: Agent uses GLM
+ *   5.3 Flash and Ask uses DeepSeek V4 Flash 0731. Ultra Auto uses DeepSeek
+ *   V4 Pro 0813. Explicit Pro uses Pro 0813, and Max uses Grok 4.6. Images
+ *   retain their existing direct or auxiliary vision behavior.
  * @returns Model name to use
  */
 export function selectModel(
@@ -74,7 +74,7 @@ export function selectModel(
     ? "model-glm-5.3-flash-agent"
     : "model-deepseek-v4-flash-0731";
   const paidAutoTextModel: ModelName =
-    subscription === "pro-plus" || subscription === "ultra"
+    subscription === "ultra"
       ? "model-deepseek-v4-pro-0813"
       : paidStandardTextModel;
   const directVisionModel: ModelName =
@@ -114,7 +114,7 @@ export function selectModel(
     return autoModel;
   }
 
-  // Explicit Standard remains on Flash even when Pro Plus/Ultra Auto uses Pro.
+  // Explicit Standard remains on Flash even when Ultra Auto uses Pro.
   // Keep an explicit key so model display surfaces show the selected tier.
   if (allowedSelectedModel === "hackerai-standard") {
     return hasProviderImage ? "model-grok-4.5" : paidStandardTextModel;


### PR DESCRIPTION
## Summary

- restore Pro Plus Auto/default to the mode-specific Standard route
- route Pro Plus Agent Auto text/PDF to GLM 5.3 Flash and Ask Auto text/PDF to DeepSeek V4 Flash 0731
- restore Pro Plus Auto direct GLM vision to the Standard GLM Flash route
- keep Ultra Auto on DeepSeek V4 Pro 0813 and preserve explicit Pro/Max selections
- add focused regression coverage for Pro Plus and Ultra routing

## Why

Pro Plus active-user churn increased from 4.08% to 7.38% in the complete week after the permanent HAC-73 ship, while treatment economics were underpowered and highly concentrated. HAC-92 tracks the seven-complete-day post-rollback readout and separates payment-failed from nonpayment churn.

Linear: https://linear.app/hackerai/issue/HAC-92/measure-pro-plus-auto-rollback-impact-on-churn-and-usage-economics

## Validation

- `pnpm test -- --runInBand lib/chat/__tests__/chat-processor.test.ts` — 97 passed
- `pnpm typecheck`
- targeted ESLint
- Prettier check
- local dependency guard
- repository pre-commit full test suite before rebasing onto current main

## Manual production verification

After deployment:

1. Submit bounded Pro Plus Agent Auto text and PDF requests; the recorded response model should be GLM 5.3 Flash.
2. Submit a bounded Pro Plus Ask Auto request; the recorded response model should be DeepSeek V4 Flash 0731.
3. Submit a Pro Plus explicit HackerAI Pro request; it should remain DeepSeek V4 Pro 0813.
4. Submit an Ultra Auto request; it should remain DeepSeek V4 Pro 0813.
5. Verify no route leakage and record the deployment boundary in HAC-92.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic model selection for Pro Plus plans based on the request type.
  * Pro Plus text and PDF requests now use the appropriate Standard models.
  * Pro Plus image requests now use the standard vision model.
  * Ultra automatic requests continue to use DeepSeek V4 Pro.
  * Updated routing behavior for paid automatic and default agent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->