### PR TITLE
Fix weekly Codex Security findings

### DIFF
--- a/convex/__tests__/chats.agentApprovalLifecycle.test.ts
+++ b/convex/__tests__/chats.agentApprovalLifecycle.test.ts
@@ -107,6 +107,107 @@ describe("Agent approval lifecycle guards", () => {
     expect(patch).not.toHaveBeenCalled();
   });
 
+  it("deletes all child records before deleting a chat", async () => {
+    const tables: Record<string, Array<Record<string, any>>> = {
+      chats: [
+        {
+          _id: "chat-doc-1",
+          id: "chat-1",
+          user_id: "user-1",
+          canceled_at: 1,
+        },
+      ],
+      messages: [],
+      chat_summaries: [],
+      subagent_runs: [
+        {
+          _id: "subagent-run-1",
+          subagent_id: "sa-1",
+          chat_id: "chat-1",
+          status: "completed",
+        },
+      ],
+      subagent_messages: [
+        {
+          _id: "subagent-message-1",
+          subagent_id: "sa-1",
+        },
+      ],
+      subagent_events: [
+        {
+          _id: "subagent-event-1",
+          subagent_id: "sa-1",
+        },
+      ],
+      subagent_work_items: [
+        {
+          _id: "subagent-work-1",
+          subagent_id: "sa-1",
+        },
+      ],
+    };
+    const deletedIds: string[] = [];
+    const query = jest.fn((table: string) => ({
+      withIndex: jest.fn((_index: string, build: (q: any) => unknown) => {
+        const filters: Array<[string, unknown]> = [];
+        const q = {
+          eq: (field: string, value: unknown) => {
+            filters.push([field, value]);
+            return q;
+          },
+        };
+        build(q);
+        const rows = () =>
+          (tables[table] ?? []).filter((candidate) =>
+            filters.every(([field, value]) => candidate[field] === value),
+          );
+        return {
+          first: jest.fn(async () => rows()[0] ?? null),
+          take: jest.fn(async (limit: number) => rows().slice(0, limit)),
+        };
+      }),
+    }));
+    const db = {
+      query,
+      patch: jest.fn<any>().mockResolvedValue(undefined),
+      delete: jest.fn(async (id: string) => {
+        deletedIds.push(id);
+        for (const [table, rows] of Object.entries(tables)) {
+          tables[table] = rows.filter((candidate) => candidate._id !== id);
+        }
+      }),
+    };
+    const ctx = {
+      db,
+      scheduler: { runAfter: jest.fn<any>().mockResolvedValue(undefined) },
+    } as any;
+
+    await expect(
+      deleteChatForBackend.handler(ctx, {
+        serviceKey: "service-key",
+        chatId: "chat-1",
+        userId: "user-1",
+        expectedTriggerRunId: null,
+        expectedApprovalSessionId: null,
+      }),
+    ).resolves.toBe("deleted");
+
+    expect(tables.subagent_messages).toHaveLength(0);
+    expect(tables.subagent_events).toHaveLength(0);
+    expect(tables.subagent_work_items).toHaveLength(0);
+    expect(tables.subagent_runs).toHaveLength(0);
+    expect(tables.chats).toHaveLength(0);
+    expect(deletedIds.indexOf("subagent-event-1")).toBeLessThan(
+      deletedIds.indexOf("subagent-run-1"),
+    );
+    expect(deletedIds.indexOf("subagent-work-1")).toBeLessThan(
+      deletedIds.indexOf("subagent-run-1"),
+    );
+    expect(deletedIds.indexOf("subagent-run-1")).toBeLessThan(
+      deletedIds.indexOf("chat-doc-1"),
+    );
+  });
+
   it("does not attach a new run after chat deletion starts", async () => {
     const { ctx, patch } = makeCtx({
       _id: "chat-doc-1",

--- a/convex/__tests__/referralsNotifications.test.ts
+++ b/convex/__tests__/referralsNotifications.test.ts
@@ -275,7 +275,7 @@ describe("referral reward notifications", () => {
     expect(tables.referral_rewards[1].notification_seen_at).toBeUndefined();
   });
 
-  it("enables extra usage for referral credits without changing auto-reload", async () => {
+  it("enables referral credits without restoring a disabled user's auto-reload", async () => {
     const { awardConversionReward } = await import("../referrals");
     const { ctx, tables, queryCalls } = makeMockCtx({
       referral_attributions: [
@@ -338,11 +338,76 @@ describe("referral reward notifications", () => {
       {
         user_id: USER_ID,
         balance_points: 120_000,
-        auto_reload_enabled: true,
+        auto_reload_enabled: false,
       },
     ]);
     expect(tables.user_customization[0].extra_usage_enabled).toBe(true);
     expect(queryCalls).toContain("user_customization");
+  });
+
+  it("preserves auto-reload for a referrer who already enabled extra usage", async () => {
+    const { awardConversionReward } = await import("../referrals");
+    const { ctx, tables } = makeMockCtx({
+      referral_attributions: [
+        {
+          _id: "attribution_1",
+          referred_user_id: REFERRED_USER_ID,
+          referrer_user_id: USER_ID,
+          referral_code: "ABC1234",
+          referrer_subscription_tier: "pro",
+          status: "attributed",
+          sign_up_reward_status: "awarded",
+          conversion_reward_status: "pending",
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+      referral_codes: [
+        {
+          _id: "code_1",
+          user_id: USER_ID,
+          code: "ABC1234",
+          status: "active",
+          referrer_subscription_tier: "pro",
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+      user_customization: [
+        {
+          _id: "customization_1",
+          user_id: USER_ID,
+          extra_usage_enabled: true,
+          updated_at: 1,
+        },
+      ],
+      extra_usage: [
+        {
+          _id: "extra_usage_1",
+          user_id: USER_ID,
+          balance_points: 20_000,
+          auto_reload_enabled: true,
+          updated_at: 1,
+        },
+      ],
+    });
+
+    await awardConversionReward.handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referrerRewardDollars: 10,
+      referredUserId: REFERRED_USER_ID,
+      stripeCustomerId: "cus_123",
+      stripeSubscriptionId: "sub_123",
+      stripeInvoiceId: "in_123",
+      plan: "pro-monthly-plan",
+      tier: "pro",
+    });
+
+    expect(tables.extra_usage[0]).toMatchObject({
+      balance_points: 120_000,
+      auto_reload_enabled: true,
+    });
+    expect(tables.user_customization[0].extra_usage_enabled).toBe(true);
   });
 
   it("withholds conversion rewards from free referrer codes", async () => {

--- a/convex/__tests__/subagents.test.ts
+++ b/convex/__tests__/subagents.test.ts
@@ -80,11 +80,16 @@ const makeCtx = ({
   parentRuns = [],
   sameCandidate = [],
   deletionFenced = false,
+  chat = {
+    id: "chat-1",
+    user_id: "user-1",
+  },
 }: {
   exact?: Record<string, any> | null;
   parentRuns?: Array<Record<string, any>>;
   sameCandidate?: Array<Record<string, any>>;
   deletionFenced?: boolean;
+  chat?: Record<string, any> | null;
 }) => {
   const insert = jest.fn<any>().mockResolvedValue("subagent-doc");
   const patch = jest.fn<any>().mockResolvedValue(undefined);
@@ -105,10 +110,7 @@ const makeCtx = ({
       }
       if (table === "chats") {
         return {
-          first: jest.fn<any>().mockResolvedValue({
-            id: "chat-1",
-            user_id: "user-1",
-          }),
+          first: jest.fn<any>().mockResolvedValue(chat),
         };
       }
       if (indexName === "by_parent_run_and_tool_call") {
@@ -193,6 +195,66 @@ describe("subagent continuation", () => {
       }),
     );
     expect(runAfter).toHaveBeenCalled();
+  });
+
+  it("does not resume a child after account deletion starts", async () => {
+    const { ctx, patch, runAfter } = makeCtx({
+      deletionFenced: true,
+      parentRuns: [
+        {
+          _id: "run-1",
+          subagent_id: "sa_completed",
+          profile: "general",
+          status: "completed",
+          created_at: 123,
+        },
+      ],
+    });
+
+    await expect(
+      resumeForBackend.handler(ctx, {
+        serviceKey: "service-key",
+        userId: "user-1",
+        chatId: "chat-1",
+        parentTriggerRunId: "parent-run",
+        targetAgentId: "sa_completed",
+        followUp: "Continue after deletion",
+      }),
+    ).resolves.toEqual({ outcome: "not_found" });
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+
+  it("does not resume a child after chat deletion starts", async () => {
+    const { ctx, patch, runAfter } = makeCtx({
+      chat: {
+        id: "chat-1",
+        user_id: "user-1",
+        deletion_started_at: 123,
+      },
+      parentRuns: [
+        {
+          _id: "run-1",
+          subagent_id: "sa_completed",
+          profile: "general",
+          status: "completed",
+          created_at: 123,
+        },
+      ],
+    });
+
+    await expect(
+      resumeForBackend.handler(ctx, {
+        serviceKey: "service-key",
+        userId: "user-1",
+        chatId: "chat-1",
+        parentTriggerRunId: "parent-run",
+        targetAgentId: "sa_completed",
+        followUp: "Continue after deletion",
+      }),
+    ).resolves.toEqual({ outcome: "not_found" });
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -538,6 +538,58 @@ function seedTables(userId = "user_123", otherUserId = "user_other"): Tables {
       { _id: "fence-user", user_id: userId, started_at: 1 },
       { _id: "fence-other", user_id: otherUserId, started_at: 1 },
     ],
+    subagent_runs: [
+      {
+        _id: "subagent-run-user",
+        subagent_id: "sa-user",
+        user_id: userId,
+        chat_id: "chat-1",
+        status: "completed",
+      },
+      {
+        _id: "subagent-run-other",
+        subagent_id: "sa-other",
+        user_id: otherUserId,
+        chat_id: "chat-other-id",
+        status: "completed",
+      },
+    ],
+    subagent_messages: [
+      {
+        _id: "subagent-message-user",
+        subagent_id: "sa-user",
+        user_id: userId,
+      },
+      {
+        _id: "subagent-message-other",
+        subagent_id: "sa-other",
+        user_id: otherUserId,
+      },
+    ],
+    subagent_events: [
+      {
+        _id: "subagent-event-user",
+        subagent_id: "sa-user",
+        user_id: userId,
+      },
+      {
+        _id: "subagent-event-other",
+        subagent_id: "sa-other",
+        user_id: otherUserId,
+      },
+    ],
+    subagent_work_items: [
+      {
+        _id: "subagent-work-user",
+        subagent_id: "sa-user",
+        user_id: userId,
+      },
+      {
+        _id: "subagent-work-other",
+        subagent_id: "sa-other",
+        user_id: otherUserId,
+      },
+    ],
     research_runs: [
       {
         _id: "research-run",
@@ -640,6 +692,16 @@ describe("userDeletion", () => {
     expect(row(tables, "research_runs", "research-run")).toBeTruthy();
     expect(row(tables, "research_reports", "research-report")).toBeTruthy();
     expect(row(tables, "user_deletion_fences", "fence-user")).toBeTruthy();
+    expect(
+      row(tables, "subagent_events", "subagent-event-user"),
+    ).toBeUndefined();
+    expect(row(tables, "subagent_events", "subagent-event-other")).toBeTruthy();
+    expect(
+      row(tables, "subagent_work_items", "subagent-work-user"),
+    ).toBeUndefined();
+    expect(
+      row(tables, "subagent_work_items", "subagent-work-other"),
+    ).toBeTruthy();
 
     expect(row(tables, "cancellation_reasons", "cancel-user")).toMatchObject({
       user_id: DELETED_USER_ID,
@@ -744,6 +806,12 @@ describe("userDeletion", () => {
     expect(deletedIds.indexOf("summary-by-chat")).toBeLessThan(
       deletedIds.indexOf("chat-doc"),
     );
+    expect(deletedIds.indexOf("subagent-event-user")).toBeLessThan(
+      deletedIds.indexOf("subagent-run-user"),
+    );
+    expect(deletedIds.indexOf("subagent-work-user")).toBeLessThan(
+      deletedIds.indexOf("subagent-run-user"),
+    );
   });
 
   it("deletes user data through the service-key mutation without auth", async () => {
@@ -841,6 +909,62 @@ describe("userDeletion", () => {
     expect(row(tables, "chat_summaries", "summary-orphan")).toBeUndefined();
     expect(row(tables, "chat_summaries", "summary-latest")).toBeUndefined();
     expect(row(tables, "chat_summaries", "summary-other")).toBeTruthy();
+  });
+
+  it("dry-runs and executes orphan subagent residue cleanup", async () => {
+    const { cleanupDeletedUserResidue } = await import("../userDeletion");
+    const tables = seedTables();
+    tables.subagent_events.push({
+      _id: "subagent-event-orphan",
+      subagent_id: "sa-missing",
+      user_id: "deleted-user",
+    });
+    tables.subagent_work_items.push({
+      _id: "subagent-work-orphan",
+      subagent_id: "sa-missing",
+      user_id: "deleted-user",
+    });
+    const { ctx } = createMockCtx(tables);
+
+    const dryRun = await cleanupDeletedUserResidue.handler(ctx as any, {
+      serviceKey: "service_key",
+      orphanSubagentTable: "subagent_events",
+      orphanNumItems: 100,
+    });
+
+    expect(dryRun.hasMore).toBe(false);
+    expect(dryRun.orphanSubagentRowsTable).toBe("subagent_events");
+    expect(dryRun.orphanSubagentRowsScanned).toBe(3);
+    expect(dryRun.orphanSubagentRowsDeleted).toBe(1);
+    expect(
+      row(tables, "subagent_events", "subagent-event-orphan"),
+    ).toBeTruthy();
+
+    const eventExecute = await cleanupDeletedUserResidue.handler(ctx as any, {
+      serviceKey: "service_key",
+      orphanSubagentTable: "subagent_events",
+      dryRun: false,
+      orphanNumItems: 100,
+    });
+    const workExecute = await cleanupDeletedUserResidue.handler(ctx as any, {
+      serviceKey: "service_key",
+      orphanSubagentTable: "subagent_work_items",
+      dryRun: false,
+      orphanNumItems: 100,
+    });
+
+    expect(eventExecute.orphanSubagentRowsDeleted).toBe(1);
+    expect(workExecute.orphanSubagentRowsDeleted).toBe(1);
+    expect(
+      row(tables, "subagent_events", "subagent-event-orphan"),
+    ).toBeUndefined();
+    expect(
+      row(tables, "subagent_work_items", "subagent-work-orphan"),
+    ).toBeUndefined();
+    expect(row(tables, "subagent_events", "subagent-event-user")).toBeTruthy();
+    expect(
+      row(tables, "subagent_work_items", "subagent-work-other"),
+    ).toBeTruthy();
   });
 
   it("rejects bulk deleted-user residue cleanup in one transaction", async () => {

--- a/convex/__tests__/userDeletionFence.test.ts
+++ b/convex/__tests__/userDeletionFence.test.ts
@@ -48,5 +48,8 @@ describe("user deletion fence", () => {
     expect(subagents).toMatch(
       /reserveForBackend = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, args\.userId\)/,
     );
+    expect(subagents).toMatch(
+      /resumeForBackend = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, args\.userId\)/,
+    );
   });
 });

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -315,6 +315,28 @@ async function deleteSubagentDataForChat(
       await ctx.db.delete(message._id);
     }
     if (transcript.length > DELETE_CHAT_SUBAGENT_BATCH_SIZE) return true;
+
+    const events = await ctx.db
+      .query("subagent_events")
+      .withIndex("by_subagent", (q) => q.eq("subagent_id", child.subagent_id))
+      .take(DELETE_CHAT_SUBAGENT_BATCH_SIZE + 1);
+    for (const event of events.slice(0, DELETE_CHAT_SUBAGENT_BATCH_SIZE)) {
+      await ctx.db.delete(event._id);
+    }
+    if (events.length > DELETE_CHAT_SUBAGENT_BATCH_SIZE) return true;
+
+    const workItems = await ctx.db
+      .query("subagent_work_items")
+      .withIndex("by_subagent", (q) => q.eq("subagent_id", child.subagent_id))
+      .take(DELETE_CHAT_SUBAGENT_BATCH_SIZE + 1);
+    for (const workItem of workItems.slice(
+      0,
+      DELETE_CHAT_SUBAGENT_BATCH_SIZE,
+    )) {
+      await ctx.db.delete(workItem._id);
+    }
+    if (workItems.length > DELETE_CHAT_SUBAGENT_BATCH_SIZE) return true;
+
     await ctx.db.delete(child._id);
   }
   if (children.length > DELETE_CHAT_SUBAGENT_BATCH_SIZE) return true;

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -138,7 +138,7 @@ async function addPersonalCredits(
     ? await ctx.db
         .query("user_customization")
         .withIndex("by_user_id", (q) => q.eq("user_id", userId))
-        .first()
+        .unique()
     : null;
   const row = await ctx.db
     .query("extra_usage")

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -134,6 +134,12 @@ async function addPersonalCredits(
   options?: { activateForPaidUse?: boolean },
 ) {
   const amountPoints = dollarsToPoints(amountDollars);
+  const customization = options?.activateForPaidUse
+    ? await ctx.db
+        .query("user_customization")
+        .withIndex("by_user_id", (q) => q.eq("user_id", userId))
+        .first()
+    : null;
   const row = await ctx.db
     .query("extra_usage")
     .withIndex("by_user_id", (q) => q.eq("user_id", userId))
@@ -143,6 +149,10 @@ async function addPersonalCredits(
   if (row) {
     await ctx.db.patch(row._id, {
       balance_points: newBalancePoints,
+      ...(options?.activateForPaidUse &&
+      customization?.extra_usage_enabled !== true
+        ? { auto_reload_enabled: false }
+        : {}),
       updated_at: now,
     });
   } else {
@@ -154,11 +164,6 @@ async function addPersonalCredits(
   }
 
   if (options?.activateForPaidUse) {
-    const customization = await ctx.db
-      .query("user_customization")
-      .withIndex("by_user_id", (q) => q.eq("user_id", userId))
-      .first();
-
     if (customization) {
       await ctx.db.patch(customization._id, {
         extra_usage_enabled: true,

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -138,7 +138,7 @@ async function addPersonalCredits(
     ? await ctx.db
         .query("user_customization")
         .withIndex("by_user_id", (q) => q.eq("user_id", userId))
-        .unique()
+        .first()
     : null;
   const row = await ctx.db
     .query("extra_usage")

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1345,6 +1345,7 @@ export default defineSchema({
     created_at: v.number(),
   })
     .index("by_subagent", ["subagent_id"])
+    .index("by_user_id", ["user_id"])
     .index("by_parent_run", ["parent_trigger_run_id"])
     .index("by_parent_run_and_consumed_at", [
       "parent_trigger_run_id",
@@ -1377,6 +1378,7 @@ export default defineSchema({
     updated_at: v.number(),
   })
     .index("by_subagent", ["subagent_id"])
+    .index("by_user_id", ["user_id"])
     .index("by_parent_run", ["parent_trigger_run_id"]),
 
   // Webhook idempotency (prevents double-crediting on Stripe retries)

--- a/convex/subagents.ts
+++ b/convex/subagents.ts
@@ -111,6 +111,22 @@ const subagentSummaryValidator = v.object({
   updated_at: v.number(),
 });
 
+async function isSubagentChatAvailable(
+  ctx: MutationCtx,
+  userId: string,
+  chatId: string,
+) {
+  const chat = await ctx.db
+    .query("chats")
+    .withIndex("by_chat_id", (q) => q.eq("id", chatId))
+    .first();
+  return (
+    chat !== null &&
+    chat.user_id === userId &&
+    chat.deletion_started_at === undefined
+  );
+}
+
 const ACTIVE_SUBAGENT_STATUSES = ["queued", "running", "finalizing"] as const;
 const SUBAGENT_DELETION_CANCELLATION_BATCH_SIZE = 100;
 const MAX_SUBAGENT_PROGRESS_EVENTS = 32;
@@ -263,16 +279,7 @@ export const reserveForBackend = mutation({
     if (await isUserDeletionFenced(ctx.db, args.userId)) {
       return { outcome: "chat_missing" as const };
     }
-
-    const chat = await ctx.db
-      .query("chats")
-      .withIndex("by_chat_id", (q) => q.eq("id", args.chatId))
-      .first();
-    if (
-      !chat ||
-      chat.user_id !== args.userId ||
-      chat.deletion_started_at !== undefined
-    ) {
+    if (!(await isSubagentChatAvailable(ctx, args.userId, args.chatId))) {
       return { outcome: "chat_missing" as const };
     }
 
@@ -1900,6 +1907,12 @@ export const resumeForBackend = mutation({
   returns: v.any(),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
+    if (await isUserDeletionFenced(ctx.db, args.userId)) {
+      return { outcome: "not_found" as const };
+    }
+    if (!(await isSubagentChatAvailable(ctx, args.userId, args.chatId))) {
+      return { outcome: "not_found" as const };
+    }
     const rows = await ctx.db
       .query("subagent_runs")
       .withIndex("by_user_chat_and_parent_run", (q) =>

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -25,6 +25,8 @@ export const USER_DELETION_TABLE_POLICY = {
     "research_run_members",
     "research_user_profiles",
     "subagent_messages",
+    "subagent_events",
+    "subagent_work_items",
     "subagent_runs",
   ],
   anonymize: [
@@ -57,6 +59,7 @@ export const USER_DELETION_TABLE_POLICY = {
 
 type AnyDoc = { _id: Id<any>; [key: string]: any };
 type CleanupMode = "execute" | "dryRun";
+type OrphanSubagentTable = "subagent_events" | "subagent_work_items";
 
 // Convex counts full document payloads toward a mutation's 16 MiB read limit.
 // Share one document budget across the entire cleanup pass; the account
@@ -77,6 +80,11 @@ type CleanupStats = {
   orphanChatSummariesScanned: number;
   orphanChatSummariesIsDone: boolean;
   orphanChatSummariesContinueCursor?: string;
+  orphanSubagentRowsTable?: OrphanSubagentTable;
+  orphanSubagentRowsDeleted: number;
+  orphanSubagentRowsScanned: number;
+  orphanSubagentRowsIsDone: boolean;
+  orphanSubagentRowsContinueCursor?: string;
   s3ObjectsQueued: number;
 };
 
@@ -94,6 +102,13 @@ const cleanupStatsValidator = v.object({
   orphanChatSummariesScanned: v.number(),
   orphanChatSummariesIsDone: v.boolean(),
   orphanChatSummariesContinueCursor: v.optional(v.string()),
+  orphanSubagentRowsTable: v.optional(
+    v.union(v.literal("subagent_events"), v.literal("subagent_work_items")),
+  ),
+  orphanSubagentRowsDeleted: v.number(),
+  orphanSubagentRowsScanned: v.number(),
+  orphanSubagentRowsIsDone: v.boolean(),
+  orphanSubagentRowsContinueCursor: v.optional(v.string()),
   s3ObjectsQueued: v.number(),
 });
 
@@ -108,6 +123,9 @@ function createStats(): CleanupStats {
     orphanChatSummariesDeleted: 0,
     orphanChatSummariesScanned: 0,
     orphanChatSummariesIsDone: true,
+    orphanSubagentRowsDeleted: 0,
+    orphanSubagentRowsScanned: 0,
+    orphanSubagentRowsIsDone: true,
     s3ObjectsQueued: 0,
   };
 }
@@ -135,6 +153,12 @@ function mergeStats(target: CleanupStats, source: CleanupStats) {
   target.orphanChatSummariesIsDone = source.orphanChatSummariesIsDone;
   target.orphanChatSummariesContinueCursor =
     source.orphanChatSummariesContinueCursor;
+  target.orphanSubagentRowsTable = source.orphanSubagentRowsTable;
+  target.orphanSubagentRowsDeleted += source.orphanSubagentRowsDeleted;
+  target.orphanSubagentRowsScanned += source.orphanSubagentRowsScanned;
+  target.orphanSubagentRowsIsDone = source.orphanSubagentRowsIsDone;
+  target.orphanSubagentRowsContinueCursor =
+    source.orphanSubagentRowsContinueCursor;
 }
 
 function uniqueDocs<T extends AnyDoc>(docs: Array<T | null | undefined>): T[] {
@@ -445,6 +469,18 @@ async function cleanupUserDataForUser(
   >(ctx, budget, "subagent_messages", "by_user_id", (q) =>
     q.eq("user_id", userId),
   );
+  const subagentEventsBatch = await collectByIndexBatch<Doc<"subagent_events">>(
+    ctx,
+    budget,
+    "subagent_events",
+    "by_user_id",
+    (q) => q.eq("user_id", userId),
+  );
+  const subagentWorkItemsBatch = await collectByIndexBatch<
+    Doc<"subagent_work_items">
+  >(ctx, budget, "subagent_work_items", "by_user_id", (q) =>
+    q.eq("user_id", userId),
+  );
   const subagentRunsBatch = await collectByIndexBatch<Doc<"subagent_runs">>(
     ctx,
     budget,
@@ -467,6 +503,8 @@ async function cleanupUserDataForUser(
     researchRunMembersBatch,
     researchUserProfilesBatch,
     subagentMessagesBatch,
+    subagentEventsBatch,
+    subagentWorkItemsBatch,
     subagentRunsBatch,
   ];
   stats.hasMore ||= deletionBatches.some((batch) => batch.hasMore);
@@ -483,11 +521,15 @@ async function cleanupUserDataForUser(
   const researchRunMembers = researchRunMembersBatch.docs;
   const researchUserProfiles = researchUserProfilesBatch.docs;
   const subagentMessages = subagentMessagesBatch.docs;
+  const subagentEvents = subagentEventsBatch.docs;
+  const subagentWorkItems = subagentWorkItemsBatch.docs;
   const subagentRuns = subagentRunsBatch.docs;
 
   const chatsReadyToDelete =
     messagesBatch.hasMore ||
     subagentMessagesBatch.hasMore ||
+    subagentEventsBatch.hasMore ||
+    subagentWorkItemsBatch.hasMore ||
     subagentRunsBatch.hasMore
       ? []
       : chats.filter((chat) => !incompleteChatIds.has(chat.id));
@@ -499,6 +541,8 @@ async function cleanupUserDataForUser(
   await deleteDocs(ctx, stats, "messages", messages, mode);
   await deleteDocs(ctx, stats, "chat_summaries", chatSummaries, mode);
   await deleteDocs(ctx, stats, "subagent_messages", subagentMessages, mode);
+  await deleteDocs(ctx, stats, "subagent_events", subagentEvents, mode);
+  await deleteDocs(ctx, stats, "subagent_work_items", subagentWorkItems, mode);
   await deleteDocs(ctx, stats, "subagent_runs", subagentRuns, mode);
   await deleteDocs(ctx, stats, "chats", chatsReadyToDelete, mode);
   await deleteDocs(ctx, stats, "projects", projects, mode);
@@ -851,6 +895,43 @@ async function cleanupOrphanChatSummaries(
   return stats;
 }
 
+async function cleanupOrphanSubagentRows(
+  ctx: MutationCtx,
+  mode: CleanupMode,
+  table: OrphanSubagentTable,
+  opts: { cursor?: string | null; numItems: number },
+) {
+  const stats = createStats();
+  const page = await (ctx.db.query(table) as any).paginate({
+    cursor: opts.cursor ?? null,
+    numItems: opts.numItems,
+  });
+
+  stats.orphanSubagentRowsTable = table;
+  stats.orphanSubagentRowsScanned = page.page.length;
+  stats.orphanSubagentRowsIsDone = page.isDone;
+  stats.orphanSubagentRowsContinueCursor = page.continueCursor ?? undefined;
+  stats.hasMore = !page.isDone;
+
+  const orphanRows: Array<Doc<"subagent_events"> | Doc<"subagent_work_items">> =
+    [];
+  for (const row of page.page as Array<
+    Doc<"subagent_events"> | Doc<"subagent_work_items">
+  >) {
+    const run = await firstByIndex<Doc<"subagent_runs">>(
+      ctx,
+      "subagent_runs",
+      "by_subagent_id",
+      (q) => q.eq("subagent_id", row.subagent_id),
+    );
+    if (!run) orphanRows.push(row);
+  }
+
+  stats.orphanSubagentRowsDeleted = orphanRows.length;
+  await deleteDocs(ctx, stats, table, orphanRows, mode);
+  return stats;
+}
+
 /**
  * Preserve the legacy public function as a fail-closed compatibility shim.
  * Account deletion must run through the server route so Trigger runs and
@@ -911,6 +992,9 @@ export const cleanupDeletedUserResidue = mutation({
     userIds: v.optional(v.array(v.string())),
     dryRun: v.optional(v.boolean()),
     deleteOrphanChatSummaries: v.optional(v.boolean()),
+    orphanSubagentTable: v.optional(
+      v.union(v.literal("subagent_events"), v.literal("subagent_work_items")),
+    ),
     orphanCursor: v.optional(v.union(v.string(), v.null())),
     orphanNumItems: v.optional(v.number()),
   },
@@ -921,16 +1005,23 @@ export const cleanupDeletedUserResidue = mutation({
     const mode: CleanupMode = args.dryRun === false ? "execute" : "dryRun";
     const stats = createStats();
     const userIds = args.userIds ?? [];
+    const orphanOperations =
+      Number(args.deleteOrphanChatSummaries === true) +
+      Number(args.orphanSubagentTable !== undefined);
 
-    if (userIds.length === 0 && !args.deleteOrphanChatSummaries) {
+    if (userIds.length === 0 && orphanOperations === 0) {
+      throw new Error("Pass at least one userId or select one orphan cleanup");
+    }
+
+    if (userIds.length > 0 && orphanOperations > 0) {
       throw new Error(
-        "Pass at least one userId or enable deleteOrphanChatSummaries",
+        "Run user data cleanup and orphan cleanup in separate mutations to keep Convex transactions bounded",
       );
     }
 
-    if (userIds.length > 0 && args.deleteOrphanChatSummaries) {
+    if (orphanOperations > 1) {
       throw new Error(
-        "Run user data cleanup and orphan chat summary cleanup in separate mutations to keep Convex transactions bounded",
+        "Run each orphan cleanup in a separate mutation to keep Convex transactions bounded",
       );
     }
 
@@ -950,6 +1041,16 @@ export const cleanupDeletedUserResidue = mutation({
         await cleanupOrphanChatSummaries(ctx, mode, {
           cursor: args.orphanCursor,
           numItems: Math.min(Math.max(args.orphanNumItems ?? 500, 1), 1000),
+        }),
+      );
+    }
+
+    if (args.orphanSubagentTable) {
+      mergeStats(
+        stats,
+        await cleanupOrphanSubagentRows(ctx, mode, args.orphanSubagentTable, {
+          cursor: args.orphanCursor,
+          numItems: Math.min(Math.max(args.orphanNumItems ?? 100, 1), 100),
         }),
       );
     }

--- a/scripts/cleanup-deleted-user-residue.ts
+++ b/scripts/cleanup-deleted-user-residue.ts
@@ -131,9 +131,10 @@ function parseArgs(argv: string[]): Options {
     throw new Error("Select only one orphan cleanup per run");
   }
 
+  const maxOrphanNumItems = options.orphanSubagentTable ? 100 : 1000;
   options.orphanNumItems = Math.min(
     Math.max(Math.round(options.orphanNumItems), 1),
-    1000,
+    maxOrphanNumItems,
   );
 
   return options;

--- a/scripts/cleanup-deleted-user-residue.ts
+++ b/scripts/cleanup-deleted-user-residue.ts
@@ -12,6 +12,7 @@ type Options = {
   userIds: string[];
   execute: boolean;
   deleteOrphanChatSummaries: boolean;
+  orphanSubagentTable?: "subagent_events" | "subagent_work_items";
   orphanCursor?: string;
   orphanNumItems: number;
 };
@@ -25,13 +26,16 @@ Dry-run is the default. Pass --execute to apply the cleanup.
 Usage:
   pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --user <workos_user_id>
   pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --orphans
-  pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --user <id> --orphans --execute
+  pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --orphan-subagent-events
+  pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --orphan-subagent-work-items
 
 Options:
   --user <id>       Deleted WorkOS user id to clean. Run once per user id.
   --orphans         Include orphan chat_summaries cleanup.
-  --cursor <cursor> Continue an orphan chat_summaries scan from a prior result.
-  --limit <number>  Orphan chat_summaries page size. Default 500, max 1000.
+  --orphan-subagent-events     Scan subagent_events whose parent run is gone.
+  --orphan-subagent-work-items Scan subagent_work_items whose parent run is gone.
+  --cursor <cursor> Continue the selected orphan scan from a prior result.
+  --limit <number>  Orphan page size. Default 500; subagent scans max at 100.
   --execute         Apply changes. Omit for dry-run.
   --help            Show this message.
 `);
@@ -59,6 +63,16 @@ function parseArgs(argv: string[]): Options {
 
     if (arg === "--orphans") {
       options.deleteOrphanChatSummaries = true;
+      continue;
+    }
+
+    if (arg === "--orphan-subagent-events") {
+      options.orphanSubagentTable = "subagent_events";
+      continue;
+    }
+
+    if (arg === "--orphan-subagent-work-items") {
+      options.orphanSubagentTable = "subagent_work_items";
       continue;
     }
 
@@ -109,6 +123,14 @@ function parseArgs(argv: string[]): Options {
     throw new Error("Run this script once per --user to keep cleanup bounded");
   }
 
+  if (
+    Number(options.deleteOrphanChatSummaries) +
+      Number(options.orphanSubagentTable !== undefined) >
+    1
+  ) {
+    throw new Error("Select only one orphan cleanup per run");
+  }
+
   options.orphanNumItems = Math.min(
     Math.max(Math.round(options.orphanNumItems), 1),
     1000,
@@ -119,7 +141,11 @@ function parseArgs(argv: string[]): Options {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  if (options.userIds.length === 0 && !options.deleteOrphanChatSummaries) {
+  if (
+    options.userIds.length === 0 &&
+    !options.deleteOrphanChatSummaries &&
+    !options.orphanSubagentTable
+  ) {
     printUsage();
     process.exit(1);
   }
@@ -140,6 +166,7 @@ async function main() {
       userIds: options.userIds.length > 0 ? options.userIds : undefined,
       dryRun: !options.execute,
       deleteOrphanChatSummaries: options.deleteOrphanChatSummaries,
+      orphanSubagentTable: options.orphanSubagentTable,
       orphanCursor: options.orphanCursor,
       orphanNumItems: options.orphanNumItems,
     },
@@ -157,12 +184,14 @@ async function main() {
   );
 
   if (
-    options.deleteOrphanChatSummaries &&
-    result.orphanChatSummariesContinueCursor
+    (options.deleteOrphanChatSummaries &&
+      result.orphanChatSummariesContinueCursor) ||
+    (options.orphanSubagentTable && result.orphanSubagentRowsContinueCursor)
   ) {
-    console.log(
-      `Next orphan cursor: ${result.orphanChatSummariesContinueCursor}`,
-    );
+    const nextCursor = options.deleteOrphanChatSummaries
+      ? result.orphanChatSummariesContinueCursor
+      : result.orphanSubagentRowsContinueCursor;
+    console.log(`Next orphan cursor: ${nextCursor}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- prevent referral credit activation from restoring auto-reload after a user disabled Extra Usage, while preserving auto-reload for already-enabled users
- delete subagent events and work items during chat and account deletion before their parent runs
- fence subagent continuation on account deletion and live chat ownership/deletion state
- add bounded, dry-run-by-default cleanup commands for historical orphan subagent residue

## Security properties

- automatic referral activation cannot authorize a retained auto-reload preference
- account and chat deletion drain subagent child records before deleting parent runs
- continuation cannot recreate work after account or chat deletion begins
- rows orphaned by pre-fix deletions have an explicit bounded remediation path

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm exec jest --runInBand` — 434 suites, 4,529 tests passed
- changed-file ESLint and Prettier checks
- repository lint — zero errors; seven existing warnings outside this diff
- local dependency isolation and Strix skill-catalog checks
- independent read-only security bypass review — no actionable findings

The repository-wide Prettier check remains red on ten unrelated pre-existing files; every changed file passes Prettier.

## Post-deploy residue cleanup

Do not run these commands until the target Convex account, team, project, deployment, URL, and local CLI selection have been independently verified for the intended HackerAI environment.

Start with dry runs and follow any returned cursor one page at a time:

```sh
pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --orphan-subagent-events
pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --orphan-subagent-work-items
```

After reviewing dry-run counts, repeat with `--execute`; pass `--cursor <cursor>` until each scan is complete. Run Preview and Production separately against their designated Convex accounts/deployments.

## Manual verification

After deployment, in a disposable account/chat:

1. Disable Extra Usage with auto-reload previously enabled, award a referral conversion, and verify referral credits are usable while auto-reload remains off.
2. Start account/chat deletion with completed subagent data present and verify events, work items, messages, runs, and the chat are removed in dependency order.
3. Attempt `continue_agent` after account deletion is fenced and after chat deletion begins; verify no child is requeued.

No feature flag is used because these are correctness and security fixes that should apply consistently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat deletion now removes associated subagent activity and work records.
  * User deletion cleanup removes related subagent data and orphaned records while preserving other users’ data.
  * Resuming subagent work is blocked for deleted users or unavailable chats.
  * Referral credit awards now correctly manage auto-reload settings.

* **Maintenance**
  * Added safeguards, indexing, and progress tracking for large, resumable cleanup operations.
  * Improved detection and cleanup of orphaned subagent records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->