### PR TITLE
Fix chat history stalls and add loading recovery

### DIFF
--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -3,13 +3,15 @@
 import { useConvexAuth } from "convex/react";
 import { ChatLayout } from "@/app/components/ChatLayout";
 import Loading from "@/components/ui/loading";
+import { SlowLoadingNotice } from "@/app/components/SlowLoadingNotice";
 import { useHasAuthenticatedBefore } from "@/app/hooks/useHasAuthenticatedBefore";
 import { ChatRoutePresentationProvider } from "@/app/contexts/ChatRoutePresentationContext";
 
 const fullWidthShell = (
   <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
-    <div className="flex-1 flex items-center justify-center min-h-0">
+    <div className="flex-1 flex flex-col items-center justify-center min-h-0">
       <Loading />
+      <SlowLoadingNotice label="Connecting…" />
     </div>
   </div>
 );

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -460,6 +460,17 @@ const ChatItem: React.FC<ChatItemProps> = ({
   return (
     <div
       ref={setDraggableNodeRef}
+      style={
+        isDropdownOpen ||
+        showRenameDialog ||
+        showShareDialog ||
+        showMoveProjectDialog ||
+        showCreateProjectDialog ||
+        showDeleteDialog ||
+        isDragging
+          ? undefined
+          : { contentVisibility: "auto", containIntrinsicSize: "auto 20px" }
+      }
       className={`group relative flex w-full cursor-pointer select-none items-center rounded-lg py-2 pe-0.5 ${rowStartPaddingClass} hover:bg-sidebar-accent/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
         isCurrentlyActive
           ? "bg-sidebar-accent text-sidebar-accent-foreground"
@@ -777,13 +788,15 @@ const ChatItem: React.FC<ChatItemProps> = ({
       </Dialog>
 
       {/* Share Dialog */}
-      <ShareDialog
-        open={showShareDialog}
-        onOpenChange={setShowShareDialog}
-        chatId={id}
-        chatTitle={taskTitle}
-        existingShareId={shareId}
-      />
+      {showShareDialog && (
+        <ShareDialog
+          open={showShareDialog}
+          onOpenChange={setShowShareDialog}
+          chatId={id}
+          chatTitle={taskTitle}
+          existingShareId={shareId}
+        />
+      )}
 
       {showMoveProjectDialog ? (
         <MoveChatToProjectDialog
@@ -848,4 +861,4 @@ const ChatItem: React.FC<ChatItemProps> = ({
   );
 };
 
-export default ChatItem;
+export default React.memo(ChatItem);

--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -10,6 +10,7 @@ import { useChats } from "../hooks/useChats";
 import { useProjects } from "../hooks/useProjects";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import MainSidebar from "./Sidebar";
+import { ConvexErrorBoundary } from "./ConvexErrorBoundary";
 import {
   loadSettingsDialog,
   onOpenSettingsDialog,
@@ -29,6 +30,14 @@ const SettingsDialog = dynamic(
  * Does NOT include the Computer Sidebar (right); that remains in ChatContent.
  */
 export function ChatLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ConvexErrorBoundary>
+      <ChatLayoutContent>{children}</ChatLayoutContent>
+    </ConvexErrorBoundary>
+  );
+}
+
+function ChatLayoutContent({ children }: { children: React.ReactNode }) {
   const isMobile = useIsMobile();
   const pathname = usePathname();
   const compactTaskSidebar = useCompactTaskSidebar();

--- a/app/components/SidebarHistory.tsx
+++ b/app/components/SidebarHistory.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useEffect } from "react";
 import { MessageSquare } from "lucide-react";
 import ChatItem from "./ChatItem";
 import Loading from "@/components/ui/loading";
+import { SlowLoadingNotice } from "./SlowLoadingNotice";
 
 export type SidebarPaginationStatus =
   "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
@@ -21,6 +22,7 @@ const SidebarHistory: React.FC<SidebarHistoryProps> = ({
   chats,
   paginationStatus,
   loadMore,
+  containerRef,
   showEmptyState = true,
   testId = "sidebar-chat-list",
 }) => {
@@ -37,7 +39,7 @@ const SidebarHistory: React.FC<SidebarHistoryProps> = ({
 
     if (paginationStatus === "CanLoadMore" && loadMore) {
       const options: IntersectionObserverInit = {
-        root: null,
+        root: containerRef?.current ?? null,
         rootMargin: "50px",
         threshold: 0.1,
       };
@@ -45,6 +47,8 @@ const SidebarHistory: React.FC<SidebarHistoryProps> = ({
       observerRef.current = new IntersectionObserver((entries) => {
         const [entry] = entries;
         if (entry.isIntersecting && statusRef.current === "CanLoadMore") {
+          // Lock synchronously: observers can fire again before React commits.
+          statusRef.current = "LoadingMore";
           loadMore(28);
         }
       }, options);
@@ -60,12 +64,13 @@ const SidebarHistory: React.FC<SidebarHistoryProps> = ({
         observerRef.current.disconnect();
       }
     };
-  }, [paginationStatus, loadMore, chats.length]);
+  }, [paginationStatus, loadMore, chats.length, containerRef]);
 
   if (paginationStatus === "LoadingFirstPage") {
     // Loading state
     return (
       <div className="p-2">
+        <SlowLoadingNotice label="Loading task history…" />
         <div className="space-y-3">
           {[...Array(5)].map((_, i) => (
             <div key={i} className="animate-pulse">

--- a/app/components/SlowLoadingNotice.tsx
+++ b/app/components/SlowLoadingNotice.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Keep brief auth refreshes quiet, but never leave a failed load unexplained. */
+export function SlowLoadingNotice({
+  label = "Loading task…",
+}: {
+  label?: string;
+}) {
+  const [isSlow, setIsSlow] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsSlow(true), 15_000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div
+      className="space-y-2 p-3 text-center text-sm text-muted-foreground"
+      role="status"
+    >
+      <p>{isSlow ? "This is taking longer than expected." : label}</p>
+      {isSlow && (
+        <>
+          <p>Check your connection, then reload to reconnect.</p>
+          <button
+            type="button"
+            className="rounded-md border px-3 py-2 text-foreground hover:bg-accent"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/components/__tests__/ChatLayout.accessibility.test.tsx
+++ b/app/components/__tests__/ChatLayout.accessibility.test.tsx
@@ -8,6 +8,7 @@ let mockCompactTaskSidebar = false;
 let mockChatSidebarOpen = true;
 let mockComputerSidebarOpen = false;
 let mockPathname = "/c/task-1";
+let mockHistoryError = false;
 const mockSetChatSidebarOpen = jest.fn();
 
 jest.mock("next/dynamic", () => ({
@@ -31,11 +32,14 @@ jest.mock("@/app/contexts/GlobalState", () => ({
   }),
 }));
 jest.mock("@/app/hooks/useChats", () => ({
-  useChats: () => ({
-    results: [],
-    status: "Exhausted",
-    loadMore: jest.fn(),
-  }),
+  useChats: () => {
+    if (mockHistoryError) throw new Error("History unavailable");
+    return {
+      results: [],
+      status: "Exhausted",
+      loadMore: jest.fn(),
+    };
+  },
 }));
 jest.mock("@/app/hooks/useProjects", () => ({
   useProjects: () => ({
@@ -102,12 +106,32 @@ const { ChatLayout } =
 
 describe("ChatLayout responsive accessibility", () => {
   beforeEach(() => {
+    mockHistoryError = false;
     mockIsMobile = true;
     mockCompactTaskSidebar = false;
     mockChatSidebarOpen = true;
     mockComputerSidebarOpen = false;
     mockPathname = "/c/task-1";
     mockSetChatSidebarOpen.mockReset();
+  });
+
+  it("catches history subscription failures and can retry after recovery", () => {
+    mockHistoryError = true;
+    const log = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      render(
+        <ChatLayout>
+          <div>Task content</div>
+        </ChatLayout>,
+      );
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+      expect(screen.queryByText("Task content")).not.toBeInTheDocument();
+      mockHistoryError = false;
+      fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+      expect(screen.getByText("Task content")).toBeInTheDocument();
+    } finally {
+      log.mockRestore();
+    }
   });
 
   it("gives the mobile task sidebar dialog an accessible name", () => {

--- a/app/components/__tests__/SidebarHistory.test.tsx
+++ b/app/components/__tests__/SidebarHistory.test.tsx
@@ -29,6 +29,38 @@ const chat = (overrides: Record<string, unknown>) => ({
 });
 
 describe("SidebarHistory", () => {
+  it("uses the sidebar scroll root and requests a page only once before the status update", () => {
+    let callback!: IntersectionObserverCallback;
+    const observer = jest.fn((cb: IntersectionObserverCallback) => {
+      callback = cb;
+      return { observe: jest.fn(), disconnect: jest.fn() };
+    });
+    const previous = global.IntersectionObserver;
+    global.IntersectionObserver = observer as any;
+    try {
+      const root = document.createElement("div");
+      const loadMore = jest.fn();
+      render(
+        <SidebarHistory
+          chats={[]}
+          paginationStatus="CanLoadMore"
+          loadMore={loadMore}
+          containerRef={{ current: root }}
+        />,
+      );
+      expect(observer).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ root }),
+      );
+      const entries = [{ isIntersecting: true }] as IntersectionObserverEntry[];
+      callback(entries, {} as IntersectionObserver);
+      callback(entries, {} as IntersectionObserver);
+      expect(loadMore).toHaveBeenCalledTimes(1);
+    } finally {
+      global.IntersectionObserver = previous;
+    }
+  });
+
   it("marks chats with active ask streams as streaming", () => {
     render(
       <SidebarHistory

--- a/app/components/__tests__/SlowLoadingNotice.test.tsx
+++ b/app/components/__tests__/SlowLoadingNotice.test.tsx
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom";
+import { act, render, screen } from "@testing-library/react";
+import { SlowLoadingNotice } from "../SlowLoadingNotice";
+
+describe("SlowLoadingNotice", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it("allows normal loading, then offers recovery after 15 seconds", () => {
+    render(<SlowLoadingNotice label="Loading task history…" />);
+    expect(screen.getByText("Loading task history…")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    act(() => jest.advanceTimersByTime(15_000));
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(
+      screen.getByText("This is taking longer than expected."),
+    ).toBeInTheDocument();
+  });
+
+  it("cleans up the timer when loading completes", () => {
+    const { unmount } = render(<SlowLoadingNotice />);
+    unmount();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -97,6 +97,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useComputerSidebarOverlay } from "@/hooks/use-workspace-layout";
 import { useParams, useRouter } from "next/navigation";
 import { ConvexErrorBoundary } from "./ConvexErrorBoundary";
+import { SlowLoadingNotice } from "./SlowLoadingNotice";
 import { useAutoResume } from "../hooks/useAutoResume";
 import { useAutoContinue } from "../hooks/useAutoContinue";
 import { findActiveTimelineAnchorMessageId } from "./message-timeline-rows";
@@ -515,6 +516,14 @@ function ForkAutoSendEffect({
 }
 
 export const Chat = ({ autoResume }: { autoResume: boolean }) => {
+  return (
+    <ConvexErrorBoundary>
+      <ChatContent autoResume={autoResume} />
+    </ConvexErrorBoundary>
+  );
+};
+
+const ChatContent = ({ autoResume }: { autoResume: boolean }) => {
   const params = useParams();
   const routeChatId = params?.id as string | undefined;
   const router = useRouter();
@@ -2116,7 +2125,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     messages.some((message) => message.role === "user");
 
   return (
-    <ConvexErrorBoundary>
+    <>
       <StreamEffects
         key={chatId}
         chatId={chatId}
@@ -2198,7 +2207,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                       role="status"
                       data-testid="chat-timeline-loading"
                     >
-                      Loading task…
+                      <SlowLoadingNotice key={chatId} label="Loading task…" />
                     </div>
                   ) : (
                     <Messages
@@ -2348,6 +2357,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           </div>
         )}
       </div>
-    </ConvexErrorBoundary>
+    </>
   );
 };

--- a/app/hooks/__tests__/useFileUrlCache.test.tsx
+++ b/app/hooks/__tests__/useFileUrlCache.test.tsx
@@ -1,0 +1,106 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ChatMessage } from "@/types";
+import { useFileUrlCache } from "../useFileUrlCache";
+
+const mockFetch = jest.fn();
+jest.mock("convex/react", () => ({ useAction: () => mockFetch }));
+jest.mock("@/convex/_generated/api", () => ({
+  api: { s3Actions: { getFileUrlsBatchAction: "get-urls" } },
+}));
+jest.mock("@/lib/utils/file-utils", () => ({
+  isSupportedImageMediaType: (type: string) => type === "image/png",
+}));
+
+function images(count: number): ChatMessage[] {
+  return [
+    {
+      id: "msg",
+      role: "user",
+      parts: Array.from({ length: count }, (_, i) => ({
+        type: "file",
+        fileId: `file-${i}`,
+        s3Key: `key-${i}`,
+        mediaType: "image/png",
+      })),
+    },
+  ] as unknown as ChatMessage[];
+}
+
+describe("image URL prefetching", () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it("deduplicates pending images across streaming updates", async () => {
+    let resolve!: (value: Record<string, string>) => void;
+    mockFetch.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const { result, rerender } = renderHook(
+      ({ messages }) => useFileUrlCache(messages),
+      { initialProps: { messages: images(1) } },
+    );
+    for (let i = 0; i < 50; i++) rerender({ messages: images(1) });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await act(async () => resolve({ "file-0": "https://example.com/image" }));
+    expect(result.current.getCachedUrl("file-0")).toBe(
+      "https://example.com/image",
+    );
+    rerender({ messages: images(1) });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("reserves queued batches and retains successful results when another batch fails", async () => {
+    let resolve!: (value: Record<string, string>) => void;
+    mockFetch
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolve = r;
+        }),
+      )
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({ "file-100": "https://example.com/last" });
+    const log = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { result, rerender } = renderHook(
+        ({ messages }) => useFileUrlCache(messages),
+        { initialProps: { messages: images(101) } },
+      );
+      rerender({ messages: images(101) });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      await act(async () =>
+        resolve(
+          Object.fromEntries(
+            Array.from({ length: 50 }, (_, i) => [
+              `file-${i}`,
+              `https://example.com/${i}`,
+            ]),
+          ),
+        ),
+      );
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
+      expect(mockFetch.mock.calls.map(([args]) => args.fileIds.length)).toEqual(
+        [50, 50, 1],
+      );
+      expect(result.current.getCachedUrl("file-0")).toBe(
+        "https://example.com/0",
+      );
+      expect(result.current.getCachedUrl("file-100")).toBe(
+        "https://example.com/last",
+      );
+      expect(result.current.getCachedUrl("file-50")).toBeNull();
+      mockFetch.mockResolvedValueOnce({
+        "file-50": "https://example.com/retried",
+      });
+      rerender({ messages: images(101) });
+      await waitFor(() =>
+        expect(result.current.getCachedUrl("file-50")).toBe(
+          "https://example.com/retried",
+        ),
+      );
+      expect(mockFetch.mock.calls[3][0].fileIds).toHaveLength(50);
+    } finally {
+      log.mockRestore();
+    }
+  });
+});

