### PR TITLE
Retry Abliteration failures on baseline models

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2013,6 +2013,17 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
   });
 
+  test("Abliteration API fallback requires the assignment to remain active", () => {
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      expect(source).toMatch(
+        /shouldRetryAbliterationApiError\(\s*activeAbliteratedExperiment,\s*error,?\s*\)/,
+      );
+      expect(source).not.toMatch(
+        /shouldRetryAbliterationApiError\(\s*abliteratedExperiment,\s*error,?\s*\)/,
+      );
+    }
+  });
+
   test("provider content blocks preserve their classification and complete after the error stream", () => {
     expect(taskSrc).toMatch(
       /USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES[\s\S]*"content_blocked"/,

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -14,6 +14,7 @@ import {
   isExplicitDeepSeekProSelectionForRetry,
   isProviderApiError,
   resolveServedModelForCostAccounting,
+  shouldRetryAbliterationApiError,
 } from "@/lib/api/chat-stream-helpers";
 
 jest.mock("@/lib/db/actions", () => ({
@@ -1016,6 +1017,43 @@ describe("getRetryFallbackModel", () => {
     expect(getRetryFallbackModel("model-grok-4.6", "ask")).toBe(
       "model-glm-5.3",
     );
+  });
+});
+
+describe("shouldRetryAbliterationApiError", () => {
+  it("falls back for a treatment provider media-policy failure", () => {
+    expect(
+      shouldRetryAbliterationApiError(
+        { variant: "test" },
+        new Error("Image dimensions exceed the project media policy."),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not retry an image URL that another provider cannot download", () => {
+    expect(
+      shouldRetryAbliterationApiError(
+        { variant: "test" },
+        new Error(
+          "Failed to download the provided image. Image host returned HTTP status 404",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not change control or non-experiment provider recovery", () => {
+    expect(
+      shouldRetryAbliterationApiError(
+        { variant: "control" },
+        new Error("Provider unavailable"),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryAbliterationApiError(
+        undefined,
+        new Error("Provider unavailable"),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1586,7 +1586,10 @@ export const createChatHandler = () => {
                 (countFileAttachments(state.finalMessages).imageCount > 0 ||
                   uiMessagesContainImageViewResult(state.finalMessages));
               const shouldRecoverAbliterationApiError =
-                shouldRetryAbliterationApiError(abliteratedExperiment, error);
+                shouldRetryAbliterationApiError(
+                  activeAbliteratedExperiment,
+                  error,
+                );
               // If provider returns an API error before streaming, retry with fallback.
               if (
                 isProviderApiError(error) &&

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -98,6 +98,7 @@ import {
   isAutoModelSelectionForRetry,
   isExplicitDeepSeekProSelectionForRetry,
   resolveServedModelForCostAccounting,
+  shouldRetryAbliterationApiError,
 } from "@/lib/api/chat-stream-helpers";
 import { geolocation } from "@vercel/functions";
 import { NextRequest } from "next/server";
@@ -1584,11 +1585,15 @@ export const createChatHandler = () => {
                 !visionSummaryRecovery.isEnabled() &&
                 (countFileAttachments(state.finalMessages).imageCount > 0 ||
                   uiMessagesContainImageViewResult(state.finalMessages));
+              const shouldRecoverAbliterationApiError =
+                shouldRetryAbliterationApiError(abliteratedExperiment, error);
               // If provider returns an API error before streaming, retry with fallback.
               if (
                 isProviderApiError(error) &&
                 !isRetryWithFallback &&
-                (isAutoModel || shouldRecoverVisionApiError)
+                (isAutoModel ||
+                  shouldRecoverVisionApiError ||
+                  shouldRecoverAbliterationApiError)
               ) {
                 const apiRetryModel = shouldRecoverVisionApiError
                   ? selectModel(

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -38,6 +38,7 @@ import {
   myProvider,
 } from "@/lib/ai/providers";
 import type { ModelName } from "@/lib/ai/providers";
+import type { AbliteratedAssignment } from "@/lib/experiments/abliterated-model";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { UIMessagePart } from "ai";
 import {
@@ -68,6 +69,7 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 import {
   extractErrorDetails,
   getProviderStatusCode,
+  isInvalidImageInputError,
 } from "@/lib/utils/error-utils";
 
 /**
@@ -806,6 +808,19 @@ export function getRetryFallbackModel(
     return "model-deepseek-v4-pro-0813";
   }
   return "model-grok-4.6";
+}
+
+/**
+ * Abliteration is an experiment route, so a pre-stream provider failure should
+ * fall back to the user's original model even when they selected Pro or Max.
+ * Invalid image URLs remain user-correctable because retrying another provider
+ * cannot make the source image downloadable.
+ */
+export function shouldRetryAbliterationApiError(
+  assignment: Pick<AbliteratedAssignment, "variant"> | undefined,
+  error: unknown,
+): boolean {
+  return assignment?.variant === "test" && !isInvalidImageInputError(error);
 }
 
 const CONTENT_FILTER_RETRY_CANDIDATES = [

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -59,6 +59,7 @@ import {
   isAutoModelSelectionForRetry,
   isExplicitDeepSeekProSelectionForRetry,
   resolveServedModelForCostAccounting,
+  shouldRetryAbliterationApiError,
 } from "@/lib/api/chat-stream-helpers";
 import {
   BudgetMonitor,
@@ -4546,11 +4547,15 @@ export const agentLongTask = task({
                 !visionSummaryRecovery.isEnabled() &&
                 (countFileAttachments(state.finalMessages).imageCount > 0 ||
                   uiMessagesContainImageViewResult(state.finalMessages));
+              const shouldRecoverAbliterationApiError =
+                shouldRetryAbliterationApiError(abliteratedExperiment, error);
               if (
                 isProviderApiError(error) &&
                 !isInvalidImageInputError(error) &&
                 !isRetryWithFallback &&
-                (isAutoModel || shouldRecoverVisionApiError)
+                (isAutoModel ||
+                  shouldRecoverVisionApiError ||
+                  shouldRecoverAbliterationApiError)
               ) {
                 const apiRetryModel = shouldRecoverVisionApiError
                   ? selectModel(

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -4548,7 +4548,10 @@ export const agentLongTask = task({
                 (countFileAttachments(state.finalMessages).imageCount > 0 ||
                   uiMessagesContainImageViewResult(state.finalMessages));
               const shouldRecoverAbliterationApiError =
-                shouldRetryAbliterationApiError(abliteratedExperiment, error);
+                shouldRetryAbliterationApiError(
+                  activeAbliteratedExperiment,
+                  error,
+                );
               if (
                 isProviderApiError(error) &&
                 !isInvalidImageInputError(error) &&


### PR DESCRIPTION
Abliteration returned HTTP 413 (`media_dimensions_too_large`) for a paid user who explicitly selected HackerAI Pro with an image. Auto requests already retried provider API failures, but explicit Pro/Max experiment treatments terminated instead of returning to their original model.

This makes pre-stream Abliteration treatment failures retry the assignment's baseline model in both direct chat and Trigger Agent execution. The retry keys off the final active Abliteration assignment so a later routing decision cannot inherit the fallback. Invalid or expired image URLs remain user-correctable and are not retried because another provider cannot download them either.

Production is temporarily limited to the `hackerai.tech@gmail.com` allowlist while this deploys. The provider plan was upgraded separately, so this is defense in depth for future provider-specific failures.

Validation:
- `pnpm typecheck`
- `pnpm test` — 462 suites, 4,862 tests passed
- Production text smoke test completed on `abliterated-model`; the triggering vision failure was confirmed in Trigger and PostHog before containment
