### PR TITLE
Fix consent banner on static public pages

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -109,13 +109,14 @@ describe("proxy", () => {
   });
 
   it.each([
+    "/api/analytics-consent",
     "/api/health/connectivity",
     "/api/health/core",
     "/api/health/trigger-agent-mode",
     "/api/cron/platform-costs/convex",
     "/api/cron/platform-costs/vercel",
   ])(
-    "bypasses AuthKit for the independently authenticated endpoint %s",
+    "bypasses AuthKit for the public or independently authenticated endpoint %s",
     async (pathname) => {
       const { default: proxy } = await import("../proxy");
 

--- a/app/api/analytics-consent/__tests__/route.test.ts
+++ b/app/api/analytics-consent/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+const mockNextResponseJson = jest.fn(
+  (body: unknown, init?: { headers?: Record<string, string> }) => ({
+    headers: new Headers(init?.headers),
+    json: async () => body,
+  }),
+);
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: mockNextResponseJson,
+  },
+}));
+
+const originalNodeEnv = process.env.NODE_ENV;
+const { GET } = jest.requireActual<typeof import("../route")>("../route");
+
+function createRequest({
+  consent,
+  countryCode,
+}: {
+  consent?: string;
+  countryCode?: string;
+}): NextRequest {
+  return {
+    cookies: {
+      get: jest.fn((name: string) =>
+        name === "hackerai_analytics_consent" && consent
+          ? { name, value: consent }
+          : undefined,
+      ),
+    },
+    headers: new Headers(
+      countryCode ? { "x-vercel-ip-country": countryCode } : undefined,
+    ),
+  } as unknown as NextRequest;
+}
+
+describe("GET /api/analytics-consent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NODE_ENV = "test";
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("does not require an initial choice in the United States", async () => {
+    const response = await GET(createRequest({ countryCode: "US" }));
+
+    await expect(response.json()).resolves.toEqual({
+      consent: null,
+      consentRequired: false,
+    });
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("requires a choice in a covered country", async () => {
+    const response = await GET(createRequest({ countryCode: "DE" }));
+
+    await expect(response.json()).resolves.toEqual({
+      consent: null,
+      consentRequired: true,
+    });
+  });
+
+  it("returns a saved choice", async () => {
+    const response = await GET(
+      createRequest({ countryCode: "DE", consent: "declined" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      consent: "declined",
+      consentRequired: true,
+    });
+  });
+
+  it("fails closed in production when country data is unavailable", async () => {
+    process.env.NODE_ENV = "production";
+
+    const response = await GET(createRequest({}));
+
+    await expect(response.json()).resolves.toEqual({
+      consent: null,
+      consentRequired: true,
+    });
+  });
+});

--- a/app/api/analytics-consent/route.ts
+++ b/app/api/analytics-consent/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  ANALYTICS_CONSENT_COOKIE_NAME,
+  countryCodeFromHeaders,
+  getAnalyticsConsentDecision,
+} from "@/lib/privacy/analytics-consent";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(request: NextRequest) {
+  const decision = getAnalyticsConsentDecision({
+    cookieValue: request.cookies.get(ANALYTICS_CONSENT_COOKIE_NAME)?.value,
+    countryCode: countryCodeFromHeaders(request.headers),
+    failClosed: process.env.NODE_ENV === "production",
+  });
+
+  return NextResponse.json(
+    {
+      consent: decision.consent,
+      consentRequired: decision.consentRequired,
+    },
+    {
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    },
+  );
+}

--- a/app/components/AnalyticsConsentManager.tsx
+++ b/app/components/AnalyticsConsentManager.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { XIcon } from "lucide-react";
+import useSWRImmutable from "swr/immutable";
 import {
   createContext,
   useCallback,
@@ -21,7 +22,9 @@ import {
 import type { FirstTouchAttribution } from "@/lib/analytics/acquisition";
 import {
   type AnalyticsConsent,
+  type AnalyticsConsentStatus,
   isAnalyticsAllowed,
+  parseAnalyticsConsent,
 } from "@/lib/privacy/analytics-consent";
 
 type AnalyticsConsentManagerProps = {
@@ -29,6 +32,7 @@ type AnalyticsConsentManagerProps = {
   consentRequired: boolean;
   firstTouchAttribution?: FirstTouchAttribution | null;
   initialConsent: AnalyticsConsent | null;
+  initialDecisionResolved?: boolean;
 };
 
 type ChoiceButtonsProps = {
@@ -47,6 +51,31 @@ type AnalyticsConsentPreferencesContextValue = {
 
 const AnalyticsConsentPreferencesContext =
   createContext<AnalyticsConsentPreferencesContextValue | null>(null);
+
+const ANALYTICS_CONSENT_STATUS_ENDPOINT = "/api/analytics-consent";
+
+async function fetchAnalyticsConsentStatus(
+  url: string,
+): Promise<AnalyticsConsentStatus> {
+  const response = await fetch(url, {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+  if (!response.ok) {
+    throw new Error("Unable to resolve analytics consent");
+  }
+
+  const status = (await response.json()) as Partial<AnalyticsConsentStatus>;
+  const consent = parseAnalyticsConsent(status.consent);
+  if (
+    typeof status.consentRequired !== "boolean" ||
+    (status.consent !== null && consent === null)
+  ) {
+    throw new Error("Invalid analytics consent response");
+  }
+
+  return { consent, consentRequired: status.consentRequired };
+}
 
 export function useAnalyticsConsentPreferencesAvailable() {
   return useContext(AnalyticsConsentPreferencesContext)?.available ?? false;
@@ -174,20 +203,50 @@ export function AnalyticsConsentManager({
   consentRequired,
   firstTouchAttribution = null,
   initialConsent,
+  initialDecisionResolved = true,
 }: AnalyticsConsentManagerProps) {
-  const [consent, setConsent] = useState(initialConsent);
+  const [chosenConsent, setChosenConsent] = useState<AnalyticsConsent | null>(
+    null,
+  );
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  const analyticsAllowed = isAnalyticsAllowed({ consent, consentRequired });
-  const needsInitialChoice = consentRequired && consent === null;
+  const { data: runtimeStatus, error: runtimeStatusError } =
+    useSWRImmutable<AnalyticsConsentStatus>(
+      initialDecisionResolved ? null : ANALYTICS_CONSENT_STATUS_ENDPOINT,
+      fetchAnalyticsConsentStatus,
+      { shouldRetryOnError: false },
+    );
+
+  const decisionResolved =
+    initialDecisionResolved ||
+    runtimeStatus !== undefined ||
+    runtimeStatusError !== undefined;
+  const runtimeResolutionFailed =
+    !initialDecisionResolved && runtimeStatusError !== undefined;
+  const effectiveConsentRequired =
+    !decisionResolved || runtimeResolutionFailed
+      ? true
+      : (runtimeStatus?.consentRequired ?? consentRequired);
+  const resolvedConsent =
+    runtimeStatus === undefined ? initialConsent : runtimeStatus.consent;
+  const consent = chosenConsent ?? resolvedConsent;
+
+  const analyticsAllowed =
+    decisionResolved &&
+    isAnalyticsAllowed({
+      consent,
+      consentRequired: effectiveConsentRequired,
+    });
+  const needsInitialChoice =
+    decisionResolved && effectiveConsentRequired && consent === null;
 
   const chooseConsent = useCallback(async (choice: AnalyticsConsent) => {
     setIsSaving(true);
     setSaveError(null);
     try {
       await saveAnalyticsConsent(choice);
-      setConsent(choice);
+      setChosenConsent(choice);
       return true;
     } catch {
       setSaveError("We couldn't save your choice. Please try again.");
@@ -199,20 +258,20 @@ export function AnalyticsConsentManager({
 
   const preferences = useMemo(
     () => ({
-      available: consent !== null,
+      available: decisionResolved && consent !== null,
       consent,
       isSaving,
       saveError,
       chooseConsent,
     }),
-    [consent, isSaving, saveError, chooseConsent],
+    [consent, decisionResolved, isSaving, saveError, chooseConsent],
   );
 
   return (
     <AnalyticsConsentPreferencesContext.Provider value={preferences}>
       <PostHogProvider
         analyticsAllowed={analyticsAllowed}
-        consentRequired={consentRequired}
+        consentRequired={effectiveConsentRequired}
         firstTouchAttribution={firstTouchAttribution}
       >
         {children}

--- a/app/components/__tests__/AnalyticsConsentManager.test.tsx
+++ b/app/components/__tests__/AnalyticsConsentManager.test.tsx
@@ -1,8 +1,18 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { SWRConfig } from "swr";
 
 const mockSaveAnalyticsConsent = jest.fn<() => Promise<void>>();
+const mockFetch = jest.fn<typeof fetch>();
+const originalFetch = global.fetch;
 
 jest.mock("@/app/actions/analytics-consent", () => ({
   saveAnalyticsConsent: mockSaveAnalyticsConsent,
@@ -43,10 +53,21 @@ function TestContent() {
   );
 }
 
+function renderWithFreshSWR(children: React.ReactNode) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>,
+  );
+}
+
 describe("AnalyticsConsentManager", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSaveAnalyticsConsent.mockResolvedValue(undefined);
+    global.fetch = mockFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   it("blocks analytics and asks covered visitors for a choice", () => {
@@ -169,6 +190,84 @@ describe("AnalyticsConsentManager", () => {
     expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
       "data-analytics-allowed",
       "true",
+    );
+  });
+
+  it("resolves a static-page visitor before enabling analytics", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ consent: null, consentRequired: false }),
+    } as Response);
+
+    renderWithFreshSWR(
+      <AnalyticsConsentManager
+        consentRequired
+        initialConsent={null}
+        initialDecisionResolved={false}
+      >
+        <TestContent />
+      </AnalyticsConsentManager>,
+    );
+
+    expect(screen.queryByText("Optional analytics")).not.toBeInTheDocument();
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+        "data-analytics-allowed",
+        "true",
+      ),
+    );
+    expect(mockFetch).toHaveBeenCalledWith("/api/analytics-consent", {
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    expect(screen.queryByText("Optional analytics")).not.toBeInTheDocument();
+  });
+
+  it("asks a covered static-page visitor after resolving their region", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ consent: null, consentRequired: true }),
+    } as Response);
+
+    renderWithFreshSWR(
+      <AnalyticsConsentManager
+        consentRequired
+        initialConsent={null}
+        initialDecisionResolved={false}
+      >
+        <TestContent />
+      </AnalyticsConsentManager>,
+    );
+
+    expect(await screen.findByText("Optional analytics")).toBeInTheDocument();
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
+    );
+  });
+
+  it("fails closed when static-page consent resolution fails", async () => {
+    mockFetch.mockRejectedValue(new Error("network"));
+
+    renderWithFreshSWR(
+      <AnalyticsConsentManager
+        consentRequired={false}
+        initialConsent={null}
+        initialDecisionResolved={false}
+      >
+        <TestContent />
+      </AnalyticsConsentManager>,
+    );
+
+    expect(await screen.findByText("Optional analytics")).toBeInTheDocument();
+    expect(screen.getByTestId("posthog-provider")).toHaveAttribute(
+      "data-analytics-allowed",
+      "false",
     );
   });
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -138,9 +138,10 @@ export default async function RootLayout({
   const firstTouchAttribution = parseFirstTouchAttributionCookie(
     cookieStore.get(FIRST_TOUCH_ATTRIBUTION_COOKIE_NAME)?.value,
   );
+  const countryCode = countryCodeFromHeaders(requestHeaders);
   const analyticsConsent = getAnalyticsConsentDecision({
     cookieValue: cookieStore.get(ANALYTICS_CONSENT_COOKIE_NAME)?.value,
-    countryCode: countryCodeFromHeaders(requestHeaders),
+    countryCode,
     // If a production proxy ever stops providing country data, ask rather
     // than silently placing optional analytics storage on a covered visitor.
     failClosed: process.env.NODE_ENV === "production",
@@ -152,6 +153,7 @@ export default async function RootLayout({
         consentRequired={analyticsConsent.consentRequired}
         firstTouchAttribution={firstTouchAttribution}
         initialConsent={analyticsConsent.consent}
+        initialDecisionResolved={countryCode !== null}
       >
         <AgentAutoReviewAvailabilityProvider>
           <ChunkLoadRecovery />

--- a/lib/privacy/analytics-consent.ts
+++ b/lib/privacy/analytics-consent.ts
@@ -3,6 +3,11 @@ export const ANALYTICS_CONSENT_MAX_AGE_SECONDS = 180 * 24 * 60 * 60;
 
 export type AnalyticsConsent = "accepted" | "declined";
 
+export type AnalyticsConsentStatus = {
+  consent: AnalyticsConsent | null;
+  consentRequired: boolean;
+};
+
 const CONSENT_REQUIRED_COUNTRY_CODES = new Set([
   // European Union
   "AT",

--- a/proxy.ts
+++ b/proxy.ts
@@ -21,6 +21,7 @@ import {
 } from "@/lib/privacy/analytics-consent";
 
 const AUTHKIT_BYPASS_PATHS = new Set([
+  "/api/analytics-consent",
   "/api/health/connectivity",
   "/api/health/core",
   "/api/health/trigger-agent-mode",


### PR DESCRIPTION
## Summary
- preserve static public-page rendering while resolving analytics consent from a request-time endpoint
- keep analytics disabled until the region and saved choice are known, with fail-closed behavior on lookup failure
- expose the status endpoint without AuthKit and add regression coverage for U.S., covered-region, saved-choice, and failure paths

## Validation
- `pnpm test --runInBand` — 439 suites and 4,552 tests passed
- `pnpm typecheck`
- `pnpm lint` — no errors; 7 pre-existing warnings
- `pnpm build` — public pages remain static and `/api/analytics-consent` is dynamic
- Browser: simulated U.S. Terms page renders without the banner
- Browser: simulated German Privacy page renders with the banner
- Browser console: no errors on the verified flow

## Manual verification
1. Open `/terms-of-service` or `/privacy-policy` from a U.S. connection in a fresh tab; the page should render without the analytics banner.
2. Open either page from an EU/EEA/UK connection with no saved choice; the analytics banner should appear.
3. Save a choice and reload; the saved choice should be honored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime analytics-consent resolution based on visitor location and saved preferences.
  * Visitors in covered regions are prompted for consent before analytics is enabled.
  * Visitors exempt from consent requirements can use analytics without an additional prompt.
  * Consent decisions are handled conservatively when location or resolution data is unavailable.
  * Added a public endpoint for retrieving the current analytics-consent decision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->