### PR TITLE
Fix comparative PM user research payloads

### DIFF
--- a/.agents/skills/hackerai-user-research/SKILL.md
+++ b/.agents/skills/hackerai-user-research/SKILL.md
@@ -107,6 +107,14 @@ For a comparison, also add group membership selected in PostHog:
 
 ```json
 {
+  "userIds": [
+    "internal-user-id-1",
+    "internal-user-id-2",
+    "internal-user-id-3",
+    "internal-user-id-4",
+    "internal-user-id-5",
+    "internal-user-id-6"
+  ],
   "comparisonGroups": [
     {
       "label": "Model rollout A",

--- a/.agents/skills/hackerai-user-research/SKILL.md
+++ b/.agents/skills/hackerai-user-research/SKILL.md
@@ -35,6 +35,10 @@ Read [references/privacy-policy.md](references/privacy-policy.md) and
    select PostHog `distinct_id` as the internal Convex/WorkOS user ID; do not
    require a duplicate person property or infer identity from email. Stop unless
    3-20 unique internal user IDs remain after filtering.
+   For comparisons, preserve membership in `comparisonGroups`; use 2-4 groups
+   with at least three users each, and assign every `userIds` entry exactly
+   once. Group labels may describe the selected model, rollout, or funnel
+   treatment, but must not identify a person or organization.
    For event-based questions, also select the PostHog event timestamp for each
    user. Use it as that user's evidence anchor; do not substitute one shared
    timestamp for the cohort.
@@ -99,6 +103,32 @@ For churn or another event-based question, add:
 }
 ```
 
+For a comparison, also add group membership selected in PostHog:
+
+```json
+{
+  "comparisonGroups": [
+    {
+      "label": "Model rollout A",
+      "userIds": ["internal-user-id-1", "internal-user-id-2", "internal-user-id-3"]
+    },
+    {
+      "label": "Model rollout B",
+      "userIds": ["internal-user-id-4", "internal-user-id-5", "internal-user-id-6"]
+    }
+  ]
+}
+```
+
+The gateway accepts `cohortSelectedAt` and `anchorAt` as epoch milliseconds or
+ISO timestamps. It also accepts the PostHog handoff name
+`selectionQuerySha256` and stores it canonically as
+`selectionQueryFingerprint`. The Trigger task and Convex audit always receive
+canonical millisecond timestamps and the canonical fingerprint field.
+When evidence anchors or an evidence-window length are present and
+`samplingMode` is omitted, the gateway canonicalizes the request to
+`pre_event` sampling.
+
 `evidenceAnchors` must contain exactly one PostHog event timestamp for every
 cohort user. Omit sampling fields for ordinary representative-history research.
 
@@ -124,6 +154,9 @@ payload. `userIds` must be the internal Convex/WorkOS user IDs.
   causal evidence even when pre-event sampling is used. Compare them with
   explicit survey reasons or a controlled experiment before making causal
   claims.
+- Comparison synthesis fails closed if fewer than three readable profiles
+  remain in any group. Grok 4.6 receives only pseudonyms and sanitized group
+  labels, never the internal ID-to-group mapping.
 - Say `unknown` when the evidence does not establish context. Never infer a
   company or occupation from an email address.
 - A failed or partial run is not permission to inspect messages manually. Fix

--- a/.agents/skills/hackerai-user-research/references/pm-runbook.md
+++ b/.agents/skills/hackerai-user-research/references/pm-runbook.md
@@ -26,6 +26,9 @@ of the selection query, and short limitations that affect interpretation. Never
 send the raw query. For event-based research such as churn, select the event
 timestamp beside each user ID and provide it as that member's evidence anchor.
 Use a bounded pre-event window; do not use one cohort-wide timestamp.
+For comparative research, retain 2-4 PostHog-selected group labels and their
+internal user IDs. Each group must contain at least three users and every cohort
+user must belong to exactly one group.
 
 ## 2. Run through Codex
 
@@ -46,6 +49,8 @@ gateway key is required. The gateway can start and read only
 task runs one parallel worker per user and a final cohort synthesis. Both calls use
 `x-ai/grok-4.6` with OpenRouter reasoning set to low
 and zero-data-retention routing required.
+Comparison membership is converted to sanitized labels and pseudonyms before
+the final Grok 4.6 synthesis; internal user IDs are not sent to the model.
 
 Create the temporary request JSON outside the repository with mode 600, pass its
 path to the runner, then remove it. Never commit the request file. User IDs from
@@ -67,6 +72,8 @@ event-based research, include one event timestamp beside every user ID and the
 event label or reason when known. State that the timestamp is the per-user
 evidence anchor, specify the pre-event window, and require the same privacy
 boundary as the gateway workflow.
+For comparisons, include each labeled group's complete user list instead of
+flattening the users into one unlabeled cohort.
 
 Do not send a Slack request that merely says to analyze churn, refers to a cohort
 "above," or expects Slack Codex to discover the IDs. Do not ask Slack Codex to

--- a/.agents/skills/hackerai-user-research/references/pm-runbook.md
+++ b/.agents/skills/hackerai-user-research/references/pm-runbook.md
@@ -28,7 +28,8 @@ timestamp beside each user ID and provide it as that member's evidence anchor.
 Use a bounded pre-event window; do not use one cohort-wide timestamp.
 For comparative research, retain 2-4 PostHog-selected group labels and their
 internal user IDs. Each group must contain at least three users and every cohort
-user must belong to exactly one group.
+user must belong to exactly one group. Labels may describe a model, rollout, or
+funnel treatment, but must not identify a person or organization.
 
 ## 2. Run through Codex
 

--- a/.agents/skills/hackerai-user-research/scripts/run-research.mjs
+++ b/.agents/skills/hackerai-user-research/scripts/run-research.mjs
@@ -11,7 +11,31 @@ const MAX_WAIT_MS = 35 * 60 * 1_000;
 const REQUEST_TIMEOUT_MS = 20_000;
 const MAX_PAYLOAD_BYTES = 32 * 1024;
 const MAX_REPORTED_ISSUES = 8;
