### PR TITLE
Structure desktop attachment staging failures

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -2485,6 +2485,22 @@ describe("CentrifugoSandbox", () => {
       // No certutil / cmd.exe artifacts.
       expect(runs[1]).not.toContain("certutil");
     });
+
+    it("keeps a bounded exit status when local file preparation has no output", async () => {
+      const { sandbox } = createWindowsBashSandbox();
+      (sandbox as any).commands.run = jest.fn(async () => ({
+        stdout: "",
+        stderr: "",
+        exitCode: 1,
+      }));
+
+      await expect(
+        sandbox.files.copyLocal(
+          "C:\\Users\\alice\\private-report.pdf",
+          "/tmp/hackerai-upload/private-report.pdf",
+        ),
+      ).rejects.toThrow("Failed to prepare local file: exit status 1");
+    });
   });
 
   describe("getSandboxContext", () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1694,9 +1694,9 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         displayName: `Preparing: ${fileName}`,
       });
       if (result.exitCode !== 0) {
-        throw new Error(
-          `Failed to prepare local file: ${result.stderr || result.stdout}`,
-        );
+        const failureDetail =
+          result.stderr || result.stdout || `exit status ${result.exitCode}`;
+        throw new Error(`Failed to prepare local file: ${failureDetail}`);
       }
     },
 

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -577,14 +577,26 @@ export const createAgentTriggerPost =
           let stagedSandbox: any = null;
           let uploadResult: Awaited<ReturnType<typeof uploadSandboxFiles>>;
           try {
-            uploadResult = await uploadSandboxFiles(sandboxFiles, async () => {
-              const { sandbox } = await getSandboxWithFallbackGuard({
-                sandboxManager,
-                requireLocalSandbox: true,
-              });
-              stagedSandbox = sandbox;
-              return sandbox;
-            });
+            uploadResult = await uploadSandboxFiles(
+              sandboxFiles,
+              async () => {
+                const { sandbox } = await getSandboxWithFallbackGuard({
+                  sandboxManager,
+                  requireLocalSandbox: true,
+                });
+                stagedSandbox = sandbox;
+                return sandbox;
+              },
+              {
+                logContext: {
+                  service: "hackerai-web",
+                  requestId:
+                    req.headers.get("x-vercel-id")?.slice(0, 128) ?? undefined,
+                  userId,
+                  chatId,
+                },
+              },
+            );
           } finally {
             await stagedSandbox?.close?.().catch(() => {});
           }

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -593,7 +593,7 @@ export const createAgentTriggerPost =
                   requestId:
                     req.headers.get("x-vercel-id")?.slice(0, 128) ?? undefined,
                   userId,
-                  chatId,
+                  chatId: chatId.slice(0, 128),
                 },
               },
             );

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -1149,6 +1149,12 @@ describe("desktop-local sandbox file helpers", () => {
           upload_failure_transient_sandbox_command: false,
           upload_failure_sandbox_readiness_reason: "unknown",
         });
+        expect(
+          JSON.parse(String(consoleErrorSpy.mock.calls[0]?.[0])),
+        ).toMatchObject({
+          event: "sandbox_attachment_staging_failed",
+          failure_exit_code: exitCode,
+        });
       } finally {
         consoleErrorSpy.mockRestore();
       }
