### PR TITLE
HAC-95: Complete cancellation retention analytics

### DIFF
--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -154,7 +154,13 @@ describe("cancelSubscriptionAction", () => {
                 price: {
                   id: "price_pro",
                   lookup_key: "pro-monthly-plan",
+                  unit_amount: 2500,
+                  recurring: {
+                    interval: "month",
+                    interval_count: 1,
+                  },
                 },
+                quantity: 2,
               },
             ],
           },
@@ -203,6 +209,15 @@ describe("cancelSubscriptionAction", () => {
       PAID_FUNNEL_EVENTS.cancellationCompleted,
       expect.objectContaining({
         $insert_id: cancellationCompletionInsertId("sub_123"),
+        cancellation_reason: "cancellation_requested",
+        churn_type: "voluntary",
+        voluntary_churn: true,
+        involuntary_churn: false,
+        billing_interval: "month",
+        billing_interval_count: 1,
+        subscription_mrr_dollars: 50,
+        attributed_mrr_dollars: 50,
+        at_risk_mrr_dollars: 50,
       }),
     );
   });

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -162,6 +162,18 @@ describe("cancelSubscriptionAction", () => {
                 },
                 quantity: 2,
               },
+              {
+                price: {
+                  id: "price_addon",
+                  lookup_key: "agent-addon-yearly",
+                  unit_amount: 12000,
+                  recurring: {
+                    interval: "year",
+                    interval_count: 1,
+                  },
+                },
+                quantity: 1,
+              },
             ],
           },
         },
@@ -213,11 +225,12 @@ describe("cancelSubscriptionAction", () => {
         churn_type: "voluntary",
         voluntary_churn: true,
         involuntary_churn: false,
-        billing_interval: "month",
-        billing_interval_count: 1,
-        subscription_mrr_dollars: 50,
-        attributed_mrr_dollars: 50,
-        at_risk_mrr_dollars: 50,
+        billing_interval: undefined,
+        billing_interval_count: undefined,
+        subscription_item_count: 2,
+        subscription_mrr_dollars: 60,
+        attributed_mrr_dollars: 60,
+        at_risk_mrr_dollars: 60,
       }),
     );
   });

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -23,7 +23,12 @@ import {
   cancellationCompletionInsertId,
   paidFunnelProperties,
   planLookupKeyToTier,
+  subscriptionChurnHealthProperties,
 } from "@/lib/analytics/paid-funnel";
