### PR TITLE
HAC-96: Record pause offer evaluations and flush their telemetry

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -115,6 +115,7 @@ describe("proxy", () => {
     "/api/health/trigger-agent-mode",
     "/api/cron/platform-costs/convex",
     "/api/cron/platform-costs/vercel",
+    "/api/cron/subscription-pauses",
   ])(
     "bypasses AuthKit for the public or independently authenticated endpoint %s",
     async (pathname) => {

--- a/app/api/billing/__tests__/retention-routes.test.ts
+++ b/app/api/billing/__tests__/retention-routes.test.ts
@@ -21,7 +21,7 @@ jest.mock("@/lib/actions/resume-subscription", () => ({
 }));
 
 jest.mock("@/lib/posthog/server", () => ({
-  phLogger: { flush: jest.fn() },
+  phLogger: { flush: jest.fn(), event: jest.fn() },
 }));
 
 jest.mock("next/server", () => ({

--- a/app/api/billing/pause/route.ts
+++ b/app/api/billing/pause/route.ts
@@ -1,9 +1,10 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 
 import pauseSubscription from "@/lib/actions/pause-subscription";
 import { billingRouteErrorResponse } from "@/lib/billing/api-response";
 import { BILLING_ERRORS } from "@/lib/billing/billing-errors";
+import { phLogger } from "@/lib/posthog/server";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +36,7 @@ function parsePauseSubscriptionInput(
 
 /** Accept the retention "pause" offer instead of cancelling outright. */
 export async function POST(request: NextRequest) {
+  after(() => phLogger.flush());
   try {
     const body = await request.json().catch(() => null);
     const input = parsePauseSubscriptionInput(body);

--- a/app/api/billing/retention-offers/route.ts
+++ b/app/api/billing/retention-offers/route.ts
@@ -1,8 +1,9 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 
 import getRetentionOffers from "@/lib/actions/retention-offers";
 import { billingRouteErrorResponse } from "@/lib/billing/api-response";
+import { phLogger } from "@/lib/posthog/server";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 /** Preview which retention offers apply to the selected cancellation reason. */
 export async function POST(request: NextRequest) {
+  // Flush queued PostHog events and logs after the response is sent; the
+  // evaluation event and flag telemetry are otherwise lost on freeze.
+  after(() => phLogger.flush());
   try {
     const body = await request.json().catch(() => null);
     const reasonCategory = isRecord(body) ? body.reasonCategory : undefined;

--- a/app/api/cron/subscription-pauses/route.ts
+++ b/app/api/cron/subscription-pauses/route.ts
@@ -19,6 +19,7 @@ const MAX_RESUMES_PER_RUN = 50;
  */
 export async function GET(request: Request) {
   const requestId = request.headers.get("x-vercel-id") ?? randomUUID();
+  after(() => phLogger.flush());
   if (!isAuthorizedCronRequest(request)) {
     phLogger.warn("subscription_pause_cron_unauthorized", {
       request_id: requestId,
@@ -98,7 +99,6 @@ export async function GET(request: Request) {
       duration_ms: Date.now() - startedAt,
       ...counts,
     });
-    after(() => phLogger.flush());
     return NextResponse.json({ ok: true, ...counts });
   } catch (error) {
     phLogger.error("subscription_pause_cron_failed", {
@@ -108,7 +108,6 @@ export async function GET(request: Request) {
       ...counts,
       error,
     });
-    after(() => phLogger.flush());
     return NextResponse.json(
       { ok: false, error: "Subscription pause resume run failed", ...counts },
       { status: 500 },

--- a/docs/internal/retention-offers.md
+++ b/docs/internal/retention-offers.md
@@ -54,6 +54,10 @@ Users can cancel a scheduled pause with the existing **Keep plan** action
 
 Events (all carry `paid_funnel_event_version`):
 
+- `retention_offer_evaluated` (server, every offers request) with
+  `pause_offer_flag_state` (`enabled` / `disabled` / `unavailable`),
+  `pause_offered`, and `pause_ineligibility_reason`; the first place to look
+  when a canceller did not see the offer
 - `retention_offer_impressed` (client, exposure) with `offers_shown`
 - `retention_offer_accepted` / `retention_offer_declined`
 - `subscription_pause_scheduled`, `subscription_pause_canceled`,
@@ -68,7 +72,9 @@ The Convex cancellation report now includes `pausedCount` per reason group.
 ## Environment
 
 - `PAUSE_OFFER_ENABLED=true|false` overrides the PostHog flag (local dev or
-  kill switch). Leave unset in production.
+  kill switch). Leave unset in production. A flag lookup that times out is
+  retried once, then logged as `pause_offer_flag_unavailable` and treated as
+  disabled.
 - `CRON_SECRET` protects the resume cron, like the existing platform-cost crons.
 - The Convex schema adds the `subscription_pauses` table; deploy Convex before
   enabling the flag.

--- a/lib/actions/__tests__/pause-subscription.test.ts
+++ b/lib/actions/__tests__/pause-subscription.test.ts
@@ -57,6 +57,8 @@ jest.mock("@/convex/_generated/api", () => ({
 
 jest.mock("@/lib/billing/retention-offers.server", () => ({
   isPauseOfferEnabledForUser: mockIsPauseOfferEnabledForUser,
+  getPauseOfferFlagState: async (userId: string) =>
+    (await mockIsPauseOfferEnabledForUser(userId)) ? "enabled" : "disabled",
 }));
 
 jest.mock("@/lib/posthog/server", () => ({

--- a/lib/actions/retention-offers.ts
+++ b/lib/actions/retention-offers.ts
@@ -5,9 +5,15 @@ import type { RetentionOffers } from "@/lib/billing/api-types";
 import { CANCELLATION_REASON_INPUT_ERRORS } from "@/lib/billing/cancellation-reason-input";
 import { isCancellationReasonCategory } from "@/lib/billing/cancellation-reasons";
 import {
+  PAID_FUNNEL_EVENTS,
+  paidFunnelProperties,
+} from "@/lib/analytics/paid-funnel";
+import {
   buildRetentionOffers,
   evaluateRetentionOffersForUser,
+  retentionOfferEvaluationProperties,
 } from "@/lib/billing/retention-offer-evaluation";
+import { phLogger } from "@/lib/posthog/server";
 
 type GetRetentionOffersInput = {
   reasonCategory?: unknown;
@@ -21,12 +27,27 @@ export default async function getRetentionOffersAction(
     throw new Error(CANCELLATION_REASON_INPUT_ERRORS.missingCategory);
   }
 
-  const { user, stripeCustomerId } = await getBillingActionContext();
+  const { organizationId, user, stripeCustomerId } =
+    await getBillingActionContext();
   const evaluation = await evaluateRetentionOffersForUser({
     userId: user.id,
     stripeCustomerId,
     reasonCategory: input.reasonCategory,
   });
+
+  // Server-side record of every decision, including the silent "no offer"
+  // outcomes the client never reports.
+  phLogger.event(
+    PAID_FUNNEL_EVENTS.retentionOfferEvaluated,
+    paidFunnelProperties({
+      userId: user.id,
+      org_id: organizationId,
+      stripe_customer_id: stripeCustomerId,
+      surface: "cancel_subscription_dialog",
+      source: "account_settings",
+      ...retentionOfferEvaluationProperties(evaluation, input.reasonCategory),
+    }),
+  );
 
   return buildRetentionOffers(evaluation);
 }

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -21,6 +21,7 @@ export const PAID_FUNNEL_EVENTS = {
   cancellationReasonSubmitted: "cancellation_reason_free_text_submitted",
   cancellationCompleted: "cancellation_completed",
   cancellationReversed: "cancellation_reversed",
+  retentionOfferEvaluated: "retention_offer_evaluated",
   retentionOfferImpressed: "retention_offer_impressed",
   retentionOfferAccepted: "retention_offer_accepted",
   retentionOfferDeclined: "retention_offer_declined",

--- a/lib/billing/__tests__/retention-offers.server.test.ts
+++ b/lib/billing/__tests__/retention-offers.server.test.ts
@@ -1,0 +1,65 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const mockGetFlagValue = jest.fn();
+const mockWarn = jest.fn();
+
+jest.mock("@/lib/posthog/server", () => ({
+  getPostHogFeatureFlagValueForUser: mockGetFlagValue,
+  phLogger: { warn: mockWarn },
+}));
+
+describe("getPauseOfferFlagState", () => {
+  const originalOverride = process.env.PAUSE_OFFER_ENABLED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.PAUSE_OFFER_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalOverride === undefined) delete process.env.PAUSE_OFFER_ENABLED;
+    else process.env.PAUSE_OFFER_ENABLED = originalOverride;
+  });
+
+  it("maps flag values to enabled and disabled", async () => {
+    const { getPauseOfferFlagState } =
+      await import("../retention-offers.server");
+    mockGetFlagValue.mockResolvedValueOnce(true as never);
+    await expect(getPauseOfferFlagState("user_1")).resolves.toBe("enabled");
+    mockGetFlagValue.mockResolvedValueOnce(false as never);
+    await expect(getPauseOfferFlagState("user_1")).resolves.toBe("disabled");
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it("retries once and reports an unavailable flag service", async () => {
+    const { getPauseOfferFlagState, isPauseOfferEnabledForUser } =
+      await import("../retention-offers.server");
+    mockGetFlagValue
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(true as never);
+    await expect(getPauseOfferFlagState("user_1")).resolves.toBe("enabled");
+    expect(mockGetFlagValue).toHaveBeenCalledTimes(2);
+
+    mockGetFlagValue.mockResolvedValue(null as never);
+    await expect(isPauseOfferEnabledForUser("user_1")).resolves.toBe(false);
+    expect(mockWarn).toHaveBeenCalledWith(
+      "pause_offer_flag_unavailable",
+      expect.objectContaining({ userId: "user_1" }),
+    );
+  });
+
+  it("honours the environment override without calling PostHog", async () => {
+    process.env.PAUSE_OFFER_ENABLED = "false";
+    const { getPauseOfferFlagState } =
+      await import("../retention-offers.server");
+    await expect(getPauseOfferFlagState("user_1")).resolves.toBe("disabled");
+    expect(mockGetFlagValue).not.toHaveBeenCalled();
+  });
+});

--- a/lib/billing/retention-offer-evaluation.ts
+++ b/lib/billing/retention-offer-evaluation.ts
@@ -11,12 +11,16 @@ import {
   evaluatePauseOfferEligibility,
   type PauseOfferEligibility,
 } from "@/lib/billing/retention-offers";
-import { isPauseOfferEnabledForUser } from "@/lib/billing/retention-offers.server";
+import {
+  getPauseOfferFlagState,
+  type PauseOfferFlagState,
+} from "@/lib/billing/retention-offers.server";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { phLogger } from "@/lib/posthog/server";
 
 export type RetentionOfferEvaluation = {
   offersEnabled: boolean;
+  flagState: PauseOfferFlagState;
   pause: PauseOfferEligibility;
   subscription: CurrentSubscriptionContext;
   lastPauseRequestedAtMs?: number;
@@ -58,7 +62,8 @@ export async function evaluateRetentionOffersForUser(args: {
   const subscription =
     args.subscription ??
     (await getCurrentSubscriptionContext(args.stripeCustomerId));
-  const offersEnabled = await isPauseOfferEnabledForUser(args.userId);
+  const flagState = await getPauseOfferFlagState(args.userId);
+  const offersEnabled = flagState === "enabled";
   const lastPauseRequestedAtMs = offersEnabled
     ? await lastPauseRequestedAt(args.userId)
     : undefined;
@@ -76,7 +81,34 @@ export async function evaluateRetentionOffersForUser(args: {
     lastPauseRequestedAtMs,
   });
 
-  return { offersEnabled, pause, subscription, lastPauseRequestedAtMs };
+  return {
+    offersEnabled,
+    flagState,
+    pause,
+    subscription,
+    lastPauseRequestedAtMs,
+  };
+}
+
+/** Privacy-safe analytics properties describing an offer evaluation. */
+export function retentionOfferEvaluationProperties(
+  evaluation: RetentionOfferEvaluation,
+  reasonCategory: CancellationReasonCategory,
+) {
+  const { pause, subscription } = evaluation;
+  return {
+    subscription_tier: subscription.tier,
+    plan: subscription.plan,
+    stripe_price_lookup_key: subscription.plan,
+    billing_interval: subscription.billingInterval,
+    subscription_status: subscription.status,
+    reason_category: reasonCategory,
+    pause_offer_flag_state: evaluation.flagState,
+    pause_offered: pause.eligible,
+    pause_ineligibility_reason: pause.eligible ? undefined : pause.reason,
+    stripe_subscription_id: subscription.id,
+    stripe_price_id: subscription.priceId,
+  };
 }
 
 export function buildRetentionOffers(

--- a/lib/billing/retention-offers.server.ts
+++ b/lib/billing/retention-offers.server.ts
@@ -1,22 +1,51 @@
 import { PAUSE_OFFER_FLAG_KEY } from "@/lib/billing/retention-offers";
-import { getPostHogFeatureFlagValueForUser } from "@/lib/posthog/server";
+import {
+  getPostHogFeatureFlagValueForUser,
+  phLogger,
+} from "@/lib/posthog/server";
+
+export type PauseOfferFlagState = "enabled" | "disabled" | "unavailable";
 
 /**
  * The pause offer is staged through the PostHog flag. The environment
  * override exists for local development and incident kill-switches; unset it
  * in production so PostHog stays the source of truth for the rollout.
+ *
+ * A flag lookup that times out or errors returns "unavailable". The offer
+ * fails closed in that case, and the state is reported so a slow flag service
+ * cannot silently hide the offer from every canceller.
  */
-export async function isPauseOfferEnabledForUser(
+export async function getPauseOfferFlagState(
   userId: string,
-): Promise<boolean> {
+): Promise<PauseOfferFlagState> {
   const override = process.env.PAUSE_OFFER_ENABLED?.trim().toLowerCase();
-  if (override === "true") return true;
-  if (override === "false") return false;
+  if (override === "true") return "enabled";
+  if (override === "false") return "disabled";
 
-  const value = await getPostHogFeatureFlagValueForUser(
+  let value = await getPostHogFeatureFlagValueForUser(
     PAUSE_OFFER_FLAG_KEY,
     userId,
   );
-  // Fail closed: a missing flag or PostHog outage shows the plain cancel flow.
-  return value === true;
+  if (value === null) {
+    // One retry covers the common transient: a cold flag request that hits
+    // the client's short timeout.
+    value = await getPostHogFeatureFlagValueForUser(
+      PAUSE_OFFER_FLAG_KEY,
+      userId,
+    );
+  }
+  if (value === null) {
+    phLogger.warn("pause_offer_flag_unavailable", {
+      userId,
+      flag_key: PAUSE_OFFER_FLAG_KEY,
+    });
+    return "unavailable";
+  }
+  return value ? "enabled" : "disabled";
+}
+
+export async function isPauseOfferEnabledForUser(
+  userId: string,
+): Promise<boolean> {
+  return (await getPauseOfferFlagState(userId)) === "enabled";
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -27,6 +27,7 @@ const AUTHKIT_BYPASS_PATHS = new Set([
   "/api/health/trigger-agent-mode",
   "/api/cron/platform-costs/convex",
   "/api/cron/platform-costs/vercel",
+  "/api/cron/subscription-pauses",
   "/api/internal/user-research",
   "/robots.txt",
   "/sitemap.xml",


### PR DESCRIPTION
## Summary

Follow-up to #1252 (HAC-96), driven by the first hours in production.

1. **Cron was blocked by the auth middleware.** Both scheduled runs of `/api/cron/subscription-pauses` returned 401 because the path was not in the middleware's `AUTHKIT_BYPASS_PATHS` allowlist, so Vercel's request never reached the route's `CRON_SECRET` check. Added it (with the proxy test).
2. **Offer evaluations were invisible server-side.** An eligible canceller went through the flow with no offer signal and nothing could say why: the offers route never flushed its PostHog queue, and a flag lookup timeout silently degrades to the plain cancel flow.

## Changes

- Middleware: allow `/api/cron/subscription-pauses` through AuthKit like the platform-cost crons.
- `retention_offer_evaluated` server event on every `/api/billing/retention-offers` call with `pause_offer_flag_state` (`enabled` / `disabled` / `unavailable`), `pause_offered`, and `pause_ineligibility_reason`.
- Flag lookup retries once on a null answer, then logs `pause_offer_flag_unavailable` and fails closed.
- `after(() => phLogger.flush())` on the offers and pause routes and on every exit path of the resume cron.

## Verified in production before this PR

- Offer flow works end to end: a Pro monthly canceller at 19:56 UTC got a 200 from the offers route, saw the pause card (`retention_offer_impressed`, `offers_shown=["pause"]`), declined, and cancelled.
- Cron requests at 19:23 and 20:23 UTC returned 401 (the bug fixed here).

## Test plan

- [x] `pnpm typecheck`, lint on changed files, proxy/billing/cron test suites (new tests for the flag state helper and the bypass path)
- [ ] After deploy: the next `:23` cron run returns 200 and `subscription_pause_cron_completed` appears in PostHog logs
- [ ] `retention_offer_evaluated` appears in PostHog for the next cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Retention offers now report evaluation outcomes, including eligibility, offer visibility, and feature-flag status.
  - Feature-flag checks retry once when unavailable and fail closed if the issue persists.
  - Environment overrides can control pause-offer availability.

- **Documentation**
  - Added guidance for retention-offer analytics, flag evaluation states, retry behavior, and unavailable-flag handling.

- **Bug Fixes**
  - Improved completion of billing and subscription-pause event tracking across successful and failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->