--- a/app/hooks/__tests__/useFileUrlCache.test.tsx
+++ b/app/hooks/__tests__/useFileUrlCache.test.tsx
@@ -29,6 +29,51 @@ function images(count: number): ChatMessage[] {
 describe("image URL prefetching", () => {
   beforeEach(() => mockFetch.mockReset());
 
+  it.each([false, true])(
+    "queues newly arriving IDs behind a pending request (first fails: %s)",
+    async (firstFails) => {
+      let finish!: () => void;
+      mockFetch
+        .mockReturnValueOnce(
+          new Promise((resolve, reject) => {
+            finish = () =>
+              firstFails
+                ? reject(new Error("temporary failure"))
+                : resolve({ "file-0": "https://example.com/0" });
+          }),
+        )
+        .mockImplementation(async ({ fileIds }: { fileIds: string[] }) =>
+          Object.fromEntries(
+            fileIds.map((id) => [id, `https://example.com/${id}`]),
+          ),
+        );
+      const log = jest.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const { result, rerender } = renderHook(
+          ({ messages }) => useFileUrlCache(messages),
+          { initialProps: { messages: images(1) } },
+        );
+        await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+        for (const count of [2, 3, 3, 3]) {
+          await act(async () => rerender({ messages: images(count) }));
+        }
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        await act(async () => finish());
+        await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
+        expect(mockFetch.mock.calls.map(([args]) => args.fileIds)).toEqual([
+          ["file-0"],
+          ["file-1"],
+          ["file-2"],
+        ]);
+        expect(result.current.getCachedUrl("file-2")).toBe(
+          "https://example.com/file-2",
+        );
+      } finally {
+        log.mockRestore();
+      }
+    },
+  );
+
   it("deduplicates pending images across streaming updates", async () => {
     let resolve!: (value: Record<string, string>) => void;
     mockFetch.mockReturnValue(

--- a/app/hooks/useFileUrlCache.ts
+++ b/app/hooks/useFileUrlCache.ts
@@ -29,6 +29,7 @@ export function useFileUrlCache(messages: ChatMessage[]) {
   const urlCacheRef = useRef<Map<string, CachedUrl>>(new Map());
   const prefetchedIdsRef = useRef<Set<string>>(new Set());
   const pendingIdsRef = useRef<Set<string>>(new Set());
+  const prefetchQueueRef = useRef<Promise<void> | null>(null);
 
   // Get cached URL for a file (returns null if expired or not cached)
   const getCachedUrl = useCallback((fileId: string): string | null => {
@@ -126,25 +127,33 @@ export function useFileUrlCache(messages: ChatMessage[]) {
         chunks.push(fileIds.slice(i, i + MAX_BATCH_SIZE));
       }
 
-      // Fetch batches sequentially instead of fanning out with history size.
-      for (const chunk of chunks) {
-        try {
-          const urlMap = await getFileUrlsBatchAction({ fileIds: chunk });
-          const now = Date.now();
-          if (urlMap && typeof urlMap === "object") {
-            for (const [fileId, url] of Object.entries(urlMap) as Array<
-              [string, string]
-            >) {
-              urlCacheRef.current.set(fileId, { url, timestamp: now });
-              prefetchedIdsRef.current.add(fileId);
+      const runBatches = async () => {
+        for (const chunk of chunks) {
+          try {
+            const urlMap = await getFileUrlsBatchAction({ fileIds: chunk });
+            const now = Date.now();
+            if (urlMap && typeof urlMap === "object") {
+              for (const [fileId, url] of Object.entries(urlMap) as Array<
+                [string, string]
+              >) {
+                urlCacheRef.current.set(fileId, { url, timestamp: now });
+                prefetchedIdsRef.current.add(fileId);
+              }
             }
+          } catch (error) {
+            console.error("Failed to prefetch image URLs:", error);
+          } finally {
+            for (const fileId of chunk) pendingIdsRef.current.delete(fileId);
           }
-        } catch (error) {
-          console.error("Failed to prefetch image URLs:", error);
-        } finally {
-          for (const fileId of chunk) pendingIdsRef.current.delete(fileId);
         }
-      }
+      };
+
+      // Serialize across effects too: newly arriving IDs wait behind active work.
+      const previousWork = prefetchQueueRef.current;
+      prefetchQueueRef.current = previousWork
+        ? previousWork.then(runBatches, runBatches)
+        : runBatches();
+      await prefetchQueueRef.current;
     }
 
     prefetchImageUrls();

--- a/app/hooks/useFileUrlCache.ts
+++ b/app/hooks/useFileUrlCache.ts
@@ -28,6 +28,7 @@ export function useFileUrlCache(messages: ChatMessage[]) {
   );
   const urlCacheRef = useRef<Map<string, CachedUrl>>(new Map());
   const prefetchedIdsRef = useRef<Set<string>>(new Set());
+  const pendingIdsRef = useRef<Set<string>>(new Set());
 
   // Get cached URL for a file (returns null if expired or not cached)
   const getCachedUrl = useCallback((fileId: string): string | null => {
@@ -76,6 +77,7 @@ export function useFileUrlCache(messages: ChatMessage[]) {
             file.mediaType &&
             isSupportedImageMediaType(file.mediaType) &&
             !prefetchedIdsRef.current.has(file.fileId) &&
+            !pendingIdsRef.current.has(file.fileId) &&
             !seenInThisRun.has(file.fileId)
           ) {
             s3ImageFiles.push({
@@ -99,6 +101,7 @@ export function useFileUrlCache(messages: ChatMessage[]) {
             isSupportedImageMediaType(part.mediaType) &&
             typeof part.fileId === "string" &&
             !prefetchedIdsRef.current.has(part.fileId) &&
+            !pendingIdsRef.current.has(part.fileId) &&
             !seenInThisRun.has(part.fileId)
           ) {
             s3ImageFiles.push({
@@ -115,20 +118,19 @@ export function useFileUrlCache(messages: ChatMessage[]) {
         return;
       }
 
-      // Batch fetch URLs with deduplicated fileIds, chunked to respect server limit
-      try {
-        const fileIds = s3ImageFiles.map((f) => f.fileId);
-        const chunks: Array<Array<Id<"files">>> = [];
-        for (let i = 0; i < fileIds.length; i += MAX_BATCH_SIZE) {
-          chunks.push(fileIds.slice(i, i + MAX_BATCH_SIZE));
-        }
+      // Reserve all IDs before awaiting so streaming renders cannot enqueue them again.
+      const fileIds = s3ImageFiles.map((f) => f.fileId);
+      for (const fileId of fileIds) pendingIdsRef.current.add(fileId);
+      const chunks: Array<Array<Id<"files">>> = [];
+      for (let i = 0; i < fileIds.length; i += MAX_BATCH_SIZE) {
+        chunks.push(fileIds.slice(i, i + MAX_BATCH_SIZE));
+      }
 
-        const urlMaps = await Promise.all(
-          chunks.map((chunk) => getFileUrlsBatchAction({ fileIds: chunk })),
-        );
-
-        const now = Date.now();
-        for (const urlMap of urlMaps) {
+      // Fetch batches sequentially instead of fanning out with history size.
+      for (const chunk of chunks) {
+        try {
+          const urlMap = await getFileUrlsBatchAction({ fileIds: chunk });
+          const now = Date.now();
           if (urlMap && typeof urlMap === "object") {
             for (const [fileId, url] of Object.entries(urlMap) as Array<
               [string, string]
@@ -137,9 +139,11 @@ export function useFileUrlCache(messages: ChatMessage[]) {
               prefetchedIdsRef.current.add(fileId);
             }
           }
+        } catch (error) {
+          console.error("Failed to prefetch image URLs:", error);
+        } finally {
+          for (const fileId of chunk) pendingIdsRef.current.delete(fileId);
         }
-      } catch (error) {
-        console.error("Failed to prefetch image URLs:", error);
       }
     }
 

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -1003,7 +1003,7 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
   /**
    * Sets up the chained mock for ctx.db.query so that different tables/indexes
    * return different results. Call order within deleteLastAssistantMessage:
-   *   1. messages.by_chat_id (with filter+order+first) -> last assistant msg
+   *   1. messages.by_chat_id (descending iterator) -> trailing response chain
    *   2. chats.by_chat_id (first) -> chat doc              [inside checkAndInvalidateSummary]
    *   3. messages.by_message_id (first) -> cutoff message   [inside checkAndInvalidateSummary]
    *   4. possibly more messages.by_message_id calls         [inside tryFallbackSummary]
@@ -1014,6 +1014,7 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     chatDoc: Record<string, any> | null;
     cutoffMessage: Record<string, any> | null;
     fallbackCutoffMessages?: (Record<string, any> | null)[];
+    trailingMessages?: AsyncIterable<Record<string, any>>;
   }): void {
     let callIndex = 0;
     const {
@@ -1027,12 +1028,14 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
       const currentCall = callIndex++;
 
       if (currentCall === 0 && table === "messages") {
-        // deleteLastAssistantMessage now fetches all messages desc to walk back the chain
+        // Regeneration reads only the trailing response chain via an iterator.
         const allMessages = assistantMessage ? [assistantMessage] : [];
         return {
           withIndex: jest.fn().mockReturnValue({
             order: jest.fn().mockReturnValue({
-              collect: jest.fn<any>().mockResolvedValue(allMessages),
+              async *[Symbol.asyncIterator]() {
+                yield* config.trailingMessages ?? allMessages;
+              },
             }),
           }),
         };
@@ -1076,6 +1079,36 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
       };
     });
   }
+
+  it("stops reading a 10,000-message history at the visible request while deleting hidden continuations", async () => {
+    let reads = 0;
+    setupDbQueryChain({
+      assistantMessage: null,
+      chatDoc: makeChatDoc({ latest_summary_id: undefined }),
+      cutoffMessage: null,
+      trailingMessages: {
+        async *[Symbol.asyncIterator]() {
+          for (let i = 0; i < 10_000; i++) {
+            reads++;
+            yield makeAssistantMessage({
+              _id: `doc-${i}`,
+              id: `msg-${i}`,
+              role: i === 1 || i >= 3 ? "user" : "assistant",
+              is_hidden: i === 1,
+            });
+          }
+        },
+      },
+    });
+    const { deleteLastAssistantMessage } = await import("../messages");
+    await deleteLastAssistantMessage.handler(mockCtx, { chatId: CHAT_ID });
+    expect(reads).toBe(4);
+    expect(mockCtx.db.delete.mock.calls).toEqual([
+      ["doc-0"],
+      ["doc-1"],
+      ["doc-2"],
+    ]);
+  });
 
   it("should NOT invalidate when deleted message is newer than cutoff", async () => {
     const assistantMsg = makeAssistantMessage({ _creationTime: 5000 });
@@ -1150,7 +1183,9 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
         return {
           withIndex: jest.fn().mockReturnValue({
             order: jest.fn().mockReturnValue({
-              collect: jest.fn<any>().mockResolvedValue([assistantMsg]),
+              async *[Symbol.asyncIterator]() {
+                yield assistantMsg;
+              },
             }),
           }),
         };

--- a/convex/__tests__/chats.getUserChats.test.ts
+++ b/convex/__tests__/chats.getUserChats.test.ts
@@ -140,6 +140,37 @@ describe("getUserChats", () => {
     ).rejects.toThrow("unexpected");
   });
 
+  it.each(["sidebar", "task"])(
+    "surfaces %s database failures instead of claiming history is missing",
+    async (surface) => {
+      const error = new Error("database unavailable");
+      const ctx = {
+        auth: {
+          getUserIdentity: jest
+            .fn<any>()
+            .mockResolvedValue({ subject: "user-123" }),
+        },
+        db: {
+          query: jest.fn(() => {
+            throw error;
+          }),
+        },
+      };
+      const log = jest.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        await expect(
+          surface === "sidebar"
+            ? getUserChats.handler(ctx as any, {
+                paginationOpts: { numItems: 28, cursor: null },
+              })
+            : getChatByIdFromClient.handler(ctx as any, { id: "task-1" }),
+        ).rejects.toThrow(error);
+      } finally {
+        log.mockRestore();
+      }
+    },
+  );
+
   it("returns pinned project tasks in the global pinned results", async () => {
     const pinnedProjectTask = {
       _id: "pinned-doc",

--- a/convex/__tests__/notes.performance.test.ts
+++ b/convex/__tests__/notes.performance.test.ts
@@ -1,0 +1,95 @@
+jest.mock("../_generated/server", () => ({
+  query: (config: unknown) => config,
+  mutation: (config: unknown) => config,
+}));
+jest.mock("../lib/utils", () => ({ validateServiceKey: jest.fn() }));
+
+import { getNotesForBackend } from "../notes";
+
+function setup(tokens = 1000) {
+  let reads = 0;
+  const order = jest.fn(() => ({
+    async *[Symbol.asyncIterator]() {
+      for (let i = 0; i < 10_000; i++) {
+        reads++;
+        yield {
+          note_id: `note-${i}`,
+          title: "Note",
+          content: "context",
+          category: "general",
+          tags: [],
+          updated_at: 10_000 - i,
+          tokens,
+        };
+      }
+    },
+  }));
+  const range = { eq: jest.fn().mockReturnThis() };
+  const withIndex = jest.fn(
+    (_: string, build: (q: typeof range) => unknown) => {
+      build(range);
+      return { order };
+    },
+  );
+  return {
+    ctx: { db: { query: jest.fn(() => ({ withIndex })) } },
+    withIndex,
+    range,
+    order,
+    reads: () => reads,
+  };
+}
+
+describe("prompt notes read budget", () => {
+  it.each([
+    ["free", 5],
+    ["pro", 15],
+  ] as const)(
+    "reads only the %s prompt budget out of 10,000 notes",
+    async (subscription, count) => {
+      const db = setup();
+      const result = await (getNotesForBackend as any).handler(db.ctx, {
+        serviceKey: "test",
+        userId: "user-1",
+        subscription,
+      });
+      expect(result).toHaveLength(count);
+      expect(db.reads()).toBe(count);
+      expect(db.withIndex).toHaveBeenCalledWith(
+        "by_user_and_category_and_updated",
+        expect.any(Function),
+      );
+      expect(db.range.eq.mock.calls).toEqual([
+        ["user_id", "user-1"],
+        ["category", "general"],
+      ]);
+      expect(db.order).toHaveBeenCalledWith("desc");
+      expect(result[0].note_id).toBe("note-0");
+    },
+  );
+
+  it.each([0, -1, NaN, 1])(
+    "bounds tiny or invalid token counts (%s)",
+    async (tokens) => {
+      const db = setup(tokens);
+      const result = await (getNotesForBackend as any).handler(db.ctx, {
+        serviceKey: "test",
+        userId: "user-1",
+        subscription: "pro",
+      });
+      expect(result).toHaveLength(100);
+      expect(db.reads()).toBe(100);
+    },
+  );
+
+  it("stops at the first note exceeding the remaining budget", async () => {
+    const db = setup(3000);
+    expect(
+      await (getNotesForBackend as any).handler(db.ctx, {
+        serviceKey: "test",
+        userId: "user-1",
+      }),
+    ).toHaveLength(1);
+    expect(db.reads()).toBe(2);
+  });
+});

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -569,7 +569,7 @@ export const getChatByIdFromClient = query({
       return chatPublic;
     } catch (error) {
       console.error("Failed to get chat by id:", error);
-      return null;
+      throw error;
     }
   },
 });
@@ -1148,7 +1148,8 @@ export const getUserChats = query({
             ? { name: error.name, message: error.message }
             : String(error),
       });
-      return emptyChatsPage();
+      // A failed query is not an empty account. Let the client offer recovery.
+      throw error;
     }
   },
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1258,14 +1258,14 @@ export const deleteLastAssistantMessage = mutation({
       // Walk backwards from newest message and collect the entire trailing chain:
       // assistant messages + hidden (auto-continue) user messages.
       // Stop at the first non-hidden user message so regenerate targets the original request.
-      const trailingMessages = await ctx.db
+      const trailingMessages = ctx.db
         .query("messages")
         .withIndex("by_chat_id", (q) => q.eq("chat_id", args.chatId))
-        .order("desc")
-        .collect();
+        .order("desc");
 
-      const messagesToDelete: typeof trailingMessages = [];
-      for (const msg of trailingMessages) {
+      // Do not load the rest of a long conversation just to regenerate its tail.
+      const messagesToDelete: Doc<"messages">[] = [];
+      for await (const msg of trailingMessages) {
         if (msg.role === "assistant") {
           messagesToDelete.push(msg);
         } else if (msg.role === "user" && msg.is_hidden) {

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -166,16 +166,12 @@ export const getNotesForBackend = query({
     try {
       // Get only "general" category notes for system prompt injection
       // Other categories must be retrieved via list_notes tool
-      const notes = await ctx.db
+      const notes = ctx.db
         .query("notes")
-        .withIndex("by_user_and_category", (q) =>
+        .withIndex("by_user_and_category_and_updated", (q) =>
           q.eq("user_id", args.userId).eq("category", "general"),
         )
-        .order("desc")
-        .collect();
-
-      // Sort by updated_at descending (newest first)
-      notes.sort((a, b) => b.updated_at - a.updated_at);
+        .order("desc");
 
       // Calculate total tokens and enforce token limit based on subscription
       // Default to free tier (5000) when subscription is not provided
@@ -184,13 +180,26 @@ export const getNotesForBackend = query({
       let totalTokens = 0;
       const validNotes = [];
 
-      for (const note of notes) {
+      // A prompt needs only a bounded prefix, not every note in the account.
+      for await (const note of notes) {
         const tokensValue = Number(note.tokens);
         const safeTokens =
-          Number.isFinite(tokensValue) && tokensValue > 0 ? tokensValue : 0;
+          Number.isFinite(tokensValue) && tokensValue > 0
+            ? tokensValue
+            : Math.max(
+                1,
+                estimateNoteTokens(
+                  note.title,
+                  note.content,
+                  note.category,
+                  note.tags,
+                ),
+              );
         if (totalTokens + safeTokens <= tokenLimit) {
           totalTokens += safeTokens;
           validNotes.push(note);
+          // Also bound legacy/tiny notes whose stored token counts are too low.
+          if (validNotes.length >= 100 || totalTokens >= tokenLimit) break;
         } else {
           // Token limit exceeded, stop adding notes
           break;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -833,6 +833,11 @@ export default defineSchema({
   })
     .index("by_note_id", ["note_id"])
     .index("by_user_and_category", ["user_id", "category"])
+    .index("by_user_and_category_and_updated", [
+      "user_id",
+      "category",
+      "updated_at",
+    ])
     .index("by_user_and_updated", ["user_id", "updated_at"])
     .searchIndex("search_notes", {
       searchField: "content",

--- a/docs/chat-reliability-review.md
+++ b/docs/chat-reliability-review.md
@@ -1,0 +1,82 @@
+# Chat-history reliability and performance
+
+## Changes
+
+- Regeneration iterates backwards only through trailing assistant messages and
+  hidden continuations, stopping at the visible request. It no longer collects
+  the entire conversation before finding that boundary. Existing ownership,
+  summary invalidation, file cleanup, and transactional deletion remain intact.
+- Prompt-note injection uses the `by_user_and_category_and_updated` index instead
+  of collecting and sorting every general note. It stops at the existing plan
+  token budget or 100 notes, whichever comes first. Invalid token counts fall
+  back to an estimate. Notes outside this prompt prefix are not deleted.
+- Image URL prefetch reserves IDs before awaiting network requests, including
+  queued batches. Batches run sequentially per prefetch pass, and a failed batch
+  no longer discards successful batches. Lazy non-image fetching is unchanged.
+- History-query failures propagate to an error boundary around the components
+  that own the subscriptions. They no longer masquerade as an empty account or
+  missing task. Intentional unauthenticated/not-owned results remain unchanged.
+- Loading lasting 15 seconds offers a connection/reload notice, without
+  interrupting short authentication refreshes or automatically reloading a task.
+- Sidebar rows are memoized, use off-screen content visibility, and mount their
+  share dialogs only when opened. Containment is disabled for open menus/dialogs
+  and dragging. The intrinsic content height excludes the row's padding.
+- Sidebar pagination observes its scroll container and synchronously locks a
+  load request until the next pagination update.
+
+## Reference
+
+Reviewed [t3code's sidebar at b438447f](https://github.com/pingdotgg/t3code/blob/b438447f67b6b61bbe6f564d8b78fd90702117c5/apps/web/src/components/Sidebar.tsx).
+Its memoized rows and off-screen `content-visibility` informed the sidebar
+changes. HackerAI already uses LegendList transcript virtualization, paginated
+message loading, stable timeline rows, and isolated composer state; those systems
+were retained rather than replaced.
+
+## Regression coverage
+
+- A synthetic 10,000-message history reads four records to regenerate a trailing
+  assistant/hidden-continuation/assistant chain, deleting only those three rows.
+- Synthetic 10,000-note accounts stop after 5 or 15 notes at 1,000 tokens per
+  note; tiny/invalid counts are bounded by the 100-note cap.
+- Fifty streaming rerenders produce one pending image-URL request; a 101-image
+  case exercises batch ordering, partial failure, cache retention, and retries.
+- Query failures surface as failures; the history boundary can retry after
+  recovery. Loading notices delay recovery UI and clean up their timers.
+- Pagination tests verify the scroll root and duplicate-callback suppression.
+- Chromium verification with 1,000 synthetic tasks using the actual sidebar
+  components and application CSS: the list retained its 40,012px scroll height
+  from top to bottom; the last row was visible and keyboard activation selected
+  `/c/chat-999`; the task menu and delayed Reload notice displayed correctly;
+  no share dialogs mounted while closed. Backend and drag state were mocked.
+
+## Manual verification before production confidence
+
+1. In an authenticated preview, open an established account's task history.
+   Scroll through multiple pages, open old tasks, and rapidly switch tasks.
+   Check that the selected transcript, unread indicators, and scroll position
+   remain correct on desktop and mobile.
+2. Exercise keyboard navigation, task menus, pinning, project moves, sharing,
+   and dragging after scrolling far down the sidebar. Menus/dialogs must remain
+   visible and interactive. The isolated browser fixture mocks backend and drag
+   state, so it cannot replace this authenticated check.
+3. Delay or disconnect the backend: loading should offer Reload after 15 seconds.
+   For an actual query error, restore connectivity and use Try Again/Refresh
+   Page. Do not confuse missing-history errors with a legitimately empty account.
+4. Regenerate a long task with hidden continuations, including summary reset.
+   Only the latest response chain should disappear; earlier requests must remain.
+5. Open an image-heavy task while streaming. Confirm URL batches are not
+   duplicated for pending images, and completed images survive another batch's
+   failure. Send a new prompt from an account with many notes and check context.
+6. Deploy the Convex schema/index and functions with the frontend release.
+   Reproduce the customer incident and correlate the existing diagnostics before
+   claiming that their account-specific problem is resolved.
+
+## Remaining limits
+
+These changes address concrete code risks, not a proven root cause for a
+particular account. Large branch/copy operations and exceptionally large trailing
+response chains can still exceed one mutation's resource limits; converting them
+to resumable batched operations requires a separate transactional design. CSS
+content visibility defers layout/painting, not React mounts or all subscriptions;
+the sidebar still retains previously loaded pages. Provider latency and account
+authentication/authorization must be checked against live diagnostic evidence.

--- a/docs/chat-reliability-review.md
+++ b/docs/chat-reliability-review.md
@@ -11,7 +11,8 @@
   token budget or 100 notes, whichever comes first. Invalid token counts fall
   back to an estimate. Notes outside this prompt prefix are not deleted.
 - Image URL prefetch reserves IDs before awaiting network requests, including
-  queued batches. Batches run sequentially per prefetch pass, and a failed batch
+  queued batches. One promise queue serializes batches across prefetch passes,
+  including newly arriving IDs during an active request, and a failed batch
   no longer discards successful batches. Lazy non-image fetching is unchanged.
 - History-query failures propagate to an error boundary around the components
   that own the subscriptions. They no longer masquerade as an empty account or


### PR DESCRIPTION
## Summary

Addresses concrete code paths that can make established accounts feel frozen or unreliable. This is not yet a confirmed diagnosis of the reported customer's account.

- Read only the trailing response chain during regeneration, instead of collecting the whole conversation.
- Use an indexed, bounded recent-note prefix for prompt injection; retain existing plan token budgets and cap the prefix at 100 notes.
- Deduplicate pending image URL requests across streaming renders, serialize all prefetch passes through one queue, and retain successful batches after a partial failure.
- Surface history-query failures through error boundaries around the subscription owners; offer a Reload action after 15 seconds of loading.
- Memoize sidebar rows, defer off-screen layout/painting, mount share dialogs on demand, and prevent duplicate pagination callbacks.

The sidebar approach was informed by [t3code](https://github.com/pingdotgg/t3code/blob/b438447f67b6b61bbe6f564d8b78fd90702117c5/apps/web/src/components/Sidebar.tsx). Existing LegendList transcript virtualization and composer isolation are retained.

## Validation

- Full Jest suite: 457 suites / 4,720 tests passed after the review fix.
- TypeScript, targeted ESLint, formatting, and diff checks passed.
- Regression tests cover 10,000-message/10,000-note histories, duplicate image prefetches, partial batch failures, history recovery, delayed loading notices, and pagination callback deduplication.
- Local Chromium fixture with the actual sidebar components and CSS: 1,000 tasks, stable scroll height, last-task keyboard navigation, menu positioning, and delayed Reload notice verified. Backend and drag state were mocked; this does not claim authenticated end-to-end verification.

## Manual verification

1. In the authenticated preview, load several history pages and switch between old tasks on desktop and mobile. Confirm the correct transcript and selection appear.
2. Test keyboard navigation, menus, pinning, project moves, sharing, and dragging after scrolling far down the sidebar. Check that portals remain visible.
3. Delay/disconnect the backend and verify the 15-second notice. Restore it and retry a failed history load.
4. Regenerate a long task with hidden continuations and summary reset; only the trailing response chain should be removed.
5. Open an image-heavy task during streaming and send a prompt from an account with many notes; inspect request deduplication and retained context.

## Deployment and limits

- Deploy the new Convex note index/functions together with the frontend. No production changes have been made by this PR.
- Large branch/copy operations and unusually large trailing response chains still need a separate resumable-operation design.
- Correlate a fresh customer reproduction with the existing diagnostics before claiming their account issue is fixed.

See `docs/chat-reliability-review.md` for implementation details and remaining limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer loading messages, including connection guidance and a reload option when loading takes too long.
  - Added recoverable error states with a “Try Again” action when chat history fails to load.

- **Bug Fixes**
  - Chat history errors are now surfaced instead of appearing as empty results.
  - Improved sidebar pagination reliability and prevented duplicate image-loading requests.

- **Performance**
  - Improved responsiveness for large chat histories and note collections.
  - Reduced unnecessary updates and delayed loading of inactive chat items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->