### PR TITLE
Simplify agent system prompt

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -782,6 +782,12 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).not.toContain("You are in ASK MODE");
     expect(prompt).not.toContain("<inline_line_numbers>");
     expect(prompt).not.toContain("<task_management>");
+    expect(prompt).not.toContain("Do what has been asked; nothing more");
+    expect(prompt).not.toContain("NEVER create files unless");
+    expect(prompt).not.toContain("ALWAYS prefer editing an existing file");
+    expect(prompt).not.toContain(
+      "NEVER proactively create documentation files",
+    );
   });
 
   it("explains ask-approval mode without asking in chat first", async () => {

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -124,7 +124,7 @@ describe("systemPrompt security instructions", () => {
     expect(prompt).toBe(baseline);
   });
 
-  it("shares response style, mistake recovery, and freshness guidance across modes", async () => {
+  it("shares response style and freshness guidance across modes", async () => {
     const askPrompt = await systemPrompt(
       "user_123",
       "ask",
@@ -155,12 +155,6 @@ describe("systemPrompt security instructions", () => {
       );
       expect(prompt.match(/emojis/gi)).toHaveLength(1);
 
-      expect(prompt).toContain("<mistake_recovery>");
-      expect(prompt).toContain("address their specific criticism directly");
-      expect(prompt).toContain("Own and correct mistakes honestly.");
-      expect(prompt).toContain("Avoid excessive apology");
-      expect(prompt).not.toContain("'thumbs down' button");
-
       expect(prompt).toContain("<freshness_and_web_search>");
       expect(prompt).toContain("Your reliable knowledge cutoff is");
       expect(prompt).toContain(
@@ -172,7 +166,6 @@ describe("systemPrompt security instructions", () => {
       expect(prompt).toContain("Do not search for stable general concepts");
 
       expect(prompt.match(/<response_style>/g)).toHaveLength(1);
-      expect(prompt.match(/<mistake_recovery>/g)).toHaveLength(1);
       expect(prompt.match(/<freshness_and_web_search>/g)).toHaveLength(1);
     }
   });
@@ -717,44 +710,18 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
   });
 
   it.each([
-    [
-      "free Ask",
-      "ask",
-      "free",
-      null,
-      "requires a connected local machine on the free plan, or a paid plan for isolated cloud Agent access",
-    ],
-    [
-      "paid Ask",
-      "ask",
-      "pro",
-      null,
-      "Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Control.",
-    ],
-    [
-      "cloud Agent",
-      "agent",
-      "pro",
-      null,
-      "For the default cloud sandbox, commands run in an isolated container",
-    ],
-    [
-      "local Agent",
-      "agent",
-      "pro",
-      "Local sandbox context",
-      "Local sandbox context",
-    ],
+    ["free Ask", "ask"],
+    ["free Agent", "agent"],
   ] as const)(
     "adds local-machine connection guidance once for %s",
-    async (_label, mode, subscription, sandboxContext, expectedVariant) => {
+    async (_label, mode) => {
       const prompt = await systemPrompt(
         "user_123",
         mode,
-        subscription,
+        "free",
         mode === "ask" ? "ask-model" : "agent-model",
         null,
-        sandboxContext,
+        null,
       );
       const setupUrl =
         "https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine";
@@ -770,7 +737,29 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
         "Local Agent access is available on every plan, including Free.",
       );
       expect(prompt.split(setupUrl)).toHaveLength(2);
-      expect(prompt).toContain(expectedVariant);
+    },
+  );
+
+  it.each([
+    ["paid Ask", "ask", null],
+    ["paid cloud Agent", "agent", null],
+    ["paid local Agent", "agent", "Local sandbox context"],
+  ] as const)(
+    "omits local-machine connection guidance for %s",
+    async (_label, mode, sandboxContext) => {
+      const prompt = await systemPrompt(
+        "user_123",
+        mode,
+        "pro",
+        mode === "ask" ? "ask-model" : "agent-model",
+        null,
+        sandboxContext,
+      );
+
+      expect(prompt).not.toContain("<local_machine_access>");
+      expect(prompt).not.toContain(
+        "For local-machine access questions, follow the requirements in <local_machine_access>.",
+      );
     },
   );
 
@@ -791,6 +780,8 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     );
     expect(prompt).toContain("Do not tell the user to switch to Agent mode.");
     expect(prompt).not.toContain("You are in ASK MODE");
+    expect(prompt).not.toContain("<inline_line_numbers>");
+    expect(prompt).not.toContain("<task_management>");
   });
 
   it("explains ask-approval mode without asking in chat first", async () => {

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -167,6 +167,13 @@ describe("systemPrompt security instructions", () => {
 
       expect(prompt.match(/<response_style>/g)).toHaveLength(1);
       expect(prompt.match(/<freshness_and_web_search>/g)).toHaveLength(1);
+      expect(prompt).toContain("<evidence_and_inference>");
+      expect(prompt).toContain(
+        "Do not claim that an action was performed or a result was observed without conversation or tool evidence.",
+      );
+      expect(prompt).toContain(
+        "Clearly distinguish observations, inferences, and unresolved uncertainty.",
+      );
     }
   });
 
@@ -332,6 +339,15 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
       expect(prompt).toContain(
         "label it as a hypothesis or needs-validation item rather than a confirmed vulnerability",
       );
+      expect(prompt).toContain(
+        "Close each vulnerability candidate as confirmed, ruled out by specific counterevidence, or needing validation.",
+      );
+      expect(prompt).toContain(
+        "Missing information, unavailable execution, and failed setup are proof gaps—not evidence of safety.",
+      );
+      expect(prompt).toContain(
+        "Use the least disruptive proof necessary to demonstrate impact.",
+      );
     }
   });
 
@@ -346,6 +362,7 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     );
 
     expect(prompt).not.toContain("<finding_quality>");