+import {
+  priceBillingInterval,
+  subscriptionMrrDollars,
+} from "@/lib/billing/subscription-mrr";
 import type { SubscriptionTier } from "@/types";
 import {
   proMonthlyPricingAssignmentFromMetadata,
@@ -50,9 +55,11 @@ type ParsedCancellationReasonInput = {
 type SubscriptionContext = {
   id: string;
   status: Stripe.Subscription.Status;
+  price?: Stripe.Price;
   priceId?: string;
   plan?: string;
   tier?: SubscriptionTier;
+  quantity?: number;
   currentPeriodEnd?: number;
   cancelAtPeriodEnd: boolean;
   pricingExperiment?: ProMonthlyPricingExperimentAssignment;
@@ -138,13 +145,16 @@ async function getActiveSubscriptionContext(
     throw new Error("No active subscription found");
   }
 
-  const price = currentSubscription.items.data[0]?.price;
+  const item = currentSubscription.items.data[0];
+  const price = item?.price;
   return {
     id: currentSubscription.id,
     status: currentSubscription.status,
+    price,
     priceId: price?.id,
     plan: price?.lookup_key ?? undefined,
     tier: subscriptionTierFromLookupKey(price?.lookup_key),
+    quantity: item?.quantity ?? undefined,
     currentPeriodEnd: currentPeriodEndMs(currentSubscription),
     cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
     pricingExperiment: proMonthlyPricingAssignmentFromMetadata(
@@ -309,6 +319,10 @@ export default async function cancelSubscriptionAction(
   const completedAt = updatedSubscription.canceled_at
     ? updatedSubscription.canceled_at * 1000
     : Date.now();
+  const subscriptionMrr = subscriptionMrrDollars({
+    price: subscriptionContext.price,
+    quantity: subscriptionContext.quantity ?? 1,
+  });
 
   if (serviceKey) {
     try {
@@ -367,8 +381,16 @@ export default async function cancelSubscriptionAction(
         subscription_tier: subscriptionContext.tier,
         plan: subscriptionContext.plan,
         stripe_price_lookup_key: subscriptionContext.plan,
+        billing_interval: priceBillingInterval(subscriptionContext.price),
+        billing_interval_count:
+          subscriptionContext.price?.recurring?.interval_count,
         reason_category: cancellationReason.reasonCategory,
         reason_subcategory: cancellationReason.reasonSubcategory,
+        cancellation_reason: "cancellation_requested",
+        ...subscriptionChurnHealthProperties("cancellation_requested"),
+        subscription_mrr_dollars: subscriptionMrr,
+        attributed_mrr_dollars: subscriptionMrr,
+        at_risk_mrr_dollars: subscriptionMrr,
         cancellation_completion_type: cancelImmediately
           ? "immediate_in_app"
           : "scheduled_in_app",

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -52,14 +52,20 @@ type ParsedCancellationReasonInput = {
   reasonDetails: string;
 };
 
+type SubscriptionItemContext = {
+  price: Stripe.Price;
+  quantity: number;
+};
+
 type SubscriptionContext = {
   id: string;
   status: Stripe.Subscription.Status;
-  price?: Stripe.Price;
+  items: SubscriptionItemContext[];
   priceId?: string;
   plan?: string;
   tier?: SubscriptionTier;
-  quantity?: number;
+  billingInterval?: ReturnType<typeof priceBillingInterval>;
+  billingIntervalCount?: number;
   currentPeriodEnd?: number;
   cancelAtPeriodEnd: boolean;
   pricingExperiment?: ProMonthlyPricingExperimentAssignment;
@@ -128,6 +134,21 @@ function currentPeriodEndMs(subscription: unknown): number | undefined {
     : undefined;
 }
 
+function subscriptionItemsMrrDollars(
+  items: SubscriptionItemContext[],
+): number | undefined {
+  if (items.length === 0) return undefined;
+
+  let totalMrrDollars = 0;
+  for (const item of items) {
+    const itemMrrDollars = subscriptionMrrDollars(item);
+    if (itemMrrDollars === undefined) return undefined;
+    totalMrrDollars += itemMrrDollars;
+  }
+
+  return totalMrrDollars;
+}
+
 async function getActiveSubscriptionContext(
   stripeCustomerId: string,
 ): Promise<SubscriptionContext> {
@@ -145,16 +166,34 @@ async function getActiveSubscriptionContext(
     throw new Error("No active subscription found");
   }
 
-  const item = currentSubscription.items.data[0];
-  const price = item?.price;
+  const items = currentSubscription.items.data.map((item) => ({
+    price: item.price,
+    quantity: item.quantity ?? 1,
+  }));
+  const primaryItem =
+    items.find((item) =>
+      Boolean(subscriptionTierFromLookupKey(item.price.lookup_key)),
+    ) ?? items[0];
+  const price = primaryItem?.price;
+  const billingInterval = priceBillingInterval(price);
+  const billingIntervalCount = price?.recurring?.interval_count;
+  const hasSharedBillingInterval = items.every(
+    (item) =>
+      priceBillingInterval(item.price) === billingInterval &&
+      item.price.recurring?.interval_count === billingIntervalCount,
+  );
+
   return {
     id: currentSubscription.id,
     status: currentSubscription.status,
-    price,
+    items,
     priceId: price?.id,
     plan: price?.lookup_key ?? undefined,
     tier: subscriptionTierFromLookupKey(price?.lookup_key),
-    quantity: item?.quantity ?? undefined,
+    billingInterval: hasSharedBillingInterval ? billingInterval : undefined,
+    billingIntervalCount: hasSharedBillingInterval
+      ? billingIntervalCount
+      : undefined,
     currentPeriodEnd: currentPeriodEndMs(currentSubscription),
     cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
     pricingExperiment: proMonthlyPricingAssignmentFromMetadata(
@@ -319,10 +358,9 @@ export default async function cancelSubscriptionAction(
   const completedAt = updatedSubscription.canceled_at
     ? updatedSubscription.canceled_at * 1000
     : Date.now();
-  const subscriptionMrr = subscriptionMrrDollars({
-    price: subscriptionContext.price,
-    quantity: subscriptionContext.quantity ?? 1,
-  });
+  const subscriptionMrr = subscriptionItemsMrrDollars(
+    subscriptionContext.items,
+  );
 
   if (serviceKey) {
     try {
@@ -381,9 +419,9 @@ export default async function cancelSubscriptionAction(
         subscription_tier: subscriptionContext.tier,
         plan: subscriptionContext.plan,
         stripe_price_lookup_key: subscriptionContext.plan,
-        billing_interval: priceBillingInterval(subscriptionContext.price),
-        billing_interval_count:
-          subscriptionContext.price?.recurring?.interval_count,
+        billing_interval: subscriptionContext.billingInterval,
+        billing_interval_count: subscriptionContext.billingIntervalCount,
+        subscription_item_count: subscriptionContext.items.length,
         reason_category: cancellationReason.reasonCategory,
         reason_subcategory: cancellationReason.reasonSubcategory,
         cancellation_reason: "cancellation_requested",


### PR DESCRIPTION
## Summary

- enrich direct in-app cancellation events with churn classification and recurring-revenue fields
- preserve the existing deterministic insert ID while ensuring the first captured event is complete
- cover recurring interval and multi-quantity MRR in the cancellation action test
- document the corrected production PostHog retention dashboard

## Why

The direct cancellation action emitted `cancellation_completed` before the Stripe webhook using the same PostHog insert ID. PostHog deduplicated the later webhook event, so in-app cancellations were missing churn and MRR properties.

## PostHog

Production dashboard: https://us.posthog.com/project/144137/dashboard/2060267

- added retained MRR by paid plan
- added lost MRR by churn type
- corrected at-risk latency from total stream duration to request-to-first-model-chunk, with a minimum sample guard
- kept HAC-46 pricing paused and made no model-routing changes

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm lint` (0 errors; 4 existing unrelated warnings)
- `corepack pnpm exec jest --runInBand` (443 suites, 4,598 tests)
- normal pre-commit full test hook (443 suites, 4,598 tests)
- targeted cancellation action test (10 tests)
- Prettier check and `git diff --check`

## Manual verification after deployment

In Stripe test mode, cancel a subscription with a known recurring price and quantity. Confirm the single `cancellation_completed` event contains voluntary churn fields plus `subscription_mrr_dollars`, `attributed_mrr_dollars`, and `at_risk_mrr_dollars`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Subscription cancellation reporting includes billing interval, monthly recurring revenue, attributed revenue, and at-risk revenue.
  - Cancellation completion analytics include churn-health metrics, a standardized cancellation reason, and the total number of subscription items.
  - Reporting accurately reflects subscription pricing, including plan quantity and unit amount.
  - Revenue calculations now aggregate values across multiple subscription items.
  - Shared billing interval details are reported only when consistent across all subscription items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->