### PR TITLE
Use low reasoning for free Ask

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -113,7 +113,7 @@ describe("provider registry", () => {
     expect(
       (myProvider.languageModel("ask-model-free") as { modelId: string })
         .modelId,
-    ).toBe("deepseek/deepseek-v4-flash");
+    ).toBe("deepseek/deepseek-v4-flash-0731");
     expect(
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
@@ -272,11 +272,11 @@ describe("provider registry", () => {
     expect(isDeepSeekModel("agent-auto-review-model")).toBe(true);
   });
 
-  it("keeps tracked free Ask and Agent on their compatible Flash revisions", () => {
+  it("keeps tracked free Ask and Agent on the current Flash revision", () => {
     const provider = createTrackedProvider();
     expect(
       (provider.languageModel("ask-model-free") as { modelId: string }).modelId,
-    ).toBe("deepseek/deepseek-v4-flash");
+    ).toBe("deepseek/deepseek-v4-flash-0731");
     expect(
       (provider.languageModel("agent-model-free") as { modelId: string })
         .modelId,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1226,9 +1226,9 @@ export const getOpenRouterProviderRoutingForModel = (
 
 const buildProviderMap = (
   or: OpenRouterInstance,
-  // The 0731 endpoint rejects disabled reasoning, so keep non-reasoning Free
-  // Ask on the previous Flash route. Free Agent still uses 0731 with reasoning.
-  freeAskModelSlug = DEEPSEEK_V4_FLASH_PREVIOUS_SLUG,
+  // DeepSeek V4 Flash requires reasoning. Free Ask uses the same current model
+  // as Free Agent, with a lower reasoning effort set per request.
+  freeAskModelSlug = DEEPSEEK_V4_FLASH_SLUG,
   freeAgentModelSlug = DEEPSEEK_V4_FLASH_SLUG,
 ) =>
   ({

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -269,14 +269,14 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("runs free Ask on the non-reasoning-compatible DeepSeek Flash route", () => {
+  it("runs free Ask with low reasoning across its fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
     expect(opts.openrouter).toMatchObject({
-      reasoning: { enabled: false },
-      provider: { ignore: ["novita"] },
+      reasoning: { enabled: true, effort: "low" },
       models: [GLM_FLASH_SLUG, DEEPSEEK_V4_PRO_0813_SLUG, GLM_SLUG],
       user: "user-1",
     });
+    expect(opts.openrouter).not.toHaveProperty("provider");
     expect(opts.openrouter.models).toHaveLength(3);
   });
 
@@ -440,10 +440,11 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it("disables reasoning for free Ask across its fallback chain", () => {
+  it("uses low reasoning for free Ask across its fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
     expect(opts.openrouter.reasoning).toEqual({
-      enabled: false,
+      enabled: true,
+      effort: "low",
     });
     expect(opts.openrouter.models).toEqual([
       GLM_FLASH_SLUG,
@@ -452,7 +453,7 @@ describe("buildProviderOptions fallback chain", () => {
     ]);
   });
 
-  it("keeps free Ask reasoning disabled over a scoped override", () => {
+  it("keeps free Ask reasoning low over a scoped override", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -464,7 +465,8 @@ describe("buildProviderOptions fallback chain", () => {
     );
 
     expect(opts.openrouter.reasoning).toEqual({
-      enabled: false,
+      enabled: true,
+      effort: "low",
     });
     expect(opts.openrouter.models).toEqual([
       GLM_FLASH_SLUG,
@@ -473,7 +475,7 @@ describe("buildProviderOptions fallback chain", () => {
     ]);
   });
 
-  it("keeps free Ask reasoning disabled over an explicit high override", () => {
+  it("keeps free Ask reasoning low over an explicit high override", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -485,7 +487,8 @@ describe("buildProviderOptions fallback chain", () => {
     );
 
     expect(opts.openrouter.reasoning).toEqual({
-      enabled: false,
+      enabled: true,
+      effort: "low",
     });
   });
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -962,8 +962,8 @@ export function buildProviderOptions(
     options.requestedModelSlug ??
     (modelName ? resolveSlug(modelName) : undefined);
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
-  // Free Ask is intentionally fast/non-reasoning even when a caller supplies
-  // a reasoning override. Its provider mapping must remain compatible with it.
+  // Free Ask keeps mandatory reasoning low even when a caller supplies a
+  // different reasoning override.
   const isFreeAsk = mode === "ask" && modelName === "ask-model-free";
   const isGrok45 = modelId === GROK_4_5_SLUG;
   const isGrok46 = modelId === GROK_4_6_SLUG;
@@ -1027,7 +1027,7 @@ export function buildProviderOptions(
   return {
     openrouter: {
       ...(!usesDefaultGlmFlashAgentReasoning && {
-        reasoning: isFreeAsk ? { enabled: false } : reasoning,
+        reasoning: isFreeAsk ? { enabled: true, effort: "low" } : reasoning,
       }),
       ...(options.hasPdfAttachments && isDeepSeekV4
         ? {

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -570,7 +570,6 @@ describe("token-bucket", () => {
     );
 
     it.each([
-      "ask-model-free",
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-flash-20260423",
     ])(
@@ -582,6 +581,7 @@ describe("token-bucket", () => {
     );
 
     it.each([
+      "ask-model-free",
       "agent-model-free",
       "agent-auto-review-model",
       "deepseek/deepseek-v4-flash-0731",

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -140,9 +140,9 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "agent-model": GROK_4_6_BASE_PRICING,
   "fallback-agent-model": GROK_4_6_BASE_PRICING,
   "fallback-ask-model": GROK_4_6_BASE_PRICING,
-  // Free Ask retains the non-reasoning-compatible Flash route while free
-  // Agent uses 0731. Provider fallbacks reconcile against their served model.
-  "ask-model-free": DEEPSEEK_V4_FLASH_PRICING,
+  // Free Ask and Free Agent use DeepSeek 0731 at different reasoning efforts.
+  // Provider fallbacks reconcile against their served model.
+  "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   // DeepSeek V4 Flash 0731 rates from OpenRouter: $0.14 in / $0.28 out per 1M tokens.
   "agent-auto-review-model": DEEPSEEK_V4_FLASH_0731_PRICING,


### PR DESCRIPTION
## Summary
- restore Free Ask to DeepSeek V4 Flash 0731
- send mandatory reasoning at low effort and keep reasoning visible
- retain the existing provider fallback chain with the same low reasoning contract
- reconcile Free Ask token accounting with the 0731 route

## Production evidence
The merged non-reasoning fix is deployed, but production continues to return `Reasoning is mandatory for this endpoint and cannot be disabled.` for `ask-model-free`. Live OpenRouter probes confirmed the primary and every fallback accept `{ enabled: true, effort: "low" }` with tools and the app's 32k output setting.

## Validation
- focused provider/fallback/pricing tests: 267 passed
- full Jest suite: 451 suites, 4,668 tests passed
- TypeScript typecheck
- ESLint and Prettier

## Manual verification
On production after merge, submit a Free Ask prompt and a follow-up. The response should stream successfully, show low-effort reasoning, and produce no mandatory-reasoning provider error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Model Updates**
  - Free Ask now uses the current DeepSeek V4 Flash 0731 model revision.
  - Pricing is aligned with the current model version.

- **Reasoning**
  - Free Ask now uses low-effort reasoning by default.
  - Higher reasoning requests are appropriately limited to the supported low-effort level for this route.

- **Reliability**
  - Provider fallback behavior remains consistent with the model being served.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->