+    expect(prompt).not.toContain("Close each vulnerability candidate");
   });
 
   it("adds bounded reconnaissance and artifact hygiene in cloud and local agent modes", async () => {

--- a/lib/ai/tools/__tests__/schemas.test.ts
+++ b/lib/ai/tools/__tests__/schemas.test.ts
@@ -7,6 +7,7 @@ import {
   createRunTerminalCmdToolSchema,
   createWebSearchToolSchema,
   runTerminalCmdTool,
+  todoWriteTool,
 } from "../schemas";
 
 const getDescription = (value: unknown): string =>
@@ -86,6 +87,25 @@ describe("agent tool schema descriptions", () => {
     );
     expect(getDescription(fullAccessTool)).toContain(
       "automatically routes subsequent Agent steps to a vision-capable model",
+    );
+  });
+
+  test("keeps inline line-number parsing guidance with the file tool", () => {
+    const fileTool = createFileToolSchema({ supportsView: true });
+
+    expect(getDescription(fileTool)).toContain("LINE_NUMBER|LINE_CONTENT");
+    expect(getDescription(fileTool)).toContain(
+      "Treat LINE_NUMBER| as metadata, not as part of the file content.",
+    );
+  });
+
+  test("keeps task-management completion guidance with the todo tool", () => {
+    expect(getDescription(todoWriteTool)).toContain(
+      "### When to Use This Tool",
+    );
+    expect(getDescription(todoWriteTool)).toContain("### When NOT to Use");
+    expect(getDescription(todoWriteTool)).toContain(
+      "Before finishing your turn, complete every todo or cancel it if it is no longer relevant",
     );
   });
 

--- a/lib/ai/tools/schemas.ts
+++ b/lib/ai/tools/schemas.ts
@@ -296,6 +296,7 @@ export const createFileToolSchema = ({
     "'edit' can make multiple targeted replacements at once; all must succeed or none are applied.",
     "For extensive modifications to shorter files, use 'write' to rewrite the entire file instead of 'edit'.",
     "Under read action, the range parameter represents line number ranges (1-indexed, -1 for end of file).",
+    "Text content returned by this tool may prefix each line using the right-aligned, six-character LINE_NUMBER|LINE_CONTENT format. Treat LINE_NUMBER| as metadata, not as part of the file content.",
     "If the range parameter is not specified, the entire file will be read by default.",
     "Oversized files are not loaded in full; read will return file metadata and range guidance instead.",
     "DO NOT use the range parameter when reading a file for the first time; if the content is too long and gets truncated, the result will include range hints.",
@@ -489,6 +490,7 @@ NEVER INCLUDE THESE IN TODOS: basic enumeration steps; reading tool output; rout
   - Mark complete IMMEDIATELY after finishing
   - Only ONE task in_progress at a time
   - Complete current tasks before starting new ones
+  - Before finishing your turn, complete every todo or cancel it if it is no longer relevant
 
 3. **Task Breakdown:**
   - Create specific, actionable security tests

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -45,6 +45,10 @@ Give the best useful answer before asking a follow-up question. Ask no more than
 Do not use emojis unless the user asks for them or their immediately previous message uses one; even then, use them sparingly.
 </response_style>`;
 
+const EVIDENCE_AND_INFERENCE_SECTION = `<evidence_and_inference>
+Do not claim that an action was performed or a result was observed without conversation or tool evidence. Clearly distinguish observations, inferences, and unresolved uncertainty.
+</evidence_and_inference>`;
+
 const getFreshnessAndWebSearchSection = (modelName: ModelName): string => {
   const knowledgeCutoffDate = getModelCutoffDate(modelName);
   const knowledgeCutoffGuidance = knowledgeCutoffDate
@@ -319,6 +323,7 @@ Calibrate severity to only the weakness and impact actually demonstrated. Accoun
 Reserve high-impact ratings for demonstrated broad or systemic impact, while preserving severe ratings when a complete attack chain proves them.
 Deduplicate equivalent findings and consolidate repeated evidence instead of reporting the same issue multiple times.
 If impact cannot be reproduced, label it as a hypothesis or needs-validation item rather than a confirmed vulnerability.
+Close each vulnerability candidate as confirmed, ruled out by specific counterevidence, or needing validation. Missing information, unavailable execution, and failed setup are proof gaps—not evidence of safety. Use the least disruptive proof necessary to demonstrate impact.
 </finding_quality>
 
 ${sandboxContext ? sandboxContext : getDefaultSandboxEnvironmentSection(cloudSandboxProvider)}
@@ -444,6 +449,7 @@ The current date is ${currentDateTime}.`;
     LANGUAGE_SECTION,
     GENERAL_RESPONSE_SECTION,
     RESPONSE_STYLE_SECTION,
+    EVIDENCE_AND_INFERENCE_SECTION,
     getFreshnessAndWebSearchSection(modelName),
   ];
 

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -45,11 +45,6 @@ Give the best useful answer before asking a follow-up question. Ask no more than
 Do not use emojis unless the user asks for them or their immediately previous message uses one; even then, use them sparingly.
 </response_style>`;
 
-const MISTAKE_RECOVERY_SECTION = `<mistake_recovery>
-When the user says a response is wrong, unhelpful, or unsatisfactory, address their specific criticism directly.
-Own and correct mistakes honestly. Avoid excessive apology, self-critique, self-abasement, or submissive language; stay respectful and focused on solving the problem.
-</mistake_recovery>`;
-
 const getFreshnessAndWebSearchSection = (modelName: ModelName): string => {
   const knowledgeCutoffDate = getModelCutoffDate(modelName);
   const knowledgeCutoffGuidance = knowledgeCutoffDate
@@ -258,16 +253,11 @@ ${AGENT_BROWSER_SECTION}
 };
 
 const getAgentModeSection = (
-  mode: ChatMode,
+  subscription: SubscriptionTier,
   sandboxContext?: string | null,
   agentPermissionMode: AgentPermissionMode = "full_access",
   cloudSandboxProvider?: CloudSandboxProvider,
 ): string => {
-  const agentSpecificNote =
-    mode === "agent"
-      ? "If you've performed an edit that may partially fulfill the USER's query, but you're not confident, gather more information or use more tools before ending your turn.\n"
-      : "";
-
   return `<current_mode>
 You are in AGENT MODE. Use the available tools to read files, edit code, run terminal commands, and execute code when useful. Do not tell the user to switch to Agent mode.
 </current_mode>
@@ -312,53 +302,10 @@ USE SEQUENTIAL tool calls when there are dependencies:
 Before executing tools, carefully consider: Do these operations have dependencies, or are they truly independent? Default to sequential execution unless you're confident operations can run in parallel without issues. Limit parallel operations to 3-5 concurrent calls to avoid timeouts.
 </maximize_parallel_tool_calls>
 
-<maximize_context_understanding>
-Be THOROUGH when gathering information. Make sure you have the FULL picture before replying. Use additional tool calls or clarifying questions as needed.
-TRACE every symbol back to its definitions and usages so you fully understand it.
-Look past the first seemingly relevant result. EXPLORE alternative implementations, edge cases, and varied search terms until you have COMPREHENSIVE coverage of the topic.
-${agentSpecificNote}
-Bias towards not asking the user for help if you can find the answer yourself.
-</maximize_context_understanding>
-
 Do what has been asked; nothing more, nothing less.
 NEVER create files unless they're absolutely necessary for achieving your goal.
 ALWAYS prefer editing an existing file to creating a new one.
 NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
-
-<inline_line_numbers>
-Code chunks that you receive (via tool calls or from user) may include inline line numbers in the form LINE_NUMBER|LINE_CONTENT. Treat the LINE_NUMBER| prefix as metadata and do NOT treat it as part of the actual code. LINE_NUMBER is right-aligned number padded with spaces to 6 characters.
-</inline_line_numbers>
-
-<task_management>
-You have access to the todo_write tool to help you manage and plan tasks. Use this tool whenever you are working on a complex task, and skip it if the task is simple or would only require 1-2 steps.
-IMPORTANT: Make sure you don't end your turn before you've completed all todos.
-</task_management>
-
-<summary_spec>
-At the end of your turn, you should provide a summary.
-
-Summarize any changes you made at a high-level and their impact. If the user asked for info, summarize the answer but don't explain your search process. If the user asked a basic query, skip the summary entirely.
-Use concise bullet points for lists; short paragraphs if needed. Use markdown if you need headings.
-Don't repeat the plan.
-It's very important that you keep the summary short, non-repetitive, and high-signal, or it will be too long to read. The user can view your full assessment results in the terminal, so only flag specific findings that are very important to highlight to the user.
-Don't add headings like "Summary:" or "Update:".
-</summary_spec>
-
-<output_efficiency>
-Be concise. Lead with the action or answer, not reasoning. Skip filler words and preamble.
-- Do NOT preface with "I'll do X", "Let me X", "Here's what I found" — just do it or state it
-- Do NOT repeat back what the user said or summarize their request before acting
-- Do NOT add trailing summaries of what you just did unless it's a natural end-of-turn summary
-- One-line answers are fine for simple questions
-- After completing a tool operation, move to the next step — don't narrate what you just did
-</output_efficiency>
-
-<code_quality>
-- Do not add comments to code you write unless the code is genuinely complex or the user asks for them
-- When writing exploit code or scripts, make them complete and working — never use pseudocode or placeholder functions
-- Fix problems at the root cause, not with surface-level patches
-- Prefer using tool results you already have over making redundant tool calls for the same information
-</code_quality>
 
 <scan_methodology>
 When running security scans:
@@ -381,9 +328,7 @@ If impact cannot be reproduced, label it as a hypothesis or needs-validation ite
 
 ${sandboxContext ? sandboxContext : getDefaultSandboxEnvironmentSection(cloudSandboxProvider)}
 
-${getProductQuestionsSection()}
-
-Answer the user's request using the relevant tool(s), if they are available. Check that all the required parameters for each tool call are provided or can reasonably be inferred from context. IF there are no relevant tools or there are missing values for required parameters, ask the user to supply these values; otherwise proceed with the tool calls. If the user provides a specific value for a parameter (for example provided in quotes), make sure to use that value EXACTLY. DO NOT make up values for or ask about optional parameters. Carefully analyze descriptive terms in the request as they may indicate required parameter values that should be included even if not explicitly quoted.`;
+${getProductQuestionsSection(subscription)}`;
 };
 
 const getAgentToolApprovalSection = (
@@ -414,9 +359,8 @@ Agent tool approval mode: Full access. Tool calls can run without per-action app
 </agent_tool_approval>`;
 };
 
-const getProductQuestionsSection = (): string =>
-  `For local-machine access questions, follow the requirements in <local_machine_access>. \
-For all other product questions, including how many messages they can send, HackerAI costs, \
+const getProductQuestionsSection = (subscription: SubscriptionTier): string =>
+  `${subscription === "free" ? "For local-machine access questions, follow the requirements in <local_machine_access>. For all other" : "For"} product questions, including how many messages they can send, HackerAI costs, \
 or how to perform actions within the application, HackerAI should say that it doesn't know \
 and point them to 'https://help.hackerai.co'.`;
 
@@ -461,7 +405,7 @@ edit code, run terminal commands, or execute code. ${agentModeCTA}
 </current_mode>
 
 `;
-  return `${modeReminder}${getProductQuestionsSection()}`;
+  return `${modeReminder}${getProductQuestionsSection(subscription)}`;
 };
 
 const GENERIC_DELEGATION_SECTION = `<generic_delegation>
@@ -504,18 +448,20 @@ The current date is ${currentDateTime}.`;
     basePrompt,
     LANGUAGE_SECTION,
     GENERAL_RESPONSE_SECTION,
-    LOCAL_MACHINE_ACCESS_SECTION,
     RESPONSE_STYLE_SECTION,
-    MISTAKE_RECOVERY_SECTION,
     getFreshnessAndWebSearchSection(modelName),
   ];
+
+  if (subscription === "free") {
+    sections.push(LOCAL_MACHINE_ACCESS_SECTION);
+  }
 
   if (mode === "ask") {
     sections.push(getAskModeSection(subscription, shouldIncludeNotes));
   } else {
     sections.push(
       getAgentModeSection(
-        mode,
+        subscription,
         sandboxContext,
         agentPermissionMode,
         cloudSandboxProvider,

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -302,11 +302,6 @@ USE SEQUENTIAL tool calls when there are dependencies:
 Before executing tools, carefully consider: Do these operations have dependencies, or are they truly independent? Default to sequential execution unless you're confident operations can run in parallel without issues. Limit parallel operations to 3-5 concurrent calls to avoid timeouts.
 </maximize_parallel_tool_calls>
 
-Do what has been asked; nothing more, nothing less.
-NEVER create files unless they're absolutely necessary for achieving your goal.
-ALWAYS prefer editing an existing file to creating a new one.
-NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
-
 <scan_methodology>
 When running security scans:
 - Parse and summarize results — don't dump raw output without analysis


### PR DESCRIPTION
## Summary
- remove redundant mistake recovery, context expansion, summary, output efficiency, code quality, and final tool-parameter instructions from the base prompt
- inject local-machine access guidance only for Free users and avoid dangling paid-tier references
- move inline line-number parsing and todo completion guidance into their owning tool descriptions
- update prompt and tool-schema regression coverage

## Testing
- pnpm typecheck
- pnpm test: 443 suites and 4,602 tests passed
- targeted ESLint and Prettier checks
- git diff --check

## Manual verification
- Generate Free Ask and Agent prompts and confirm the local-machine access block appears exactly once.
- Generate paid Ask, cloud Agent, and local Agent prompts and confirm that block and its cross-reference are absent.
- Inspect file and todo tool descriptions and confirm the relocated guidance is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - AI responses now provide more subscription-aware guidance for product questions.
  - Free experiences include guidance for accessing the local machine where applicable.
  - File-related responses clarify that line-number prefixes are metadata, not file content.
  - Task tracking guidance now requires todos to be completed or cancelled before a turn ends.
  - Agent responses have streamlined guidance for clearer, more focused interactions.
  - Vulnerability findings now distinguish confirmed evidence from inference and identify items requiring validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->