### PR TITLE
Harden spreadsheet exports against formula interpretation

### DIFF
--- a/app/components/MarkdownTable.tsx
+++ b/app/components/MarkdownTable.tsx
@@ -2,6 +2,11 @@ import type { ReactNode } from "react";
 import { useRef, useState } from "react";
 import { Download, Copy, Check } from "lucide-react";
 import { downloadFile } from "@/lib/utils/file-download";
+import {
+  neutralizeSpreadsheetFormula,
+  serializeSpreadsheetCsv,
+  serializeSpreadsheetTsv,
+} from "@/lib/utils/spreadsheet-export";
 
 function extractTableData(tableEl: HTMLTableElement): string[][] {
   const rows: string[][] = [];
@@ -15,19 +20,17 @@ function extractTableData(tableEl: HTMLTableElement): string[][] {
   return rows;
 }
 
-function toCSV(data: string[][]): string {
-  return data
-    .map((row) =>
-      row
-        .map((cell) => {
-          if (cell.includes(",") || cell.includes('"') || cell.includes("\n")) {
-            return `"${cell.replace(/"/g, '""')}"`;
-          }
-          return cell;
-        })
-        .join(","),
-    )
-    .join("\n");
+function serializeSpreadsheetTableHtml(tableEl: HTMLTableElement): string {
+  const clone = tableEl.cloneNode(true) as HTMLTableElement;
+
+  for (const cell of Array.from(clone.querySelectorAll("th, td"))) {
+    const value = cell.textContent || "";
+    if (neutralizeSpreadsheetFormula(value) !== value) {
+      cell.insertBefore(document.createTextNode("'"), cell.firstChild);
+    }
+  }
+
+  return clone.outerHTML;
 }
 
 interface MarkdownTableProps {
@@ -54,17 +57,18 @@ export function MarkdownTable({
   const handleCopy = async () => {
     const data = getTableData();
     if (!data) return;
+    const tsv = serializeSpreadsheetTsv(data);
     try {
       const tableEl = wrapperRef.current?.querySelector("table");
-      const tsv = data.map((row) => row.join("\t")).join("\n");
       await navigator.clipboard.write([
         new ClipboardItem({
           "text/plain": new Blob([tsv], { type: "text/plain" }),
           ...(tableEl
             ? {
-                "text/html": new Blob([tableEl.outerHTML], {
-                  type: "text/html",
-                }),
+                "text/html": new Blob(
+                  [serializeSpreadsheetTableHtml(tableEl)],
+                  { type: "text/html" },
+                ),
               }
             : {}),
         }),
@@ -74,7 +78,6 @@ export function MarkdownTable({
     } catch {
       // Fallback to plain text copy
       try {
-        const tsv = data.map((row) => row.join("\t")).join("\n");
         await navigator.clipboard.writeText(tsv);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -89,7 +92,7 @@ export function MarkdownTable({
     if (!data) return;
     downloadFile({
       filename: "table.csv",
-      content: toCSV(data),
+      content: serializeSpreadsheetCsv(data),
       mimeType: "text/csv",
     });
   };

--- a/app/components/__tests__/MarkdownTable.test.tsx
+++ b/app/components/__tests__/MarkdownTable.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { downloadFile } from "@/lib/utils/file-download";
+import { MarkdownTable } from "../MarkdownTable";
+
+jest.mock("@/lib/utils/file-download", () => ({
+  downloadFile: jest.fn(),
+}));
+
+const mockedDownloadFile = jest.mocked(downloadFile);
+
+class TestBlob {
+  readonly content: string;
+  readonly type: string;
+
+  constructor(parts: BlobPart[], options?: BlobPropertyBag) {
+    this.content = parts.map(String).join("");
+    this.type = options?.type || "";
+  }
+}
+
+class TestClipboardItem {
+  constructor(readonly data: Record<string, TestBlob>) {}
+}
+
+const clipboardWrite = jest.fn();
+const clipboardWriteText = jest.fn();
+const originalBlob = globalThis.Blob;
+const originalClipboardItem = globalThis.ClipboardItem;
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+
+describe("MarkdownTable", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "Blob", {
+      configurable: true,
+      value: TestBlob,
+    });
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: TestClipboardItem,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        write: clipboardWrite.mockResolvedValue(undefined),
+        writeText: clipboardWriteText.mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(globalThis, "Blob", {
+      configurable: true,
+      value: originalBlob,
+    });
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: originalClipboardItem,
+    });
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  });
+
+  it("downloads formula-like cells as literal spreadsheet text", () => {
+    render(
+      <MarkdownTable>
+        <tbody>
+          <tr>
+            <td>Label</td>
+            <td>Value</td>
+          </tr>
+          <tr>
+            <td>Equals</td>
+            <td>=HYPERLINK(&quot;https://example.test&quot;)</td>
+          </tr>
+          <tr>
+            <td>Plus</td>
+            <td>+SUM(1,2)</td>
+          </tr>
+          <tr>
+            <td>Minus</td>
+            <td>-1+2</td>
+          </tr>
+          <tr>
+            <td>At</td>
+            <td>@SUM(1,2)</td>
+          </tr>
+          <tr>
+            <td>Full width</td>
+            <td>＝SUM(1,2)</td>
+          </tr>
+        </tbody>
+      </MarkdownTable>,
+    );
+
+    fireEvent.click(screen.getByTitle("Download as CSV"));
+
+    expect(mockedDownloadFile).toHaveBeenCalledWith({
+      filename: "table.csv",
+      content: [
+        '"Label","Value"',
+        '"Equals","\'=HYPERLINK(""https://example.test"")"',
+        '"Plus","\'+SUM(1,2)"',
+        '"Minus","\'-1+2"',
+        '"At","\'@SUM(1,2)"',
+        '"Full width","\'＝SUM(1,2)"',
+      ].join("\r\n"),
+      mimeType: "text/csv",
+    });
+  });
+
+  it("copies safe plain-text and rich table representations", async () => {
+    render(
+      <MarkdownTable>
+        <tbody>
+          <tr>
+            <th>Value</th>
+            <th>Details</th>
+          </tr>
+          <tr>
+            <td>
+              <strong>=1+1</strong>
+            </td>
+            <td>{"line\nbreak\tcell"}</td>
+          </tr>
+        </tbody>
+      </MarkdownTable>,
+    );
+
+    fireEvent.click(screen.getByTitle("Copy table"));
+
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(1));
+    const [items] = clipboardWrite.mock.calls[0] as [[TestClipboardItem]];
+    const payload = items[0].data;
+
+    expect(payload["text/plain"].content).toBe(
+      "Value\tDetails\r\n'=1+1\tline break cell",
+    );
+    expect(payload["text/html"].content).toContain(
+      "<td>'<strong>=1+1</strong></td>",
+    );
+    expect(payload["text/html"].content).not.toContain(
+      "<td><strong>=1+1</strong></td>",
+    );
+    expect(screen.getByText("=1+1").closest("td")?.innerHTML).toBe(
+      "<strong>=1+1</strong>",
+    );
+  });
+
+  it("uses the same safe TSV for the plain-text clipboard fallback", async () => {
+    clipboardWrite.mockRejectedValueOnce(new Error("rich copy unavailable"));
+
+    render(
+      <MarkdownTable>
+        <tbody>
+          <tr>
+            <td>=1+1</td>
+            <td>{"line\nbreak"}</td>
+          </tr>
+        </tbody>
+      </MarkdownTable>,
+    );
+
+    fireEvent.click(screen.getByTitle("Copy table"));
+
+    await waitFor(() =>
+      expect(clipboardWriteText).toHaveBeenCalledWith("'=1+1\tline break"),
+    );
+  });
+});

--- a/app/components/usage/UsageLogsTable.tsx
+++ b/app/components/usage/UsageLogsTable.tsx
@@ -17,6 +17,7 @@ import {
   type UsageLogBilling,
 } from "@/app/components/usage/usage-charge";
 import type { DateRange } from "react-day-picker";
+import { serializeSpreadsheetCsv } from "@/lib/utils/spreadsheet-export";
 
 type Preset = "1d" | "7d" | "30d" | "custom";
 
@@ -161,9 +162,7 @@ const UsageLogsTable = () => {
       ];
     });
 
-    const csvContent = [headers, ...rows]
-      .map((row) => row.join(","))
-      .join("\n");
+    const csvContent = serializeSpreadsheetCsv([headers, ...rows]);
     const blob = new Blob([csvContent], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/app/components/usage/__tests__/UsageLogsTable.test.tsx
+++ b/app/components/usage/__tests__/UsageLogsTable.test.tsx
@@ -1,14 +1,62 @@
 import "@testing-library/jest-dom";
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { UsageLogsTable } from "../UsageLogsTable";
 
 const convexReact = require("convex/react");
 
+class TestBlob {
+  readonly content: string;
+  readonly type: string;
+
+  constructor(parts: BlobPart[], options?: BlobPropertyBag) {
+    this.content = parts.map(String).join("");
+    this.type = options?.type || "";
+  }
+}
+
+const originalBlob = globalThis.Blob;
+const originalCreateObjectURL = Object.getOwnPropertyDescriptor(
+  URL,
+  "createObjectURL",
+);
+const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(
+  URL,
+  "revokeObjectURL",
+);
+
+function restoreUrlProperty(
+  key: "createObjectURL" | "revokeObjectURL",
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(URL, key, descriptor);
+  } else {
+    Reflect.deleteProperty(URL, key);
+  }
+}
+
 describe("UsageLogsTable", () => {
   beforeEach(() => {
     convexReact.resetMockConvexQueries?.();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "Blob", {
+      configurable: true,
+      value: originalBlob,
+    });
+    restoreUrlProperty("createObjectURL", originalCreateObjectURL);
+    restoreUrlProperty("revokeObjectURL", originalRevokeObjectURL);
+    jest.restoreAllMocks();
   });
 
   it("shows the amount deducted from extra-usage credits in the Cost column", () => {
@@ -70,5 +118,62 @@ describe("UsageLogsTable", () => {
 
     expect(screen.getByText("$2.50")).toBeInTheDocument();
     expect(screen.queryByText(/Included \$0\.00/)).not.toBeInTheDocument();
+  });
+
+  it("uses the spreadsheet-safe serializer for CSV exports", () => {
+    convexReact.setMockPaginatedQueryResult?.({
+      results: [
+        {
+          _id: "usage-export",
+          _creationTime: Date.parse("2026-07-19T15:29:18.000Z"),
+          type: "included",
+          model: "=FORMULA,with comma",
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+          cost_dollars: 1.25,
+          included_points_deducted: 1,
+          extra_usage_points_deducted: 0,
+        },
+      ],
+      status: "Exhausted",
+      loadMore: jest.fn(),
+      isLoading: false,
+    });
+    const createObjectURL = jest.fn(() => "blob:usage-export");
+    const revokeObjectURL = jest.fn();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+    Object.defineProperty(globalThis, "Blob", {
+      configurable: true,
+      value: TestBlob,
+    });
+    const anchorClick = jest
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    render(
+      <TooltipProvider>
+        <UsageLogsTable />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Export usage data as CSV" }),
+    );
+
+    const exportedBlob = createObjectURL.mock.calls[0]?.[0] as TestBlob;
+    expect(exportedBlob.type).toBe("text/csv");
+    expect(exportedBlob.content).toContain(
+      '"2026-07-19T15:29:18.000Z","Included","\'=FORMULA,with comma"',
+    );
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:usage-export");
+    expect(anchorClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/utils/__tests__/spreadsheet-export.test.ts
+++ b/lib/utils/__tests__/spreadsheet-export.test.ts
@@ -1,0 +1,63 @@
+import {
+  neutralizeSpreadsheetFormula,
+  serializeSpreadsheetCsv,
+  serializeSpreadsheetTsv,
+} from "../spreadsheet-export";
+
+describe("spreadsheet export", () => {
+  it.each([
+    "=SUM(1,2)",
+    "+SUM(1,2)",
+    "-1+2",
+    "@SUM(1,2)",
+    "  =SUM(1,2)",
+    "\t=SUM(1,2)",
+    "＝SUM(1,2)",
+    "＋SUM(1,2)",
+    "－1+2",
+    "＠SUM(1,2)",
+    "\u200b=SUM(1,2)",
+  ])("neutralizes formula-like value %j", (value) => {
+    expect(neutralizeSpreadsheetFormula(value)).toBe(`'${value}`);
+  });
+
+  it.each(["plain text", "123", "1+2", "'=-1+2", "https://example.test"])(
+    "leaves ordinary value %j intact",
+    (value) => {
+      expect(neutralizeSpreadsheetFormula(value)).toBe(value);
+    },
+  );
+
+  it("quotes every CSV field and preserves delimiters, quotes, and line breaks", () => {
+    expect(
+      serializeSpreadsheetCsv([
+        ["plain", "comma, value", 'say "hello"'],
+        ["line\nbreak", "carriage\rreturn", "windows\r\nbreak"],
+        ["=1+1", "-42", ""],
+      ]),
+    ).toBe(
+      [
+        '"plain","comma, value","say ""hello"""',
+        '"line\nbreak","carriage\rreturn","windows\r\nbreak"',
+        '"\'=1+1","\'-42",""',
+      ].join("\r\n"),
+    );
+  });
+
+  it("keeps TSV rows intact when cell text contains separators", () => {
+    expect(
+      serializeSpreadsheetTsv([
+        [
+          "plain",
+          "embedded\ttab",
+          "line\nbreak",
+          "carriage\rreturn",
+          "windows\r\nbreak",
+        ],
+        ["=1+1", "safe"],
+      ]),
+    ).toBe(
+      "plain\tembedded tab\tline break\tcarriage return\twindows break\r\n'=1+1\tsafe",
+    );
+  });
+});

--- a/lib/utils/spreadsheet-export.ts
+++ b/lib/utils/spreadsheet-export.ts
@@ -1,0 +1,34 @@
+const FORMULA_PREFIX = /^[=+\-@]/u;
+const LEADING_IGNORABLES =
+  /^[\s\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]*/u;
+
+export function neutralizeSpreadsheetFormula(value: string): string {
+  const normalizedStart = value
+    .normalize("NFKC")
+    .replace(LEADING_IGNORABLES, "");
+
+  return FORMULA_PREFIX.test(normalizedStart) ? `'${value}` : value;
+}
+
+function encodeCsvCell(value: string): string {
+  const literalValue = neutralizeSpreadsheetFormula(value);
+  return `"${literalValue.replace(/"/g, '""')}"`;
+}
+
+export function serializeSpreadsheetCsv(rows: string[][]): string {
+  return rows.map((row) => row.map(encodeCsvCell).join(",")).join("\r\n");
+}
+
+export function serializeSpreadsheetTsv(rows: string[][]): string {
+  return rows
+    .map((row) =>
+      row
+        .map((value) =>
+          // Clipboard TSV has no consistently supported escaping convention,
+          // so keep cell boundaries intact by flattening embedded separators.
+          neutralizeSpreadsheetFormula(value.replace(/[\t\r\n]+/g, " ")),
+        )
+        .join("\t"),
+    )
+    .join("\r\n");
+}


### PR DESCRIPTION
## Summary

- add a shared spreadsheet-safe CSV/TSV serializer that neutralizes formula-like prefixes and preserves CSV field boundaries
- protect Markdown table downloads plus plain-text and rich clipboard copies
- reuse the same CSV boundary for usage-log exports
- add focused regression coverage for operator prefixes, Unicode variants, delimiters, line breaks, clipboard MIME payloads, fallback copy, and usage exports

## Testing

- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with four pre-existing warnings)
- `corepack pnpm run test:ci` (443 suites, 4,596 tests)
- focused Jest, ESLint, and Prettier checks for all changed files
- independent LibreOffice Calc import check confirmed formula-like cells import as text while quoted delimiters and line breaks retain their field boundaries

## Manual verification

1. In a Preview chat, render a Markdown table containing cells that begin with `=`, `+`, `-`, `@`, and a full-width operator.
2. Download the table as CSV and open it in Excel, Google Sheets, or Numbers.
3. Confirm each formula-like value is displayed as literal text and ordinary commas, quotes, and line breaks remain in the original cell.
4. Copy the same table and paste it into the spreadsheet; confirm the plain/rich clipboard route also keeps those values literal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CSV and TSV exports with safer spreadsheet formatting, including formula neutralization and correct handling of quotes, separators, and line breaks.
  * Enhanced table copying with rich HTML and plain-text clipboard formats.
  * Added a reliable fallback when rich clipboard copying is unavailable.

* **Bug Fixes**
  * Usage log exports now preserve spreadsheet-safe formatting and consistently generate downloadable CSV files.

* **Tests**
  * Added coverage for export formatting, formula safety, clipboard behavior, and download handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->