@@ -1186,6 +1192,64 @@ describe("desktop-local sandbox file helpers", () => {
       expect(getSandboxUploadUserMessage(result)).toContain(
         "selected Windows computer",
       );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs bounded context for local attachment preparation failures", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const sourcePath = "C:\\Users\\alice\\private-report.pdf";
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "localPath",
+            path: sourcePath,
+            localPath: "/tmp/hackerai-upload/private-report.pdf",
+          },
+        ],
+        async () => ({
+          files: {
+            copyLocal: jest
+              .fn()
+              .mockRejectedValue(
+                new Error("Failed to prepare local file: exit status 1"),
+              ),
+          },
+        }),
+        {
+          logContext: {
+            service: "hackerai-web",
+            requestId: "request-1",
+            userId: "user-1",
+            chatId: "chat-1",
+          },
+        },
+      );
+
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_reason: "local_file_prepare_failed",
+      });
+      const structuredLog = JSON.parse(
+        String(consoleErrorSpy.mock.calls[0]?.[0]),
+      );
+      expect(structuredLog).toMatchObject({
+        event: "sandbox_attachment_staging_failed",
+        service: "hackerai-web",
+        request_id: "request-1",
+        user_id: "user-1",
+        chat_id: "chat-1",
+        failed_count: 1,
+        total_count: 1,
+        failure_reason: "local_file_prepare_failed",
+        failure_exit_code: 1,
+      });
+      expect(JSON.stringify(structuredLog)).not.toContain(sourcePath);
+      expect(JSON.stringify(structuredLog)).not.toContain("private-report.pdf");
     } finally {
       consoleErrorSpy.mockRestore();
     }

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -35,6 +35,7 @@ export type SandboxUploadResult = {
 export type SandboxUploadFailureReason =
   | "local_command_no_response"
   | "local_command_unavailable"
+  | "local_file_prepare_failed"
   | "windows_command_syntax"
   | "sandbox_placement_failure"
   | "sandbox_operation_timeout"
@@ -71,7 +72,7 @@ type EnsureSandboxForUpload = (options?: SandboxRefreshOptions) => Promise<any>;
 type UploadSandboxFilesOptions = {
   retryWithFreshSandboxOnTransientFailure?: boolean | (() => boolean);
   logContext?: {
-    service: "agent-long" | "chat-handler";
+    service: "agent-long" | "chat-handler" | "hackerai-web";
     requestId?: string;
     userId: string;
     chatId: string;
@@ -109,7 +110,9 @@ const extractCommandExitCode = (error: unknown): number | null => {
   }
 
   const message = error instanceof Error ? error.message : String(error);
-  const match = message.match(/\bexit status (\d+)\b/i);
+  const match =
+    message.match(/\b(?:exit status|exitCode:|curl exit)\s*(\d+)\b/i) ??
+    message.match(/\bcurl:\s*\((\d+)\)/i);
   if (!match) return null;
 
   return Number.parseInt(match[1], 10);
@@ -144,6 +147,7 @@ const LOCAL_COMMAND_NO_RESPONSE_PATTERN =
   /\bCommand timeout after \d+ms\b[^\n]*\bpublished:\s*\d+ms\b[^\n]*\bfirstMsg:\s*no\b[^\n]*\bconnectionId=/i;
 const LOCAL_COMMAND_UNAVAILABLE_PATTERN =
   /\blocal sandbox connection\b.*\bis not subscribed to the command relay\b/i;
+const LOCAL_FILE_PREPARE_FAILURE_PATTERN = /\bFailed to prepare local file\b/i;
 const WINDOWS_COMMAND_SYNTAX_PATTERN =
   /\bthe syntax of the command is incorrect\b|\bis not recognized as an internal or external command\b/i;
 const FILE_TRANSFER_TIMEOUT_PATTERN =
@@ -185,6 +189,9 @@ const classifySandboxUploadFailureReason = (
   }
   if (WINDOWS_COMMAND_SYNTAX_PATTERN.test(message)) {
     return "windows_command_syntax";
+  }
+  if (LOCAL_FILE_PREPARE_FAILURE_PATTERN.test(message)) {
+    return "local_file_prepare_failed";
   }
   if (sandboxReadinessReason === "placement_failure") {
     return "sandbox_placement_failure";
@@ -968,20 +975,6 @@ const redactSensitiveValues = (
   return message;
 };
 
-const describeSandboxFileForLog = (file: SandboxFile) => {
-  if (file.kind === "url") {
-    return {
-      kind: file.kind,
-      urlLength: file.url.length,
-      protocol: file.url.split("://")[0],
-    };
-  }
-  return {
-    kind: file.kind,
-    sourcePath: "[redacted-local-path]",
-  };
-};
-
 const summarizeSandboxUploadFailure = (
   file: SandboxFile,
   error: unknown,
@@ -1022,6 +1015,7 @@ const shouldRetryWithFreshSandbox = (
 const uploadSandboxFilesOnce = async (
   sandboxFiles: SandboxFile[],
   sandbox: any,
+  options?: UploadSandboxFilesOptions,
 ): Promise<SandboxUploadResult> => {
   const results = await Promise.allSettled(
     sandboxFiles.map((file) => stageSandboxFile(sandbox, file)),
@@ -1030,20 +1024,6 @@ const uploadSandboxFilesOnce = async (
   const failedIndices = results
     .map((r, i) => (r.status === "rejected" ? i : -1))
     .filter((i) => i !== -1);
-
-  if (failedIndices.length > 0) {
-    console.error(
-      `Failed uploading ${failedIndices.length}/${sandboxFiles.length} files to sandbox:`,
-    );
-    failedIndices.forEach((i) => {
-      const file = sandboxFiles[i];
-      const result = results[i] as PromiseRejectedResult;
-      console.error("  -", {
-        ...describeSandboxFileForLog(file),
-        error: redactSandboxUploadError(file, result.reason),
-      });
-    });
-  }
 
   const pathRewrites = results.flatMap((result) =>
     result.status === "fulfilled" && result.value ? [result.value] : [],
@@ -1054,6 +1034,45 @@ const uploadSandboxFilesOnce = async (
       (results[i] as PromiseRejectedResult).reason,
     ),
   );
+
+  if (failureDetails.length > 0) {
+    const primaryFailure = failureDetails[0];
+    const failureReasonCounts = failureDetails.reduce<Record<string, number>>(
+      (counts, failure) => {
+        counts[failure.reason] = (counts[failure.reason] ?? 0) + 1;
+        return counts;
+      },
+      {},
+    );
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "error",
+        event: "sandbox_attachment_staging_failed",
+        service: options?.logContext?.service ?? "chat-handler",
+        environment:
+          process.env.TRIGGER_ENV ??
+          process.env.VERCEL_ENV ??
+          process.env.NODE_ENV ??
+          "unknown",
+        request_id: options?.logContext?.requestId ?? null,
+        user_id: options?.logContext?.userId ?? null,
+        chat_id: options?.logContext?.chatId ?? null,
+        failed_count: failureDetails.length,
+        total_count: sandboxFiles.length,
+        failure_reason: primaryFailure.reason,
+        failure_reason_counts: failureReasonCounts,
+        failure_kind: primaryFailure.kind,
+        ...(primaryFailure.kind === "localPath"
+          ? { source_path: "[redacted-local-path]" }
+          : {}),
+        failure_exit_code: extractCommandExitCode(primaryFailure.error),
+        transient_sandbox_command: primaryFailure.transientSandboxCommand,
+        sandbox_readiness_reason: primaryFailure.sandboxReadinessReason,
+        protocol: primaryFailure.protocol ?? null,
+      }),
+    );
+  }
 
   return {
     failedCount: failedIndices.length,
@@ -1279,7 +1298,11 @@ export const uploadSandboxFiles = async (
     }
   }
 
-  const firstResult = await uploadSandboxFilesOnce(sandboxFiles, sandbox);
+  const firstResult = await uploadSandboxFilesOnce(
+    sandboxFiles,
+    sandbox,
+    options,
+  );
 
   if (
     firstResult.failedCount > 0 &&
@@ -1305,6 +1328,7 @@ export const uploadSandboxFiles = async (
       const retryResult = await uploadSandboxFilesOnce(
         sandboxFiles,
         refreshedSandbox,
+        options,
       );
       return { ...retryResult, retriedWithFreshSandbox: true };
     } catch (error) {


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-09-02T20:01:49Z`–`2026-09-03T20:01:49Z`.

The current Vercel production deployment emitted two post-READY `/api/agent` 400s while preparing desktop-local attachments. Both logs ended at `Failed to prepare local file:` with an empty diagnostic and carried no request, user, or chat correlation fields. This made a current user-correctable failure impossible to distinguish from connection, path, shell, or command-exit failures.

The broader Trigger.dev attachment increase was operational and is intentionally not behaviorally changed: 47 failures spanned stopped sandboxes, placement/readiness timeouts, and EU S3 DNS failures across multiple worker versions.

## Root cause

The desktop copy command suppresses normal command output on Windows. When it returned a non-zero exit with empty stdout/stderr, the wrapper constructed an empty failure detail. Attachment staging then logged one unstructured row per file without distributed correlation fields.

## Change

- Preserve a bounded `exit status N` fallback when desktop copy output is empty.
- Classify these failures as `local_file_prepare_failed`.
- Replace per-file unstructured error rows with one aggregate JSON event carrying bounded reason/exit-code fields and opaque request, user, and chat IDs.
- Pass Vercel request context from the Agent start route.
- Do not log filenames, local paths, signed URLs, prompt content, or command output.

No retry, sandbox-selection, upload, authorization, or user-facing response behavior changes.

## Validation

- Focused Jest: 3 suites, 126 tests passed.
- TypeScript: `pnpm run typecheck` passed.
- Changed-file ESLint and Prettier passed.
- Commit hook: 441 suites / 4,576 tests passed.
- Adversarial review checked all three callers, multi-file aggregation, retry paths, Windows syntax precedence, curl exit-code preservation, privacy bounds, and Vercel/Trigger deploy skew.

## Manual verification

1. In a Preview Agent session using the desktop sandbox, attach a local file and submit; staging should succeed unchanged.
2. Move or remove an attached file before submission to force preparation failure; the user should receive the existing safe 400 response.
3. Confirm the Preview runtime emits `sandbox_attachment_staging_failed` with `failure_reason=local_file_prepare_failed`, an exit code, and opaque correlation IDs, with no filename/path/URL content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file upload failures when local file preparation produces no output, including clearer fallback error details.
  - Added a specific classification for local attachment preparation failures.

- **Improvements**
  - Enhanced upload diagnostics with structured, redacted context and exit-status details.
  - Improved staging-failure reporting by summarizing failure reasons while preserving existing cleanup behavior.

- **Tests**
  - Added regression coverage for bounded error handling and structured upload-failure logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->