### PR TITLE
Simplify platform cost sync configuration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -150,10 +150,7 @@ E2B_TEMPLATE=terminal-agent-sandbox
 # VERCEL_BILLING_READ_TOKEN=
 # Vercel team id whose FOCUS billing charges should be reconciled daily.
 # VERCEL_BILLING_TEAM_ID=
-# CONVEX_DEPLOY_KEY and CONVEX_SERVICE_ROLE_KEY are reused to record deployment
-# usage in the existing PostHog warehouse source. Set the canonical deployment
-# URL only when the deploy-key format does not identify a single deployment.
-# CONVEX_DEPLOYMENT_URL=https://your-deployment.convex.cloud
+# Everything else reuses existing app configuration.
 
 # Protects /api/health/core, which checks the WorkOS dependency for uptime monitoring.
 # Add the same value as the x-hackerai-health-token header in the uptime monitor.

--- a/app/api/cron/platform-costs/convex/route.ts
+++ b/app/api/cron/platform-costs/convex/route.ts
@@ -31,8 +31,7 @@ export async function GET(request: Request) {
   try {
     const deployKey = requireEnvironment("CONVEX_DEPLOY_KEY");
     const convexUrl = convexUsageBaseUrl(
-      deployKey,
-      process.env.CONVEX_DEPLOYMENT_URL,
+      requireEnvironment("NEXT_PUBLIC_CONVEX_URL"),
     );
     const usage = await fetchWithRetry(
       `${convexUrl.replace(/\/$/, "")}/api/v1/get_current_usage`,

--- a/docs/platform-cost-sync.md
+++ b/docs/platform-cost-sync.md
@@ -35,19 +35,16 @@ which avoids unnecessary warehouse sync churn.
   economics. The separate table prevents platform overhead from being counted
   in both user-level and organization-level economics.
 
-## Required production environment
+## Production environment
 
-- `CRON_SECRET`
-- `VERCEL_BILLING_READ_TOKEN`
-- `VERCEL_BILLING_TEAM_ID`
-- `CONVEX_DEPLOY_KEY`
-- `NEXT_PUBLIC_CONVEX_URL`
-- `CONVEX_SERVICE_ROLE_KEY`
+The only platform-cost-specific variables are `CRON_SECRET`,
+`VERCEL_BILLING_READ_TOKEN`, and `VERCEL_BILLING_TEAM_ID`.
 
-`CONVEX_DEPLOYMENT_URL` is only required when `CONVEX_DEPLOY_KEY` is not a
-deployment-scoped `prod:<deployment>|...` or `dev:<deployment>|...` key. When
-set, it must be the canonical `https://<deployment>.convex.cloud` URL; custom
-domains do not expose the authenticated deployment-usage endpoint.
+The jobs reuse the app's existing `CONVEX_DEPLOY_KEY`,
+`NEXT_PUBLIC_CONVEX_URL`, and `CONVEX_SERVICE_ROLE_KEY` configuration.
+`NEXT_PUBLIC_CONVEX_URL` must be the canonical
+`https://<deployment>.convex.cloud` URL; custom domains do not expose the
+authenticated deployment-usage endpoint.
 
 The Vercel token should be scoped to the owning team and used only for this
 billing-read integration. Never log it or expose it to the browser.

--- a/lib/billing/__tests__/platform-costs.test.ts
+++ b/lib/billing/__tests__/platform-costs.test.ts
@@ -155,23 +155,17 @@ describe("platform cost normalization", () => {
   });
 
   it("uses Convex's canonical deployment URL for admin usage requests", () => {
-    expect(convexUsageBaseUrl("prod:happy-capybara-123|secret-value")).toBe(
-      "https://happy-capybara-123.convex.cloud",
+    expect(convexUsageBaseUrl("https://careful-otter-456.convex.cloud")).toBe(
+      "https://careful-otter-456.convex.cloud",
     );
-    expect(
-      convexUsageBaseUrl(
-        "project:team:project|secret-value",
-        "https://careful-otter-456.convex.cloud",
-      ),
-    ).toBe("https://careful-otter-456.convex.cloud");
+    expect(() => convexUsageBaseUrl("https://example.com")).toThrow(
+      "canonical https://*.convex.cloud URL",
+    );
+    expect(() => convexUsageBaseUrl("https://.convex.cloud")).toThrow(
+      "canonical https://*.convex.cloud URL",
+    );
     expect(() =>
-      convexUsageBaseUrl("project:team:project|secret-value"),
-    ).toThrow("CONVEX_DEPLOYMENT_URL is required");
-    expect(() =>
-      convexUsageBaseUrl(
-        "prod:happy-capybara-123|secret-value",
-        "https://example.com",
-      ),
+      convexUsageBaseUrl("https://careful-otter-456.convex.cloud:8443"),
     ).toThrow("canonical https://*.convex.cloud URL");
   });
 });

--- a/lib/billing/__tests__/platform-costs.test.ts
+++ b/lib/billing/__tests__/platform-costs.test.ts
@@ -167,5 +167,11 @@ describe("platform cost normalization", () => {
     expect(() =>
       convexUsageBaseUrl("https://careful-otter-456.convex.cloud:8443"),
     ).toThrow("canonical https://*.convex.cloud URL");
+    expect(() =>
+      convexUsageBaseUrl("https://nested.careful-otter-456.convex.cloud"),
+    ).toThrow("canonical https://*.convex.cloud URL");
+    expect(() =>
+      convexUsageBaseUrl("https://-careful-otter-456.convex.cloud"),
+    ).toThrow("canonical https://*.convex.cloud URL");
   });
 });

