### PR TITLE
Retire generic delegation rollout flag

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1188,14 +1188,11 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
   });
 
-  test("full-access runs gate generic delegation behind the rollout flag", () => {
+  test("full-access runs enable generic delegation without a rollout flag", () => {
     expect(routeSrc).toMatch(
-      /const genericDelegationFlagPromise\s*=\s*agentPermissionMode === "full_access"/,
+      /const genericDelegationEnabled\s*=\s*agentPermissionMode === "full_access"/,
     );
-    expect(routeSrc).toMatch(
-      /existingChat, userCustomization, genericDelegationEnabled[\s\S]*Promise\.all/,
-    );
-    expect(routeSrc).toContain('"agent-generic-delegation-v1"');
+    expect(routeSrc).not.toContain('"agent-generic-delegation-v1"');
     expect(routeSrc).not.toContain("securityValidationSubagentsEnabled");
     expect(routeSrc).not.toContain("securityTaskSubagentsEnabled");
   });

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -69,7 +69,6 @@ import {
   DEFAULT_AGENT_AUTO_REVIEW_ASSIGNMENT,
   type AgentAutoReviewAssignment,
 } from "@/lib/experiments/agent-auto-review";
-import { getPostHogFeatureFlagForUser } from "@/lib/posthog/server";
 
 type AgentTriggerMachinePreset = "small-1x" | "small-2x";
 
@@ -465,10 +464,7 @@ export const createAgentTriggerPost =
       const userLocation = geolocation(req);
       const triggerRegion =
         getTriggerRegionForVercelRequest(req, userLocation) ?? "us-east-1";
-      const genericDelegationFlagPromise =
-        agentPermissionMode === "full_access"
-          ? getPostHogFeatureFlagForUser("agent-generic-delegation-v1", userId)
-          : Promise.resolve(false);
+      const genericDelegationEnabled = agentPermissionMode === "full_access";
 
       assertFreeAgentGates({
         mode: "agent",
@@ -503,12 +499,10 @@ export const createAgentTriggerPost =
       // These independent authorization/config reads used to run serially
       // before Trigger was called. Overlap them so the worker starts booting as
       // soon as possible after the suspension check succeeds.
-      const [existingChat, userCustomization, genericDelegationEnabled] =
-        await Promise.all([
-          getChatById({ id: chatId }),
-          getUserCustomization({ userId }),
-          genericDelegationFlagPromise,
-        ]);
+      const [existingChat, userCustomization] = await Promise.all([
+        getChatById({ id: chatId }),
+        getUserCustomization({ userId }),
+      ]);
 
       // Fetch existing chat to: (a) detect isNewChat for title generation,
       // (b) pass to handleInitialChatAndUserMessage so it skips saveChat on


### PR DESCRIPTION
## Summary

- enable generic delegation directly for Full-access Agent runs
- remove the server-side PostHog evaluation for `agent-generic-delegation-v1`
- preserve the existing `genericDelegationEnabled` Trigger payload contract for a one-service rollout

## Rollout

- Production flag: `agent-generic-delegation-v1` / PostHog ID `854343`
- keep the flag active until this change is merged and verified on Vercel Production
- after production verification, soft-delete the flag from PostHog project `144137`

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; 4 pre-existing warnings)
- `pnpm exec jest --runInBand lib/api/__tests__/agent-long-contracts.test.ts lib/posthog/__tests__/server.test.ts` (2 suites, 114 tests)
- pre-push full suite (443 suites, 4,598 tests)
- Prettier check and `git diff --check`

## Manual verification

1. After the Vercel Production deployment is live, start a disposable Agent task in Full access mode.
2. Ask it to delegate one bounded task.
3. Confirm `delegate_task` is available and the child result is consumed before synthesis.
4. Confirm ask-approval and auto-review modes do not receive generic delegation.
5. Verify PostHog flag `854343` is no longer called, then soft-delete it.

Related: HAC-85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Generic delegation is now enabled directly when the agent permission mode is set to full access.
  * Generic delegation no longer depends on a rollout flag.
* **Performance**
  * Reduced unnecessary feature-flag lookups when handling agent trigger requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->