### PR TITLE
Stop the automatic retry loop after a monthly limit error

### DIFF
--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -39,6 +39,7 @@ import {
   shouldShowUpgradeCta,
 } from "@/lib/limit-pressure";
 import type { RetryOptions } from "../hooks/useChatHandlers";
+import { decideExtraUsageResumeRetry } from "@/lib/chat/extra-usage-resume-retry";
 import { formatTaskUiCopy } from "@/app/utils/task-ui-copy";
 
 interface MessageErrorStateProps {
@@ -197,23 +198,31 @@ export const MessageErrorState = ({
       ),
     );
 
+  // Retry the stopped task once after returning from an extra-usage purchase
+  // or payment update. The decision is guarded per chat so a flag that comes
+  // back on the URL after a failed retry cannot fire the retry in a loop.
   useEffect(() => {
-    const url = new URL(window.location.href);
-    const shouldResume =
-      url.searchParams.get("extra-usage-resume") === "true" ||
-      url.searchParams.get("extra-usage-payment-retry") === "true";
+    let storage: Storage | null = null;
+    try {
+      storage = window.sessionStorage;
+    } catch {
+      storage = null;
+    }
+    const decision = decideExtraUsageResumeRetry({
+      href: window.location.href,
+      storage,
+    });
+    if (!decision.flagged) return;
 
-    if (!shouldResume) return;
-
-    url.searchParams.delete("extra-usage-resume");
-    url.searchParams.delete("extra-usage-payment-retry");
-    window.history.replaceState(
-      window.history.state,
-      "",
-      url.pathname + url.search + url.hash,
-    );
-    onRetry();
-  }, [onRetry]);
+    window.history.replaceState(window.history.state, "", decision.nextUrl);
+    captureAuthenticatedEvent("extra_usage_resume_retry", {
+      source: decision.source,
+      retried: decision.retry,
+      ...(decision.retry ? {} : { skipped_reason: decision.reason }),
+      cap_reason: capReason,
+    });
+    if (decision.retry) onRetry();
+  }, [onRetry, capReason]);
 
   const handlePurchaseCredits = async (amountDollars: number) => {
     setIsPurchasing(true);

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -12,6 +12,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
 import { getPaidDailyFreeAllowanceCtaText } from "@/lib/limit-pressure";
+import { resetExtraUsageResumeRetryGuardForTests } from "@/lib/chat/extra-usage-resume-retry";
 
 let mockSubscription: "free" | "pro" = "pro";
 const mockSetSelectedModel = jest.fn();
@@ -51,6 +52,7 @@ jest.mock("convex/react", () => ({
 const { TestWrapper } = require("../testUtils");
 const { MessageErrorState } = require("../MessageErrorState");
 const {
+  captureAuthenticatedEvent,
   capturePaidDailyFreeAllowanceClick,
   capturePaidDailyFreeAllowanceImpression,
 } = require("@/lib/analytics/client");
@@ -59,6 +61,8 @@ const { openSettingsDialog } = require("@/lib/utils/settings-dialog");
 describe("MessageErrorState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.sessionStorage.clear();
+    resetExtraUsageResumeRetryGuardForTests();
     mockSubscription = "pro";
     mockConvexAction.mockResolvedValue({
       hasPaymentMethod: true,
@@ -327,6 +331,47 @@ describe("MessageErrorState", () => {
 
     expect(onRetry).toHaveBeenCalledTimes(1);
     expect(window.location.search).not.toContain("extra-usage-resume");
+    expect(captureAuthenticatedEvent).toHaveBeenCalledWith(
+      "extra_usage_resume_retry",
+      expect.objectContaining({ source: "extra-usage-resume", retried: true }),
+    );
+  });
+
+  it("does not retry again when the resume flag reappears after a failed retry", () => {
+    const onRetry = jest.fn();
+    const renderWithFlag = () => {
+      window.history.replaceState(
+        window.history.state,
+        "",
+        "/c/chat_1?extra-usage-resume=true",
+      );
+      return render(
+        <TestWrapper>
+          <MessageErrorState
+            error={
+              new ChatSDKError("rate_limit:chat", "Limit reached", {
+                capReason: "monthly_exhausted",
+              })
+            }
+            onRetry={onRetry}
+          />
+        </TestWrapper>,
+      );
+    };
+
+    renderWithFlag().unmount();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    renderWithFlag();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(window.location.search).not.toContain("extra-usage-resume");
+    expect(captureAuthenticatedEvent).toHaveBeenLastCalledWith(
+      "extra_usage_resume_retry",
+      expect.objectContaining({
+        retried: false,
+        skipped_reason: "already_retried",
+      }),
+    );
   });
 
   it("offers the daily allowance for a structured Agent stream error", () => {

--- a/lib/chat/__tests__/extra-usage-resume-retry.test.ts
+++ b/lib/chat/__tests__/extra-usage-resume-retry.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import {
+  decideExtraUsageResumeRetry,
+  EXTRA_USAGE_RESUME_RETRY_GUARD_TTL_MS,
+  resetExtraUsageResumeRetryGuardForTests,
+} from "../extra-usage-resume-retry";
+
+const createStorage = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    store,
+  };
+};
+
+const CHAT_URL = "https://hackerai.co/c/chat_1";
+
+describe("decideExtraUsageResumeRetry", () => {
+  beforeEach(() => {
+    resetExtraUsageResumeRetryGuardForTests();
+  });
+
+  it("ignores URLs without a resume flag", () => {
+    expect(
+      decideExtraUsageResumeRetry({
+        href: `${CHAT_URL}?extra-usage-purchased=true&amount=15`,
+        storage: createStorage(),
+      }),
+    ).toEqual({ flagged: false });
+  });
+
+  it("retries once and strips both flags from the URL", () => {
+    const storage = createStorage();
+
+    expect(
+      decideExtraUsageResumeRetry({
+        href: `${CHAT_URL}?extra-usage-purchased=true&amount=15&extra-usage-resume=true#x`,
+        storage,
+        now: 1_000,
+      }),
+    ).toEqual({
+      flagged: true,
+      retry: true,
+      source: "extra-usage-resume",
+      nextUrl: "/c/chat_1?extra-usage-purchased=true&amount=15#x",
+    });
+    expect(storage.store.size).toBe(1);
+  });
+
+  it("does not retry again when the flag reappears in the same page load", () => {
+    const storage = createStorage();
+    const href = `${CHAT_URL}?extra-usage-resume=true`;
+
+    decideExtraUsageResumeRetry({ href, storage, now: 1_000 });
+
+    expect(
+      decideExtraUsageResumeRetry({ href, storage, now: 5 * 60 * 1000 }),
+    ).toMatchObject({ flagged: true, retry: false, reason: "already_retried" });
+  });
+
+  it("remembers the retry across page loads through storage", () => {
+    const storage = createStorage();
+    const href = `${CHAT_URL}?extra-usage-payment-retry=true`;
+
+    decideExtraUsageResumeRetry({ href, storage, now: 1_000 });
+    resetExtraUsageResumeRetryGuardForTests();
+
+    expect(
+      decideExtraUsageResumeRetry({ href, storage, now: 2_000 }),
+    ).toMatchObject({
+      flagged: true,
+      retry: false,
+      source: "extra-usage-payment-retry",
+    });
+  });
+
+  it("retries again once the guard window has passed", () => {
+    const storage = createStorage();
+    const href = `${CHAT_URL}?extra-usage-resume=true`;
+
+    decideExtraUsageResumeRetry({ href, storage, now: 1_000 });
+    resetExtraUsageResumeRetryGuardForTests();
+
+    expect(
+      decideExtraUsageResumeRetry({
+        href,
+        storage,
+        now: 1_000 + EXTRA_USAGE_RESUME_RETRY_GUARD_TTL_MS + 1,
+      }),
+    ).toMatchObject({ flagged: true, retry: true });
+  });
+
+  it("keys the guard per chat", () => {
+    const storage = createStorage();
+
+    decideExtraUsageResumeRetry({
+      href: `${CHAT_URL}?extra-usage-resume=true`,
+      storage,
+      now: 1_000,
+    });
+
+    expect(
+      decideExtraUsageResumeRetry({
+        href: "https://hackerai.co/c/chat_2?extra-usage-resume=true",
+        storage,
+        now: 1_000,
+      }),
+    ).toMatchObject({ flagged: true, retry: true });
+  });
+
+  it("still retries once when storage is unavailable or throws", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    const href = `${CHAT_URL}?extra-usage-resume=true`;
+
+    expect(
+      decideExtraUsageResumeRetry({ href, storage: throwing }),
+    ).toMatchObject({ retry: true });
+    expect(
+      decideExtraUsageResumeRetry({ href, storage: throwing }),
+    ).toMatchObject({ retry: false });
+    expect(decideExtraUsageResumeRetry({ href: "not a url" })).toEqual({
+      flagged: false,
+    });
+  });
+});

--- a/lib/chat/extra-usage-resume-retry.ts
+++ b/lib/chat/extra-usage-resume-retry.ts
@@ -1,0 +1,122 @@
+/**
+ * One-shot guard for the "resume after purchase" automatic retry.
+ *
+ * The extra-usage confirm route sends the user back to the chat with
+ * `?extra-usage-resume=true` (or `?extra-usage-payment-retry=true`), and the
+ * limit error state retries the stopped task once on mount. In production a
+ * single open tab retried every ~5 minutes for 14 hours because the flag kept
+ * reappearing on the URL after each failed retry (Next.js restores the
+ * canonical URL on re-render), so every remount of the error state fired the
+ * retry again. This module decides whether a flag on the current URL should
+ * trigger a retry, remembering what it already consumed for this chat in
+ * memory (this page load) and in session storage (reloads).
+ */
+
+export const EXTRA_USAGE_RESUME_PARAMS = [
+  "extra-usage-resume",
+  "extra-usage-payment-retry",
+] as const;
+
+export type ExtraUsageResumeSource = (typeof EXTRA_USAGE_RESUME_PARAMS)[number];
+
+/** A second flag on the same chat within this window is not retried again. */
+export const EXTRA_USAGE_RESUME_RETRY_GUARD_TTL_MS = 30 * 60 * 1000;
+
+const STORAGE_KEY_PREFIX = "hackerai:extra-usage-resume-retry:";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+export type ExtraUsageResumeDecision =
+  | { flagged: false }
+  | {
+      flagged: true;
+      retry: true;
+      source: ExtraUsageResumeSource;
+      /** URL with the flags removed, safe to pass to history.replaceState. */
+      nextUrl: string;
+    }
+  | {
+      flagged: true;
+      retry: false;
+      source: ExtraUsageResumeSource;
+      nextUrl: string;
+      reason: "already_retried";
+    };
+
+const consumedThisPageLoad = new Set<string>();
+
+export function resetExtraUsageResumeRetryGuardForTests() {
+  consumedThisPageLoad.clear();
+}
+
+function readTimestamp(storage: StorageLike | null | undefined, key: string) {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(key);
+    const parsed = raw === null ? Number.NaN : Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeTimestamp(
+  storage: StorageLike | null | undefined,
+  key: string,
+  value: number,
+) {
+  if (!storage) return;
+  try {
+    storage.setItem(key, String(value));
+  } catch {
+    // Storage can be full or blocked; the in-memory guard still applies.
+  }
+}
+
+export function decideExtraUsageResumeRetry({
+  href,
+  storage,
+  now = Date.now(),
+}: {
+  href: string;
+  storage?: StorageLike | null;
+  now?: number;
+}): ExtraUsageResumeDecision {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return { flagged: false };
+  }
+
+  const source = EXTRA_USAGE_RESUME_PARAMS.find(
+    (param) => url.searchParams.get(param) === "true",
+  );
+  if (!source) return { flagged: false };
+
+  for (const param of EXTRA_USAGE_RESUME_PARAMS) {
+    url.searchParams.delete(param);
+  }
+  const nextUrl = url.pathname + url.search + url.hash;
+  const key = `${STORAGE_KEY_PREFIX}${url.pathname}`;
+
+  const lastRetryAt = readTimestamp(storage, key);
+  const alreadyRetried =
+    consumedThisPageLoad.has(key) ||
+    (lastRetryAt !== null &&
+      now - lastRetryAt < EXTRA_USAGE_RESUME_RETRY_GUARD_TTL_MS);
+
+  if (alreadyRetried) {
+    return {
+      flagged: true,
+      retry: false,
+      source,
+      nextUrl,
+      reason: "already_retried",
+    };
+  }
+
+  consumedThisPageLoad.add(key);
+  writeTimestamp(storage, key, now);
+  return { flagged: true, retry: true, source, nextUrl };
+}


### PR DESCRIPTION
## Summary

One exhausted Pro+ user's open chat tab re-sent an Agent request every ~5 minutes for 14 hours with no clicks: 171 `limit_hit` events over three days, 167 of them on 2026-09-04 with a median gap of 4.9 minutes, all from one browser session on the post-purchase chat URL. Each hit starts a Trigger.dev run that is refused immediately, so it costs little, but it inflates the limit-hit metrics on the allowance readout dashboard and it is a real loop in the client.

**Cause.** After an extra-usage purchase the confirm route redirects to the chat with `?extra-usage-resume=true`, and `MessageErrorState` retries the stopped task once on mount, stripping the flag with `history.replaceState`. In this session the flag kept coming back on the URL after each failed retry (Next.js restores its canonical URL on re-render), so every remount of the error state fired the retry again. PostHog cannot show the flag because the effect strips it before the impression event captures `$current_url`, but the session's URL still carried the sibling `extra-usage-purchased=true&amount=15` params for all 14 hours, and the impression consistently precedes the server limit hit by about a second, which is the mount-then-retry order.

**Fix.** The retry decision moves to `lib/chat/extra-usage-resume-retry.ts` and is one-shot per chat: consumed once per page load in memory and remembered in `sessionStorage` for 30 minutes, keyed by pathname, so a flag that reappears cannot loop. Storage failures fall back to the in-memory guard. Both flags (`extra-usage-resume`, `extra-usage-payment-retry`) are handled the same way.

**Observability.** The error state now emits `extra_usage_resume_retry` with `source`, `retried`, `skipped_reason`, and `cap_reason`. After deploy, a `retried: false` event every 5 minutes from one session confirms the loop mechanism; the corresponding `limit_hit` events should stop.

## Changes

- `lib/chat/extra-usage-resume-retry.ts`: new decision helper with in-memory and session-storage guards.
- `app/components/MessageErrorState.tsx`: use the helper, emit the analytics event.
- Tests: 7 unit tests for the helper (single retry, same-page-load repeat, cross-reload repeat, TTL expiry, per-chat keys, storage failures) and a component test that remounts with the flag restored and asserts no second retry.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] After deploy: person `2fd92cd2-b164-5fe3-92b7-ab85282f3e01` stops producing `limit_hit` every 5 minutes; `extra_usage_resume_retry` events appear with `retried: false` in its place until the tab is closed.
- [ ] Manual: buy credits from the limit error, confirm the task resumes once on return; reload the chat within 30 minutes with `?extra-usage-resume=true` appended and confirm it does not retry again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery after completing an extra-usage purchase or payment by automatically retrying the interrupted action when appropriate.
  - Prevented repeated retries when recovery fails or the resume request is encountered again.
  - Resume requests now expire after a limited period and are handled safely when unavailable or invalid.
  - Removed processed recovery indicators from the URL to avoid unintended repeat behavior.
- **Tests**
  - Added coverage for successful retries, failed-retry protection, expiration, separate chats, malformed links, and storage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->