--- a/lib/billing/platform-costs.ts
+++ b/lib/billing/platform-costs.ts
@@ -317,30 +317,18 @@ export function completedUtcDayWindow(
   };
 }
 
-export function convexUsageBaseUrl(
-  deployKey: string,
-  configuredUrl?: string,
-): string {
-  if (configuredUrl?.trim()) {
-    const url = new URL(configuredUrl);
-    if (
-      url.protocol !== "https:" ||
-      !url.hostname.endsWith(".convex.cloud") ||
-      url.pathname !== "/"
-    ) {
-      throw new Error(
-        "CONVEX_DEPLOYMENT_URL must be a canonical https://*.convex.cloud URL",
-      );
-    }
-    return url.origin;
-  }
-
-  const keyTarget = deployKey.slice(0, deployKey.indexOf("|"));
-  const match = /^(?:prod|dev):([a-z0-9-]+)$/.exec(keyTarget);
-  if (!match) {
+export function convexUsageBaseUrl(configuredUrl: string): string {
+  const url = new URL(configuredUrl);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname === ".convex.cloud" ||
+    !url.hostname.endsWith(".convex.cloud") ||
+    url.port !== "" ||
+    url.pathname !== "/"
+  ) {
     throw new Error(
-      "CONVEX_DEPLOYMENT_URL is required for this deploy key format",
+      "NEXT_PUBLIC_CONVEX_URL must be a canonical https://*.convex.cloud URL",
     );
   }
-  return `https://${match[1]}.convex.cloud`;
+  return url.origin;
 }

--- a/lib/billing/platform-costs.ts
+++ b/lib/billing/platform-costs.ts
@@ -321,8 +321,7 @@ export function convexUsageBaseUrl(configuredUrl: string): string {
   const url = new URL(configuredUrl);
   if (
     url.protocol !== "https:" ||
-    url.hostname === ".convex.cloud" ||
-    !url.hostname.endsWith(".convex.cloud") ||
+    !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.convex\.cloud$/.test(url.hostname) ||
     url.port !== "" ||
     url.pathname !== "/"
   ) {


### PR DESCRIPTION
## Summary
- remove only the unnecessary `CONVEX_DEPLOYMENT_URL` override
- reuse the existing canonical `NEXT_PUBLIC_CONVEX_URL` for Convex usage
- keep `VERCEL_BILLING_TEAM_ID` as deployment configuration instead of hardcoding account ownership
- tighten canonical Convex URL validation with regression coverage

Supersedes #1231 and #1233. Their isolated Convex preview deployments failed during `deploy2/start_push`; this replacement is rebuilt from current `main` and forces a new preview allocation.

## Validation
- full pre-commit suite: 427 suites / 4,482 tests
- TypeScript, ESLint, Prettier, and diff checks
- CodeRabbit finding from #1231 fixed and regression-tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Simplified Convex setup by using the canonical application URL directly.
  * Removed the obsolete deployment URL setting.

* **Bug Fixes**
  * Added stricter validation for Convex URLs, requiring secure, portless `.convex.cloud` addresses.

* **Documentation**
  * Updated platform cost synchronization guidance to reflect the simplified configuration requirements.

* **Tests**
  * Expanded coverage for valid and invalid Convex URL formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->