### PR TITLE
HAC-93: handle Vercel billing window overlap

### DIFF
--- a/app/api/cron/platform-costs/vercel/route.ts
+++ b/app/api/cron/platform-costs/vercel/route.ts
@@ -19,6 +19,7 @@ export const maxDuration = 120;
 
 const RECONCILIATION_DAYS = 35;
 
+/** Reconciles completed Vercel billing days into the platform cost table. */
 export async function GET(request: Request) {
   const requestId = request.headers.get("x-vercel-id") ?? randomUUID();
   if (!isAuthorizedCronRequest(request)) {

--- a/app/api/cron/platform-costs/vercel/route.ts
+++ b/app/api/cron/platform-costs/vercel/route.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import {
   completedUtcDayWindow,
+  filterRowsToDayWindow,
   parseVercelFocusStream,
 } from "@/lib/billing/platform-costs";
 import {
@@ -38,7 +39,7 @@ export async function GET(request: Request) {
     url.searchParams.set("to", window.to);
     url.searchParams.set("teamId", teamId);
 
-    const rows = await fetchWithRetry(
+    const fetchedRows = await fetchWithRetry(
       url.toString(),
       {
         headers: {
@@ -55,6 +56,11 @@ export async function GET(request: Request) {
         return await parseVercelFocusStream(response.body);
       },
     );
+    const rows = filterRowsToDayWindow(
+      fetchedRows,
+      window.startDay,
+      window.endDay,
+    );
     const result = await replaceCostWindow({
       vendor: "vercel",
       startDay: window.startDay,
@@ -68,6 +74,7 @@ export async function GET(request: Request) {
       vendor: "vercel",
       duration_ms: Date.now() - startedAt,
       row_count: rows.length,
+      excluded_row_count: fetchedRows.length - rows.length,
       start_day: window.startDay,
       end_day: window.endDay,
       ...result,

--- a/lib/billing/__tests__/platform-costs.test.ts
+++ b/lib/billing/__tests__/platform-costs.test.ts
@@ -1,6 +1,7 @@
 import {
   completedUtcDayWindow,
   convexUsageBaseUrl,
+  filterRowsToDayWindow,
   mapConvexUsageToRows,
   parseConvexDeploymentUsage,
   parseVercelFocusStream,
@@ -101,6 +102,39 @@ describe("platform cost normalization", () => {
         ]),
       ),
     ).rejects.toThrow("BilledCost must be finite");
+  });
+
+  it("excludes Vercel charge periods that only overlap a day window boundary", async () => {
+    const base = {
+      BillingCurrency: "USD",
+      ChargePeriodEnd: "2026-07-29T07:00:00.000Z",
+      ChargeCategory: "Usage",
+      ServiceName: "Fluid compute",
+      ServiceCategory: "Compute",
+      BilledCost: 1,
+    };
+    const rows = await parseVercelFocusStream(
+      jsonlStream([
+        {
+          ...base,
+          ChargePeriodStart: "2026-07-28T07:00:00.000Z",
+        },
+        {
+          ...base,
+          ChargePeriodStart: "2026-07-29T07:00:00.000Z",
+          ChargePeriodEnd: "2026-07-30T07:00:00.000Z",
+        },
+        {
+          ...base,
+          ChargePeriodStart: "2026-09-02T07:00:00.000Z",
+          ChargePeriodEnd: "2026-09-03T07:00:00.000Z",
+        },
+      ]),
+    );
+
+    expect(filterRowsToDayWindow(rows, "2026-07-29", "2026-09-01")).toEqual([
+      expect.objectContaining({ day: "2026-07-29" }),
+    ]);
   });
 
   it("maps Convex deployment usage to metered rows without fake dollars", () => {

--- a/lib/billing/__tests__/platform-costs.test.ts
+++ b/lib/billing/__tests__/platform-costs.test.ts
@@ -126,6 +126,11 @@ describe("platform cost normalization", () => {
         },
         {
           ...base,
+          ChargePeriodStart: "2026-09-01T07:00:00.000Z",
+          ChargePeriodEnd: "2026-09-02T07:00:00.000Z",
+        },
+        {
+          ...base,
           ChargePeriodStart: "2026-09-02T07:00:00.000Z",
           ChargePeriodEnd: "2026-09-03T07:00:00.000Z",
         },
@@ -134,6 +139,7 @@ describe("platform cost normalization", () => {
 
     expect(filterRowsToDayWindow(rows, "2026-07-29", "2026-09-01")).toEqual([
       expect.objectContaining({ day: "2026-07-29" }),
+      expect.objectContaining({ day: "2026-09-01" }),
     ]);
   });
 

--- a/lib/billing/platform-costs.ts
+++ b/lib/billing/platform-costs.ts
@@ -229,6 +229,19 @@ export async function parseVercelFocusStream(
     );
 }
 
+/**
+ * Keep only rows whose normalized UTC day belongs to the replacement window.
+ * Vercel may return a charge period that overlaps the requested range even
+ * when that period starts on the preceding day.
+ */
+export function filterRowsToDayWindow(
+  rows: PlatformCostRow[],
+  startDay: string,
+  endDay: string,
+): PlatformCostRow[] {
+  return rows.filter((row) => row.day >= startDay && row.day <= endDay);
+}
+
 const CONVEX_CATEGORY_BY_METRIC: Record<string, string> = {
   actionComputeConvexGbHours: "compute",
   actionComputeCpuGbHours: "compute",


### PR DESCRIPTION
## Summary
- filter Vercel FOCUS aggregates to the exact Convex replacement day window
- preserve idempotent replacement behavior when Vercel returns an overlapping boundary period
- log the number of excluded boundary aggregates
- add regression coverage for Pacific-time (`07:00Z`) billing intervals

## Verification
- `pnpm typecheck`
- `pnpm test` (434 suites, 4525 tests)
- focused ESLint and Prettier checks
- `pnpm run check:local-dependencies`

## Production evidence
The replacement token reaches the billing API successfully. The remaining production failure was Convex request `9a84640d93211aa4`: `row.day must be inside the replacement window`. The live Vercel response included a charge beginning `2026-07-28T07:00:00.000Z` for a requested window starting `2026-07-29T00:00:00.000Z`, confirming the provider returns a period overlapping the lower boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Platform cost synchronization now includes only charges whose UTC dates fall within the requested day range.
  * Charges outside the range—including those overlapping its boundaries—are excluded.
  * Charges occurring on the final day of the requested window remain included.
  * Completion logs now report the number of excluded billing rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->