### PR TITLE
Auto-select newly connected local machines from chat

### DIFF
--- a/app/components/AgentPermissionSelector.tsx
+++ b/app/components/AgentPermissionSelector.tsx
@@ -95,8 +95,8 @@ export function AgentPermissionSelector({
 
   const buttonClassName =
     size === "md"
-      ? "h-9 px-3 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
-      : "h-8 px-2.5 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink";
+      ? "h-9 max-w-full px-3 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
+      : "h-8 max-w-full px-2.5 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink";
 
   const iconClassName = size === "md" ? "h-4 w-4 shrink-0" : "h-5 w-5 shrink-0";
 
@@ -109,7 +109,9 @@ export function AgentPermissionSelector({
           className={buttonClassName}
         >
           <Icon className={iconClassName} aria-hidden="true" />
-          <span className="truncate">{selectedOption.shortLabel}</span>
+          <span className="min-w-0 flex-1 truncate">
+            {selectedOption.shortLabel}
+          </span>
           <ChevronDown
             aria-hidden="true"
             className={

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -12,7 +12,10 @@ import { FileUploadPreview } from "../FileUploadPreview";
 import { QueuedMessagesPanel } from "../QueuedMessagesPanel";
 import { ScrollToBottomButton } from "../ScrollToBottomButton";
 import { useFileUpload } from "@/app/hooks/useFileUpload";
-import { readGeneratedTextAttachment } from "@/app/hooks/useTauri";
+import {
+  isTauriEnvironment,
+  readGeneratedTextAttachment,
+} from "@/app/hooks/useTauri";
 import {
   getDraftAttachmentsById,
   removeDraft,
@@ -633,7 +636,10 @@ export const ChatInput = ({
   // 2. Force local sandbox preference (not e2b)
   // 3. Force auto model selection
   const isFreeAgent =
-    !isCheckingProPlan && subscription === "free" && isAgentMode(chatMode);
+    !isCheckingProPlan &&
+    subscription === "free" &&
+    isAgentMode(chatMode) &&
+    (!isTauriEnvironment() || freeDesktopAgentOnlyActive);
   const freeAgentSandboxAvailable = freeDesktopAgentOnlyActive
     ? isFreeDesktopSandboxAvailable({
         sandboxPreference,

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -918,12 +918,17 @@ export const ChatInput = ({
             data-compact={compactAgentControls ? "true" : "false"}
             data-testid="chat-input-agent-context"
           >
-            <SandboxSelector
-              value={sandboxPreference}
-              onChange={setSandboxPreference}
-            />
             <div
-              className={`ml-auto min-w-0 ${compactAgentControls ? "" : "md:hidden"}`}
+              className="min-w-0 flex-1"
+              data-testid="chat-input-mobile-sandbox"
+            >
+              <SandboxSelector
+                value={sandboxPreference}
+                onChange={setSandboxPreference}
+              />
+            </div>
+            <div
+              className={`ml-auto min-w-0 max-w-[56%] shrink-0 ${compactAgentControls ? "" : "md:hidden"}`}
               data-testid="chat-input-mobile-permission"
             >
               <AgentPermissionSelector analyticsSurface="chat_input" />

--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -33,6 +33,7 @@ interface LocalConnection {
   isDesktop: boolean;
 }
 
+/** Renders connection status and setup controls for local Remote Control. */
 const RemoteControlTab = () => {
   const [token, setToken] = useState<string | null>(null);
   const [isPreparingCommand, setIsPreparingCommand] = useState(false);

--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -18,12 +18,7 @@ import {
 import { toast } from "sonner";
 import { runCommand, convexUrlFlag } from "@/lib/utils/sandbox-command";
 import { useGlobalState } from "@/app/contexts/GlobalState";
-import type {
-  ChatMode,
-  SandboxPreference,
-  SelectedModel,
-  SubscriptionTier,
-} from "@/types/chat";
+import { useNewRemoteConnection } from "@/app/hooks/useAutoSelectNewRemoteConnection";
 
 interface LocalConnection {
   connectionId: string;
@@ -38,79 +33,6 @@ interface LocalConnection {
   isDesktop: boolean;
 }
 
-interface UseAutoSelectNewRemoteConnectionArgs {
-  connections: LocalConnection[] | undefined;
-  chatMode: ChatMode;
-  setChatMode: (mode: ChatMode) => void;
-  subscription: SubscriptionTier;
-  sandboxPreference: SandboxPreference;
-  setSandboxPreference: (preference: SandboxPreference) => void;
-  selectedModel: SelectedModel;
-  setSelectedModel: (model: SelectedModel) => void;
-  onNewConnection?: () => void;
-}
-
-function useAutoSelectNewRemoteConnection({
-  connections,
-  chatMode,
-  setChatMode,
-  subscription,
-  sandboxPreference,
-  setSandboxPreference,
-  selectedModel,
-  setSelectedModel,
-  onNewConnection,
-}: UseAutoSelectNewRemoteConnectionArgs) {
-  const previousRemoteConnectionIdsRef = useRef<Set<string> | null>(null);
-
-  useEffect(() => {
-    if (connections === undefined) return;
-
-    const remoteConnections = connections.filter((conn) => !conn.isDesktop);
-    const currentIds = new Set(
-      remoteConnections.map((conn) => conn.connectionId),
-    );
-    const previousIds = previousRemoteConnectionIdsRef.current;
-    previousRemoteConnectionIdsRef.current = currentIds;
-
-    // Treat the first loaded query result as baseline so existing connections
-    // do not hijack the user's saved mode on settings open or page load.
-    if (previousIds === null) return;
-
-    const newConnection = remoteConnections.find(
-      (conn) => !previousIds.has(conn.connectionId),
-    );
-    if (!newConnection) return;
-
-    onNewConnection?.();
-
-    if (sandboxPreference !== newConnection.connectionId) {
-      setSandboxPreference(newConnection.connectionId);
-    }
-
-    if (subscription === "free" && selectedModel !== "auto") {
-      setSelectedModel("auto");
-    }
-
-    if (chatMode !== "agent") {
-      setChatMode("agent");
-      toast.success("Local sandbox connected. Switched to Agent mode.");
-    } else {
-      toast.success("Local sandbox connected.");
-    }
-  }, [
-    chatMode,
-    connections,
-    onNewConnection,
-    sandboxPreference,
-    selectedModel,
-    setChatMode,
-    setSandboxPreference,
-    setSelectedModel,
-    subscription,
-  ]);
-}
-
 const RemoteControlTab = () => {
   const [token, setToken] = useState<string | null>(null);
   const [isPreparingCommand, setIsPreparingCommand] = useState(false);
@@ -121,30 +43,14 @@ const RemoteControlTab = () => {
     null,
   );
 
-  const {
-    chatMode,
-    setChatMode,
-    subscription,
-    sandboxPreference,
-    setSandboxPreference,
-    selectedModel,
-    setSelectedModel,
-    localConnections: connections,
-  } = useGlobalState();
+  const { localConnections: connections } = useGlobalState();
 
   const tokenResult = useMutation(api.localSandbox.getToken);
   const regenerateToken = useMutation(api.localSandbox.regenerateToken);
   const hideConnectSetup = useCallback(() => setShowConnectSetup(false), []);
 
-  useAutoSelectNewRemoteConnection({
-    chatMode,
+  useNewRemoteConnection({
     connections,
-    sandboxPreference,
-    selectedModel,
-    setChatMode,
-    setSandboxPreference,
-    setSelectedModel,
-    subscription,
     onNewConnection: hideConnectSetup,
   });
 

--- a/app/components/SandboxSelector.tsx
+++ b/app/components/SandboxSelector.tsx
@@ -259,10 +259,10 @@ export function SandboxSelector({
 
   const buttonClassName =
     size === "md"
-      ? "h-9 px-3 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
+      ? "h-9 max-w-full px-3 gap-2 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
       : size === "toolbar"
-        ? "h-7 max-w-44 px-2 gap-1 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink"
-        : "h-7 px-2 gap-1 text-xs font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink";
+        ? "h-7 max-w-full px-2 gap-1 text-sm font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink sm:max-w-44"
+        : "h-7 max-w-full px-2 gap-1 text-xs font-medium rounded-md bg-transparent hover:bg-muted/30 focus-visible:ring-1 min-w-0 shrink";
 
   const iconClassName = size === "md" ? "h-4 w-4 shrink-0" : "h-3 w-3 shrink-0";
 

--- a/app/components/__tests__/AgentPermissionSelector.test.tsx
+++ b/app/components/__tests__/AgentPermissionSelector.test.tsx
@@ -45,6 +45,18 @@ describe("AgentPermissionSelector", () => {
     expect(resolveAgentAutoReviewAvailability).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the trigger contents within constrained mobile toolbars", () => {
+    render(<AgentPermissionSelector analyticsSurface="chat_input" />);
+
+    const trigger = screen.getByRole("button", { name: /full access/i });
+    expect(trigger).toHaveClass("max-w-full", "min-w-0", "shrink");
+    expect(screen.getByText("Full access")).toHaveClass(
+      "min-w-0",
+      "flex-1",
+      "truncate",
+    );
+  });
+
   it("captures permission mode changes before updating the selection", () => {
     render(<AgentPermissionSelector analyticsSurface="chat_input" />);
 

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -492,8 +492,14 @@ describe("ChatInput - Integration Tests", () => {
         "rounded-b-[18px]",
         "md:hidden",
       );
+      expect(screen.getByTestId("chat-input-mobile-sandbox")).toHaveClass(
+        "min-w-0",
+        "flex-1",
+      );
       expect(screen.getByTestId("chat-input-mobile-permission")).toHaveClass(
         "ml-auto",
+        "max-w-[56%]",
+        "shrink-0",
         "md:hidden",
       );
     });

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -16,25 +16,9 @@ type MockConnection = {
 };
 
 let mockConnections: MockConnection[] | undefined;
-let mockChatMode: "ask" | "agent";
-let mockSubscription: "free" | "pro";
-let mockSandboxPreference: string;
-let mockSelectedModel: "auto" | "hackerai-standard" | "hackerai-pro";
-
 const mockGetToken = jest.fn<() => Promise<{ token: string }>>();
 const mockRegenerateToken = jest.fn<() => Promise<{ token: string }>>();
 const mockWriteText = jest.fn<(text: string) => Promise<void>>();
-const mockSetChatMode = jest.fn((mode: "ask" | "agent") => {
-  mockChatMode = mode;
-});
-const mockSetSandboxPreference = jest.fn((preference: string) => {
-  mockSandboxPreference = preference;
-});
-const mockSetSelectedModel = jest.fn(
-  (model: "auto" | "hackerai-standard" | "hackerai-pro") => {
-    mockSelectedModel = model;
-  },
-);
 
 jest.mock("@/convex/_generated/api", () => ({
   api: {
@@ -53,13 +37,6 @@ jest.mock("convex/react", () => ({
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
-    chatMode: mockChatMode,
-    setChatMode: mockSetChatMode,
-    subscription: mockSubscription,
-    sandboxPreference: mockSandboxPreference,
-    setSandboxPreference: mockSetSandboxPreference,
-    selectedModel: mockSelectedModel,
-    setSelectedModel: mockSetSelectedModel,
     localConnections: mockConnections,
   }),
 }));
@@ -107,10 +84,6 @@ describe("RemoteControlTab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockConnections = [];
-    mockChatMode = "ask";
-    mockSubscription = "free";
-    mockSandboxPreference = "e2b";
-    mockSelectedModel = "hackerai-pro";
     mockGetToken.mockResolvedValue({ token: "test-token" });
     mockRegenerateToken.mockResolvedValue({ token: "regenerated-token" });
     mockWriteText.mockResolvedValue(undefined);
@@ -120,32 +93,25 @@ describe("RemoteControlTab", () => {
     });
   });
 
-  it("selects agent mode with the new local connection after an empty baseline", async () => {
+  it("hides setup when a new local connection appears", async () => {
     const { rerender } = render(<RemoteControlTab />);
 
-    expect(mockSetChatMode).not.toHaveBeenCalled();
     expect(screen.getByText("No active connections")).toBeInTheDocument();
 
     mockConnections = [remoteConnection];
     rerender(<RemoteControlTab />);
 
-    await waitFor(() => {
-      expect(mockSetSandboxPreference).toHaveBeenCalledWith("conn-remote-1");
-    });
-    expect(mockSetSelectedModel).toHaveBeenCalledWith("auto");
-    expect(mockSetChatMode).toHaveBeenCalledWith("agent");
-    expect(toast.success).toHaveBeenCalledWith(
-      "Local sandbox connected. Switched to Agent mode.",
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Connect another machine" }),
+      ).toBeInTheDocument(),
     );
-    expect(
-      screen.getByRole("button", { name: "Connect another machine" }),
-    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Copy connect command" }),
     ).not.toBeInTheDocument();
   });
 
-  it("does not switch modes when an existing connection appears on initial query load", async () => {
+  it("treats existing connections as the initial UI baseline", async () => {
     mockConnections = undefined;
     const { rerender } = render(<RemoteControlTab />);
 
@@ -155,10 +121,7 @@ describe("RemoteControlTab", () => {
     await waitFor(() => {
       expect(screen.getByText("devbox")).toBeInTheDocument();
     });
-    expect(mockSetSandboxPreference).not.toHaveBeenCalled();
-    expect(mockSetSelectedModel).not.toHaveBeenCalled();
-    expect(mockSetChatMode).not.toHaveBeenCalled();
-    expect(toast.success).not.toHaveBeenCalled();
+    expect(screen.queryByText("Quick Start")).not.toBeInTheDocument();
   });
 
   it("shows a desktop bridge as an active connection", () => {

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -67,6 +67,16 @@ const remoteConnection: MockConnection = {
   isDesktop: false,
 };
 
+const secondRemoteConnection: MockConnection = {
+  ...remoteConnection,
+  connectionId: "conn-remote-2",
+  name: "Second Machine",
+  osInfo: {
+    ...remoteConnection.osInfo!,
+    hostname: "second-devbox",
+  },
+};
+
 const desktopConnection: MockConnection = {
   connectionId: "conn-desktop-1",
   name: "HackerAI Desktop",
@@ -94,11 +104,17 @@ describe("RemoteControlTab", () => {
   });
 
   it("hides setup when a new local connection appears", async () => {
+    mockConnections = [remoteConnection];
     const { rerender } = render(<RemoteControlTab />);
 
-    expect(screen.getByText("No active connections")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Connect another machine" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Copy connect command" }),
+    ).toBeInTheDocument();
 
-    mockConnections = [remoteConnection];
+    mockConnections = [remoteConnection, secondRemoteConnection];
     rerender(<RemoteControlTab />);
 
     await waitFor(() =>

--- a/app/components/__tests__/SandboxSelector.test.tsx
+++ b/app/components/__tests__/SandboxSelector.test.tsx
@@ -37,6 +37,16 @@ const { SandboxSelector } =
   require("../SandboxSelector") as typeof import("../SandboxSelector");
 
 describe("SandboxSelector", () => {
+  it("keeps its trigger within constrained mobile toolbars", () => {
+    render(<SandboxSelector value="desktop" />);
+
+    expect(screen.getByRole("button", { name: /local/i })).toHaveClass(
+      "max-w-full",
+      "min-w-0",
+      "shrink",
+    );
+  });
+
   beforeEach(() => {
     mockGlobalState.subscription = "free";
     mockGlobalState.localConnections = [];
@@ -100,7 +110,8 @@ describe("SandboxSelector", () => {
     render(<SandboxSelector value="remote-office-pc" size="toolbar" />);
 
     expect(screen.getByRole("button", { name: hostname })).toHaveClass(
-      "max-w-44",
+      "max-w-full",
+      "sm:max-w-44",
       "min-w-0",
     );
     expect(screen.getByTitle(hostname)).toBeInTheDocument();

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -60,6 +60,7 @@ import {
   normalizeAgentFirstSandboxType,
 } from "@/lib/activation/agent-first-default";
 import { resolveFreeDesktopSandboxPreference } from "@/lib/activation/free-desktop-sandbox";
+import { useAutoSelectNewRemoteConnection } from "@/app/hooks/useAutoSelectNewRemoteConnection";
 import {
   ComposerStateProvider,
   useComposerActions,
@@ -701,6 +702,18 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     },
     [agentOnlyActive],
   );
+
+  useAutoSelectNewRemoteConnection({
+    connections: localConnections,
+    enabled: Boolean(user),
+    chatMode: accessibleChatMode,
+    setChatMode,
+    subscription: paidAgentSubscription,
+    sandboxPreference,
+    setSandboxPreference,
+    selectedModel,
+    setSelectedModel: setSelectedModelState,
+  });
 
   useEffect(() => {
     if (!agentOnlyActive) return;

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -561,6 +561,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
 
   useEffect(() => {
     if (!subscriptionResolved) return;
+    if (subscription === "free" && !freeSubscriptionResolved) return;
     const normalizedModel = normalizeSelectedModelForSubscription(
       selectedModel,
       subscription,
@@ -568,7 +569,12 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     if (normalizedModel !== selectedModel) {
       setSelectedModelRaw(normalizedModel);
     }
-  }, [selectedModel, subscription, subscriptionResolved]);
+  }, [
+    freeSubscriptionResolved,
+    selectedModel,
+    subscription,
+    subscriptionResolved,
+  ]);
 
   const setSelectedModelState = useCallback((model: SelectedModel) => {
     setSelectedModelRaw(model);
@@ -685,7 +691,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     paidAgentSubscription !== "free";
   const freeDesktopAgentOnlyActive =
     Boolean(user) &&
-    subscriptionResolved &&
+    freeSubscriptionResolved &&
     !isCheckingProPlan &&
     paidAgentSubscription === "free" &&
     isTauriEnvironment();

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -444,6 +444,10 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     userId: string;
     count: number;
   } | null>(null);
+  const [entitlementRefreshFailure, setEntitlementRefreshFailure] = useState<{
+    userId: string;
+    count: number;
+  } | null>(null);
 
   // Rate limit warning dismissal state (persists across chat switches)
   const [
@@ -525,7 +529,6 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
       entitlementApiResolvedUserId === user?.id) &&
     !entitlementRefreshRequested &&
     !automaticEntitlementRefreshPending;
-  const entitlementRefreshFailure = entitlementRefreshFailureRef.current;
   const tokenFreeAutomaticRefreshExhausted =
     subscriptionFromEntitlements === "free" &&
     entitlementRefreshFailure?.userId === user?.id &&
@@ -792,6 +795,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
       setSubscription("free");
       entitlementRefreshUserRef.current = null;
       entitlementRefreshFailureRef.current = null;
+      setEntitlementRefreshFailure(null);
       setEntitlementApiResolvedUserId(null);
       return;
     }
@@ -854,6 +858,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
         setSubscriptionWithNormalize(tier);
         setEntitlementApiResolvedUserId(user.id);
         entitlementRefreshFailureRef.current = null;
+        setEntitlementRefreshFailure(null);
         // The API response is authoritative for the UI. Refresh AuthKit and the
         // shared access token in the background so a slow token refresh cannot
         // keep the free Ask/Agent selector hidden.
@@ -870,10 +875,12 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
               ? entitlementRefreshFailureRef.current.count
               : 0;
           const failureCount = previousFailureCount + 1;
-          entitlementRefreshFailureRef.current = {
+          const nextFailure = {
             userId: user.id,
             count: failureCount,
           };
+          entitlementRefreshFailureRef.current = nextFailure;
+          setEntitlementRefreshFailure(nextFailure);
           const retryDelay =
             ENTITLEMENT_REFRESH_RETRY_DELAYS_MS[failureCount - 1];
           if (retryDelay !== undefined) {

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -525,6 +525,17 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
       entitlementApiResolvedUserId === user?.id) &&
     !entitlementRefreshRequested &&
     !automaticEntitlementRefreshPending;
+  const entitlementRefreshFailure = entitlementRefreshFailureRef.current;
+  const tokenFreeAutomaticRefreshExhausted =
+    subscriptionFromEntitlements === "free" &&
+    entitlementRefreshFailure?.userId === user?.id &&
+    (entitlementRefreshFailure?.count ?? 0) >
+      ENTITLEMENT_REFRESH_RETRY_DELAYS_MS.length;
+  const freeSubscriptionResolved =
+    subscriptionResolved &&
+    (!automaticEntitlementRefreshNeeded ||
+      entitlementApiResolvedUserId === user?.id ||
+      tokenFreeAutomaticRefreshExhausted);
 
   // Persist queue behavior to localStorage
   useEffect(() => {
@@ -709,7 +720,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     chatMode: accessibleChatMode,
     setChatMode,
     subscription: paidAgentSubscription,
-    subscriptionResolved,
+    freeSubscriptionResolved,
     sandboxPreference,
     setSandboxPreference,
     selectedModel,

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -585,6 +585,10 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     subscriptionFromEntitlements !== "free"
       ? subscriptionFromEntitlements
       : subscription;
+  const agentFirstSubscriptionResolved =
+    paidAgentSubscription === "free"
+      ? freeSubscriptionResolved
+      : subscriptionResolved;
 
   useEffect(() => {
     if (agentFirstDefaultAppliedRef.current) return;
@@ -601,7 +605,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
       isCheckingProPlan,
       isMobile,
       subscription: paidAgentSubscription,
-      subscriptionResolved,
+      subscriptionResolved: agentFirstSubscriptionResolved,
       userPresent: Boolean(user),
     });
 
@@ -670,6 +674,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     );
   }, [
     chatMode,
+    agentFirstSubscriptionResolved,
     defaultLocalSandboxPreference,
     hasLocalSandbox,
     isCheckingProPlan,

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -709,6 +709,7 @@ const GlobalStateProviderInner: React.FC<GlobalStateProviderProps> = ({
     chatMode: accessibleChatMode,
     setChatMode,
     subscription: paidAgentSubscription,
+    subscriptionResolved,
     sandboxPreference,
     setSandboxPreference,
     selectedModel,

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -11,6 +11,13 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { useAccessToken, useAuth } from "@workos-inc/authkit-nextjs/components";
 import { SHARED_TOKEN_KEY } from "@/lib/auth/shared-token";
 
+const mockUseAutoSelectNewRemoteConnection = jest.fn();
+
+jest.mock("@/app/hooks/useAutoSelectNewRemoteConnection", () => ({
+  useAutoSelectNewRemoteConnection: (args: unknown) =>
+    mockUseAutoSelectNewRemoteConnection(args),
+}));
+
 jest.mock("@/app/hooks/useSandboxPreference", () => {
   const setSandboxPreference = jest.fn();
   const retryDesktopBridge = jest.fn();
@@ -218,6 +225,34 @@ describe("GlobalStateProvider agent defaults", () => {
       );
       expect(screen.getByTestId("chat-mode")).toHaveTextContent("agent");
     });
+  });
+
+  it("does not confirm free model selection during the Tauri entitlement refresh", async () => {
+    window.__TAURI_INTERNALS__ = {};
+    mockAuthUser([]);
+    global.fetch = jest.fn((input) =>
+      String(input) === "/api/entitlements"
+        ? new Promise(() => {})
+        : Promise.resolve({ ok: false }),
+    ) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent("true");
+    });
+    expect(mockUseAutoSelectNewRemoteConnection).toHaveBeenCalled();
+    expect(
+      mockUseAutoSelectNewRemoteConnection.mock.calls.some(
+        ([args]) =>
+          (args as { freeSubscriptionResolved: boolean })
+            .freeSubscriptionResolved,
+      ),
+    ).toBe(false);
   });
 
   it("forces returning free Desktop users out of saved Ask mode", async () => {

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -12,6 +12,7 @@ import { useAccessToken, useAuth } from "@workos-inc/authkit-nextjs/components";
 import { SHARED_TOKEN_KEY } from "@/lib/auth/shared-token";
 
 const mockUseAutoSelectNewRemoteConnection = jest.fn();
+let mockDesktopBridgeActive = false;
 
 jest.mock("@/app/hooks/useAutoSelectNewRemoteConnection", () => ({
   useAutoSelectNewRemoteConnection: (args: unknown) =>
@@ -26,8 +27,8 @@ jest.mock("@/app/hooks/useSandboxPreference", () => {
     useSandboxPreference: () => ({
       sandboxPreference: "e2b",
       setSandboxPreference,
-      desktopBridgeActive: false,
-      desktopBridgeStatus: "idle",
+      desktopBridgeActive: mockDesktopBridgeActive,
+      desktopBridgeStatus: mockDesktopBridgeActive ? "connected" : "idle",
       retryDesktopBridge,
     }),
   };
@@ -141,6 +142,7 @@ describe("GlobalStateProvider agent defaults", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
+    mockDesktopBridgeActive = false;
     delete window.__TAURI_INTERNALS__;
     window.history.pushState({}, "", "/");
     window.localStorage.clear();
@@ -260,6 +262,7 @@ describe("GlobalStateProvider agent defaults", () => {
     window.__TAURI_INTERNALS__ = {};
     window.localStorage.setItem("selected_model", "hackerai-pro");
     mockAuthUser([]);
+    mockDesktopBridgeActive = true;
     let entitlementAttempts = 0;
     global.fetch = jest.fn((input) => {
       if (String(input) === "/api/entitlements") {
@@ -287,6 +290,7 @@ describe("GlobalStateProvider agent defaults", () => {
     expect(screen.getByTestId("selected-model")).toHaveTextContent(
       "hackerai-pro",
     );
+    expect(screen.getByTestId("chat-mode")).toHaveTextContent("ask");
   });
 
   it("forces returning free Desktop users out of saved Ask mode", async () => {

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -255,6 +255,40 @@ describe("GlobalStateProvider agent defaults", () => {
     ).toBe(false);
   });
 
+  it("preserves the paid model between a failed Tauri refresh and its retry", async () => {
+    jest.useFakeTimers();
+    window.__TAURI_INTERNALS__ = {};
+    window.localStorage.setItem("selected_model", "hackerai-pro");
+    mockAuthUser([]);
+    let entitlementAttempts = 0;
+    global.fetch = jest.fn((input) => {
+      if (String(input) === "/api/entitlements") {
+        entitlementAttempts += 1;
+        return Promise.resolve({ ok: false });
+      }
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(entitlementAttempts).toBe(1);
+      expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent(
+        "false",
+      );
+    });
+    expect(screen.getByTestId("free-desktop-agent-only")).toHaveTextContent(
+      "false",
+    );
+    expect(screen.getByTestId("selected-model")).toHaveTextContent(
+      "hackerai-pro",
+    );
+  });
+
   it("forces returning free Desktop users out of saved Ask mode", async () => {
     window.__TAURI_INTERNALS__ = {};
     window.localStorage.setItem("chat_mode", "ask");

--- a/app/hooks/__tests__/useAutoSelectNewRemoteConnection.test.tsx
+++ b/app/hooks/__tests__/useAutoSelectNewRemoteConnection.test.tsx
@@ -29,6 +29,7 @@ function makeProps() {
     chatMode: "ask" as const,
     setChatMode: jest.fn(),
     subscription: "free" as const,
+    subscriptionResolved: true,
     sandboxPreference: "e2b",
     setSandboxPreference: jest.fn(),
     selectedModel: "hackerai-pro" as const,
@@ -106,6 +107,25 @@ describe("useAutoSelectNewRemoteConnection", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "Local machine connected and selected.",
     );
+  });
+
+  it("preserves the model while subscription entitlements are unresolved", () => {
+    const props = {
+      ...makeProps(),
+      subscription: "free" as const,
+      subscriptionResolved: false,
+      selectedModel: "hackerai-pro" as const,
+    };
+    const { rerender } = renderHook(
+      (currentProps) => useAutoSelectNewRemoteConnection(currentProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, connections: [remoteConnection] });
+
+    expect(props.setSandboxPreference).toHaveBeenCalledWith("remote-1");
+    expect(props.setSelectedModel).not.toHaveBeenCalled();
+    expect(props.setChatMode).toHaveBeenCalledWith("agent");
   });
 
   it("resets its baseline when authentication is disabled", () => {

--- a/app/hooks/__tests__/useAutoSelectNewRemoteConnection.test.tsx
+++ b/app/hooks/__tests__/useAutoSelectNewRemoteConnection.test.tsx
@@ -1,0 +1,124 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+  },
+}));
+
+const { useAutoSelectNewRemoteConnection } = jest.requireActual<
+  typeof import("../useAutoSelectNewRemoteConnection")
+>("../useAutoSelectNewRemoteConnection");
+const { toast } = jest.requireMock<typeof import("sonner")>("sonner");
+
+const remoteConnection = {
+  connectionId: "remote-1",
+  isDesktop: false,
+};
+
+const desktopConnection = {
+  connectionId: "desktop-1",
+  isDesktop: true,
+};
+
+function makeProps() {
+  return {
+    connections: [] as Array<{ connectionId: string; isDesktop: boolean }>,
+    enabled: true,
+    chatMode: "ask" as const,
+    setChatMode: jest.fn(),
+    subscription: "free" as const,
+    sandboxPreference: "e2b",
+    setSandboxPreference: jest.fn(),
+    selectedModel: "hackerai-pro" as const,
+    setSelectedModel: jest.fn(),
+  };
+}
+
+describe("useAutoSelectNewRemoteConnection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("selects a new remote machine globally and switches free users to Agent", () => {
+    const props = makeProps();
+    const { rerender } = renderHook(
+      (currentProps) => useAutoSelectNewRemoteConnection(currentProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, connections: [remoteConnection] });
+
+    expect(props.setSandboxPreference).toHaveBeenCalledWith("remote-1");
+    expect(props.setSelectedModel).toHaveBeenCalledWith("auto");
+    expect(props.setChatMode).toHaveBeenCalledWith("agent");
+    expect(toast.success).toHaveBeenCalledWith(
+      "Local machine connected and selected. Switched to Agent mode.",
+    );
+  });
+
+  it("does not override Cloud with a connection present on initial load", () => {
+    const props = makeProps();
+
+    renderHook(() =>
+      useAutoSelectNewRemoteConnection({
+        ...props,
+        connections: [remoteConnection],
+      }),
+    );
+
+    expect(props.setSandboxPreference).not.toHaveBeenCalled();
+    expect(props.setChatMode).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("ignores native Desktop bridge connections", () => {
+    const props = makeProps();
+    const { rerender } = renderHook(
+      (currentProps) => useAutoSelectNewRemoteConnection(currentProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, connections: [desktopConnection] });
+
+    expect(props.setSandboxPreference).not.toHaveBeenCalled();
+    expect(props.setChatMode).not.toHaveBeenCalled();
+  });
+
+  it("selects the machine without changing an existing paid Agent setup", () => {
+    const props = {
+      ...makeProps(),
+      chatMode: "agent" as const,
+      subscription: "pro" as const,
+      selectedModel: "hackerai-pro" as const,
+    };
+    const { rerender } = renderHook(
+      (currentProps) => useAutoSelectNewRemoteConnection(currentProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, connections: [remoteConnection] });
+
+    expect(props.setSandboxPreference).toHaveBeenCalledWith("remote-1");
+    expect(props.setSelectedModel).not.toHaveBeenCalled();
+    expect(props.setChatMode).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      "Local machine connected and selected.",
+    );
+  });
+
+  it("resets its baseline when authentication is disabled", () => {
+    const props = makeProps();
+    const { rerender } = renderHook(
+      (currentProps) => useAutoSelectNewRemoteConnection(currentProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, enabled: false, connections: [] });
+    rerender({ ...props, enabled: true, connections: [remoteConnection] });
+
+    expect(props.setSandboxPreference).not.toHaveBeenCalled();
+    expect(props.setChatMode).not.toHaveBeenCalled();
+  });
+});

--- a/app/hooks/__tests__/useAutoSelectNewRemoteConnection.test.tsx
+++ b/app/hooks/__tests__/useAutoSelectNewRemoteConnection.test.tsx
@@ -29,7 +29,7 @@ function makeProps() {
     chatMode: "ask" as const,
     setChatMode: jest.fn(),
     subscription: "free" as const,
-    subscriptionResolved: true,
+    freeSubscriptionResolved: true,
     sandboxPreference: "e2b",
     setSandboxPreference: jest.fn(),
     selectedModel: "hackerai-pro" as const,
@@ -113,7 +113,7 @@ describe("useAutoSelectNewRemoteConnection", () => {
     const props = {
       ...makeProps(),
       subscription: "free" as const,
-      subscriptionResolved: false,
+      freeSubscriptionResolved: false,
       selectedModel: "hackerai-pro" as const,
     };
     const { rerender } = renderHook(

--- a/app/hooks/useAutoSelectNewRemoteConnection.ts
+++ b/app/hooks/useAutoSelectNewRemoteConnection.ts
@@ -20,6 +20,7 @@ interface UseNewRemoteConnectionArgs {
   onNewConnection: (connection: RemoteConnection) => void;
 }
 
+/** Detects remote connections added after the current session baseline. */
 export function useNewRemoteConnection({
   connections,
   enabled = true,
@@ -67,18 +68,21 @@ interface UseAutoSelectNewRemoteConnectionArgs {
   chatMode: ChatMode;
   setChatMode: (mode: ChatMode) => void;
   subscription: SubscriptionTier;
+  subscriptionResolved: boolean;
   sandboxPreference: SandboxPreference;
   setSandboxPreference: (preference: SandboxPreference) => void;
   selectedModel: SelectedModel;
   setSelectedModel: (model: SelectedModel) => void;
 }
 
+/** Selects a newly connected remote machine from any mounted app surface. */
 export function useAutoSelectNewRemoteConnection({
   connections,
   enabled,
   chatMode,
   setChatMode,
   subscription,
+  subscriptionResolved,
   sandboxPreference,
   setSandboxPreference,
   selectedModel,
@@ -90,7 +94,11 @@ export function useAutoSelectNewRemoteConnection({
         setSandboxPreference(connection.connectionId);
       }
 
-      if (subscription === "free" && selectedModel !== "auto") {
+      if (
+        subscriptionResolved &&
+        subscription === "free" &&
+        selectedModel !== "auto"
+      ) {
         setSelectedModel("auto");
       }
 
@@ -111,6 +119,7 @@ export function useAutoSelectNewRemoteConnection({
       setSandboxPreference,
       setSelectedModel,
       subscription,
+      subscriptionResolved,
     ],
   );
 

--- a/app/hooks/useAutoSelectNewRemoteConnection.ts
+++ b/app/hooks/useAutoSelectNewRemoteConnection.ts
@@ -68,7 +68,7 @@ interface UseAutoSelectNewRemoteConnectionArgs {
   chatMode: ChatMode;
   setChatMode: (mode: ChatMode) => void;
   subscription: SubscriptionTier;
-  subscriptionResolved: boolean;
+  freeSubscriptionResolved: boolean;
   sandboxPreference: SandboxPreference;
   setSandboxPreference: (preference: SandboxPreference) => void;
   selectedModel: SelectedModel;
@@ -82,7 +82,7 @@ export function useAutoSelectNewRemoteConnection({
   chatMode,
   setChatMode,
   subscription,
-  subscriptionResolved,
+  freeSubscriptionResolved,
   sandboxPreference,
   setSandboxPreference,
   selectedModel,
@@ -95,7 +95,7 @@ export function useAutoSelectNewRemoteConnection({
       }
 
       if (
-        subscriptionResolved &&
+        freeSubscriptionResolved &&
         subscription === "free" &&
         selectedModel !== "auto"
       ) {
@@ -119,7 +119,7 @@ export function useAutoSelectNewRemoteConnection({
       setSandboxPreference,
       setSelectedModel,
       subscription,
-      subscriptionResolved,
+      freeSubscriptionResolved,
     ],
   );
 

--- a/app/hooks/useAutoSelectNewRemoteConnection.ts
+++ b/app/hooks/useAutoSelectNewRemoteConnection.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { toast } from "sonner";
+import type {
+  ChatMode,
+  SandboxPreference,
+  SelectedModel,
+  SubscriptionTier,
+} from "@/types/chat";
+
+interface RemoteConnection {
+  connectionId: string;
+  isDesktop: boolean;
+}
+
+interface UseNewRemoteConnectionArgs {
+  connections: RemoteConnection[] | undefined;
+  enabled?: boolean;
+  onNewConnection: (connection: RemoteConnection) => void;
+}
+
+export function useNewRemoteConnection({
+  connections,
+  enabled = true,
+  onNewConnection,
+}: UseNewRemoteConnectionArgs) {
+  const previousConnectionIdsRef = useRef<Set<string> | null>(null);
+  const onNewConnectionRef = useRef(onNewConnection);
+
+  useEffect(() => {
+    onNewConnectionRef.current = onNewConnection;
+  }, [onNewConnection]);
+
+  useEffect(() => {
+    if (!enabled) {
+      previousConnectionIdsRef.current = null;
+      return;
+    }
+    if (connections === undefined) return;
+
+    const remoteConnections = connections.filter(
+      (connection) => !connection.isDesktop,
+    );
+    const currentConnectionIds = new Set(
+      remoteConnections.map((connection) => connection.connectionId),
+    );
+    const previousConnectionIds = previousConnectionIdsRef.current;
+    previousConnectionIdsRef.current = currentConnectionIds;
+
+    // Existing connections are only a baseline. Select a machine when its
+    // connection appears during this browser session, not on page load.
+    if (previousConnectionIds === null) return;
+
+    const newConnection = remoteConnections.find(
+      (connection) => !previousConnectionIds.has(connection.connectionId),
+    );
+    if (newConnection) {
+      onNewConnectionRef.current(newConnection);
+    }
+  }, [connections, enabled]);
+}
+
+interface UseAutoSelectNewRemoteConnectionArgs {
+  connections: RemoteConnection[] | undefined;
+  enabled: boolean;
+  chatMode: ChatMode;
+  setChatMode: (mode: ChatMode) => void;
+  subscription: SubscriptionTier;
+  sandboxPreference: SandboxPreference;
+  setSandboxPreference: (preference: SandboxPreference) => void;
+  selectedModel: SelectedModel;
+  setSelectedModel: (model: SelectedModel) => void;
+}
+
+export function useAutoSelectNewRemoteConnection({
+  connections,
+  enabled,
+  chatMode,
+  setChatMode,
+  subscription,
+  sandboxPreference,
+  setSandboxPreference,
+  selectedModel,
+  setSelectedModel,
+}: UseAutoSelectNewRemoteConnectionArgs) {
+  const selectNewConnection = useCallback(
+    (connection: RemoteConnection) => {
+      if (sandboxPreference !== connection.connectionId) {
+        setSandboxPreference(connection.connectionId);
+      }
+
+      if (subscription === "free" && selectedModel !== "auto") {
+        setSelectedModel("auto");
+      }
+
+      if (chatMode !== "agent") {
+        setChatMode("agent");
+        toast.success(
+          "Local machine connected and selected. Switched to Agent mode.",
+        );
+      } else {
+        toast.success("Local machine connected and selected.");
+      }
+    },
+    [
+      chatMode,
+      sandboxPreference,
+      selectedModel,
+      setChatMode,
+      setSandboxPreference,
+      setSelectedModel,
+      subscription,
+    ],
+  );
+
+  useNewRemoteConnection({
+    connections,
+    enabled,
+    onNewConnection: selectNewConnection,
+  });
+}


### PR DESCRIPTION
Connecting a new Remote Control machine now selects it even after the user returns to chat. Initial connections remain a baseline, so reloading does not override a saved Cloud choice. Free users move to Agent/Auto only after their tier is confirmed; unresolved paid accounts retain their model selection.

The mobile Agent control strip also keeps both selectors within its rounded boundary. Machine names use the remaining space and truncate, and the permission trigger is capped by its wrapper so its chevron cannot overflow.

## Validation

- 453 Jest suites passed (4,686 tests), including connection/entitlement regressions and selector coverage.
- Typecheck, scoped ESLint, Prettier, and diff checks passed.
- Browser layout fixture using the local compiled CSS verified containment at 320px and 375px. This checks layout, not the authenticated cross-device flow; the preview requires Vercel sign-in.

## Manual verification

1. On mobile web, open a chat, visit Settings > Remote Control, and copy the connection command. Return to chat, run the command on the local machine, and confirm that exact machine becomes selected with a confirmation toast. A confirmed free user should move to Agent/Auto.
2. Select Cloud on a paid account, reload with the machine already connected, and confirm Cloud stays selected.
3. At 320px and 375px widths, select a machine with a long name. Check Full access, Ask for approval, and Approve for me when available: both dropdown arrows must stay inside the strip, labels may truncate, and both menus must open normally.
4. Check the same controls on desktop and in a narrow chat pane with Computer open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically selects newly connected remote machines during the current session and confirms the selection with a notification.
  * Preserves appropriate model and chat-mode choices while subscription status is being resolved or refreshed.

* **Bug Fixes**
  * Prevents paid-user settings from being incorrectly replaced after entitlement refresh failures.
  * Excludes desktop connections from automatic remote selection.

* **Style**
  * Improved mobile Agent controls with flexible sizing, truncation, and better spacing for sandbox and permission selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->