### PR TITLE
Fix Vercel cost reconciliation boundary rows

### DIFF
--- a/app/api/cron/platform-costs/vercel/__tests__/route.test.ts
+++ b/app/api/cron/platform-costs/vercel/__tests__/route.test.ts
@@ -1,0 +1,153 @@
+const fetchWithRetryMock = jest.fn();
+const logCostSyncMock = jest.fn();
+const replaceCostWindowMock = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    }),
+  },
+}));
+
+jest.mock("@/lib/billing/platform-cost-sync", () => ({
+  fetchWithRetry: (...args: unknown[]) => fetchWithRetryMock(...args),
+  isAuthorizedCronRequest: () => true,
+  logCostSync: (...args: unknown[]) => logCostSyncMock(...args),
+  replaceCostWindow: (...args: unknown[]) => replaceCostWindowMock(...args),
+  requireEnvironment: (name: string) => `${name.toLowerCase()}-value`,
+  safeError: (error: unknown) => ({
+    error_name: error instanceof Error ? error.name : "UnknownError",
+    error_message: error instanceof Error ? error.message : "Unknown error",
+  }),
+}));
+
+import { GET } from "../route";
+
+const charge = (day: string) => ({
+  BilledCost: 1,
+  EffectiveCost: 1,
+  BillingCurrency: "USD",
+  ChargeCategory: "Usage",
+  ChargePeriodStart: `${day}T00:00:00.000Z`,
+  ChargePeriodEnd: `${day}T23:59:59.999Z`,
+  ConsumedQuantity: 1,
+  ConsumedUnit: "GB-hours",
+  ServiceName: `service-${day}`,
+  ServiceCategory: "Compute",
+});
+
+const billingResponse = (...days: string[]) => {
+  const payload = new TextEncoder().encode(
+    days.map((day) => JSON.stringify(charge(day))).join("\n"),
+  );
+  return {
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(payload);
+        controller.close();
+      },
+    }),
+  } as Response;
+};
+
+const cronRequest = (requestId: string) =>
+  ({
+    headers: {
+      get: (name: string) => (name === "x-vercel-id" ? requestId : null),
+    },
+  }) as Request;
+
+describe("Vercel platform cost sync", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(Date, "now")
+      .mockReturnValue(Date.parse("2026-09-02T17:00:00.000Z"));
+    replaceCostWindowMock.mockResolvedValue({
+      inserted: 1,
+      updated: 0,
+      deleted: 0,
+      unchanged: 0,
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("excludes upstream boundary rows before replacing the completed window", async () => {
+    fetchWithRetryMock.mockImplementation(
+      async (
+        _url: string,
+        _init: RequestInit,
+        consume: (response: Response) => Promise<unknown>,
+      ) => consume(billingResponse("2026-07-28", "2026-09-01", "2026-09-02")),
+    );
+
+    const response = await GET(cronRequest("iad1::request-1"));
+
+    expect(response.status).toBe(200);
+    expect(replaceCostWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDay: "2026-07-29",
+        endDay: "2026-09-01",
+        rows: [expect.objectContaining({ day: "2026-09-01" })],
+      }),
+    );
+    expect(logCostSyncMock).toHaveBeenCalledWith(
+      "warn",
+      "platform_cost_sync_rows_excluded_outside_window",
+      expect.objectContaining({
+        excluded_row_count: 2,
+        excluded_before_start: 1,
+        excluded_after_end: 1,
+      }),
+    );
+  });
+
+  it("fails closed when every returned row is outside the requested window", async () => {
+    fetchWithRetryMock.mockImplementation(
+      async (
+        _url: string,
+        _init: RequestInit,
+        consume: (response: Response) => Promise<unknown>,
+      ) => consume(billingResponse("2026-07-28", "2026-09-02")),
+    );
+
+    const response = await GET(cronRequest("iad1::request-2"));
+
+    expect(response.status).toBe(500);
+    expect(replaceCostWindowMock).not.toHaveBeenCalled();
+    expect(logCostSyncMock).toHaveBeenCalledWith(
+      "error",
+      "platform_cost_sync_failed",
+      expect.objectContaining({
+        stage: "normalize",
+        error_message:
+          "Vercel billing response contains no rows inside the requested window",
+      }),
+    );
+  });
+
+  it("preserves an authoritative empty response for window cleanup", async () => {
+    fetchWithRetryMock.mockImplementation(
+      async (
+        _url: string,
+        _init: RequestInit,
+        consume: (response: Response) => Promise<unknown>,
+      ) => consume(billingResponse()),
+    );
+
+    const response = await GET(cronRequest("iad1::request-3"));
+
+    expect(response.status).toBe(200);
+    expect(replaceCostWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rows: [] }),
+    );
+    expect(logCostSyncMock).not.toHaveBeenCalledWith(
+      "warn",
+      "platform_cost_sync_rows_excluded_outside_window",
+      expect.anything(),
+    );
+  });
+});

