### PR TITLE
Fix EU attachment download TLS failures

### DIFF
--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -165,6 +165,9 @@ describe("s3Utils", () => {
       expect(S3Client).toHaveBeenCalledWith(
         expect.objectContaining({ region: "eu-central-1" }),
       );
+      expect(S3Client).toHaveBeenCalledWith(
+        expect.not.objectContaining({ forcePathStyle: true }),
+      );
       expect(PutObjectCommand).toHaveBeenCalledWith(
         expect.objectContaining({ Bucket: "test-eu-bucket" }),
       );
@@ -224,6 +227,52 @@ describe("s3Utils", () => {
 
       expect(url).toBe("https://s3.amazonaws.com/download-url");
       expect(mockGetSignedUrl).toHaveBeenCalled();
+      const { S3Client } = await import("@aws-sdk/client-s3");
+      expect(S3Client).toHaveBeenCalledWith(
+        expect.not.objectContaining({ forcePathStyle: true }),
+      );
+    });
+
+    it("uses a path-style hostname for persisted EU files", async () => {
+      const { S3Client } = await import("@aws-sdk/client-s3");
+      const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
+      (
+        getSignedUrl as jest.MockedFunction<typeof getSignedUrl>
+      ).mockResolvedValue("https://s3.eu-central-1.amazonaws.com/download-url");
+
+      const { generateS3DownloadUrl } = await import("../s3Utils");
+      await generateS3DownloadUrl("users/user123/123-uuid-test.pdf", {
+        region: "eu-central-1",
+        bucket: "test-eu-bucket",
+      });
+
+      expect(S3Client).toHaveBeenCalledWith(
+        expect.objectContaining({
+          region: "eu-central-1",
+          forcePathStyle: true,
+        }),
+      );
+      expect(getSignedUrl).toHaveBeenCalled();
+    });
+
+    it("keeps virtual-hosted URLs for persisted non-EU files", async () => {
+      const { S3Client } = await import("@aws-sdk/client-s3");
+      const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
+      (
+        getSignedUrl as jest.MockedFunction<typeof getSignedUrl>
+      ).mockResolvedValue(
+        "https://test-west-bucket.s3.us-west-2.amazonaws.com/download-url",
+      );
+
+      const { generateS3DownloadUrl } = await import("../s3Utils");
+      await generateS3DownloadUrl("users/user123/123-uuid-test.pdf", {
+        region: "us-west-2",
+        bucket: "test-west-bucket",
+      });
+
+      expect(S3Client).toHaveBeenCalledWith(
+        expect.not.objectContaining({ forcePathStyle: true }),
+      );
     });
   });
 

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -80,13 +80,17 @@ export function getStoredS3Location(
   return { region, bucket: bucket.trim() };
 }
 
-export function getS3Client(location?: S3StorageLocation): S3Client {
+export function getS3Client(
+  location?: S3StorageLocation,
+  options: { forcePathStyle?: boolean } = {},
+): S3Client {
   const accessKeyId = getRequiredEnvVar("AWS_S3_ACCESS_KEY_ID");
   const secretAccessKey = getRequiredEnvVar("AWS_S3_SECRET_ACCESS_KEY");
   const region = location?.region ?? getLegacyS3StorageLocation().region;
 
   return new S3Client({
     region,
+    ...(options.forcePathStyle ? { forcePathStyle: true } : {}),
     // Presigned browser uploads do not provide the body while signing. The
     // SDK's default WHEN_SUPPORTED behavior otherwise signs the CRC32 of an
     // empty body, which S3 rejects when the browser PUTs the real file.
@@ -163,7 +167,13 @@ export async function generateS3DownloadUrl(
 ): Promise<string> {
   try {
     const location = storageLocation ?? getLegacyS3StorageLocation();
-    const s3Client = getS3Client(location);
+    // A production sandbox TLS path rejected the EU virtual-hosted bucket name
+    // even though the S3 certificate is valid. EU files use S3's supported
+    // path-style form so the bucket is not part of the TLS hostname. Keep
+    // legacy and other regional URL shapes unchanged without incident evidence.
+    const s3Client = getS3Client(location, {
+      forcePathStyle: storageLocation?.region === "eu-central-1",
+    });
 
     const command = new GetObjectCommand({
       Bucket: location.bucket,

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -80,6 +80,7 @@ export function getStoredS3Location(
   return { region, bucket: bucket.trim() };
 }
 
+/** Create an S3 client with optional path-style object addressing. */
 export function getS3Client(
   location?: S3StorageLocation,
   options: { forcePathStyle?: boolean } = {},


### PR DESCRIPTION
## Production evidence

Daily production error triage used the frozen window `2026-08-31T20:02:44Z`–`2026-09-01T20:02:44Z`.

Trigger.dev recorded 9 attachment-staging failures affecting 6 distinct users/chats, up from 3 in the prior equivalent window. Four were exact attachment-transfer failures. Representative current-worker run `run_06g5t3sdu01f06bt4h0eobs8c1` failed after `lwb7vohy / v20260901.10` deployed at `2026-09-01T18:57:42Z`; curl rejected the EU regional S3 virtual-hosted endpoint because the certificate subject did not match the bucket hostname. Earlier representative `run_06g5r00uc9sp4f1atomd483bc1` retried three TLS/reset failures on `v20260901.6`.

The public EU S3 endpoint presents a valid Amazon certificate outside the affected sandbox path, so this is scoped to the bucket-in-host URL shape on that transfer path rather than disabled TLS verification or a broad S3 outage.

## Root cause and change

Regional file storage introduced the EU bucket hostname at commit `5cd8ced8`. S3 supports both virtual-hosted and path-style URLs. This change forces path style only for persisted `eu-central-1` download URLs, moving the bucket from the TLS hostname into the signed path.

- Browser upload signing is unchanged.
- Legacy and non-EU download URL shapes are unchanged.
- Credentials, expiry, bucket/key authorization, and object encoding are unchanged.
- No schema, payload, or worker-version coupling is introduced.

## Validation

- Focused S3/file-action tests: 72/72
- Commit hooks: 428 suites / 4,488 tests
- `pnpm run typecheck`
- Changed-file ESLint and Prettier
- Real AWS SDK smoke: EU download host becomes `s3.eu-central-1.amazonaws.com`; US West and legacy hosts remain virtual-hosted; spaced object keys remain encoded
- Direct TLS probe of the path-style EU service endpoint succeeded

## Manual verification

After the production Convex/Vercel/Trigger deployment:

1. Start an EU-routed Agent session using the desktop computer path.
2. Attach a disposable file and submit a bounded request that reads it.
3. Confirm attachment staging completes and the Agent can read the file.
4. Confirm no new `attachment_transfer_failed` run appears for the test chat.

Backend-only URL signing change; no visual QA is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 file download compatibility for files stored in the EU Central region.
  * Preserved existing download behavior for legacy and other regional storage locations.
* **Tests**
  * Added coverage to verify S3 URL addressing across regional uploads and downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->