-const MAX_ISSUE_MESSAGE_CHARS = 240;
+const MAX_ISSUE_PATH_SEGMENTS = 8;
+const MAX_ISSUE_PATH_SEGMENT_CHARS = 64;
+const ALLOWED_GATEWAY_ERROR_CODES = new Set([
+  "invalid_payload",
+  "payload_too_large",
+  "invalid_json",
+  "invalid_idempotency_key",
+  "unauthorized",
+  "research_gateway_unavailable",
+  "research_run_start_failed",
+  "invalid_run_id",
+  "run_not_found",
+  "research_run_output_invalid",
+  "research_run_failed",
+  "research_run_status_failed",
+]);
+const ISSUE_MESSAGES = {
+  invalid_type: "has an invalid type",
+  too_small: "is below the allowed minimum",
+  too_big: "exceeds the allowed maximum",
+  invalid_format: "has an invalid format",
+  invalid_value: "has an unsupported value",
+  unrecognized_keys: "contains unsupported fields",
+  custom: "failed validation",
+};
 
 function usage() {
   console.log(`Usage: node run-research.mjs --payload /secure/path/request.json [--no-wait]
@@ -54,25 +78,33 @@ export function createProxyDispatcher(env = process.env) {
 
 const proxyDispatcher = createProxyDispatcher();
 
+/** Format a bounded gateway failure without reflecting rejected input. */
 export function formatGatewayError(status, body) {
-  const code = typeof body?.error === "string" ? body.error : "request_failed";
+  const code = ALLOWED_GATEWAY_ERROR_CODES.has(body?.error)
+    ? body.error
+    : "request_failed";
   const issues = Array.isArray(body?.issues)
     ? body.issues.slice(0, MAX_REPORTED_ISSUES).flatMap((issue) => {
         if (!issue || typeof issue !== "object") return [];
         const path = Array.isArray(issue.path)
           ? issue.path
-              .filter(
-                (part) =>
-                  typeof part === "string" || Number.isInteger(part),
-              )
+              .slice(0, MAX_ISSUE_PATH_SEGMENTS)
+              .flatMap((part) => {
+                if (Number.isInteger(part) && part >= 0 && part <= 999) {
+                  return [String(part)];
+                }
+                if (
+                  typeof part === "string" &&
+                  part.length <= MAX_ISSUE_PATH_SEGMENT_CHARS &&
+                  /^[A-Za-z][A-Za-z0-9_]*$/.test(part)
+                ) {
+                  return [part];
+                }
+                return ["field"];
+              })
               .join(".")
           : "";
-        const message =
-          typeof issue.message === "string"
-            ? issue.message
-                .replace(/[\r\n]+/g, " ")
-                .slice(0, MAX_ISSUE_MESSAGE_CHARS)
-            : "invalid value";
+        const message = ISSUE_MESSAGES[issue.code] ?? "failed validation";
         return [`${path || "payload"}: ${message}`];
       })
     : [];

--- a/.agents/skills/hackerai-user-research/scripts/run-research.mjs
+++ b/.agents/skills/hackerai-user-research/scripts/run-research.mjs
@@ -10,6 +10,8 @@ const POLL_INTERVAL_MS = 5_000;
 const MAX_WAIT_MS = 35 * 60 * 1_000;
 const REQUEST_TIMEOUT_MS = 20_000;
 const MAX_PAYLOAD_BYTES = 32 * 1024;
+const MAX_REPORTED_ISSUES = 8;
+const MAX_ISSUE_MESSAGE_CHARS = 240;
 
 function usage() {
   console.log(`Usage: node run-research.mjs --payload /secure/path/request.json [--no-wait]
@@ -52,6 +54,32 @@ export function createProxyDispatcher(env = process.env) {
 
 const proxyDispatcher = createProxyDispatcher();
 
+export function formatGatewayError(status, body) {
+  const code = typeof body?.error === "string" ? body.error : "request_failed";
+  const issues = Array.isArray(body?.issues)
+    ? body.issues.slice(0, MAX_REPORTED_ISSUES).flatMap((issue) => {
+        if (!issue || typeof issue !== "object") return [];
+        const path = Array.isArray(issue.path)
+          ? issue.path
+              .filter(
+                (part) =>
+                  typeof part === "string" || Number.isInteger(part),
+              )
+              .join(".")
+          : "";
+        const message =
+          typeof issue.message === "string"
+            ? issue.message
+                .replace(/[\r\n]+/g, " ")
+                .slice(0, MAX_ISSUE_MESSAGE_CHARS)
+            : "invalid value";
+        return [`${path || "payload"}: ${message}`];
+      })
+    : [];
+  const details = issues.length > 0 ? ` (${issues.join("; ")})` : "";
+  return `Research gateway returned ${status}: ${code}${details}`;
+}
+
 export async function gatewayRequest(
   url,
   key,
@@ -70,8 +98,7 @@ export async function gatewayRequest(
   });
   const body = await response.json().catch(() => ({}));
   if (!response.ok) {
-    const code = typeof body.error === "string" ? body.error : "request_failed";
-    throw new Error(`Research gateway returned ${response.status}: ${code}`);
+    throw new Error(formatGatewayError(response.status, body));
   }
   return body;
 }

--- a/.agents/skills/hackerai-user-research/scripts/run-research.test.mjs
+++ b/.agents/skills/hackerai-user-research/scripts/run-research.test.mjs
@@ -4,6 +4,7 @@ import { connect } from "node:net";
 import { after, before, test } from "node:test";
 import {
   createProxyDispatcher,
+  formatGatewayError,
   gatewayRequest,
 } from "./run-research.mjs";
 
@@ -83,4 +84,54 @@ test("gateway requests use the configured HTTP proxy", async () => {
 
 test("gateway requests do not create a dispatcher without proxy variables", () => {
   assert.equal(createProxyDispatcher({}), undefined);
+});
+
+test("gateway errors include bounded validation details without rejected input", async () => {
+  await assert.rejects(
+    gatewayRequest(
+      originUrl,
+      "synthetic-test-key",
+      {},
+      {
+        request: async () =>
+          new Response(
+            JSON.stringify({
+              error: "invalid_payload",
+              issues: [
+                {
+                  code: "invalid_type",
+                  path: ["cohortSelectedAt"],
+                  message: "Invalid input: expected number, received string",
+                  input: "private rejected input",
+                },
+              ],
+            }),
+            {
+              status: 400,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+      },
+    ),
+    (error) => {
+      assert.match(error.message, /cohortSelectedAt: Invalid input/);
+      assert.doesNotMatch(error.message, /private rejected input/);
+      return true;
+    },
+  );
+});
+
+test("gateway error formatting bounds issue count and message length", () => {
+  const error = formatGatewayError(400, {
+    error: "invalid_payload",
+    issues: Array.from({ length: 12 }, (_, index) => ({
+      path: ["field", index],
+      message: "x".repeat(500),
+    })),
+  });
+
+  assert.match(error, /^Research gateway returned 400: invalid_payload/);
+  assert.match(error, /field\.7:/);
+  assert.doesNotMatch(error, /field\.8:/);
+  assert.ok(error.length < 2_300);
 });

--- a/.agents/skills/hackerai-user-research/scripts/run-research.test.mjs
+++ b/.agents/skills/hackerai-user-research/scripts/run-research.test.mjs
@@ -100,8 +100,8 @@ test("gateway errors include bounded validation details without rejected input",
               issues: [
                 {
                   code: "invalid_type",
-                  path: ["cohortSelectedAt"],
-                  message: "Invalid input: expected number, received string",
+                  path: ["cohortSelectedAt", "private-rejected-input"],
+                  message: "Rejected private value private-rejected-input",
                   input: "private rejected input",
                 },
               ],
@@ -114,8 +114,12 @@ test("gateway errors include bounded validation details without rejected input",
       },
     ),
     (error) => {
-      assert.match(error.message, /cohortSelectedAt: Invalid input/);
+      assert.match(
+        error.message,
+        /cohortSelectedAt\.field: has an invalid type/,
+      );
       assert.doesNotMatch(error.message, /private rejected input/);
+      assert.doesNotMatch(error.message, /private-rejected-input/);
       return true;
     },
   );
@@ -125,13 +129,23 @@ test("gateway error formatting bounds issue count and message length", () => {
   const error = formatGatewayError(400, {
     error: "invalid_payload",
     issues: Array.from({ length: 12 }, (_, index) => ({
-      path: ["field", index],
+      path: ["field", index, ...Array.from({ length: 20 }, () => "nested")],
       message: "x".repeat(500),
     })),
   });
 
   assert.match(error, /^Research gateway returned 400: invalid_payload/);
-  assert.match(error, /field\.7:/);
-  assert.doesNotMatch(error, /field\.8:/);
+  assert.match(error, /field\.7\.nested/);
+  assert.doesNotMatch(error, /field\.8\.nested/);
+  assert.doesNotMatch(error, /(?:\.nested){7}/);
   assert.ok(error.length < 2_300);
+});
+
+test("gateway error formatting allow-lists the top-level error code", () => {
+  const error = formatGatewayError(502, {
+    error: "private-rejected-input",
+    issues: [],
+  });
+
+  assert.equal(error, "Research gateway returned 502: request_failed");
 });

--- a/app/api/internal/user-research/__tests__/route.test.ts
+++ b/app/api/internal/user-research/__tests__/route.test.ts
@@ -232,6 +232,67 @@ describe("PM user research gateway", () => {
     infoSpy.mockRestore();
   });
 
+  it("normalizes PostHog timestamps and SHA-256 field names for comparisons", async () => {
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    const { POST } = await import("../route");
+    const userIds = [
+      "user-1",
+      "user-2",
+      "user-3",
+      "user-4",
+      "user-5",
+      "user-6",
+    ];
+    const comparisonGroups = [
+      { label: "Model A", userIds: userIds.slice(0, 3) },
+      { label: "Model B", userIds: userIds.slice(3) },
+    ];
+    const evidenceAnchors = userIds.map((userId, index) => ({
+      userId,
+      anchorAt: new Date(
+        validPayload.cohortSelectedAt - (index + 1) * 60_000,
+      ).toISOString(),
+    }));
+    const normalizedEvidenceAnchors = evidenceAnchors.map((anchor) => ({
+      ...anchor,
+      anchorAt: Date.parse(anchor.anchorAt),
+    }));
+    const { selectionQueryFingerprint, ...payloadWithoutFingerprint } =
+      validPayload;
+
+    const response = await POST(
+      request({
+        body: {
+          ...payloadWithoutFingerprint,
+          userIds,
+          cohortSelectedAt: new Date(
+            validPayload.cohortSelectedAt,
+          ).toISOString(),
+          selectionQuerySha256: selectionQueryFingerprint,
+          comparisonGroups,
+          evidenceWindowDays: 30,
+          evidenceAnchors,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(triggerTask).toHaveBeenCalledWith(
+      "pm-user-research",
+      {
+        ...validTriggeredPayload,
+        userIds,
+        comparisonGroups,
+        samplingMode: "pre_event",
+        evidenceWindowDays: 30,
+        evidenceAnchors: normalizedEvidenceAnchors,
+        requestedBy: "pm-gateway",
+      },
+      expect.any(Object),
+    );
+    infoSpy.mockRestore();
+  });
+
   it("rejects an invalid credential before parsing or triggering", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const invalid = request({ token: "wrong-secret" });
@@ -260,6 +321,14 @@ describe("PM user research gateway", () => {
       request({ body: { ...validPayload, userIds: ["user-1", "user-2"] } }),
     );
     expect(invalidCohort.status).toBe(400);
+    await expect(invalidCohort.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: "invalid_payload",
+        issues: expect.arrayContaining([
+          expect.objectContaining({ path: ["userIds"] }),
+        ]),
+      }),
+    );
     expect(triggerTask).not.toHaveBeenCalled();
   });
 

--- a/app/api/internal/user-research/route.ts
+++ b/app/api/internal/user-research/route.ts
@@ -3,6 +3,7 @@ import { runs, tasks } from "@trigger.dev/sdk";
 import { NextResponse, type NextRequest } from "next/server";
 import type { pmUserResearch } from "@/trigger/user-research";
 import {
+  normalizePmUserResearchGatewayInput,
   pmUserResearchGatewayRequestSchema,
   pmUserResearchResultSchema,
 } from "@/lib/research/user-research";
@@ -153,7 +154,9 @@ export async function POST(request: NextRequest) {
     return json({ error: "invalid_json" }, { status: 400 });
   }
 
-  const parsed = pmUserResearchGatewayRequestSchema.safeParse(rawPayload);
+  const parsed = pmUserResearchGatewayRequestSchema.safeParse(
+    normalizePmUserResearchGatewayInput(rawPayload),
+  );
   if (!parsed.success) {
     return json(
       {

--- a/convex/__tests__/userResearch.test.ts
+++ b/convex/__tests__/userResearch.test.ts
@@ -391,6 +391,23 @@ describe("userResearch.createRun", () => {
         ),
       }),
     ).rejects.toThrow("at least three members each");
+    await expect(
+      createRun.handler({ db: {} } as never, {
+        ...baseArgs,
+        members: members.map((member) => ({
+          ...member,
+          comparisonGroupLabel: "   ",
+        })),
+      }),
+    ).rejects.toThrow("must not be blank");
+    await expect(
+      createRun.handler({ db: {} } as never, {
+        ...baseArgs,
+        members: members.map((member, index) =>
+          index === 0 ? { ...member, comparisonGroupLabel: "" } : member,
+        ),
+      }),
+    ).rejects.toThrow("must not be blank");
   });
 });
 

--- a/convex/__tests__/userResearch.test.ts
+++ b/convex/__tests__/userResearch.test.ts
@@ -336,6 +336,62 @@ describe("userResearch.createRun", () => {
       }),
     ).rejects.toThrow("Every pre_event member requires");
   });
+
+  it("persists complete comparison membership and rejects undersized groups", async () => {
+    const insert = jest.fn(async () => "document-id");
+    const ctx = {
+      db: {
+        query: jest.fn(() => ({
+          withIndex: jest.fn(() => ({
+            unique: jest.fn(async () => null),
+          })),
+        })),
+        insert,
+      },
+    };
+    const { createRun } = await import("../userResearch");
+    const baseArgs = {
+      serviceKey: "service-key",
+      analysisId: "analysis-comparison",
+      question: "How do recurring jobs and friction differ by model cohort?",
+      cohortLabel: "PostHog model conversion comparison",
+      requestedBy: "pm-gateway",
+      cohortSource: "posthog" as const,
+      posthogProjectId: 144137,
+      cohortSelectedAt: Date.UTC(2026, 7, 25),
+      selectionQueryFingerprint:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      selectionLimitations: [],
+      samplingMode: "representative" as const,
+      maxChatsPerUser: 12,
+      model: "x-ai/grok-4.6",
+      reasoningEnabled: true,
+      reasoningEffort: "low" as const,
+    };
+    const members = Array.from({ length: 6 }, (_, index) => ({
+      userId: `user-${index + 1}`,
+      pseudonym: `U${String(index + 1).padStart(2, "0")}`,
+      comparisonGroupLabel: index < 3 ? "Model A" : "Model B",
+    }));
+
+    await createRun.handler(ctx as never, { ...baseArgs, members });
+
+    expect(insert).toHaveBeenCalledWith(
+      "research_run_members",
+      expect.objectContaining({
+        user_id: "user-1",
+        comparison_group_label: "Model A",
+      }),
+    );
+    await expect(
+      createRun.handler({ db: {} } as never, {
+        ...baseArgs,
+        members: members.map((member, index) =>
+          index === 2 ? { ...member, comparisonGroupLabel: "Model B" } : member,
+        ),
+      }),
+    ).rejects.toThrow("at least three members each");
+  });
 });
 
 describe("userResearch.failRun", () => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1132,6 +1132,7 @@ export default defineSchema({
     user_id: v.string(),
     pseudonym: v.string(),
     evidence_anchor_at: v.optional(v.number()),
+    comparison_group_label: v.optional(v.string()),
     created_at: v.number(),
   })
     .index("by_analysis_and_user", ["analysis_id", "user_id"])

--- a/convex/userResearch.ts
+++ b/convex/userResearch.ts
@@ -23,6 +23,9 @@ const MAX_MESSAGE_CHARS = 8_000;
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const MAX_EVIDENCE_WINDOW_DAYS = 365;
 const MAX_SELECTION_LIMITATIONS = 8;
+const MIN_COMPARISON_GROUPS = 2;
+const MAX_COMPARISON_GROUPS = 4;
+const MIN_USERS_PER_COMPARISON_GROUP = 3;
 const SHA_256_PATTERN = /^[a-f0-9]{64}$/;
 
 const researchChatValidator = v.object({
@@ -129,11 +132,12 @@ export const createRun = mutation({
         userId: v.string(),
         pseudonym: v.string(),
         evidenceAnchorAt: v.optional(v.number()),
+        comparisonGroupLabel: v.optional(v.string()),
       }),
     ),
     maxChatsPerUser: v.number(),
-    model: v.string(),
-    reasoningEnabled: v.boolean(),
+    model: v.literal("x-ai/grok-4.6"),
+    reasoningEnabled: v.literal(true),
     reasoningEffort: v.literal("low"),
   },
   returns: v.null(),
@@ -213,6 +217,35 @@ export const createRun = mutation({
       );
     }
 
+    const comparisonGroupLabels = args.members.flatMap((member) =>
+      member.comparisonGroupLabel ? [member.comparisonGroupLabel] : [],
+    );
+    if (
+      comparisonGroupLabels.length > 0 &&
+      comparisonGroupLabels.length !== args.members.length
+    ) {
+      throw new ConvexError(
+        "Comparison groups must assign every research member",
+      );
+    }
+    if (comparisonGroupLabels.length > 0) {
+      const groupCounts = new Map<string, number>();
+      for (const label of comparisonGroupLabels) {
+        groupCounts.set(label, (groupCounts.get(label) ?? 0) + 1);
+      }
+      if (
+        groupCounts.size < MIN_COMPARISON_GROUPS ||
+        groupCounts.size > MAX_COMPARISON_GROUPS ||
+        Array.from(groupCounts.values()).some(
+          (count) => count < MIN_USERS_PER_COMPARISON_GROUP,
+        )
+      ) {
+        throw new ConvexError(
+          "Comparison research requires 2-4 groups with at least three members each",
+        );
+      }
+    }
+
     const existing = await ctx.db
       .query("research_runs")
       .withIndex("by_analysis_id", (q) => q.eq("analysis_id", args.analysisId))
@@ -249,13 +282,13 @@ export const createRun = mutation({
       const expectedMembers = args.members
         .map(
           (member) =>
-            `${member.userId}:${member.pseudonym}:${member.evidenceAnchorAt ?? ""}`,
+            `${member.userId}:${member.pseudonym}:${member.evidenceAnchorAt ?? ""}:${member.comparisonGroupLabel ?? ""}`,
         )
         .sort();
       const actualMembers = existingMembers
         .map(
           (member) =>
-            `${member.user_id}:${member.pseudonym}:${member.evidence_anchor_at ?? ""}`,
+            `${member.user_id}:${member.pseudonym}:${member.evidence_anchor_at ?? ""}:${member.comparison_group_label ?? ""}`,
         )
         .sort();
       if (JSON.stringify(expectedMembers) !== JSON.stringify(actualMembers)) {
@@ -308,6 +341,9 @@ export const createRun = mutation({
           pseudonym: member.pseudonym,
           ...(member.evidenceAnchorAt !== undefined
             ? { evidence_anchor_at: member.evidenceAnchorAt }
+            : {}),
+          ...(member.comparisonGroupLabel
+            ? { comparison_group_label: member.comparisonGroupLabel }
             : {}),
           created_at: now,
         }),
@@ -521,7 +557,7 @@ export const saveUserProfile = mutation({
     pseudonym: v.string(),
     profile: researchUserProfileValidator,
     coverage: researchCoverageValidator,
-    model: v.string(),
+    model: v.literal("x-ai/grok-4.6"),
     promptVersion: v.string(),
     ...usageFields,
   },
@@ -609,7 +645,7 @@ export const completeRun = mutation({
     serviceKey: v.string(),
     analysisId: v.string(),
     report: researchCohortReportValidator,
-    model: v.string(),
+    model: v.literal("x-ai/grok-4.6"),
     promptVersion: v.string(),
     ...usageFields,
   },

--- a/convex/userResearch.ts
+++ b/convex/userResearch.ts
@@ -218,8 +218,13 @@ export const createRun = mutation({
     }
 
     const comparisonGroupLabels = args.members.flatMap((member) =>
-      member.comparisonGroupLabel ? [member.comparisonGroupLabel] : [],
+      member.comparisonGroupLabel !== undefined
+        ? [member.comparisonGroupLabel]
+        : [],
     );
+    if (comparisonGroupLabels.some((label) => label.trim().length === 0)) {
+      throw new ConvexError("Comparison group labels must not be blank");
+    }
     if (
       comparisonGroupLabels.length > 0 &&
       comparisonGroupLabels.length !== args.members.length
@@ -342,7 +347,7 @@ export const createRun = mutation({
           ...(member.evidenceAnchorAt !== undefined
             ? { evidence_anchor_at: member.evidenceAnchorAt }
             : {}),
-          ...(member.comparisonGroupLabel
+          ...(member.comparisonGroupLabel !== undefined
             ? { comparison_group_label: member.comparisonGroupLabel }
             : {}),
           created_at: now,

--- a/convex/userResearchValidators.ts
+++ b/convex/userResearchValidators.ts
@@ -101,6 +101,14 @@ const researchBasisValidator = v.object({
   selectionLimitations: v.array(v.string()),
   samplingMode: researchSamplingModeValidator,
   evidenceWindowDays: v.optional(v.number()),
+  comparisonGroups: v.optional(
+    v.array(
+      v.object({
+        label: v.string(),
+        userCount: v.number(),
+      }),
+    ),
+  ),
   causalAttributionConfidence: researchConfidenceValidator,
 });
 

--- a/docs/internal/user-research.md
+++ b/docs/internal/user-research.md
@@ -18,6 +18,8 @@ called through the repo-owned Codex skill `$hackerai-user-research`.
 4. Redacts direct identifiers, targets, secrets, paths, code blocks, and command
    arguments before sending evidence to the model.
 5. Runs one profile worker per user in parallel, then synthesizes the cohort.
+   Comparative runs preserve 2-4 PostHog-selected groups, but expose only
+   sanitized labels and pseudonyms to synthesis.
 6. Stores the audit record, bounded PostHog cohort provenance, structured
    per-user profiles keyed by internal user ID, aggregate report, evidence
    coverage, token usage, and provider cost in Convex. The audit stores only a
@@ -93,6 +95,14 @@ milliseconds. Behavioral evidence remains low-confidence for causal
 attribution even when it immediately precedes the event; combine it with an
 explicit survey or experiment before treating a friction pattern as the reason
 for churn.
+
+For comparative research, pass `comparisonGroups` with 2-4 labeled groups of
+at least three users. Every cohort user must be assigned exactly once. The
+gateway accepts ISO or epoch-millisecond cohort/evidence timestamps and accepts
+`selectionQuerySha256` as a boundary alias for the canonical
+`selectionQueryFingerprint` field. It also infers `pre_event` sampling when an
+evidence window or anchors are supplied. Invalid payload responses include
+bounded, non-sensitive schema issues, which the runner prints for correction.
 
 ### PostHog identity and revenue contract
 

--- a/lib/research/__tests__/user-research.test.ts
+++ b/lib/research/__tests__/user-research.test.ts
@@ -3,6 +3,7 @@ import {
   buildCohortPrompt,
   buildUserProfilePrompt,
   containsUnredactedResearchSecret,
+  normalizePmUserResearchGatewayInput,
   normalizeCohortSynthesis,
   normalizeResearchUserProfile,
   sanitizeResearchText,
@@ -12,6 +13,7 @@ import {
   pmUserResearchGatewayRequestSchema,
   USER_RESEARCH_PROVIDER_OPTIONS,
 } from "../user-research";
+import { GROK_4_6_SLUG, myProvider } from "@/lib/ai/providers";
 
 const baseProfile = {
   summary: "A recurring security workflow.",
@@ -110,8 +112,77 @@ describe("user research privacy controls", () => {
     ).toThrow("one evidence anchor for every cohort user");
   });
 
+  it("accepts complete comparison groups and rejects ambiguous membership", () => {
+    const userIds = [
+      "user-1",
+      "user-2",
+      "user-3",
+      "user-4",
+      "user-5",
+      "user-6",
+    ];
+    const request = {
+      question: "How do recurring jobs and friction differ by model cohort?",
+      cohortLabel: "PostHog model conversion comparison",
+      userIds,
+      cohortSelectedAt: Date.UTC(2026, 7, 25),
+      selectionQueryFingerprint:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      comparisonGroups: [
+        { label: "Model A", userIds: userIds.slice(0, 3) },
+        { label: "Model B", userIds: userIds.slice(3) },
+      ],
+    };
+
+    expect(
+      pmUserResearchGatewayRequestSchema.parse(request).comparisonGroups,
+    ).toEqual(request.comparisonGroups);
+    expect(() =>
+      pmUserResearchGatewayRequestSchema.parse({
+        ...request,
+        comparisonGroups: [
+          request.comparisonGroups[0],
+          { label: "Model B", userIds: ["user-3", "user-4", "user-5"] },
+        ],
+      }),
+    ).toThrow("each user may appear in only one comparison group");
+    expect(() =>
+      pmUserResearchGatewayRequestSchema.parse({
+        ...request,
+        comparisonGroups: [
+          request.comparisonGroups[0],
+          { label: "Model B", userIds: ["user-4", "user-5", "user-7"] },
+        ],
+      }),
+    ).toThrow("assign every cohort user exactly once");
+  });
+
+  it("normalizes common PostHog handoff timestamp and fingerprint fields", () => {
+    const normalized = normalizePmUserResearchGatewayInput({
+      cohortSelectedAt: "2026-09-03T16:31:12.688Z",
+      selectionQuerySha256:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      evidenceWindowDays: 30,
+      evidenceAnchors: [{ userId: "user-1", anchorAt: "1785841937847" }],
+    });
+
+    expect(normalized).toEqual(
+      expect.objectContaining({
+        cohortSelectedAt: 1788453072688,
+        selectionQueryFingerprint:
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        samplingMode: "pre_event",
+        evidenceAnchors: [{ userId: "user-1", anchorAt: 1785841937847 }],
+      }),
+    );
+  });
+
   it("pins Grok 4.6 for text-only research with low reasoning", () => {
     expect(USER_RESEARCH_MODEL_KEY).toBe("model-grok-4.6");
+    expect(
+      (myProvider.languageModel(USER_RESEARCH_MODEL_KEY) as { modelId: string })
+        .modelId,
+    ).toBe(GROK_4_6_SLUG);
     expect(USER_RESEARCH_PROVIDER_OPTIONS).toEqual({
       openrouter: {
         reasoning: { enabled: true, effort: "low" },
@@ -282,8 +353,28 @@ ${"QUJD".repeat(16)}
           "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         selectionLimitations: [],
         samplingMode: "representative",
+        comparisonGroups: [
+          { label: "Model A", userCount: 10 },
+          { label: "Model B", userCount: 10 },
+        ],
         causalAttributionConfidence: "low",
       },
+      comparisonGroups: [
+        {
+          label: "Model A",
+          pseudonyms: Array.from(
+            { length: 10 },
+            (_, index) => `U${String(index + 1).padStart(2, "0")}`,
+          ),
+        },
+        {
+          label: "Model B",
+          pseudonyms: Array.from(
+            { length: 10 },
+            (_, index) => `U${String(index + 11).padStart(2, "0")}`,
+          ),
+        },
+      ],
       profiles: Array.from({ length: 20 }, (_, index) => ({
         pseudonym: `U${String(index + 1).padStart(2, "0")}`,
         profile: {
@@ -307,10 +398,45 @@ ${"QUJD".repeat(16)}
       })),
     });
     const payload = prompt.split("Synthesize this cohort:\n")[1];
-    const parsed = JSON.parse(payload) as { profiles: Array<unknown> };
+    const parsed = JSON.parse(payload) as {
+      comparisonGroups: Array<{ label: string; pseudonyms: string[] }>;
+      profiles: Array<unknown>;
+    };
 
     expect(prompt.length).toBeLessThan(USER_RESEARCH_MAX_COHORT_CONTEXT_CHARS);
     expect(parsed.profiles).toHaveLength(20);
+    expect(parsed.comparisonGroups).toEqual([
+      {
+        label: "Model A",
+        pseudonyms: [
+          "U01",
+          "U02",
+          "U03",
+          "U04",
+          "U05",
+          "U06",
+          "U07",
+          "U08",
+          "U09",
+          "U10",
+        ],
+      },
+      {
+        label: "Model B",
+        pseudonyms: [
+          "U11",
+          "U12",
+          "U13",
+          "U14",
+          "U15",
+          "U16",
+          "U17",
+          "U18",
+          "U19",
+          "U20",
+        ],
+      },
+    ]);
     expect(payload).toContain("profile-0");
     expect(payload).toContain("profile-19");
     expect(payload).toContain("bug_bounty_hunter");

--- a/lib/research/__tests__/user-research.test.ts
+++ b/lib/research/__tests__/user-research.test.ts
@@ -6,6 +6,7 @@ import {
   normalizePmUserResearchGatewayInput,
   normalizeCohortSynthesis,
   normalizeResearchUserProfile,
+  sanitizeResearchComparisonGroups,
   sanitizeResearchText,
   USER_RESEARCH_MAX_COHORT_CONTEXT_CHARS,
   USER_RESEARCH_MAX_CONTEXT_CHARS,
@@ -175,6 +176,21 @@ describe("user research privacy controls", () => {
         evidenceAnchors: [{ userId: "user-1", anchorAt: 1785841937847 }],
       }),
     );
+  });
+
+  it("rejects comparison labels that collide after privacy sanitization", () => {
+    expect(() =>
+      sanitizeResearchComparisonGroups([
+        {
+          label: "first@example.com",
+          userIds: ["user-1", "user-2", "user-3"],
+        },
+        {
+          label: "second@example.com",
+          userIds: ["user-4", "user-5", "user-6"],
+        },
+      ]),
+    ).toThrow("must remain unique after privacy sanitization");
   });
 
   it("pins Grok 4.6 for text-only research with low reasoning", () => {

--- a/lib/research/user-research.ts
+++ b/lib/research/user-research.ts
@@ -5,11 +5,14 @@ import { z } from "zod";
 // accepts images, route that separate vision path to Grok 4.6 Pro with
 // reasoning enabled.
 export const USER_RESEARCH_MODEL_KEY = "model-grok-4.6" as const;
-export const USER_RESEARCH_PROMPT_VERSION = "user-research-v2";
+export const USER_RESEARCH_PROMPT_VERSION = "user-research-v3";
 export const USER_RESEARCH_MAX_CONTEXT_CHARS = 120_000;
 export const USER_RESEARCH_MAX_COHORT_CONTEXT_CHARS = 240_000;
 export const USER_RESEARCH_MIN_COHORT_SIZE = 3;
 export const USER_RESEARCH_MAX_COHORT_SIZE = 20;
+export const USER_RESEARCH_MIN_COMPARISON_GROUPS = 2;
+export const USER_RESEARCH_MAX_COMPARISON_GROUPS = 4;
+export const USER_RESEARCH_MIN_USERS_PER_COMPARISON_GROUP = 3;
 export const USER_RESEARCH_DEFAULT_MAX_CHATS_PER_USER = 12;
 export const USER_RESEARCH_PRODUCTION_POSTHOG_PROJECT_ID = 144137;
 export const USER_RESEARCH_PROVIDER_OPTIONS = {
@@ -29,6 +32,14 @@ export const researchSamplingModeSchema = z.enum([
 const evidenceAnchorSchema = z.object({
   userId: z.string().trim().min(1).max(200),
   anchorAt: z.number().int().positive(),
+});
+
+const comparisonGroupSchema = z.object({
+  label: z.string().trim().min(1).max(100),
+  userIds: z
+    .array(z.string().trim().min(1).max(200))
+    .min(USER_RESEARCH_MIN_USERS_PER_COMPARISON_GROUP)
+    .max(USER_RESEARCH_MAX_COHORT_SIZE),
 });
 
 const pmUserResearchPayloadBaseSchema = z.object({
@@ -60,6 +71,11 @@ const pmUserResearchPayloadBaseSchema = z.object({
   samplingMode: researchSamplingModeSchema.default("representative"),
   evidenceWindowDays: z.number().int().min(1).max(365).optional(),
   evidenceAnchors: z.array(evidenceAnchorSchema).max(20).optional(),
+  comparisonGroups: z
+    .array(comparisonGroupSchema)
+    .min(USER_RESEARCH_MIN_COMPARISON_GROUPS)
+    .max(USER_RESEARCH_MAX_COMPARISON_GROUPS)
+    .optional(),
   maxChatsPerUser: z
     .number()
     .int()
@@ -75,6 +91,7 @@ const requireUniqueResearchUsers = (
     samplingMode: "representative" | "pre_event";
     evidenceWindowDays?: number;
     evidenceAnchors?: Array<{ userId: string; anchorAt: number }>;
+    comparisonGroups?: Array<{ label: string; userIds: string[] }>;
   },
   ctx: z.core.$RefinementCtx,
 ) => {
@@ -136,6 +153,87 @@ const requireUniqueResearchUsers = (
       input: payload.samplingMode,
     });
   }
+
+  const comparisonGroups = payload.comparisonGroups ?? [];
+  if (comparisonGroups.length > 0) {
+    const labels = comparisonGroups.map((group) => group.label);
+    if (new Set(labels).size !== labels.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "comparisonGroups must use unique labels",
+        path: ["comparisonGroups"],
+        input: labels,
+      });
+    }
+
+    const groupedUserIds = comparisonGroups.flatMap((group) => group.userIds);
+    if (new Set(groupedUserIds).size !== groupedUserIds.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "each user may appear in only one comparison group",
+        path: ["comparisonGroups"],
+        input: groupedUserIds,
+      });
+    }
+    if (
+      groupedUserIds.length !== payload.userIds.length ||
+      groupedUserIds.some((userId) => !payload.userIds.includes(userId))
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "comparisonGroups must assign every cohort user exactly once",
+        path: ["comparisonGroups"],
+        input: groupedUserIds,
+      });
+    }
+  }
+};
+
+const normalizeGatewayTimestamp = (value: unknown): unknown => {
+  if (typeof value !== "string") return value;
+  const normalized = value.trim();
+  if (/^\d+$/.test(normalized)) return Number(normalized);
+  const timestamp = Date.parse(normalized);
+  return Number.isNaN(timestamp) ? value : timestamp;
+};
+
+/**
+ * Normalize common PostHog/PM handoff representations at the HTTP boundary.
+ * Trigger and Convex continue to receive the canonical audited shape.
+ */
+export const normalizePmUserResearchGatewayInput = (
+  value: unknown,
+): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const input = value as Record<string, unknown>;
+  const evidenceAnchors = Array.isArray(input.evidenceAnchors)
+    ? input.evidenceAnchors.map((anchor) => {
+        if (!anchor || typeof anchor !== "object" || Array.isArray(anchor)) {
+          return anchor;
+        }
+        const entry = anchor as Record<string, unknown>;
+        return {
+          ...entry,
+          anchorAt: normalizeGatewayTimestamp(entry.anchorAt),
+        };
+      })
+    : input.evidenceAnchors;
+  const samplingMode =
+    input.samplingMode === undefined &&
+    (input.evidenceWindowDays !== undefined || evidenceAnchors !== undefined)
+      ? "pre_event"
+      : input.samplingMode;
+
+  return {
+    ...input,
+    cohortSelectedAt: normalizeGatewayTimestamp(input.cohortSelectedAt),
+    ...(input.selectionQueryFingerprint === undefined &&
+    typeof input.selectionQuerySha256 === "string"
+      ? { selectionQueryFingerprint: input.selectionQuerySha256 }
+      : {}),
+    ...(samplingMode !== undefined ? { samplingMode } : {}),
+    ...(evidenceAnchors !== undefined ? { evidenceAnchors } : {}),
+  };
 };
 
 export const pmUserResearchPayloadSchema =
@@ -261,6 +359,20 @@ export const researchCohortReportSchema = cohortSynthesisSchema.extend({
     selectionLimitations: z.array(z.string().trim().min(1).max(300)).max(8),
     samplingMode: researchSamplingModeSchema,
     evidenceWindowDays: z.number().int().min(1).max(365).optional(),
+    comparisonGroups: z
+      .array(
+        z.object({
+          label: z.string().trim().min(1).max(100),
+          userCount: z
+            .number()
+            .int()
+            .min(USER_RESEARCH_MIN_USERS_PER_COMPARISON_GROUP)
+            .max(USER_RESEARCH_MAX_COHORT_SIZE),
+        }),
+      )
+      .min(USER_RESEARCH_MIN_COMPARISON_GROUPS)
+      .max(USER_RESEARCH_MAX_COMPARISON_GROUPS)
+      .optional(),
     causalAttributionConfidence: confidenceSchema,
   }),
   coverage: z.object({
@@ -282,6 +394,11 @@ export const pmUserResearchResultSchema = z.object({
     .refine((userIds) => new Set(userIds).size === userIds.length, {
       message: "userIds must be unique",
     }),
+  comparisonGroups: z
+    .array(comparisonGroupSchema)
+    .min(USER_RESEARCH_MIN_COMPARISON_GROUPS)
+    .max(USER_RESEARCH_MAX_COMPARISON_GROUPS)
+    .optional(),
   failedProfiles: z.number().int().min(0).max(20),
   usersAnalyzed: z.number().int().min(USER_RESEARCH_MIN_COHORT_SIZE).max(20),
   report: researchCohortReportSchema,
@@ -503,6 +620,7 @@ Synthesis rules:
 - Build 1-4 distinct avatars only when supported across users. Use evidenceUserCount and confidence honestly.
 - Explain main jobs, pains, desired outcomes, reasons to pay, product features used, objections/trust needs, and testable acquisition/message hypotheses.
 - Classify every cross-cohort pattern as observed or inferred, attach the number of supporting users, and keep causal claims low confidence unless the evidence directly establishes causality. Behavioral messages near an event are still not a cancellation survey.
+- When comparison groups are supplied, compare only the labeled aggregate groups, keep their evidence separate, and state whether observed differences support or contradict the question's hypotheses. Treat causal explanations as low confidence.
 - Separate observed evidence from hypotheses. Put unsupported areas in unknowns.
 - Never output direct identifiers, pseudonym mappings, quotes, sensitive personal traits, organizations, targets, findings, files, code, commands, payloads, or exploit details.
 - Recommend small follow-up experiments with measurable success metrics. Mark metrics that need a baseline and never invent numeric thresholds, effect sizes, or statistical power without supplied baseline data. Do not recommend contacting or publicly profiling specific users.
@@ -577,6 +695,7 @@ export const buildCohortPrompt = (args: {
   question: string;
   cohortLabel: string;
   researchBasis: ResearchBasis;
+  comparisonGroups?: Array<{ label: string; pseudonyms: string[] }>;
   profiles: Array<{
     pseudonym: string;
     profile: ResearchUserProfile;
@@ -604,6 +723,10 @@ export const buildCohortPrompt = (args: {
     researchQuestion: sanitizeResearchText(args.question),
     cohortLabel: sanitizeResearchText(args.cohortLabel),
     researchBasis: sanitizeStructuredResearchOutput(modelResearchBasis),
+    comparisonGroups: args.comparisonGroups?.map((group) => ({
+      label: sanitizeResearchText(group.label),
+      pseudonyms: group.pseudonyms,
+    })),
     profiles: compactProfiles,
   });
   return `${COHORT_SYSTEM_PROMPT}\n\nSynthesize this cohort:\n${payload}`;

--- a/lib/research/user-research.ts
+++ b/lib/research/user-research.ts
@@ -189,6 +189,7 @@ const requireUniqueResearchUsers = (
   }
 };
 
+/** Convert supported timestamp strings while leaving invalid values for Zod. */
 const normalizeGatewayTimestamp = (value: unknown): unknown => {
   if (typeof value !== "string") return value;
   const normalized = value.trim();
@@ -501,6 +502,30 @@ export const sanitizeResearchText = (value: string): string =>
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{4,}/g, "\n\n\n")
     .trim();
+
+/** Sanitize comparison labels and reject labels that become empty or collide. */
+export const sanitizeResearchComparisonGroups = (
+  groups: Array<{ label: string; userIds: string[] }> | undefined,
+): Array<{ label: string; userIds: string[] }> | undefined => {
+  const sanitized = groups?.map((group) => ({
+    label: sanitizeResearchText(group.label),
+    userIds: group.userIds,
+  }));
+  if (sanitized?.some((group) => !group.label)) {
+    throw new Error(
+      "Comparison group labels must contain privacy-safe descriptive text",
+    );
+  }
+  if (
+    sanitized &&
+    new Set(sanitized.map((group) => group.label)).size !== sanitized.length
+  ) {
+    throw new Error(
+      "Comparison group labels must remain unique after privacy sanitization",
+    );
+  }
+  return sanitized;
+};
 
 export const sanitizeStructuredResearchOutput = <T>(value: T): T => {
   if (typeof value === "string") {

--- a/trigger/user-research.ts
+++ b/trigger/user-research.ts
@@ -221,11 +221,28 @@ export const pmUserResearch = schemaTask({
     const selectionLimitations = payload.selectionLimitations
       .map(sanitizeResearchText)
       .filter(Boolean);
+    const comparisonGroups = payload.comparisonGroups?.map((group) => ({
+      label: sanitizeResearchText(group.label),
+      userIds: group.userIds,
+    }));
+    if (comparisonGroups?.some((group) => !group.label)) {
+      throw new Error(
+        "Comparison group labels must contain privacy-safe descriptive text",
+      );
+    }
+    const comparisonGroupByUserId = new Map(
+      (comparisonGroups ?? []).flatMap((group) =>
+        group.userIds.map((userId) => [userId, group.label] as const),
+      ),
+    );
     const members = payload.userIds.map((userId, index) => ({
       userId,
       pseudonym: `U${String(index + 1).padStart(2, "0")}`,
       ...(evidenceAnchors.has(userId)
         ? { evidenceAnchorAt: evidenceAnchors.get(userId)! }
+        : {}),
+      ...(comparisonGroupByUserId.has(userId)
+        ? { comparisonGroupLabel: comparisonGroupByUserId.get(userId)! }
         : {}),
     }));
 
@@ -297,6 +314,27 @@ export const pmUserResearch = schemaTask({
           "Fewer than three users had enough evidence for privacy-safe synthesis",
         );
       }
+      const availablePseudonyms = new Set(
+        profiles.map((profile) => profile.pseudonym),
+      );
+      const comparisonGroupsForPrompt = comparisonGroups?.map((group) => ({
+        label: group.label,
+        pseudonyms: group.userIds
+          .map((userId) => {
+            const index = payload.userIds.indexOf(userId);
+            return `U${String(index + 1).padStart(2, "0")}`;
+          })
+          .filter((pseudonym) => availablePseudonyms.has(pseudonym)),
+      }));
+      if (
+        comparisonGroupsForPrompt?.some(
+          (group) => group.pseudonyms.length < USER_RESEARCH_MIN_COHORT_SIZE,
+        )
+      ) {
+        throw new Error(
+          "Fewer than three users remained in a comparison group for privacy-safe synthesis",
+        );
+      }
 
       const researchBasis: ResearchBasis = {
         cohortSource: payload.cohortSource,
@@ -307,6 +345,14 @@ export const pmUserResearch = schemaTask({
         samplingMode: payload.samplingMode,
         ...(payload.evidenceWindowDays !== undefined
           ? { evidenceWindowDays: payload.evidenceWindowDays }
+          : {}),
+        ...(comparisonGroups
+          ? {
+              comparisonGroups: comparisonGroups.map((group) => ({
+                label: group.label,
+                userCount: group.userIds.length,
+              })),
+            }
           : {}),
         // Conversation behavior can explain friction and jobs, but it does not
         // establish the user's causal reason for cancelling.
@@ -323,6 +369,9 @@ export const pmUserResearch = schemaTask({
         question: payload.question,
         cohortLabel: payload.cohortLabel,
         researchBasis,
+        ...(comparisonGroupsForPrompt
+          ? { comparisonGroups: comparisonGroupsForPrompt }
+          : {}),
         profiles: profilesWithBasis,
       });
       assertResearchPromptIsSafe(prompt);
@@ -370,6 +419,7 @@ export const pmUserResearch = schemaTask({
         analysisId,
         status: "completed" as const,
         userIds: payload.userIds,
+        ...(comparisonGroups ? { comparisonGroups } : {}),
         failedProfiles: failedPseudonyms.length,
         usersAnalyzed: profiles.length,
         report,

--- a/trigger/user-research.ts
+++ b/trigger/user-research.ts
@@ -15,6 +15,7 @@ import {
   pmUserResearchPayloadSchema,
   researchSamplingModeSchema,
   researchUserProfileSchema,
+  sanitizeResearchComparisonGroups,
   sanitizeResearchText,
   USER_RESEARCH_MODEL_KEY,
   USER_RESEARCH_MIN_COHORT_SIZE,
@@ -221,15 +222,9 @@ export const pmUserResearch = schemaTask({
     const selectionLimitations = payload.selectionLimitations
       .map(sanitizeResearchText)
       .filter(Boolean);
-    const comparisonGroups = payload.comparisonGroups?.map((group) => ({
-      label: sanitizeResearchText(group.label),
-      userIds: group.userIds,
-    }));
-    if (comparisonGroups?.some((group) => !group.label)) {
-      throw new Error(
-        "Comparison group labels must contain privacy-safe descriptive text",
-      );
-    }
+    const comparisonGroups = sanitizeResearchComparisonGroups(
+      payload.comparisonGroups,
+    );
     const comparisonGroupByUserId = new Map(
       (comparisonGroups ?? []).flatMap((group) =>
         group.userIds.map((userId) => [userId, group.label] as const),


### PR DESCRIPTION
## Summary
- preserve PostHog-selected comparison groups through the restricted research pipeline while exposing only sanitized labels and pseudonyms to Grok 4.6
- keep both profile analysis and final cohort synthesis pinned to `x-ai/grok-4.6` with low reasoning and ZDR, and reject mismatched Convex model metadata
- normalize ISO/PostHog timestamp and SHA-256 handoff formats, infer pre-event sampling when evidence windows are supplied, and surface bounded schema validation details in the PM runner
- fail closed when a comparison group has fewer than three readable profiles

## Verification
- `pnpm test:ci` (443 suites, 4,602 tests)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 4 pre-existing unrelated warnings)
- targeted user-research gateway, schema, Convex, and runner tests

## Deployment / manual verification
1. Deploy the Convex schema/functions for the intended environment.
2. Deploy the matching Trigger.dev worker, then the Vercel gateway.
3. Submit a disposable two-group request using ISO timestamps and `selectionQuerySha256`.
4. Confirm the run records Grok 4.6 with low reasoning, returns labeled aggregate groups, and does not expose internal ID-to-pseudonym mappings or raw customer content.

No browser visual QA is needed because this is a backend-only restricted workflow fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comparative user research with 2–4 labeled groups and at least three users per group.
  * Results preserve group membership and counts, enabling separate comparisons with sanitized labels and pseudonyms.
  * Added automatic handling for timestamps, query hashes, and sampling metadata.
* **Bug Fixes**
  * Gateway errors now provide concise, bounded details without exposing rejected input.
  * Invalid or undersized cohorts return structured validation feedback.
* **Documentation**
  * Updated research guidance and runbooks with comparative cohort requirements and privacy practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->