### PR TITLE
Fix non-reasoning free Ask routing

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -113,7 +113,7 @@ describe("provider registry", () => {
     expect(
       (myProvider.languageModel("ask-model-free") as { modelId: string })
         .modelId,
-    ).toBe("deepseek/deepseek-v4-flash-0731");
+    ).toBe("deepseek/deepseek-v4-flash");
     expect(
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
@@ -272,11 +272,11 @@ describe("provider registry", () => {
     expect(isDeepSeekModel("agent-auto-review-model")).toBe(true);
   });
 
-  it("keeps both tracked free routes on DeepSeek V4 Flash", () => {
+  it("keeps tracked free Ask and Agent on their compatible Flash revisions", () => {
     const provider = createTrackedProvider();
     expect(
       (provider.languageModel("ask-model-free") as { modelId: string }).modelId,
-    ).toBe("deepseek/deepseek-v4-flash-0731");
+    ).toBe("deepseek/deepseek-v4-flash");
     expect(
       (provider.languageModel("agent-model-free") as { modelId: string })
         .modelId,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1226,7 +1226,9 @@ export const getOpenRouterProviderRoutingForModel = (
 
 const buildProviderMap = (
   or: OpenRouterInstance,
-  freeAskModelSlug = DEEPSEEK_V4_FLASH_SLUG,
+  // The 0731 endpoint rejects disabled reasoning, so keep non-reasoning Free
+  // Ask on the previous Flash route. Free Agent still uses 0731 with reasoning.
+  freeAskModelSlug = DEEPSEEK_V4_FLASH_PREVIOUS_SLUG,
   freeAgentModelSlug = DEEPSEEK_V4_FLASH_SLUG,
 ) =>
   ({

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -269,14 +269,14 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("runs free Ask on non-reasoning DeepSeek V4 Flash 0731", () => {
+  it("runs free Ask on the non-reasoning-compatible DeepSeek Flash route", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
     expect(opts.openrouter).toMatchObject({
       reasoning: { enabled: false },
+      provider: { ignore: ["novita"] },
       models: [GLM_FLASH_SLUG, DEEPSEEK_V4_PRO_0813_SLUG, GLM_SLUG],
       user: "user-1",
     });
-    expect(opts.openrouter).not.toHaveProperty("provider");
     expect(opts.openrouter.models).toHaveLength(3);
   });
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -963,7 +963,7 @@ export function buildProviderOptions(
     (modelName ? resolveSlug(modelName) : undefined);
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
   // Free Ask is intentionally fast/non-reasoning even when a caller supplies
-  // a reasoning override. DeepSeek V4 Flash 0731 defaults to reasoning on.
+  // a reasoning override. Its provider mapping must remain compatible with it.
   const isFreeAsk = mode === "ask" && modelName === "ask-model-free";
   const isGrok45 = modelId === GROK_4_5_SLUG;
   const isGrok46 = modelId === GROK_4_6_SLUG;

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -570,6 +570,7 @@ describe("token-bucket", () => {
     );
 
     it.each([
+      "ask-model-free",
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-flash-20260423",
     ])(
@@ -581,7 +582,6 @@ describe("token-bucket", () => {
     );
 
     it.each([
-      "ask-model-free",
       "agent-model-free",
       "agent-auto-review-model",
       "deepseek/deepseek-v4-flash-0731",

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -140,9 +140,9 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "agent-model": GROK_4_6_BASE_PRICING,
   "fallback-agent-model": GROK_4_6_BASE_PRICING,
   "fallback-ask-model": GROK_4_6_BASE_PRICING,
-  // Both free routes use the 0731 revision. Provider fallbacks are reconciled
-  // against their served model.
-  "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
+  // Free Ask retains the non-reasoning-compatible Flash route while free
+  // Agent uses 0731. Provider fallbacks reconcile against their served model.
+  "ask-model-free": DEEPSEEK_V4_FLASH_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   // DeepSeek V4 Flash 0731 rates from OpenRouter: $0.14 in / $0.28 out per 1M tokens.
   "agent-auto-review-model": DEEPSEEK_V4_FLASH_0731_PRICING,


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-09-03T20:02:14Z`–`2026-09-04T20:02:14Z`.

Vercel recorded four Free Ask failures across two users and two chats on production deployment `dpl_6rcANMAnvjoPdrNSn9gVBshBdqdo` (commit `d3f4f309`). OpenRouter tried Cloudflare, BaseTen, and Fireworks for `deepseek/deepseek-v4-flash-0731`; every request failed with:

> Reasoning is mandatory for this endpoint and cannot be disabled.

The application explicitly sent `reasoning.enabled=false`, so the 0731 route and the non-reasoning Free Ask contract were incompatible. These were streamed responses with HTTP 200 at Vercel, making the structured provider error the decisive evidence.

## Change

- Route `ask-model-free` back to the previous DeepSeek V4 Flash endpoint, which is already used by non-reasoning title generation.
- Keep Free Ask reasoning disabled and preserve the existing GLM/DeepSeek fallback order.
- Restore the matching previous-Flash cost accounting.
- Leave Free Agent on 0731 with reasoning enabled.

No error suppression or unrelated observability change is included.

## Validation

- Focused Jest: 267 tests passed.
- Commit hook: 450 suites / 4,660 tests passed.
- TypeScript, changed-file ESLint, Prettier, diff checks, and local dependency guard passed.
- Adversarial review covered the tracked/untracked provider registries, fallback retry model selection, cost reconciliation, paid allowance rescue, and Vercel/Trigger deploy skew.

## Manual verification

In Preview, submit a Free Ask prompt and a follow-up:

1. Both responses should complete without the mandatory-reasoning provider error.
2. Provider telemetry should show `deepseek/deepseek-v4-flash` with reasoning disabled.
3. A Free Agent run should still use `deepseek/deepseek-v4-flash-0731` with reasoning enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Free Ask to use the compatible DeepSeek V4 Flash model route.
  * Adjusted Free Ask pricing and provider selection to match the updated model route.
  * Preserved the existing DeepSeek V4 Flash 0731 route for Free Agent and auto-review requests.

* **Tests**
  * Updated coverage for model routing, provider fallback behavior, and per-model pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->