### PR TITLE
HAC-98: Gate GLM Flash return and first-paid conversion comparison

### DIFF
--- a/docs/internal/flash-routing-experiment.md
+++ b/docs/internal/flash-routing-experiment.md
@@ -17,7 +17,8 @@ control requests whose rescue model happens to equal the assigned model. Paid
 Ask, free Agent, premium/Max models, image routes, and subagents stay unchanged.
 Prompts, tools, limits, pricing, and billing rules are not changed.
 
-Free Ask pins low reasoning in both arms, including OpenRouter fallbacks. Paid
+Free Ask pins low reasoning in both arms, including OpenRouter fallbacks and
+app-side retries, using the authenticated request tier rather than a retry alias. Paid
 Agent retains the existing policies for each model: DeepSeek high and GLM's
 provider default. Thus the paid comparison measures these routing configurations,
 not model weights in isolation. App-side recovery can change models/settings;

--- a/docs/internal/flash-routing-experiment.md
+++ b/docs/internal/flash-routing-experiment.md
@@ -1,0 +1,129 @@
+# Flash routing experiment (HAC-98)
+
+Owner and decision record: [HAC-98](https://linear.app/hackerai/issue/HAC-98).
+This is a reversible comparison, not evidence that the model caused a business
+decline. Opening or merging the PR does not authorize a production ramp.
+
+## Routes
+
+| Key                              | Code-eligible population                      | Control                 | Test                |
+| -------------------------------- | --------------------------------------------- | ----------------------- | ------------------- |
+| `paid_agent_glm_flash_return_v1` | Paid Agent already resolved to Flash 0731     | DeepSeek Flash 0731     | GLM 5.3 Flash Agent |
+| `free_ask_flash_conversion_v1`   | Free Ask already resolved to `ask-model-free` | DeepSeek Flash 0731 low | GLM 5.3 Flash low   |
+
+Both exclude image attachments and image tool results already in the request.
+Paid allowance-rescue traffic is excluded after rate-limit handling, including
+control requests whose rescue model happens to equal the assigned model. Paid
+Ask, free Agent, premium/Max models, image routes, and subagents stay unchanged.
+Prompts, tools, limits, pricing, and billing rules are not changed.
+
+Free Ask pins low reasoning in both arms, including OpenRouter fallbacks. Paid
+Agent retains the existing policies for each model: DeepSeek high and GLM's
+provider default. Thus the paid comparison measures these routing configurations,
+not model weights in isolation. App-side recovery can change models/settings;
+report fallback-served rates and actual served models alongside assignment.
+
+Assignment is by authenticated user ID through PostHog, never per message or
+client-supplied model choice. Missing, inactive, invalid, or unavailable flags
+leave current routing unchanged. Flag cohorts must stay stable during a readout.
+
+## Environment and rollout
+
+| Project                           | Paid flag | Free flag | State / enrollment                        | Split                           |
+| --------------------------------- | --------- | --------- | ----------------------------------------- | ------------------------------- |
+| Preview `hackerai-dev` / `401167` | `868787`  | `868788`  | Active / 100% of code-eligible test users | 50/50                           |
+| Production `HackerAI` / `144137`  | `868785`  | `868786`  | Inactive / 0%                             | 50/50 configured, no enrollment |
+
+These are separate flags with identical keys, not shared configuration. The
+first production stage must target an explicit internal allowlist. Record the
+allowlist, subsequent enrollment, decision thresholds, and sample-size plan in
+HAC-98 before activating or expanding either flag. No automatic ramp is included.
+
+Before testing or launching, independently verify Vercel and Trigger worker
+environment, PostHog project, and the authorized Convex account/project/deployment
+mapping. Preview must use the designated HackerAI Developer Preview deployment;
+Production must use the designated HackerAI Production deployment. Do not copy
+credentials across environments. A Vercel setting does not verify Trigger.
+
+New code must be deployed to Vercel and Trigger before enrollment. Once deployed,
+flag changes affect new requests/runs without another deployment; existing runs
+keep their request-scoped assignment. Disable the relevant flag to restore the
+current DeepSeek route for new requests. Do not edit live variant percentages
+mid-readout without explicitly ending/restarting that measurement window.
+
+## Exposure and outcomes
+
+`flash_routing_experiment_exposed` is recorded once per matching provider request
+lifecycle, from the AI SDK step-start callback after step preparation. Assignment,
+preflight, blocked requests, canceled-before-start requests, and a different
+initial provider model are not exposure. The callback carries only the configured
+model ID, not SDK messages or tool content. `request_id` equals the assistant
+message ID (the Trigger run ID for durable Agent runs).
+
+Use the custom exposure event filtered by `experiment_key`, not
+`$feature_flag_called`. Usage and Agent outcome events carry the same experiment
+key/variant through the existing analytics context. Join request outcomes by
+their assistant/run identifiers and users by the authenticated analytics ID.
+OpenRouter fallbacks are outcomes of the assigned route, not new assignments.
+
+The free primary metric is **first-ever paid conversion within seven days**:
+
+1. Take each user's first eligible exposure in the enrollment window.
+2. Exclude users with successful paid subscription history before exposure;
+   use Stripe history, not only the first observed PostHog event. Reactivations
+   are not new subscribers. Reconcile customer identity across systems.
+3. Restrict the denominator to exposures with a full seven-day follow-up.
+4. Count users whose first successful subscription payment is within seven days
+   after exposure, once per user. Report numerator, denominator, confidence
+   interval, and any crossover or missing billing/identity data for each arm.
+5. Preserve intention-to-treat attribution after first exposure; do not relabel
+   users based on the model serving a later request or fallback.
+
+Use the predeclared sample-size target and minimum practical effect in HAC-98;
+seven elapsed days alone do not establish significance. Check sample-ratio
+mismatch and compare source/device composition. Do not divide today's purchases
+by today's active users and call it cohort conversion.
+
+Paid primary: natural Agent completion (`outcome=success`, `finish_reason=stop`,
+`step_limit_reached=false`) among exposed runs. Guardrails: errors, user aborts,
+fallbacks, latency, model/total cost, usage-deduction failures, and cancellation
+requests. Keep paid and free populations separate. Completed churn and failed
+renewals may reflect pre-exposure decisions and must not be attributed from the
+termination date alone.
+
+## Acquisition and billing follow-up
+
+Investigate visitors → signups → successful first answer → checkout → first
+payment, segmented by acquisition source and device. First verify the available
+events/properties and identity joins; report missing telemetry explicitly. Keep
+anonymous visitors, authenticated free users, new customers, and reactivations
+distinct. Compare matching weekday/hour windows and complete days.
+
+Split paid losses into new voluntary cancellation requests, scheduled voluntary
+endings, and payment failures. Do not change billing recovery in this routing PR.
+Any qualitative customer research must use the separate privacy-safe research
+workflow; do not inspect prompts or customer content through analytics.
+
+## Manual acceptance and cleanup
+
+- On the verified Preview URL, use separate eligible test accounts assigned to
+  each arm. Submit a bounded disposable free Ask chat; verify completion,
+  rendering, reload, configured/served model, low reasoning, one custom exposure,
+  and correctly attributed usage. Check a PDF request and provider fallback.
+- Repeat paid Agent Auto and Standard through the Preview Trigger worker. Check
+  a tool call, natural completion, stop/abort, and reload/reconnect. Confirm both
+  control and treatment retain matching billing/accounting behavior.
+- Verify no treatment/exposure for paid Ask, premium models, image requests,
+  free Agent, and paid allowance rescue. A blocked or pre-start canceled request
+  must not produce an exposure. Disable a Preview flag and confirm current
+  DeepSeek routing returns for a new request.
+- Before production, read back both environment definitions and attach actual
+  Vercel/Trigger runtime identity evidence and acceptance results to HAC-98.
+- Owner reviews health within 24 hours after launch and outcomes after at least
+  seven mature days and the planned sample size. Roll back on any billing or
+  compatibility regression; use HAC-98's completion/error/cost/latency guardrails.
+- Record win/loss/inconclusive, then explicitly select permanent routing, remove
+  experiment plumbing, deploy cleanup, and archive/deactivate both projects'
+  flags. A merged PR does not mean the experiment is complete.
+
+SDK reference: [PostHog Node feature flags](https://posthog.com/docs/libraries/node#feature-flags).

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1234,6 +1234,7 @@ const buildProviderMap = (
   ({
     "ask-model": or(GROK_4_6_SLUG),
     "ask-model-free": or(freeAskModelSlug),
+    "ask-model-free-glm": or(GLM_5_3_FLASH_SLUG),
     "agent-model": or(GROK_4_6_SLUG),
     "agent-model-free": or(freeAgentModelSlug),
     "model-grok-4.6": or(GROK_4_6_SLUG),
@@ -1299,6 +1300,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   Record<string, string> = {
   "ask-model": "Auto, an intelligent model router built by HackerAI",
   "ask-model-free": "Auto, an intelligent model router built by HackerAI",
+  "ask-model-free-glm": "Auto, an intelligent model router built by HackerAI",
   "agent-model": "Auto, an intelligent model router built by HackerAI",
   "agent-model-free": "Auto, an intelligent model router built by HackerAI",
   "model-grok-4.6": "xAI Grok 4.6",
@@ -1386,6 +1388,7 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
 
   return (
     normalized === "model-glm-5.3-flash" ||
+    normalized === "ask-model-free-glm" ||
     normalized === "model-glm-5.3-flash-pro" ||
     normalized === "model-glm-5.3-flash-agent" ||
     normalized === "model-deepseek-v4-flash-vision" ||

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -512,6 +512,37 @@ describe("createAgentStream repeated compaction", () => {
     expect(onModelChunk).toHaveBeenCalledTimes(1);
   });
 
+  it("exposes the prepared provider model only when an un-aborted step starts", async () => {
+    const onProviderRequestStart = jest.fn();
+    const onModelStreamStart = jest.fn();
+    const abortController = new AbortController();
+    const stream = (await createAgentStream(
+      "test-model",
+      createTestStreamContext({
+        onProviderRequestStart,
+        onModelStreamStart,
+        abortController,
+        summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+        usageTracker: {},
+      }) as any,
+      initAgentStreamState([uiMessage("initial", "Say hello")], {
+        usedTokens: 1000,
+        maxTokens: 128000,
+      }),
+    )) as any;
+    expect(onProviderRequestStart).not.toHaveBeenCalled();
+    stream.experimental_onStepStart({
+      model: { modelId: "z-ai/glm-5.3-flash" },
+    });
+    expect(onProviderRequestStart).toHaveBeenCalledWith("z-ai/glm-5.3-flash");
+    expect(onModelStreamStart).toHaveBeenCalledTimes(1);
+    abortController.abort();
+    stream.experimental_onStepStart({
+      model: { modelId: "z-ai/glm-5.3-flash" },
+    });
+    expect(onProviderRequestStart).toHaveBeenCalledTimes(1);
+  });
+
   it("includes sandbox and Trigger runtime in budget checks and per-step settlement", async () => {
     const checkAfterStep = jest.fn(() => undefined);
     const settleUsageAfterStep = jest.fn(async () => undefined);

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -6,6 +6,7 @@ const mockStreamText = jest.fn();
 const mockRunSummarizationStep = jest.fn();
 const mockCompactModelMessagesInRun = jest.fn();
 const mockGetProviderPromptPressure = jest.fn();
+const mockBuildProviderOptions = jest.fn(() => ({}));
 
 jest.mock("server-only", () => ({}));
 jest.mock("ai", () => ({
@@ -25,7 +26,7 @@ jest.mock("ai", () => ({
 jest.mock("@/lib/api/chat-stream-helpers", () => ({
   addCacheBreakpointToLastUserMessage: (messages: ModelMessage[]) => messages,
   applyPrepareStepReminders: async (messages: ModelMessage[]) => messages,
-  buildProviderOptions: () => ({}),
+  buildProviderOptions: mockBuildProviderOptions,
   buildSystemPrompt: (prompt: string) => prompt,
   getFallbackSlugs: () => [],
   isXaiSafetyError: () => false,
@@ -486,6 +487,36 @@ describe("createAgentStream repeated compaction", () => {
     mockCompactModelMessagesInRun.mockReset();
     mockGetProviderPromptPressure.mockReset();
   });
+
+  it.each([
+    ["ask", "free", true],
+    ["ask", "pro", false],
+    ["agent", "free", false],
+  ])(
+    "preserves the request reasoning policy for %s/%s retries",
+    async (mode, subscription, expected) => {
+      await createAgentStream(
+        "model-deepseek-v4-flash-0731",
+        createTestStreamContext({
+          mode,
+          subscription,
+          summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+          usageTracker: {},
+        }) as any,
+        initAgentStreamState([uiMessage("initial", "Say hello")], {
+          usedTokens: 1_000,
+          maxTokens: 128_000,
+        }),
+      );
+      expect(mockBuildProviderOptions).toHaveBeenCalledWith(
+        expect.anything(),
+        "user",
+        "model-deepseek-v4-flash-0731",
+        mode,
+        expect.objectContaining({ isFreeAskRequest: expected }),
+      );
+    },
+  );
 
   it("reports the first provider chunk to startup timing", async () => {
     const onModelChunk = jest.fn();

--- a/lib/api/__tests__/chat-handler-request-validation.test.ts
+++ b/lib/api/__tests__/chat-handler-request-validation.test.ts
@@ -7,6 +7,20 @@ import {
 } from "@/lib/api/chat-request-validation";
 
 describe("chat-handler request validation", () => {
+  it("checks original image attachments before Flash routing", () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, "../chat-handler.ts"),
+      "utf8",
+    );
+    const routing = source.slice(
+      source.indexOf("const flashRoutingAssignment"),
+    );
+    expect(
+      routing.slice(0, routing.indexOf("if (flashRoutingAssignment)")),
+    ).toContain(
+      "countFileAttachments(fetched.truncatedMessages).imageCount > 0",
+    );
+  });
   it("enforces the Trigger.dev Agent boundary before Vercel auth or billing work", () => {
     const source = fs.readFileSync(
       path.resolve(__dirname, "../chat-handler.ts"),

--- a/lib/api/__tests__/chat-handler-request-validation.test.ts
+++ b/lib/api/__tests__/chat-handler-request-validation.test.ts
@@ -12,14 +12,15 @@ describe("chat-handler request validation", () => {
       path.resolve(__dirname, "../chat-handler.ts"),
       "utf8",
     );
-    const routing = source.slice(
-      source.indexOf("const flashRoutingAssignment"),
-    );
-    expect(
-      routing.slice(0, routing.indexOf("if (flashRoutingAssignment)")),
-    ).toContain(
+    const routingStart = source.indexOf("const flashRoutingAssignment");
+    const routingEnd = source.indexOf("if (flashRoutingAssignment)");
+    const attachmentCheck = source.indexOf(
       "countFileAttachments(fetched.truncatedMessages).imageCount > 0",
     );
+    expect(routingStart).toBeGreaterThan(-1);
+    expect(routingEnd).toBeGreaterThan(-1);
+    expect(attachmentCheck).toBeGreaterThan(routingStart);
+    expect(attachmentCheck).toBeLessThan(routingEnd);
   });
   it("enforces the Trigger.dev Agent boundary before Vercel auth or billing work", () => {
     const source = fs.readFileSync(

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -57,6 +57,24 @@ const HIGH_REASONING_ROUTES = [
 ] as const;
 
 describe("buildProviderOptions fallback chain", () => {
+  it.each(["ask-model-free", "ask-model-free-glm"] as const)(
+    "preserves free Ask low reasoning on retries from %s",
+    (primaryModel) => {
+      for (const retryModel of [
+        getRetryFallbackModel(primaryModel, "ask"),
+        getContentFilterRetryModel(primaryModel, "ask", GLM_FLASH_SLUG),
+      ]) {
+        const opts = buildProviderOptions(true, "user-1", retryModel, "ask", {
+          isFreeAskRequest: true,
+          reasoningOverride: { enabled: true, effort: "high" },
+        });
+        expect(opts.openrouter.reasoning).toEqual({
+          enabled: true,
+          effort: "low",
+        });
+      }
+    },
+  );
   it("keeps the free GLM treatment at low reasoning with billed, retryable fallbacks", () => {
     const opts = buildProviderOptions(
       true,

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -57,6 +57,42 @@ const HIGH_REASONING_ROUTES = [
 ] as const;
 
 describe("buildProviderOptions fallback chain", () => {
+  it("keeps the free GLM treatment at low reasoning with billed, retryable fallbacks", () => {
+    const opts = buildProviderOptions(
+      true,
+      "user-1",
+      "ask-model-free-glm",
+      "ask",
+      {
+        reasoningOverride: { enabled: true, effort: "high" },
+      },
+    );
+    expect(opts.openrouter.reasoning).toEqual({ enabled: true, effort: "low" });
+    expect(opts.openrouter.models).toEqual([
+      DEEPSEEK_FLASH_SLUG,
+      DEEPSEEK_V4_PRO_0813_SLUG,
+      GLM_SLUG,
+    ]);
+    expect(opts.openrouter.provider).toEqual({
+      sort: "latency",
+      data_collection: "deny",
+    });
+    expect(getRetryFallbackModel("ask-model-free-glm", "ask")).toBe(
+      "model-deepseek-v4-flash-0731",
+    );
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "ask-model-free-glm",
+        selectedModelOverride: "hackerai-standard",
+      }),
+    ).toBe(true);
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "ask-model-free-glm",
+        responseModel: DEEPSEEK_FLASH_SLUG,
+      }),
+    ).toBe("model-deepseek-v4-flash-0731");
+  });
   it("keeps title generation on a non-reasoning route", () => {
     const opts = buildProviderOptions(
       false,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -666,6 +666,8 @@ export type AgentStreamContext = {
   usageRefundTracker: UsageRefundTracker;
   onBudgetAbort?: (details: BudgetAbortDetails & { model: string }) => void;
   onModelStreamStart?: () => void;
+  /** Called after step preparation, immediately before the actual provider call. */
+  onProviderRequestStart?: (configuredModel: string) => void;
   onModelStreamFinish?: () => void;
   onModelChunk?: () => void;
   onStartupPhaseDuration?: (
@@ -1141,7 +1143,10 @@ export async function createAgentStream(
     activeTools: initialActiveTools,
     abortSignal,
     providerOptions: initialProviderOptions,
-    experimental_onStepStart: () => ctx.onModelStreamStart?.(),
+    experimental_onStepStart: ({ model }) => {
+      ctx.onModelStreamStart?.();
+      if (!abortSignal.aborted) ctx.onProviderRequestStart?.(model.modelId);
+    },
     experimental_onToolCallStart: () => ctx.onModelStreamFinish?.(),
 
     prepareStep: async ({ steps, messages }) => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -1005,6 +1005,7 @@ export async function createAgentStream(
       ctx.mode,
       {
         requestedModelSlug,
+        isFreeAskRequest: ctx.mode === "ask" && ctx.subscription === "free",
         hasMultimodalToolResults: streamHasImageViewResults,
         hasPdfAttachments:
           streamHasPdfAttachments && !providerPdfAttachmentsDisabled,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -498,7 +498,7 @@ export const createChatHandler = () => {
         subscription,
         selectedModel,
         hasImages:
-          countFileAttachments(truncatedMessages).imageCount > 0 ||
+          countFileAttachments(fetched.truncatedMessages).imageCount > 0 ||
           uiMessagesContainImageViewResult(processedMessages),
       });
       if (flashRoutingAssignment)

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -164,6 +164,11 @@ import {
   getActiveDeepSeekV4Pro0813ExperimentAssignment,
   getDeepSeekV4Pro0813ExperimentContext,
 } from "@/lib/experiments/deepseek-v4-pro-0813";
+import {
+  evaluateFlashRouting,
+  getActiveFlashRoutingAssignment,
+  createFlashRoutingExposureRecorder,
+} from "@/lib/experiments/flash-routing";
 import { isEligibleForDirectGlmVision } from "@/lib/chat/auxiliary-vision-eligibility";
 import {
   capturePaidDailyFreeAllowanceServerEvent,
@@ -486,6 +491,18 @@ export const createChatHandler = () => {
       if (deepSeekV4Pro0813Experiment) {
         selectedModel = deepSeekV4Pro0813Experiment.modelKey;
       }
+      const flashRoutingAssignment = await evaluateFlashRouting({
+        posthog,
+        userId,
+        mode,
+        subscription,
+        selectedModel,
+        hasImages:
+          countFileAttachments(truncatedMessages).imageCount > 0 ||
+          uiMessagesContainImageViewResult(processedMessages),
+      });
+      if (flashRoutingAssignment)
+        selectedModel = flashRoutingAssignment.modelKey;
       const notesEnabled =
         (subscription !== "free" || isAgentMode(mode)) &&
         (userCustomization?.include_notes ?? true);
@@ -627,9 +644,16 @@ export const createChatHandler = () => {
           deepSeekV4Pro0813Experiment,
           selectedModel,
         );
-      const routingExperimentContext = getDeepSeekV4Pro0813ExperimentContext(
-        activeDeepSeekV4Pro0813Experiment,
+      const activeFlashRoutingAssignment = getActiveFlashRoutingAssignment(
+        flashRoutingAssignment,
+        selectedModel,
+        !!paidDailyFreeAllowanceReservation,
       );
+      const routingExperimentContext =
+        activeFlashRoutingAssignment ??
+        getDeepSeekV4Pro0813ExperimentContext(
+          activeDeepSeekV4Pro0813Experiment,
+        );
 
       const freeMonthlyBudgetSnapshot =
         subscription === "free"
@@ -1414,6 +1438,14 @@ export const createChatHandler = () => {
 
             // Shared runner context.
             const streamCtx: AgentStreamContext = {
+              onProviderRequestStart: createFlashRoutingExposureRecorder({
+                posthog,
+                assignment: activeFlashRoutingAssignment,
+                userId,
+                mode,
+                subscription,
+                requestId: assistantMessageId,
+              }),
               trackedProvider,
               currentSystemPrompt,
               tools,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -623,6 +623,7 @@ const HACKERAI_PRO_FALLBACK_CHAIN = [
 
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN,
+  "ask-model-free-glm": LEGACY_AGENT_GLM_FLASH_FALLBACK_CHAIN,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN,
   "model-glm-5.3-flash-agent": LEGACY_AGENT_GLM_FLASH_FALLBACK_CHAIN,
   "model-deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_FALLBACK_CHAIN,
@@ -649,6 +650,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
 const AUTO_MODEL_KEYS = new Set<string>([
   "ask-model",
   "ask-model-free",
+  "ask-model-free-glm",
   "agent-model",
   "agent-model-free",
 ]);
@@ -743,7 +745,10 @@ export function getRetryFallbackModel(
   modelName: ModelName,
   _mode: ChatMode,
 ): ModelName {
-  if (modelName === "model-glm-5.3-flash-agent") {
+  if (
+    modelName === "model-glm-5.3-flash-agent" ||
+    modelName === "ask-model-free-glm"
+  ) {
     return "model-deepseek-v4-flash-0731";
   }
   if (
@@ -964,7 +969,9 @@ export function buildProviderOptions(
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
   // Free Ask keeps mandatory reasoning low even when a caller supplies a
   // different reasoning override.
-  const isFreeAsk = mode === "ask" && modelName === "ask-model-free";
+  const isFreeAsk =
+    mode === "ask" &&
+    (modelName === "ask-model-free" || modelName === "ask-model-free-glm");
   const isGrok45 = modelId === GROK_4_5_SLUG;
   const isGrok46 = modelId === GROK_4_6_SLUG;
   // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -709,6 +709,8 @@ const isHighReasoningModel = (modelName?: string): boolean =>
   (HIGH_REASONING_MODELS as readonly string[]).includes(modelName);
 
 type FallbackOptions = {
+  /** Preserve the authenticated free Ask policy across model retries. */
+  isFreeAskRequest?: boolean;
   hasMultimodalToolResults?: boolean;
   hasPdfAttachments?: boolean;
   pdfParserEngine?: "mistral-ocr" | "cloudflare-ai";
@@ -971,7 +973,9 @@ export function buildProviderOptions(
   // different reasoning override.
   const isFreeAsk =
     mode === "ask" &&
-    (modelName === "ask-model-free" || modelName === "ask-model-free-glm");
+    (options.isFreeAskRequest === true ||
+      modelName === "ask-model-free" ||
+      modelName === "ask-model-free-glm");
   const isGrok45 = modelId === GROK_4_5_SLUG;
   const isGrok46 = modelId === GROK_4_6_SLUG;
   // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this

--- a/lib/experiments/__tests__/flash-routing.test.ts
+++ b/lib/experiments/__tests__/flash-routing.test.ts
@@ -1,0 +1,187 @@
+import {
+  evaluateFlashRouting,
+  getActiveFlashRoutingAssignment,
+  createFlashRoutingExposureRecorder,
+  FREE_ASK_FLASH_CONVERSION_KEY,
+  PAID_AGENT_FLASH_RETURN_KEY,
+  FLASH_ROUTING_EXPOSURE_EVENT,
+} from "@/lib/experiments/flash-routing";
+
+const free = {
+  userId: "test-user",
+  subscription: "free" as const,
+  mode: "ask" as const,
+  selectedModel: "ask-model-free",
+  hasImages: false,
+};
+const paid = {
+  ...free,
+  subscription: "pro" as const,
+  mode: "agent" as const,
+  selectedModel: "model-deepseek-v4-flash-0731",
+};
+const flags = (variant: unknown) => ({
+  evaluateFlags: jest.fn(async () => ({ getFlag: () => variant })),
+});
+
+describe("Flash routing experiments", () => {
+  it.each([
+    [free, "control", FREE_ASK_FLASH_CONVERSION_KEY, "ask-model-free"],
+    [free, "test", FREE_ASK_FLASH_CONVERSION_KEY, "ask-model-free-glm"],
+    [
+      paid,
+      "control",
+      PAID_AGENT_FLASH_RETURN_KEY,
+      "model-deepseek-v4-flash-0731",
+    ],
+    [paid, "test", PAID_AGENT_FLASH_RETURN_KEY, "model-glm-5.3-flash-agent"],
+  ] as const)(
+    "routes only the assigned eligible variant",
+    async (scope, variant, key, modelKey) => {
+      const posthog = flags(variant);
+      const result = await evaluateFlashRouting({
+        ...scope,
+        posthog: posthog as never,
+      });
+      expect(result).toEqual({
+        key,
+        variant,
+        modelKey,
+        configuredModel:
+          variant === "test"
+            ? "z-ai/glm-5.3-flash"
+            : "deepseek/deepseek-v4-flash-0731",
+      });
+      expect(posthog.evaluateFlags).toHaveBeenCalledWith("test-user", {
+        flagKeys: [key],
+      });
+    },
+  );
+
+  it.each([
+    { ...paid, mode: "ask" as const },
+    { ...paid, subscription: "free" as const },
+    { ...paid, selectedModel: "model-deepseek-v4-pro-0813" },
+    { ...paid, selectedModel: "model-opus-4.6" },
+    { ...paid, selectedModel: "model-deepseek-v4-flash-vision" },
+    { ...paid, hasImages: true },
+    { ...free, hasImages: true },
+    { ...free, userId: "" },
+    { ...free, selectedModel: "model-glm-5.3-flash" },
+  ])("does not evaluate excluded requests: %j", async (scope) => {
+    const posthog = flags("test");
+    expect(
+      await evaluateFlashRouting({ ...scope, posthog: posthog as never }),
+    ).toBeUndefined();
+    expect(posthog.evaluateFlags).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false, undefined, "unknown"])(
+    "retains current behavior for %s",
+    async (variant) => {
+      expect(
+        await evaluateFlashRouting({
+          ...free,
+          posthog: flags(variant) as never,
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  it("fails closed on missing client or flag service failure", async () => {
+    expect(
+      await evaluateFlashRouting({ ...free, posthog: null }),
+    ).toBeUndefined();
+    expect(
+      await evaluateFlashRouting({
+        ...free,
+        posthog: {
+          evaluateFlags: jest.fn().mockRejectedValue(new Error("unavailable")),
+        } as never,
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each(["control", "test"])(
+    "excludes rescue and rerouted requests even for %s",
+    async (variant) => {
+      const assignment = await evaluateFlashRouting({
+        ...paid,
+        posthog: flags(variant) as never,
+      });
+      expect(
+        getActiveFlashRoutingAssignment(
+          assignment,
+          assignment!.modelKey,
+          false,
+        ),
+      ).toBe(assignment);
+      expect(
+        getActiveFlashRoutingAssignment(assignment, assignment!.modelKey, true),
+      ).toBeUndefined();
+      expect(
+        getActiveFlashRoutingAssignment(
+          assignment,
+          "model-deepseek-v4-flash-vision",
+          false,
+        ),
+      ).toBeUndefined();
+    },
+  );
+
+  it("records only the first matching provider request, with an explicit property allowlist", async () => {
+    const assignment = await evaluateFlashRouting({
+      ...free,
+      posthog: flags("test") as never,
+    });
+    const capture = jest.fn();
+    const record = createFlashRoutingExposureRecorder({
+      ...free,
+      posthog: { capture } as never,
+      assignment,
+      requestId: "request-1",
+    });
+    expect(capture).not.toHaveBeenCalled();
+    record("deepseek/deepseek-v4-flash-vision-exp");
+    expect(capture).not.toHaveBeenCalled();
+    record("z-ai/glm-5.3-flash");
+    record("z-ai/glm-5.3-flash");
+    record("deepseek/deepseek-v4-flash-0731");
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "test-user",
+      event: FLASH_ROUTING_EXPOSURE_EVENT,
+      properties: {
+        experiment_key: FREE_ASK_FLASH_CONVERSION_KEY,
+        experiment_variant: "test",
+        [`$feature/${FREE_ASK_FLASH_CONVERSION_KEY}`]: "test",
+        subscription: "free",
+        subscription_tier: "free",
+        mode: "ask",
+        selected_model: "ask-model-free-glm",
+        configured_model: "z-ai/glm-5.3-flash",
+        request_id: "request-1",
+        exposure_surface: "provider_request",
+        $process_person_profile: false,
+      },
+    });
+  });
+
+  it("does not fail generation when capture throws", async () => {
+    const assignment = await evaluateFlashRouting({
+      ...free,
+      posthog: flags("test") as never,
+    });
+    const record = createFlashRoutingExposureRecorder({
+      ...free,
+      assignment,
+      requestId: "request-1",
+      posthog: {
+        capture: () => {
+          throw new Error("unavailable");
+        },
+      } as never,
+    });
+    expect(() => record("z-ai/glm-5.3-flash")).not.toThrow();
+  });
+});

--- a/lib/experiments/flash-routing.ts
+++ b/lib/experiments/flash-routing.ts
@@ -1,0 +1,127 @@
+import type { PostHog } from "posthog-node";
+import type { ModelName } from "@/lib/ai/providers";
+import { getExperimentAnalyticsProperties } from "@/lib/analytics/experiment-context";
+import type { ChatMode, SubscriptionTier } from "@/types";
+
+export const PAID_AGENT_FLASH_RETURN_KEY = "paid_agent_glm_flash_return_v1";
+export const FREE_ASK_FLASH_CONVERSION_KEY = "free_ask_flash_conversion_v1";
+export const FLASH_ROUTING_EXPOSURE_EVENT = "flash_routing_experiment_exposed";
+
+export type FlashRoutingAssignment = {
+  key:
+    typeof PAID_AGENT_FLASH_RETURN_KEY | typeof FREE_ASK_FLASH_CONVERSION_KEY;
+  variant: "control" | "test";
+  modelKey: ModelName;
+  configuredModel: string;
+};
+
+/** Only already-authorized standard routes participate; media and rescue do not. */
+export async function evaluateFlashRouting({
+  posthog,
+  userId,
+  mode,
+  subscription,
+  selectedModel,
+  hasImages,
+}: {
+  posthog: Pick<PostHog, "evaluateFlags"> | null;
+  userId: string;
+  mode: ChatMode;
+  subscription: SubscriptionTier;
+  selectedModel: ModelName;
+  hasImages: boolean;
+}): Promise<FlashRoutingAssignment | undefined> {
+  if (!posthog || !userId || hasImages) return undefined;
+  const key =
+    mode === "ask" &&
+    subscription === "free" &&
+    selectedModel === "ask-model-free"
+      ? FREE_ASK_FLASH_CONVERSION_KEY
+      : mode === "agent" &&
+          subscription !== "free" &&
+          selectedModel === "model-deepseek-v4-flash-0731"
+        ? PAID_AGENT_FLASH_RETURN_KEY
+        : undefined;
+  if (!key) return undefined;
+
+  try {
+    const flags = await posthog.evaluateFlags(userId, { flagKeys: [key] });
+    const variant = flags.getFlag(key);
+    if (variant !== "control" && variant !== "test") return undefined;
+    return {
+      key,
+      variant,
+      modelKey:
+        variant === "control"
+          ? selectedModel
+          : key === FREE_ASK_FLASH_CONVERSION_KEY
+            ? "ask-model-free-glm"
+            : "model-glm-5.3-flash-agent",
+      configuredModel:
+        variant === "test"
+          ? "z-ai/glm-5.3-flash"
+          : "deepseek/deepseek-v4-flash-0731",
+    };
+  } catch {
+    // Analytics availability must never make chat unavailable or change the default.
+    return undefined;
+  }
+}
+
+export function getActiveFlashRoutingAssignment(
+  assignment: FlashRoutingAssignment | undefined,
+  selectedModel: ModelName,
+  isPaidAllowanceRescue: boolean,
+): FlashRoutingAssignment | undefined {
+  return !isPaidAllowanceRescue && assignment?.modelKey === selectedModel
+    ? assignment
+    : undefined;
+}
+
+/** A request-scoped callback: assignment alone is not model exposure. */
+export function createFlashRoutingExposureRecorder({
+  posthog,
+  assignment,
+  userId,
+  mode,
+  subscription,
+  requestId,
+}: {
+  posthog: Pick<PostHog, "capture"> | null;
+  assignment: FlashRoutingAssignment | undefined;
+  userId: string;
+  mode: ChatMode;
+  subscription: SubscriptionTier;
+  requestId: string;
+}): (configuredModel: string) => void {
+  let recorded = false;
+  return (configuredModel) => {
+    if (
+      recorded ||
+      !posthog ||
+      !assignment ||
+      configuredModel !== assignment.configuredModel
+    )
+      return;
+    recorded = true;
+    try {
+      posthog.capture({
+        distinctId: userId,
+        event: FLASH_ROUTING_EXPOSURE_EVENT,
+        properties: {
+          ...getExperimentAnalyticsProperties(assignment),
+          subscription,
+          subscription_tier: subscription,
+          mode,
+          selected_model: assignment.modelKey,
+          configured_model: configuredModel,
+          request_id: requestId,
+          exposure_surface: "provider_request",
+          $process_person_profile: false,
+        },
+      });
+    } catch {
+      // An analytics failure must not interrupt a provider request.
+    }
+  };
+}

--- a/lib/experiments/flash-routing.ts
+++ b/lib/experiments/flash-routing.ts
@@ -68,6 +68,7 @@ export async function evaluateFlashRouting({
   }
 }
 
+/** Drop assignments superseded by rescue or another routing decision. */
 export function getActiveFlashRoutingAssignment(
   assignment: FlashRoutingAssignment | undefined,
   selectedModel: ModelName,

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -540,6 +540,7 @@ describe("token-bucket", () => {
       "model-glm-5.3-flash",
       "model-glm-5.3-flash-pro",
       "model-glm-5.3-flash-agent",
+      "ask-model-free-glm",
       "z-ai/glm-5.3-flash",
     ])(
       "should use the conservative GLM 5.3 Flash ceiling for %s ($0.15/$0.50)",

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -143,6 +143,7 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   // Free Ask and Free Agent use DeepSeek 0731 at different reasoning efforts.
   // Provider fallbacks reconcile against their served model.
   "ask-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
+  "ask-model-free-glm": GLM_5_3_FLASH_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_0731_PRICING,
   // DeepSeek V4 Flash 0731 rates from OpenRouter: $0.14 in / $0.28 out per 1M tokens.
   "agent-auto-review-model": DEEPSEEK_V4_FLASH_0731_PRICING,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -150,6 +150,11 @@ import {
   getActiveDeepSeekV4Pro0813ExperimentAssignment,
   getDeepSeekV4Pro0813ExperimentContext,
 } from "@/lib/experiments/deepseek-v4-pro-0813";
+import {
+  evaluateFlashRouting,
+  getActiveFlashRoutingAssignment,
+  createFlashRoutingExposureRecorder,
+} from "@/lib/experiments/flash-routing";
 import { isEligibleForDirectGlmVision } from "@/lib/chat/auxiliary-vision-eligibility";
 import type { AgentAutoReviewAssignment } from "@/lib/experiments/agent-auto-review";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
@@ -2663,6 +2668,18 @@ export const agentLongTask = task({
       if (deepSeekV4Pro0813Experiment) {
         selectedModel = deepSeekV4Pro0813Experiment.modelKey;
       }
+      const flashRoutingAssignment = await evaluateFlashRouting({
+        posthog,
+        userId,
+        mode,
+        subscription,
+        selectedModel,
+        hasImages:
+          countFileAttachments(messagesForProcessing).imageCount > 0 ||
+          uiMessagesContainImageViewResult(processedMessages),
+      });
+      if (flashRoutingAssignment)
+        selectedModel = flashRoutingAssignment.modelKey;
       const notesEnabled = userCustomization?.include_notes ?? true;
 
       const estimatedInputTokens = await estimatePreflightInputTokens({
@@ -2940,7 +2957,14 @@ export const agentLongTask = task({
                 deepSeekV4Pro0813Experiment,
                 selectedModel,
               );
+            const activeFlashRoutingAssignment =
+              getActiveFlashRoutingAssignment(
+                flashRoutingAssignment,
+                selectedModel,
+                !!paidDailyFreeAllowanceReservation,
+              );
             const routingExperimentContext =
+              activeFlashRoutingAssignment ??
               getDeepSeekV4Pro0813ExperimentContext(
                 activeDeepSeekV4Pro0813Experiment,
               );
@@ -4090,6 +4114,14 @@ export const agentLongTask = task({
 
             // Shared runner context — immutable deps + platform hook.
             const streamCtx: AgentStreamContext = {
+              onProviderRequestStart: createFlashRoutingExposureRecorder({
+                posthog,
+                assignment: activeFlashRoutingAssignment,
+                userId,
+                mode,
+                subscription,
+                requestId: assistantMessageId,
+              }),
               trackedProvider,
               currentSystemPrompt,
               tools,


### PR DESCRIPTION
## Summary

- Add separately gated, stable user-assigned Flash comparisons for paid Agent Auto/Standard and free Ask. Missing/inactive/invalid/unavailable flags retain current DeepSeek routing.
- Paid treatment uses the existing GLM Flash Agent policy. Free treatment uses a dedicated GLM alias with low reasoning, explicit fallback routing and matching cost accounting.
- Capture privacy-safe exposure once from the actual AI SDK provider step-start boundary, after preparation, and propagate experiment context to usage/outcomes. Exclude image requests, premium routes, paid Ask, free Agent and allowance rescue.
- Document first-ever paid seven-day conversion, acquisition/billing separation, staged rollout and cleanup in `docs/internal/flash-routing-experiment.md`.

Related: [HAC-98](https://linear.app/hackerai/issue/HAC-98/controlled-glm-flash-return-and-first-paid-conversion-measurement). This is a reversible routing comparison, **not a demonstrated conversion win or causal explanation for subscriber decline**.

## Flags and production safety

| PostHog project | Paid flag | Free flag | Verified state |
| --- | --- | --- | --- |
| Preview 401167 | 868787 | 868788 | Active, 100% code-eligible test enrollment, stable 50/50 |
| Production 144137 | 868785 | 868786 | Inactive, 0% enrollment; no live routing change |

Keys: `paid_agent_glm_flash_return_v1` and `free_ask_flash_conversion_v1`. Both environments were independently created and read back. Production activation/ramp is **not** part of this PR; start with an explicit internal allowlist after acceptance. New code must reach both Vercel and Trigger before enabling paid enrollment. Preview runtime identity was verified independently through Vercel build logs, Trigger branch configuration, and the actual Agent run payload; production runtime verification remains required before launch.

## Validation

- `pnpm typecheck` — passed.
- ESLint for changed source files — passed.
- Prettier and `git diff --check` — passed.
- `pnpm exec jest --runInBand --silent` — 456 suites, 4,743 tests passed.
- Local dependency isolation guard — passed.
- No infrastructure/image-build paths changed.
- All CI checks, including Rust CodeQL, and Vercel/Trigger Preview deployments passed for `4b2e1bbd`.
- CodeRabbit completed through the final commit; all three findings were fixed/resolved, with no new actionable comments.
- Authenticated paid Agent Auto Preview smoke: passed on runtime commit `65d523f3` (final commit `4b2e1bbd` only tightens a test assertion). A bounded shell echo completed on GLM 5.3 Flash; configured and served model match, natural stop, no fallback. Exactly one treatment exposure, matching usage attribution, and no deduction failure were verified in PostHog project 401167.
- Completed response and shell result rendered correctly; reopening the chat in a fresh tab retained the completed response.
- Verified Preview mapping: Vercel `dpl_HFfNbCXUmPRKcWbJQpJqgbN2v9J8` → Convex `hackerai-development/hackerai-52290/perceptive-sparrow-335`; Trigger branch `codex/glm-flash-controlled-return`, worker `20260906.2`, receives that same Convex URL in its actual payload. Trigger's public analytics key matches PostHog 401167. Existing per-run override explains its different dashboard Convex default; no configuration changes were needed.
- Remaining manual acceptance: control variant and free Ask accounts; PDF/fallback, stop/abort, exclusion cases, and flag-off recovery. The signed-in Preview account is paid and assigned treatment, so those cases are not claimed as covered.
- The disposable Preview QA chat is retained as acceptance evidence. No production chat, billing recovery, or routing configuration was changed.

## Manual verification before launch

On the verified Preview URL and its Preview Trigger worker:
1. Use eligible control/treatment accounts; submit disposable free Ask and paid Agent Auto/Standard requests, including a bounded tool call/PDF. Verify rendered completion, reload/reconnect, actual configured/served model and reasoning policy.
2. Verify exactly one custom `flash_routing_experiment_exposed` per request lifecycle and matching usage/outcome attribution; no prompt/content fields.
3. Verify paid Ask, premium/image routes, free Agent and allowance rescue remain unchanged; blocked/pre-start-aborted requests have no exposure.
4. Exercise fallback, user stop, usage accounting, and flag-off rollback.
5. Verify Vercel and Trigger use PostHog 401167 and the designated HackerAI Developer Preview Convex deployment independently. Do not infer Trigger identity from Vercel.
6. Before production launch, record runtime identity, internal allowlist, sample-size plan and acceptance evidence in HAC-98. Review mature seven-day cohorts; separate first payments from reactivations and voluntary cancellations from failed renewals.

Unrelated billing edits in the original checkout were preserved; this PR was built in an isolated worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental Flash routing for eligible Ask and Agent requests, with safeguards for unsupported or exceptional requests.
  * Added a free Ask model option powered by GLM 5.3 Flash.
  * Added automatic fallback and retry support for the new Ask model.

* **Bug Fixes**
  * Improved model selection and reasoning behavior for free Ask requests.
  * Improved request tracking without interrupting active requests when analytics services fail.

* **Tests**
  * Added coverage for routing assignments, exclusions, fallbacks, retries, exposure tracking, and aborted requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->