### PR TITLE
Use non-reasoning DeepSeek 0731 for free Ask

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -113,7 +113,7 @@ describe("provider registry", () => {
     expect(
       (myProvider.languageModel("ask-model-free") as { modelId: string })
         .modelId,
-    ).toBe("deepseek/deepseek-v4-flash");
+    ).toBe("deepseek/deepseek-v4-flash-0731");
     expect(
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
@@ -276,7 +276,7 @@ describe("provider registry", () => {
     const provider = createTrackedProvider();
     expect(
       (provider.languageModel("ask-model-free") as { modelId: string }).modelId,
-    ).toBe("deepseek/deepseek-v4-flash");
+    ).toBe("deepseek/deepseek-v4-flash-0731");
     expect(
       (provider.languageModel("agent-model-free") as { modelId: string })
         .modelId,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1226,7 +1226,7 @@ export const getOpenRouterProviderRoutingForModel = (
 
 const buildProviderMap = (
   or: OpenRouterInstance,
-  freeAskModelSlug = DEEPSEEK_V4_FLASH_PREVIOUS_SLUG,
+  freeAskModelSlug = DEEPSEEK_V4_FLASH_SLUG,
   freeAgentModelSlug = DEEPSEEK_V4_FLASH_SLUG,
 ) =>
   ({

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -269,13 +269,14 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("runs free Ask on DeepSeek V4 Flash with GLM Flash first fallback", () => {
+  it("runs free Ask on non-reasoning DeepSeek V4 Flash 0731", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
     expect(opts.openrouter).toMatchObject({
-      provider: { ignore: ["novita"] },
+      reasoning: { enabled: false },
       models: [GLM_FLASH_SLUG, DEEPSEEK_V4_PRO_0813_SLUG, GLM_SLUG],
       user: "user-1",
     });
+    expect(opts.openrouter).not.toHaveProperty("provider");
     expect(opts.openrouter.models).toHaveLength(3);
   });
 
@@ -439,11 +440,10 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it("uses high reasoning for free Ask across its fallback chain", () => {
+  it("disables reasoning for free Ask across its fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
     expect(opts.openrouter.reasoning).toEqual({
-      enabled: true,
-      effort: "high",
+      enabled: false,
     });
     expect(opts.openrouter.models).toEqual([
       GLM_FLASH_SLUG,
@@ -452,7 +452,7 @@ describe("buildProviderOptions fallback chain", () => {
     ]);
   });
 
-  it("keeps free Ask reasoning high over a lower scoped override", () => {
+  it("keeps free Ask reasoning disabled over a scoped override", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -464,8 +464,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
 
     expect(opts.openrouter.reasoning).toEqual({
-      enabled: true,
-      effort: "high",
+      enabled: false,
     });
     expect(opts.openrouter.models).toEqual([
       GLM_FLASH_SLUG,
@@ -474,7 +473,7 @@ describe("buildProviderOptions fallback chain", () => {
     ]);
   });
 
-  it("keeps free Ask high reasoning for an explicit high override", () => {
+  it("keeps free Ask reasoning disabled over an explicit high override", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -486,8 +485,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
 
     expect(opts.openrouter.reasoning).toEqual({
-      enabled: true,
-      effort: "high",
+      enabled: false,
     });
   });
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -598,12 +598,6 @@ const DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN = [
   "model-glm-5.3",
 ] as const satisfies readonly ModelName[];
 
-const DEEPSEEK_V4_FLASH_PREVIOUS_FALLBACK_CHAIN = [
-  "model-glm-5.3-flash",
-  "model-deepseek-v4-pro-0813",
-  "model-glm-5.3",
-] as const satisfies readonly ModelName[];
-
 const LEGACY_AGENT_GLM_FLASH_FALLBACK_CHAIN = [
   "model-deepseek-v4-flash-0731",
   "model-deepseek-v4-pro-0813",
@@ -628,7 +622,7 @@ const HACKERAI_PRO_FALLBACK_CHAIN = [
 ] as const satisfies readonly ModelName[];
 
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
-  "ask-model-free": DEEPSEEK_V4_FLASH_PREVIOUS_FALLBACK_CHAIN,
+  "ask-model-free": DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN,
   "model-glm-5.3-flash-agent": LEGACY_AGENT_GLM_FLASH_FALLBACK_CHAIN,
   "model-deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN,
@@ -968,6 +962,9 @@ export function buildProviderOptions(
     options.requestedModelSlug ??
     (modelName ? resolveSlug(modelName) : undefined);
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
+  // Free Ask is intentionally fast/non-reasoning even when a caller supplies
+  // a reasoning override. DeepSeek V4 Flash 0731 defaults to reasoning on.
+  const isFreeAsk = mode === "ask" && modelName === "ask-model-free";
   const isGrok45 = modelId === GROK_4_5_SLUG;
   const isGrok46 = modelId === GROK_4_6_SLUG;
   // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this
@@ -1029,7 +1026,9 @@ export function buildProviderOptions(
 
   return {
     openrouter: {
-      ...(!usesDefaultGlmFlashAgentReasoning && { reasoning }),
+      ...(!usesDefaultGlmFlashAgentReasoning && {
+        reasoning: isFreeAsk ? { enabled: false } : reasoning,
+      }),
       ...(options.hasPdfAttachments && isDeepSeekV4
         ? {
             plugins: [

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -570,7 +570,6 @@ describe("token-bucket", () => {
     );
 
     it.each([
-      "ask-model-free",
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-flash-20260423",
     ])(
@@ -582,6 +581,7 @@ describe("token-bucket", () => {
     );
 
     it.each([
+      "ask-model-free",
       "agent-model-free",
       "agent-auto-review-model",
       "deepseek/deepseek-v4-flash-0731",

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -140,9 +140,9 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "agent-model": GROK_4_6_BASE_PRICING,
   "fallback-agent-model": GROK_4_6_BASE_PRICING,
   "fallback-ask-model": GROK_4_6_BASE_PRICING,
-  // Free Ask retains the original Flash route while free Agent uses the 0731
-  // revision. Provider fallbacks are reconciled against their served model.
-  "ask-model-free": DEEPSEEK_V4_FLASH_PRICING,
+  // Both free routes use the 0731 revision. Provider fallbacks are reconciled
+  // against their served model.
+  "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   // DeepSeek V4 Flash 0731 rates from OpenRouter: $0.14 in / $0.28 out per 1M tokens.
   "agent-auto-review-model": DEEPSEEK_V4_FLASH_0731_PRICING,


### PR DESCRIPTION
## Summary
- route the free Ask model to `deepseek/deepseek-v4-flash-0731`
- explicitly disable reasoning for free Ask, including when a scoped override is present
- account free Ask usage against the existing 0731 pricing profile

DeepSeek documents V4 Flash 0731 as supporting both non-thinking and thinking modes: https://api-docs.deepseek.com/quick_start/pricing/

OpenRouter currently reports `mandatory: false` and `default_enabled: true` for this model: https://openrouter.ai/deepseek/deepseek-v4-flash-0731

## Validation
- `pnpm typecheck`
- ESLint on changed files
- `pnpm test` (441 suites, 4570 tests)

## Manual verification
- In a free account, send a text-only Ask message.
- Confirm the request resolves to `deepseek/deepseek-v4-flash-0731` with `reasoning.enabled: false`, streams a normal answer, and incurs the 0731 pricing profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - The free Ask experience now uses the latest DeepSeek V4 Flash 0731 model revision.
  - Free Ask requests now consistently follow the updated model’s pricing configuration.
  - Reasoning remains disabled for free Ask requests, regardless of selected reasoning settings.
  - Fallback behavior has been aligned with the current DeepSeek V4 Flash model route for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->