--- a/app/api/cron/platform-costs/vercel/route.ts
+++ b/app/api/cron/platform-costs/vercel/route.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import {
   completedUtcDayWindow,
+  partitionPlatformCostRowsByDayWindow,
   parseVercelFocusStream,
 } from "@/lib/billing/platform-costs";
 import {
@@ -29,6 +30,8 @@ export async function GET(request: Request) {
   }
 
   const startedAt = Date.now();
+  let stage: "configuration" | "fetch" | "normalize" | "persist" | "complete" =
+    "configuration";
   try {
     const token = requireEnvironment("VERCEL_BILLING_READ_TOKEN");
     const teamId = requireEnvironment("VERCEL_BILLING_TEAM_ID");
@@ -38,7 +41,8 @@ export async function GET(request: Request) {
     url.searchParams.set("to", window.to);
     url.searchParams.set("teamId", teamId);
 
-    const rows = await fetchWithRetry(
+    stage = "fetch";
+    const upstreamRows = await fetchWithRetry(
       url.toString(),
       {
         headers: {
@@ -55,28 +59,63 @@ export async function GET(request: Request) {
         return await parseVercelFocusStream(response.body);
       },
     );
+    stage = "normalize";
+    const partition = partitionPlatformCostRowsByDayWindow(
+      upstreamRows,
+      window.startDay,
+      window.endDay,
+    );
+    const excludedRowCount =
+      partition.excludedBeforeStart + partition.excludedAfterEnd;
+    if (excludedRowCount > 0) {
+      logCostSync("warn", "platform_cost_sync_rows_excluded_outside_window", {
+        request_id: requestId,
+        vendor: "vercel",
+        start_day: window.startDay,
+        end_day: window.endDay,
+        upstream_row_count: upstreamRows.length,
+        excluded_row_count: excludedRowCount,
+        excluded_before_start: partition.excludedBeforeStart,
+        excluded_after_end: partition.excludedAfterEnd,
+      });
+    }
+    if (upstreamRows.length > 0 && partition.rows.length === 0) {
+      throw new Error(
+        "Vercel billing response contains no rows inside the requested window",
+      );
+    }
+
+    stage = "persist";
     const result = await replaceCostWindow({
       vendor: "vercel",
       startDay: window.startDay,
       endDay: window.endDay,
       observedAt: startedAt,
-      rows,
+      rows: partition.rows,
     });
 
+    stage = "complete";
     logCostSync("info", "platform_cost_sync_completed", {
       request_id: requestId,
       vendor: "vercel",
       duration_ms: Date.now() - startedAt,
-      row_count: rows.length,
+      row_count: partition.rows.length,
+      upstream_row_count: upstreamRows.length,
+      excluded_row_count: excludedRowCount,
       start_day: window.startDay,
       end_day: window.endDay,
       ...result,
     });
-    return NextResponse.json({ ok: true, rowCount: rows.length, ...result });
+    return NextResponse.json({
+      ok: true,
+      rowCount: partition.rows.length,
+      ...result,
+    });
   } catch (error) {
     logCostSync("error", "platform_cost_sync_failed", {
       request_id: requestId,
       vendor: "vercel",
+      stage,
       duration_ms: Date.now() - startedAt,
       ...safeError(error),
     });

--- a/app/api/cron/platform-costs/vercel/route.ts
+++ b/app/api/cron/platform-costs/vercel/route.ts
@@ -19,6 +19,7 @@ export const maxDuration = 120;
 
 const RECONCILIATION_DAYS = 35;
 
+/** Reconcile the completed Vercel billing window into persisted daily costs. */
 export async function GET(request: Request) {
   const requestId = request.headers.get("x-vercel-id") ?? randomUUID();
   if (!isAuthorizedCronRequest(request)) {

--- a/lib/billing/__tests__/platform-costs.test.ts
+++ b/lib/billing/__tests__/platform-costs.test.ts
@@ -2,6 +2,7 @@ import {
   completedUtcDayWindow,
   convexUsageBaseUrl,
   mapConvexUsageToRows,
+  partitionPlatformCostRowsByDayWindow,
   parseConvexDeploymentUsage,
   parseVercelFocusStream,
 } from "../platform-costs";
@@ -151,6 +152,35 @@ describe("platform cost normalization", () => {
       to: "2026-09-01T00:00:00.000Z",
       startDay: "2026-07-28",
       endDay: "2026-08-31",
+    });
+  });
+
+  it("partitions provider rows at both replacement-window boundaries", () => {
+    const makeRow = (day: string) => ({
+      day,
+      serviceName: `service-${day}`,
+      serviceCategory: "Compute",
+      costStatus: "billed" as const,
+      billedCostDollars: 1,
+      sourcePeriodStart: `${day}T00:00:00.000Z`,
+      sourcePeriodEnd: `${day}T23:59:59.999Z`,
+    });
+
+    expect(
+      partitionPlatformCostRowsByDayWindow(
+        [
+          makeRow("2026-07-27"),
+          makeRow("2026-07-28"),
+          makeRow("2026-08-31"),
+          makeRow("2026-09-01"),
+        ],
+        "2026-07-28",
+        "2026-08-31",
+      ),
+    ).toEqual({
+      rows: [makeRow("2026-07-28"), makeRow("2026-08-31")],
+      excludedBeforeStart: 1,
+      excludedAfterEnd: 1,
     });
   });
 

--- a/lib/billing/platform-costs.ts
+++ b/lib/billing/platform-costs.ts
@@ -17,6 +17,12 @@ export type PlatformCostRow = {
   sourceChargeCount?: number;
 };
 
+export type PlatformCostWindowPartition = {
+  rows: PlatformCostRow[];
+  excludedBeforeStart: number;
+  excludedAfterEnd: number;
+};
+
 type VercelFocusCharge = {
   BilledCost?: unknown;
   EffectiveCost?: unknown;
@@ -227,6 +233,35 @@ export async function parseVercelFocusStream(
         a.usageUnit?.localeCompare(b.usageUnit ?? "") ||
         0,
     );
+}
+
+/**
+ * Keep a streamed provider response inside the exact replacement boundary.
+ * The Convex mutation remains the final invariant guard, while this partition
+ * prevents an upstream boundary row from aborting an otherwise valid sync.
+ */
+export function partitionPlatformCostRowsByDayWindow(
+  rows: readonly PlatformCostRow[],
+  startDay: string,
+  endDay: string,
+): PlatformCostWindowPartition {
+  const partition: PlatformCostWindowPartition = {
+    rows: [],
+    excludedBeforeStart: 0,
+    excludedAfterEnd: 0,
+  };
+
+  for (const row of rows) {
+    if (row.day < startDay) {
+      partition.excludedBeforeStart += 1;
+    } else if (row.day > endDay) {
+      partition.excludedAfterEnd += 1;
+    } else {
+      partition.rows.push(row);
+    }
+  }
+
+  return partition;
 }
 
 const CONVEX_CATEGORY_BY_METRIC: Record<string, string> = {


### PR DESCRIPTION
## Summary
- partition Vercel FOCUS billing rows to the exact completed UTC day window before Convex replacement
- fail closed when a non-empty upstream response contains no in-window rows
- add bounded, privacy-safe stage and exclusion diagnostics
- cover mixed-boundary, all-out-of-window, and authoritative-empty responses

## Production evidence
Frozen audit window: `2026-09-01T20:01:12Z` through `2026-09-02T20:01:12Z`.

Three Vercel 500s for `/api/cron/platform-costs/vercel` matched three PostHog occurrences of `row.day must be inside the replacement window`, all shortly after the current production deployment became ready. The evidence shows the upstream response contained at least one row outside the exact replacement key window; the Convex mutation correctly rejected it.

Vercel documents the billing query's `from` boundary as inclusive and `to` as exclusive, so this patch preserves the request and enforces the same day window on returned rows:
https://vercel.com/docs/rest-api/billing/list-focus-billing-charges

No error suppression or feature flag is included; this is a correctness and observability fix.

## Validation
- `pnpm exec jest --runInBand lib/billing/__tests__/platform-costs.test.ts app/api/cron/platform-costs/vercel/__tests__/route.test.ts convex/__tests__/platformCosts.test.ts` — 12 tests passed
- commit hook: 435 suites / 4,528 tests passed
- TypeScript, ESLint, Prettier, and `git diff --check` passed
- no Convex deployment was created or modified

## Manual verification after production deployment
Wait for the next authorized Vercel platform-cost sync. It should return 200 and complete replacement; if upstream boundary rows recur, the warning should report only bounded exclusion counts and the invariant error should not recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Platform cost synchronization now processes only billing records from the completed UTC day.
  - Records outside the requested day are excluded from persistence, preventing inaccurate cost data.
  - Synchronization now fails safely when no records fall within the requested time window.
  - Empty responses from the billing provider remain authoritative, supporting accurate cleanup of outdated records.

- **Tests**
  - Added coverage for date-window boundaries, out-of-range records, and empty billing responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->