### PR TITLE
Enforce Abliteration image limit across the full provider request

### DIFF
--- a/lib/ai/__tests__/abliteration-media.test.ts
+++ b/lib/ai/__tests__/abliteration-media.test.ts
@@ -1,0 +1,68 @@
+import type { ModelMessage } from "ai";
+import { exceedsAbliterationImageLimit } from "../abliteration-media";
+
+const attachments = (count: number): ModelMessage[] => [
+  {
+    role: "user",
+    content: Array.from({ length: count }, () => ({
+      type: "image" as const,
+      image: "https://example.test/image.png",
+    })),
+  },
+];
+
+describe("Abliteration request image budget", () => {
+  it("allows four images and rejects the observed nine-image request", () => {
+    expect(exceedsAbliterationImageLimit(attachments(4))).toBe(false);
+    expect(exceedsAbliterationImageLimit(attachments(9))).toBe(true);
+  });
+
+  it.each(["image-data", "image-url", "file-data", "file-url"])(
+    "counts %s tool images with attachments across the request",
+    (type) => {
+      const messages = [
+        ...attachments(4),
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "view-1",
+              toolName: "file",
+              output: {
+                type: "content",
+                value: [
+                  {
+                    type,
+                    data: "test",
+                    url: "https://example.test/image.png",
+                    mediaType: "image/png",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ] as ModelMessage[];
+      expect(exceedsAbliterationImageLimit(messages)).toBe(true);
+    },
+  );
+
+  it("does not count text or non-image files as images", () => {
+    const messages: ModelMessage[] = [
+      ...attachments(4),
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "image-data" },
+          {
+            type: "file",
+            data: "test",
+            mediaType: "application/pdf",
+          },
+        ],
+      },
+    ];
+    expect(exceedsAbliterationImageLimit(messages)).toBe(false);
+  });
+});

--- a/lib/ai/abliteration-media.ts
+++ b/lib/ai/abliteration-media.ts
@@ -1,0 +1,28 @@
+import type { ModelMessage } from "ai";
+
+export const ABLITERATION_MAX_IMAGES_PER_REQUEST = 4;
+
+/** Counts attachments and tool images together at the provider request boundary. */
+export function exceedsAbliterationImageLimit(
+  messages: ModelMessage[],
+): boolean {
+  let imageCount = 0;
+  const isImage = (part: { type: string; mediaType?: string }) =>
+    ["image", "image-data", "image-url"].includes(part.type) ||
+    (["file", "file-data", "file-url"].includes(part.type) &&
+      part.mediaType?.startsWith("image/"));
+
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (isImage(part)) imageCount++;
+      if (part.type === "tool-result" && part.output.type === "content") {
+        for (const output of part.output.value) {
+          if (isImage(output)) imageCount++;
+        }
+      }
+      if (imageCount > ABLITERATION_MAX_IMAGES_PER_REQUEST) return true;
+    }
+  }
+  return false;
+}

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2024,6 +2024,15 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     }
   });
 
+  test("OCR preprocessing failures never trigger generic baseline recovery", () => {
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      expect(source).toMatch(/!\(error instanceof AbliterationVisionError\)/);
+      expect(source).toMatch(
+        /const shouldAttemptProviderRetry\s*=\s*!\(\s*state\.providerError instanceof AbliterationVisionError\s*\)\s*&&/,
+      );
+    }
+  });
+
   test("Abliteration routing switches to OpenRouter after three generation steps", () => {
     for (const source of [taskSrc, chatHandlerSrc]) {
       expect(source).toMatch(

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -7,6 +7,14 @@ const mockRunSummarizationStep = jest.fn();
 const mockCompactModelMessagesInRun = jest.fn();
 const mockGetProviderPromptPressure = jest.fn();
 const mockBuildProviderOptions = jest.fn(() => ({}));
+const mockDescribeImage = jest.fn(async () => ({
+  description: "Visible image text",
+}));
+
+jest.mock("@/lib/chat/auxiliary-vision", () => ({
+  describeImageWithAuxiliaryVision: (...args: unknown[]) =>
+    mockDescribeImage(...args),
+}));
 
 jest.mock("server-only", () => ({}));
 jest.mock("ai", () => ({
@@ -479,6 +487,9 @@ describe("retry served-model telemetry", () => {
 describe("createAgentStream repeated compaction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDescribeImage
+      .mockReset()
+      .mockResolvedValue({ description: "Visible image text" });
     mockStreamText.mockImplementation((options) => options);
   });
 
@@ -620,11 +631,75 @@ describe("createAgentStream repeated compaction", () => {
           maxTokens: 128_000,
         }),
       )) as any;
-      expect(stream.model.modelId).toBe("model-grok-4.6");
+      expect(stream.model.modelId).toBe("model-abliterated");
+      expect(JSON.stringify(stream.messages)).toContain("image_description");
+      expect(JSON.stringify(stream.messages)).not.toContain(
+        '"type":"image-data"',
+      );
+      expect(JSON.stringify(stream.messages)).not.toContain('"type":"image"');
     },
   );
 
-  it("switches to the baseline when tool images exceed the combined request cap", async () => {
+  it("does not start the main provider when initial OCR fails", async () => {
+    jest.requireMock("ai").convertToModelMessages.mockResolvedValueOnce([
+      {
+        role: "user",
+        content: Array.from({ length: 5 }, (_, i) => ({
+          type: "image",
+          image: `https://example.test/${i}.png`,
+        })),
+      },
+    ]);
+    mockDescribeImage.mockRejectedValue(new Error("Auxiliary API failure"));
+    await expect(
+      createAgentStream(
+        "model-abliterated",
+        createTestStreamContext({
+          trackedProvider: {
+            languageModel: (name: string) => ({ modelId: name }),
+          },
+          abliteratedStepRouting: { baselineModel: "model-grok-4.6" },
+          summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+          usageTracker: {},
+        }) as any,
+        initAgentStreamState([uiMessage("initial", "Inspect images")], {
+          usedTokens: 1000,
+          maxTokens: 128000,
+        }),
+      ),
+    ).rejects.toHaveProperty("name", "AbliterationVisionError");
+    expect(mockStreamText).not.toHaveBeenCalled();
+  });
+
+  it("does not preprocess images for baseline providers", async () => {
+    jest.requireMock("ai").convertToModelMessages.mockResolvedValueOnce([
+      {
+        role: "user",
+        content: Array.from({ length: 5 }, (_, i) => ({
+          type: "image",
+          image: `https://example.test/${i}.png`,
+        })),
+      },
+    ]);
+    const stream = (await createAgentStream(
+      "model-grok-4.6",
+      createTestStreamContext({
+        trackedProvider: {
+          languageModel: (name: string) => ({ modelId: name }),
+        },
+        summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+        usageTracker: {},
+      }) as any,
+      initAgentStreamState([uiMessage("initial", "Inspect images")], {
+        usedTokens: 1000,
+        maxTokens: 128000,
+      }),
+    )) as any;
+    expect(stream.model.modelId).toBe("model-grok-4.6");
+    expect(mockDescribeImage).not.toHaveBeenCalled();
+  });
+
+  it("keeps Abliteration and describes images when tools exceed the request cap", async () => {
     const stream = (await createAgentStream(
       "model-abliterated",
       createTestStreamContext({
@@ -679,14 +754,15 @@ describe("createAgentStream repeated compaction", () => {
       ],
       1,
     );
-    expect(prepared.model.modelId).toBe("model-grok-4.6");
-    expect(JSON.stringify(prepared.messages)).toContain(
+    expect(prepared.model.modelId).toBe("model-abliterated");
+    expect(JSON.stringify(prepared.messages)).toContain("image_description");
+    expect(JSON.stringify(prepared.messages)).not.toContain(
       PLATFORM_AUTHORIZATION_ANNOTATION,
     );
     expect(
       (await prepare([{ role: "user", content: "Compacted context" }], 2)).model
         .modelId,
-    ).toBe("model-grok-4.6");
+    ).toBe("model-abliterated");
   });
 
   it("preserves the generation-step position across replacement streams", async () => {

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -571,33 +571,58 @@ describe("createAgentStream repeated compaction", () => {
     );
   });
 
-  it("checks serialized initial images before choosing a provider", async () => {
-    jest.requireMock("ai").convertToModelMessages.mockResolvedValueOnce([
-      {
+  it.each([
+    {
+      source: "attachments",
+      message: {
         role: "user",
         content: Array.from({ length: 9 }, () => ({
           type: "image",
           image: "https://example.test/image.png",
         })),
       },
-    ]);
-    const stream = (await createAgentStream(
-      "model-abliterated",
-      createTestStreamContext({
-        trackedProvider: {
-          languageModel: (name: string) => ({ modelId: name }),
-        },
-        abliteratedStepRouting: { baselineModel: "model-grok-4.6" },
-        summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
-        usageTracker: {},
-      }) as any,
-      initAgentStreamState([uiMessage("initial", "Inspect the images")], {
-        usedTokens: 1_000,
-        maxTokens: 128_000,
-      }),
-    )) as any;
-    expect(stream.model.modelId).toBe("model-grok-4.6");
-  });
+    },
+    {
+      source: "persisted tool images",
+      message: {
+        role: "tool",
+        content: Array.from({ length: 5 }, (_, index) => ({
+          type: "tool-result",
+          toolCallId: `view-${index}`,
+          toolName: "file",
+          output: {
+            type: "content",
+            value: [
+              { type: "image-data", data: "test", mediaType: "image/png" },
+            ],
+          },
+        })),
+      },
+    },
+  ])(
+    "checks serialized initial $source before choosing a provider",
+    async ({ message }) => {
+      jest
+        .requireMock("ai")
+        .convertToModelMessages.mockResolvedValueOnce([message]);
+      const stream = (await createAgentStream(
+        "model-abliterated",
+        createTestStreamContext({
+          trackedProvider: {
+            languageModel: (name: string) => ({ modelId: name }),
+          },
+          abliteratedStepRouting: { baselineModel: "model-grok-4.6" },
+          summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+          usageTracker: {},
+        }) as any,
+        initAgentStreamState([uiMessage("initial", "Inspect the images")], {
+          usedTokens: 1_000,
+          maxTokens: 128_000,
+        }),
+      )) as any;
+      expect(stream.model.modelId).toBe("model-grok-4.6");
+    },
+  );
 
   it("switches to the baseline when tool images exceed the combined request cap", async () => {
     const stream = (await createAgentStream(

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -571,6 +571,99 @@ describe("createAgentStream repeated compaction", () => {
     );
   });
 
+  it("checks serialized initial images before choosing a provider", async () => {
+    jest.requireMock("ai").convertToModelMessages.mockResolvedValueOnce([
+      {
+        role: "user",
+        content: Array.from({ length: 9 }, () => ({
+          type: "image",
+          image: "https://example.test/image.png",
+        })),
+      },
+    ]);
+    const stream = (await createAgentStream(
+      "model-abliterated",
+      createTestStreamContext({
+        trackedProvider: {
+          languageModel: (name: string) => ({ modelId: name }),
+        },
+        abliteratedStepRouting: { baselineModel: "model-grok-4.6" },
+        summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+        usageTracker: {},
+      }) as any,
+      initAgentStreamState([uiMessage("initial", "Inspect the images")], {
+        usedTokens: 1_000,
+        maxTokens: 128_000,
+      }),
+    )) as any;
+    expect(stream.model.modelId).toBe("model-grok-4.6");
+  });
+
+  it("switches to the baseline when tool images exceed the combined request cap", async () => {
+    const stream = (await createAgentStream(
+      "model-abliterated",
+      createTestStreamContext({
+        trackedProvider: {
+          languageModel: (name: string) => ({ modelId: name }),
+        },
+        platformAuthorized: true,
+        abliteratedStepRouting: { baselineModel: "model-grok-4.6" },
+        summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+        usageTracker: {},
+      }) as any,
+      initAgentStreamState([uiMessage("initial", "Inspect the lab")], {
+        usedTokens: 1_000,
+        maxTokens: 128_000,
+      }),
+    )) as any;
+    const attachments = {
+      role: "user",
+      content: Array.from({ length: 4 }, () => ({
+        type: "image",
+        image: "https://example.test/image.png",
+      })),
+    };
+    const prepare = (messages: unknown[], stepNumber: number) =>
+      stream.prepareStep({
+        stepNumber,
+        steps: [],
+        messages,
+      });
+    expect((await prepare([attachments], 0)).model.modelId).toBe(
+      "model-abliterated",
+    );
+    const prepared = await prepare(
+      [
+        attachments,
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "view-1",
+              toolName: "file",
+              output: {
+                type: "content",
+                value: [
+                  { type: "image-data", data: "test", mediaType: "image/png" },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      1,
+    );
+    expect(prepared.model.modelId).toBe("model-grok-4.6");
+    expect(JSON.stringify(prepared.messages)).toContain(
+      PLATFORM_AUTHORIZATION_ANNOTATION,
+    );
+    expect(
+      (await prepare([{ role: "user", content: "Compacted context" }], 2)).model
+        .modelId,
+    ).toBe("model-grok-4.6");
+  });
+
   it("preserves the generation-step position across replacement streams", async () => {
     const onProviderRequestDiagnostics = jest.fn();
     const state = initAgentStreamState(

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -671,6 +671,41 @@ describe("createAgentStream repeated compaction", () => {
     expect(mockStreamText).not.toHaveBeenCalled();
   });
 
+  it("propagates late OCR failure instead of retrying the prepare-step fallback", async () => {
+    const stream = (await createAgentStream(
+      "model-abliterated",
+      createTestStreamContext({
+        trackedProvider: {
+          languageModel: (name: string) => ({ modelId: name }),
+        },
+        abliteratedStepRouting: { baselineModel: "model-grok-4.6" },
+        summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+        usageTracker: {},
+      }) as any,
+      initAgentStreamState([uiMessage("initial", "Inspect images")], {
+        usedTokens: 1000,
+        maxTokens: 128000,
+      }),
+    )) as any;
+    mockDescribeImage.mockRejectedValue(new Error("Auxiliary API failure"));
+    await expect(
+      stream.prepareStep({
+        stepNumber: 1,
+        steps: [],
+        messages: [
+          {
+            role: "user",
+            content: Array.from({ length: 5 }, (_, i) => ({
+              type: "image",
+              image: `https://example.test/${i}.png`,
+            })),
+          },
+        ],
+      }),
+    ).rejects.toHaveProperty("name", "AbliterationVisionError");
+    expect(mockDescribeImage).toHaveBeenCalledTimes(4);
+  });
+
   it("does not preprocess images for baseline providers", async () => {
     jest.requireMock("ai").convertToModelMessages.mockResolvedValueOnce([
       {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -1,5 +1,6 @@
 import type { AbliteratedModelTelemetry } from "@/lib/analytics/abliterated-model";
 import { resolveAbliterationModelForGenerationStep } from "@/lib/experiments/abliterated-model-steps";
+import { exceedsAbliterationImageLimit } from "@/lib/ai/abliteration-media";
 /**
  * Shared streamText factory for the agent loop.
  *
@@ -976,6 +977,7 @@ export async function createAgentStream(
   const initialActiveTools = await getActiveTools();
   const maxOutputTokens = MAX_OUTPUT_TOKENS;
   let routeModelName = modelName;
+  let abliterationImageLimitExceeded = false;
   let streamHasImageViewResults =
     !ctx.auxiliaryVisionEnabled &&
     uiMessagesContainImageViewResult(state.finalMessages);
@@ -989,13 +991,15 @@ export async function createAgentStream(
   let openRouterFileAnnotations: unknown[] | undefined;
   const getEffectiveModelName = (stepIndex = generationStepOffset) =>
     resolveAgentModelForImageToolResults(
-      ctx.abliteratedStepRouting
-        ? resolveAbliterationModelForGenerationStep({
-            treatmentModel: routeModelName,
-            baselineModel: ctx.abliteratedStepRouting.baselineModel,
-            stepIndex,
-          })
-        : routeModelName,
+      ctx.abliteratedStepRouting && abliterationImageLimitExceeded
+        ? ctx.abliteratedStepRouting.baselineModel
+        : ctx.abliteratedStepRouting
+          ? resolveAbliterationModelForGenerationStep({
+              treatmentModel: routeModelName,
+              baselineModel: ctx.abliteratedStepRouting.baselineModel,
+              stepIndex,
+            })
+          : routeModelName,
       ctx.mode,
       streamHasImageViewResults,
       ctx.selectedModelOverride,
@@ -1114,10 +1118,6 @@ export async function createAgentStream(
     });
     return latestProviderRequestDiagnostics;
   };
-  const initialModelInfo = getEffectiveModelInfo();
-  const initialProviderOptions = getStepProviderOptions(
-    initialModelInfo.modelName,
-  );
   const promptSerializationTools = createPromptSerializationTools(ctx.tools);
   const initialSerializationStartedAt = Date.now();
   let initialSerializedMessages: ModelMessage[];
@@ -1134,6 +1134,13 @@ export async function createAgentStream(
       Date.now() - initialSerializationStartedAt,
     );
   }
+  abliterationImageLimitExceeded = exceedsAbliterationImageLimit(
+    initialSerializedMessages,
+  );
+  const initialModelInfo = getEffectiveModelInfo();
+  const initialProviderOptions = getStepProviderOptions(
+    initialModelInfo.modelName,
+  );
   const initialModelMessages = prepareProviderMessages(
     initialSerializedMessages,
     initialModelInfo.modelName,
@@ -1192,6 +1199,10 @@ export async function createAgentStream(
       rollingModelMessages = limitModelImageToolResults(
         rollingModelMessages as Array<Record<string, unknown>>,
       ).messages as ModelMessage[];
+      // A tool can add images after assignment. Keep the baseline for this
+      // stream once combined attachments/tool results exceed the provider cap.
+      abliterationImageLimitExceeded ||=
+        exceedsAbliterationImageLimit(rollingModelMessages);
       const lastStep = Array.isArray(steps) ? steps.at(-1) : undefined;
       const toolResults =
         (lastStep && (lastStep as { toolResults?: unknown[] }).toolResults) ||

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -1,6 +1,10 @@
 import type { AbliteratedModelTelemetry } from "@/lib/analytics/abliterated-model";
 import { resolveAbliterationModelForGenerationStep } from "@/lib/experiments/abliterated-model-steps";
-import { exceedsAbliterationImageLimit } from "@/lib/ai/abliteration-media";
+import { isAbliterationModel } from "@/lib/ai/abliteration";
+import {
+  AbliterationVisionError,
+  createAbliterationVisionPreprocessor,
+} from "@/lib/chat/abliteration-vision";
 /**
  * Shared streamText factory for the agent loop.
  *
@@ -977,7 +981,6 @@ export async function createAgentStream(
   const initialActiveTools = await getActiveTools();
   const maxOutputTokens = MAX_OUTPUT_TOKENS;
   let routeModelName = modelName;
-  let abliterationImageLimitExceeded = false;
   let streamHasImageViewResults =
     !ctx.auxiliaryVisionEnabled &&
     uiMessagesContainImageViewResult(state.finalMessages);
@@ -991,15 +994,13 @@ export async function createAgentStream(
   let openRouterFileAnnotations: unknown[] | undefined;
   const getEffectiveModelName = (stepIndex = generationStepOffset) =>
     resolveAgentModelForImageToolResults(
-      ctx.abliteratedStepRouting && abliterationImageLimitExceeded
-        ? ctx.abliteratedStepRouting.baselineModel
-        : ctx.abliteratedStepRouting
-          ? resolveAbliterationModelForGenerationStep({
-              treatmentModel: routeModelName,
-              baselineModel: ctx.abliteratedStepRouting.baselineModel,
-              stepIndex,
-            })
-          : routeModelName,
+      ctx.abliteratedStepRouting
+        ? resolveAbliterationModelForGenerationStep({
+            treatmentModel: routeModelName,
+            baselineModel: ctx.abliteratedStepRouting.baselineModel,
+            stepIndex,
+          })
+        : routeModelName,
       ctx.mode,
       streamHasImageViewResults,
       ctx.selectedModelOverride,
@@ -1042,13 +1043,25 @@ export async function createAgentStream(
       },
     );
   };
-  const prepareProviderMessages = (
+  const preprocessAbliterationImages = createAbliterationVisionPreprocessor({
+    userId: ctx.userId,
+    chatId: ctx.chatId,
+    abortSignal,
+    onCost: (cost) => {
+      ctx.usageTracker.providerCost += cost;
+      ctx.usageTracker.nonModelCost += cost;
+    },
+  });
+  const prepareProviderMessages = async (
     messages: ModelMessage[],
     effectiveModelName = getEffectiveModelName(),
-  ): ModelMessage[] => {
-    const providerMessages = providerPdfAttachmentsDisabled
-      ? omitPdfFilePartsFromModelMessages(messages)
+  ): Promise<ModelMessage[]> => {
+    const visionMessages = isAbliterationModel(effectiveModelName)
+      ? await preprocessAbliterationImages(messages)
       : messages;
+    const providerMessages = providerPdfAttachmentsDisabled
+      ? omitPdfFilePartsFromModelMessages(visionMessages)
+      : visionMessages;
     const nonEmptyMessages = filterEmptyAssistantMessages(providerMessages);
     let repairedMessages = nonEmptyMessages;
 
@@ -1134,14 +1147,11 @@ export async function createAgentStream(
       Date.now() - initialSerializationStartedAt,
     );
   }
-  abliterationImageLimitExceeded = exceedsAbliterationImageLimit(
-    initialSerializedMessages,
-  );
   const initialModelInfo = getEffectiveModelInfo();
   const initialProviderOptions = getStepProviderOptions(
     initialModelInfo.modelName,
   );
-  const initialModelMessages = prepareProviderMessages(
+  const initialModelMessages = await prepareProviderMessages(
     initialSerializedMessages,
     initialModelInfo.modelName,
   );
@@ -1199,10 +1209,6 @@ export async function createAgentStream(
       rollingModelMessages = limitModelImageToolResults(
         rollingModelMessages as Array<Record<string, unknown>>,
       ).messages as ModelMessage[];
-      // A tool can add images after assignment. Keep the baseline for this
-      // stream once combined attachments/tool results exceed the provider cap.
-      abliterationImageLimitExceeded ||=
-        exceedsAbliterationImageLimit(rollingModelMessages);
       const lastStep = Array.isArray(steps) ? steps.at(-1) : undefined;
       const toolResults =
         (lastStep && (lastStep as { toolResults?: unknown[] }).toolResults) ||
@@ -1339,7 +1345,7 @@ export async function createAgentStream(
                 baseMessages: summarizedModelMessages,
                 rawMessageCursor: rawModelMessages.length,
               };
-              const preparedMessages = prepareProviderMessages(
+              const preparedMessages = await prepareProviderMessages(
                 summarizedModelMessages,
                 continuationModelInfo.modelName,
               );
@@ -1515,7 +1521,7 @@ export async function createAgentStream(
                 const providerOptions = getStepProviderOptions(
                   continuationModelInfo.modelName,
                 );
-                const preparedMessages = prepareProviderMessages(
+                const preparedMessages = await prepareProviderMessages(
                   nextBaseMessages,
                   continuationModelInfo.modelName,
                 );
@@ -1583,13 +1589,13 @@ export async function createAgentStream(
         const providerOptions = getStepProviderOptions(
           effectiveModelInfo.modelName,
         );
-        const preparedMessages = prepareProviderMessages(
+        const preparedMessages = (await prepareProviderMessages(
           addCacheBreakpointToLastUserMessage(
             updatedMessages,
             effectiveModelInfo.modelName,
           ) as ModelMessage[],
           effectiveModelInfo.modelName,
-        ) as typeof messages;
+        )) as typeof messages;
         recordProviderRequestDiagnostics({
           modelName: effectiveModelInfo.modelName,
           requestedSlug: effectiveModelInfo.requestedSlug,
@@ -1618,6 +1624,8 @@ export async function createAgentStream(
             : {}),
         };
       } catch (error) {
+        if (error instanceof AbliterationVisionError || abortSignal.aborted)
+          throw error;
         if (error instanceof DOMException && error.name === "AbortError") {
           // Expected on user stop
         } else {
@@ -1627,10 +1635,10 @@ export async function createAgentStream(
         const providerOptions = getStepProviderOptions(
           fallbackModelInfo.modelName,
         );
-        const fallbackMessages = prepareProviderMessages(
+        const fallbackMessages = (await prepareProviderMessages(
           rollingModelMessages,
           fallbackModelInfo.modelName,
-        ) as typeof messages;
+        )) as typeof messages;
         recordProviderRequestDiagnostics({
           modelName: fallbackModelInfo.modelName,
           requestedSlug: lastRequestedSlug,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -1050,6 +1050,7 @@ export async function createAgentStream(
     onCost: (cost) => {
       ctx.usageTracker.providerCost += cost;
       ctx.usageTracker.nonModelCost += cost;
+      ctx.chatLogger?.getBuilder().addToolCost(cost);
     },
   });
   const prepareProviderMessages = async (

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -101,6 +101,7 @@ import {
   shouldRetryAbliterationApiError,
 } from "@/lib/api/chat-stream-helpers";
 import { geolocation } from "@vercel/functions";
+import { AbliterationVisionError } from "@/lib/chat/abliteration-vision";
 import { NextRequest } from "next/server";
 import {
   getMessagesByChatId,
@@ -1605,6 +1606,7 @@ export const createChatHandler = () => {
               // If provider returns an API error before streaming, retry with fallback.
               if (
                 isProviderApiError(error) &&
+                !(error instanceof AbliterationVisionError) &&
                 !isRetryWithFallback &&
                 (isAutoModel ||
                   shouldRecoverVisionApiError ||
@@ -1858,6 +1860,9 @@ export const createChatHandler = () => {
                       const retryModelSlug =
                         trackedProvider.languageModel(retryModel).modelId;
                       const shouldAttemptProviderRetry =
+                        !(
+                          state.providerError instanceof AbliterationVisionError
+                        ) &&
                         (!isAborted || stoppedDueToAssistantContentLoop) &&
                         (isAutoModel ||
                           shouldRetryWithVisionSummary ||

--- a/lib/chat/__tests__/abliteration-vision.test.ts
+++ b/lib/chat/__tests__/abliteration-vision.test.ts
@@ -1,0 +1,195 @@
+import type { ModelMessage } from "ai";
+import {
+  AbliterationVisionError,
+  createAbliterationVisionPreprocessor,
+} from "../abliteration-vision";
+import { exceedsAbliterationImageLimit } from "@/lib/ai/abliteration-media";
+
+jest.mock("server-only", () => ({}));
+jest.mock("../auxiliary-vision", () => ({
+  describeImageWithAuxiliaryVision: jest.fn(),
+}));
+
+const images = (count: number): ModelMessage[] => [
+  {
+    role: "user",
+    content: Array.from({ length: count }, (_, i) => ({
+      type: "image",
+      image: `https://example.test/${i}.png`,
+      mediaType: "image/png",
+    })),
+  },
+];
+const result = {
+  description: "OCR <text> & details",
+  inputTokens: 1,
+  outputTokens: 1,
+  durationMs: 1,
+  model: "vision",
+};
+const setup = () => {
+  const describe = jest.fn(async () => result);
+  const onCost = jest.fn();
+  const controller = new AbortController();
+  const preprocess = createAbliterationVisionPreprocessor({
+    userId: "user",
+    chatId: "chat",
+    abortSignal: controller.signal,
+    onCost,
+    describe,
+  });
+  return { describe, onCost, controller, preprocess };
+};
+
+it("leaves up to four images native without OCR", async () => {
+  const { describe, preprocess } = setup();
+  const input = images(4);
+  expect(await preprocess(input)).toBe(input);
+  expect(describe).not.toHaveBeenCalled();
+});
+
+it("describes every image in a 14-image history with indexed, escaped text", async () => {
+  const { describe, preprocess } = setup();
+  const input = images(14);
+  const original = JSON.stringify(input);
+  const output = await preprocess(input);
+  expect(describe).toHaveBeenCalledTimes(14);
+  expect(exceedsAbliterationImageLimit(output)).toBe(false);
+  expect(JSON.stringify(output)).toContain('index=\\"14\\"');
+  expect(JSON.stringify(output)).toContain("OCR &lt;text&gt; &amp; details");
+  expect(JSON.stringify(input)).toBe(original);
+  await preprocess(input);
+  expect(describe).toHaveBeenCalledTimes(14);
+});
+
+it("counts attachments and tool images together and preserves tool identity/text", async () => {
+  const { describe, preprocess } = setup();
+  const input = images(4);
+  input.push({
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: "view",
+        toolName: "file",
+        output: {
+          type: "content",
+          value: [
+            { type: "text", text: "File evidence" },
+            { type: "image-data", data: "test", mediaType: "image/png" },
+          ],
+        },
+      },
+    ],
+  });
+  const output = await preprocess(input);
+  expect(describe).toHaveBeenCalledTimes(5);
+  expect(describe).toHaveBeenLastCalledWith(
+    expect.objectContaining({ source: "file_view", image: "test" }),
+  );
+  expect(output[1]).toMatchObject({
+    role: "tool",
+    content: [
+      {
+        toolCallId: "view",
+        toolName: "file",
+        output: {
+          value: [{ type: "text", text: "File evidence" }, { type: "text" }],
+        },
+      },
+    ],
+  });
+});
+
+it("never starts a fifth OCR call until its batch finishes", async () => {
+  const pending: Array<() => void> = [];
+  const describe = jest.fn(
+    () =>
+      new Promise<typeof result>((resolve) =>
+        pending.push(() => resolve(result)),
+      ),
+  );
+  const preprocess = createAbliterationVisionPreprocessor({
+    userId: "u",
+    chatId: "c",
+    abortSignal: new AbortController().signal,
+    onCost: jest.fn(),
+    describe,
+  });
+  const work = preprocess(images(9));
+  expect(describe).toHaveBeenCalledTimes(4);
+  for (const done of pending.splice(0)) done();
+  // Yield to the batch's Promise.allSettled continuation.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(describe).toHaveBeenCalledTimes(8);
+  for (const done of pending.splice(0)) done();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(describe).toHaveBeenCalledTimes(9);
+  for (const done of pending.splice(0)) done();
+  await work;
+});
+
+it("deduplicates repeated images without losing their indexed occurrences", async () => {
+  const { describe, preprocess } = setup();
+  const repeated = images(3);
+  const input = [...repeated, ...repeated];
+  const output = await preprocess(input);
+  expect(describe).toHaveBeenCalledTimes(3);
+  expect(JSON.stringify(output)).toContain('index=\\"6\\"');
+});
+
+it("fails closed, preserves completed-call cost, and does not restart a failed batch", async () => {
+  const controller = new AbortController();
+  const onCost = jest.fn();
+  const describe = jest.fn(
+    async (args: { image: string; onCost?: (cost: number) => void }) => {
+      if (args.image.endsWith("0.png"))
+        throw new Error("provider secret error");
+      args.onCost?.(0.01);
+      return result;
+    },
+  );
+  const preprocess = createAbliterationVisionPreprocessor({
+    userId: "u",
+    chatId: "c",
+    abortSignal: controller.signal,
+    onCost,
+    describe,
+  });
+  await expect(preprocess(images(9))).rejects.toThrow(AbliterationVisionError);
+  expect(describe).toHaveBeenCalledTimes(4);
+  expect(onCost).toHaveBeenCalledTimes(3);
+  await expect(preprocess(images(9))).rejects.not.toThrow(
+    "provider secret error",
+  );
+  expect(describe).toHaveBeenCalledTimes(4);
+});
+
+it("does not launch OCR after cancellation", async () => {
+  const { describe, controller, preprocess } = setup();
+  controller.abort();
+  await expect(preprocess(images(5))).rejects.toHaveProperty(
+    "name",
+    "AbortError",
+  );
+  expect(describe).not.toHaveBeenCalled();
+});
+
+it("supports SDK binary image attachments", async () => {
+  const { describe, preprocess } = setup();
+  const input = images(4);
+  input.push({
+    role: "user",
+    content: [
+      {
+        type: "file",
+        data: new Uint8Array([1, 2, 3]),
+        mediaType: "image/jpeg",
+      },
+    ],
+  });
+  await preprocess(input);
+  expect(describe).toHaveBeenLastCalledWith(
+    expect.objectContaining({ image: "AQID", mediaType: "image/jpeg" }),
+  );
+});

--- a/lib/chat/__tests__/abliteration-vision.test.ts
+++ b/lib/chat/__tests__/abliteration-vision.test.ts
@@ -185,11 +185,13 @@ it("supports SDK binary image attachments", async () => {
         type: "file",
         data: new Uint8Array([1, 2, 3]),
         mediaType: "image/jpeg",
+        filename: 'screenshot"<one>.jpg',
       },
     ],
   });
-  await preprocess(input);
+  const output = await preprocess(input);
   expect(describe).toHaveBeenLastCalledWith(
     expect.objectContaining({ image: "AQID", mediaType: "image/jpeg" }),
   );
+  expect(JSON.stringify(output)).toContain("screenshot&quot;&lt;one&gt;.jpg");
 });

--- a/lib/chat/abliteration-vision.ts
+++ b/lib/chat/abliteration-vision.ts
@@ -1,0 +1,155 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+import type { ModelMessage } from "ai";
+import { exceedsAbliterationImageLimit } from "@/lib/ai/abliteration-media";
+import { describeImageWithAuxiliaryVision } from "./auxiliary-vision";
+
+export class AbliterationVisionError extends Error {
+  constructor() {
+    super(
+      "Image analysis could not be completed. Please retry or send fewer images.",
+    );
+    this.name = "AbliterationVisionError";
+  }
+}
+
+type ImageInput = { image: string; mediaType: string };
+
+/** Reads the SDK's attachment and multimodal tool-output image representations. */
+function imageInput(part: unknown): ImageInput | undefined {
+  if (!part || typeof part !== "object") return;
+  const value = part as Record<string, unknown>;
+  const type = value.type;
+  const mediaType =
+    typeof value.mediaType === "string" ? value.mediaType : undefined;
+  if (
+    !["image", "image-data", "image-url"].includes(String(type)) &&
+    !(
+      ["file", "file-data", "file-url"].includes(String(type)) &&
+      mediaType?.startsWith("image/")
+    )
+  )
+    return;
+  const data = value.image ?? value.data ?? value.url;
+  const image =
+    typeof data === "string"
+      ? data
+      : data instanceof URL
+        ? data.href
+        : data instanceof Uint8Array
+          ? Buffer.from(data).toString("base64")
+          : data instanceof ArrayBuffer
+            ? Buffer.from(data).toString("base64")
+            : undefined;
+  if (!image) throw new AbliterationVisionError();
+  return {
+    image,
+    mediaType: mediaType ?? /^data:([^;,]+)/.exec(image)?.[1] ?? "image/png",
+  };
+}
+
+/** Reuses existing OCR calls in batches of <=4; only the outbound copy is changed. */
+export function createAbliterationVisionPreprocessor({
+  userId,
+  chatId,
+  abortSignal,
+  onCost,
+  describe = describeImageWithAuxiliaryVision,
+}: {
+  userId: string;
+  chatId: string;
+  abortSignal: AbortSignal;
+  onCost: (cost: number) => void;
+  describe?: typeof describeImageWithAuxiliaryVision;
+}) {
+  // Store only summaries/hashes, not duplicate image payloads. Retain rejected
+  // promises too so error recovery cannot repeat an already failed OCR batch.
+  const cache = new Map<string, Promise<string>>();
+  return async (messages: ModelMessage[]): Promise<ModelMessage[]> => {
+    if (!exceedsAbliterationImageLimit(messages)) return messages;
+    const tasks: Array<{
+      position: string;
+      input: ImageInput;
+      source: "attachment" | "file_view";
+    }> = [];
+    for (const [mi, message] of messages.entries()) {
+      if (!Array.isArray(message.content)) continue;
+      for (const [pi, part] of message.content.entries()) {
+        const input = imageInput(part);
+        if (input)
+          tasks.push({ position: `${mi}:${pi}`, input, source: "attachment" });
+        if (part.type === "tool-result" && part.output.type === "content") {
+          for (const [oi, output] of part.output.value.entries()) {
+            const input = imageInput(output);
+            if (input)
+              tasks.push({
+                position: `${mi}:${pi}:${oi}`,
+                input,
+                source: "file_view",
+              });
+          }
+        }
+      }
+    }
+    const replacements = new Map<string, { type: "text"; text: string }>();
+    for (let start = 0; start < tasks.length; start += 4) {
+      abortSignal.throwIfAborted();
+      const results = await Promise.allSettled(
+        tasks.slice(start, start + 4).map(async (task, offset) => {
+          const key = createHash("sha256")
+            .update(task.input.mediaType)
+            .update("\0")
+            .update(task.input.image)
+            .digest("hex");
+          let pending = cache.get(key);
+          if (!pending) {
+            pending = describe({
+              ...task.input,
+              source: task.source,
+              userId,
+              chatId,
+              abortSignal,
+              onCost,
+            }).then((result) => result.description);
+            cache.set(key, pending);
+          }
+          const description = await pending;
+          if (!description.trim()) throw new AbliterationVisionError();
+          const escaped = description
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;");
+          replacements.set(task.position, {
+            type: "text",
+            text: `<image_description index="${start + offset + 1}" trust="untrusted">\n${escaped}\n</image_description>`,
+          });
+        }),
+      );
+      abortSignal.throwIfAborted();
+      if (results.some((result) => result.status === "rejected"))
+        throw new AbliterationVisionError();
+    }
+    return messages.map((message, mi) => {
+      if (!Array.isArray(message.content)) return message;
+      return {
+        ...message,
+        content: message.content.map((part, pi) => {
+          if (part.type === "tool-result" && part.output.type === "content") {
+            return {
+              ...part,
+              output: {
+                ...part.output,
+                value: part.output.value.map(
+                  (output, oi) =>
+                    replacements.get(`${mi}:${pi}:${oi}`) ?? output,
+                ),
+              },
+            };
+          }
+          return replacements.get(`${mi}:${pi}`) ?? part;
+        }),
+      } as ModelMessage;
+    });
+  };
+}

--- a/lib/chat/abliteration-vision.ts
+++ b/lib/chat/abliteration-vision.ts
@@ -14,7 +14,7 @@ export class AbliterationVisionError extends Error {
   }
 }
 
-type ImageInput = { image: string; mediaType: string };
+type ImageInput = { image: string; mediaType: string; filename?: string };
 
 /** Reads the SDK's attachment and multimodal tool-output image representations. */
 function imageInput(part: unknown): ImageInput | undefined {
@@ -46,6 +46,7 @@ function imageInput(part: unknown): ImageInput | undefined {
   return {
     image,
     mediaType: mediaType ?? /^data:([^;,]+)/.exec(image)?.[1] ?? "image/png",
+    ...(typeof value.filename === "string" && { filename: value.filename }),
   };
 }
 
@@ -120,9 +121,14 @@ export function createAbliterationVisionPreprocessor({
             .replaceAll("&", "&amp;")
             .replaceAll("<", "&lt;")
             .replaceAll(">", "&gt;");
+          const filename = task.input.filename
+            ?.replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;");
           replacements.set(task.position, {
             type: "text",
-            text: `<image_description index="${start + offset + 1}" trust="untrusted">\n${escaped}\n</image_description>`,
+            text: `<image_description index="${start + offset + 1}"${filename ? ` filename="${filename}"` : ""} trust="untrusted">\n${escaped}\n</image_description>`,
           });
         }),
       );

--- a/lib/experiments/__tests__/abliterated-model.test.ts
+++ b/lib/experiments/__tests__/abliterated-model.test.ts
@@ -167,7 +167,7 @@ describe("moderation-gated Abliteration assignment", () => {
     ).resolves.toMatchObject({ modelKey: ABLITERATION_MODEL_KEY });
     expect(getFeatureFlag).toHaveBeenCalledTimes(1);
   });
-  it("bypasses Abliteration when request history exceeds its image limit", async () => {
+  it("keeps over-limit image requests eligible for vision preprocessing", async () => {
     const getFeatureFlag = jest.fn().mockResolvedValue("test");
 
     await expect(
@@ -176,10 +176,10 @@ describe("moderation-gated Abliteration assignment", () => {
         messages: imageAttachmentTurn(ABLITERATION_MAX_IMAGES_PER_REQUEST + 1),
         posthog: { getFeatureFlag },
       }),
-    ).resolves.toBeUndefined();
-    expect(getFeatureFlag).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({ modelKey: ABLITERATION_MODEL_KEY });
+    expect(getFeatureFlag).toHaveBeenCalledTimes(1);
   });
-  it("applies the image limit across messages, not per turn", async () => {
+  it("keeps over-limit image history eligible across messages", async () => {
     const getFeatureFlag = jest.fn().mockResolvedValue("test");
     const messages = imageAttachmentHistory(
       ABLITERATION_MAX_IMAGES_PER_REQUEST,
@@ -203,8 +203,8 @@ describe("moderation-gated Abliteration assignment", () => {
         messages,
         posthog: { getFeatureFlag },
       }),
-    ).resolves.toBeUndefined();
-    expect(getFeatureFlag).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({ modelKey: ABLITERATION_MODEL_KEY });
+    expect(getFeatureFlag).toHaveBeenCalledTimes(1);
   });
   it.each([
     {

--- a/lib/experiments/__tests__/abliterated-model.test.ts
+++ b/lib/experiments/__tests__/abliterated-model.test.ts
@@ -2,6 +2,7 @@ import {
   evaluateAbliteratedModel,
   ABLITERATED_EXPERIMENT_KEY,
 } from "../abliterated-model";
+import { ABLITERATION_MAX_IMAGES_PER_REQUEST } from "@/lib/ai/abliteration-media";
 import type { UIMessage } from "ai";
 import type { SelectedModel, SubscriptionTier } from "@/types";
 import {
@@ -69,6 +70,28 @@ describe("moderation-gated Abliteration assignment", () => {
       ],
     },
   ] as unknown as UIMessage[];
+  const imageAttachmentHistory = (count: number) =>
+    Array.from({ length: count }, (_, index) => ({
+      id: `image-attachment-${index}`,
+      role: "user" as const,
+      parts: [
+        {
+          type: "file",
+          mediaType: "image/png",
+          url: `https://example.test/private-${index}.png`,
+        },
+      ],
+    })) as unknown as UIMessage[];
+  const imageAttachmentTurn = (count: number) =>
+    [
+      {
+        id: "image-attachment-turn",
+        role: "user" as const,
+        parts: imageAttachmentHistory(count).flatMap((message) =>
+          message.parts.map((part) => ({ ...part })),
+        ),
+      },
+    ] as unknown as UIMessage[];
   const defaults = {
     userId: "u",
     subscription: "pro" as SubscriptionTier,
@@ -130,6 +153,57 @@ describe("moderation-gated Abliteration assignment", () => {
         posthog: { getFeatureFlag },
       }),
     ).toBeUndefined();
+    expect(getFeatureFlag).not.toHaveBeenCalled();
+  });
+  it("keeps a request at the Abliteration image limit eligible", async () => {
+    const getFeatureFlag = jest.fn().mockResolvedValue("test");
+
+    await expect(
+      evaluateAbliteratedModel({
+        ...defaults,
+        messages: imageAttachmentHistory(ABLITERATION_MAX_IMAGES_PER_REQUEST),
+        posthog: { getFeatureFlag },
+      }),
+    ).resolves.toMatchObject({ modelKey: ABLITERATION_MODEL_KEY });
+    expect(getFeatureFlag).toHaveBeenCalledTimes(1);
+  });
+  it("bypasses Abliteration when request history exceeds its image limit", async () => {
+    const getFeatureFlag = jest.fn().mockResolvedValue("test");
+
+    await expect(
+      evaluateAbliteratedModel({
+        ...defaults,
+        messages: imageAttachmentTurn(ABLITERATION_MAX_IMAGES_PER_REQUEST + 1),
+        posthog: { getFeatureFlag },
+      }),
+    ).resolves.toBeUndefined();
+    expect(getFeatureFlag).not.toHaveBeenCalled();
+  });
+  it("applies the image limit across messages, not per turn", async () => {
+    const getFeatureFlag = jest.fn().mockResolvedValue("test");
+    const messages = imageAttachmentHistory(
+      ABLITERATION_MAX_IMAGES_PER_REQUEST,
+    );
+    messages.push({
+      id: "combined-image-turn",
+      role: "user",
+      parts: [
+        { type: "text", text: "Inspect the full image history" },
+        {
+          type: "file",
+          mediaType: "image/jpeg",
+          url: "https://example.test/final-private.jpg",
+        },
+      ],
+    } as unknown as UIMessage);
+
+    await expect(
+      evaluateAbliteratedModel({
+        ...defaults,
+        messages,
+        posthog: { getFeatureFlag },
+      }),
+    ).resolves.toBeUndefined();
     expect(getFeatureFlag).not.toHaveBeenCalled();
   });
   it.each([

--- a/lib/experiments/abliterated-model.ts
+++ b/lib/experiments/abliterated-model.ts
@@ -9,7 +9,6 @@ import {
   isAbliterationConfigured,
 } from "@/lib/ai/abliteration";
 import { uiMessagesContainImageViewResult } from "@/lib/chat/multimodal-tool-result-recovery";
-import { ABLITERATION_MAX_IMAGES_PER_REQUEST } from "@/lib/ai/abliteration-media";
 
 export const ABLITERATED_EXPERIMENT_KEY = "abliterated_paid_moderated_v1";
 export type AbliteratedAssignment = ExperimentAnalyticsContext & {
@@ -55,29 +54,6 @@ const messagesContainUnsupportedFiles = (messages: UIMessage[]): boolean =>
     ),
   );
 
-/**
- * Rejects attachment histories above the request-wide cap before assignment.
- * Serialized tool images are checked by the stream runner before provider selection.
- */
-const messagesExceedImageLimit = (messages: UIMessage[]): boolean => {
-  let imageCount = 0;
-
-  for (const message of messages) {
-    for (const part of message.parts) {
-      if (
-        part.type === "file" &&
-        typeof part.mediaType === "string" &&
-        part.mediaType.startsWith("image/")
-      ) {
-        imageCount += 1;
-        if (imageCount > ABLITERATION_MAX_IMAGES_PER_REQUEST) return true;
-      }
-    }
-  }
-
-  return false;
-};
-
 export function isEligibleForAbliteratedModel({
   subscription,
   selectedModelOverride,
@@ -96,8 +72,7 @@ export function isEligibleForAbliteratedModel({
     subscription !== "free" &&
     moderationEligible &&
     messages.length > 0 &&
-    !messagesContainUnsupportedFiles(messages) &&
-    !messagesExceedImageLimit(messages)
+    !messagesContainUnsupportedFiles(messages)
   );
 }
 

--- a/lib/experiments/abliterated-model.ts
+++ b/lib/experiments/abliterated-model.ts
@@ -55,8 +55,10 @@ const messagesContainUnsupportedFiles = (messages: UIMessage[]): boolean =>
     ),
   );
 
-// Abliteration applies this cap to the complete provider request, not each
-// message or upload action. Count the provider-visible history at that scope.
+/**
+ * Rejects attachment histories above the request-wide cap before assignment.
+ * Serialized tool images are checked by the stream runner before provider selection.
+ */
 const messagesExceedImageLimit = (messages: UIMessage[]): boolean => {
   let imageCount = 0;
 

--- a/lib/experiments/abliterated-model.ts
+++ b/lib/experiments/abliterated-model.ts
@@ -9,6 +9,7 @@ import {
   isAbliterationConfigured,
 } from "@/lib/ai/abliteration";
 import { uiMessagesContainImageViewResult } from "@/lib/chat/multimodal-tool-result-recovery";
+import { ABLITERATION_MAX_IMAGES_PER_REQUEST } from "@/lib/ai/abliteration-media";
 
 export const ABLITERATED_EXPERIMENT_KEY = "abliterated_paid_moderated_v1";
 export type AbliteratedAssignment = ExperimentAnalyticsContext & {
@@ -54,6 +55,27 @@ const messagesContainUnsupportedFiles = (messages: UIMessage[]): boolean =>
     ),
   );
 
+// Abliteration applies this cap to the complete provider request, not each
+// message or upload action. Count the provider-visible history at that scope.
+const messagesExceedImageLimit = (messages: UIMessage[]): boolean => {
+  let imageCount = 0;
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (
+        part.type === "file" &&
+        typeof part.mediaType === "string" &&
+        part.mediaType.startsWith("image/")
+      ) {
+        imageCount += 1;
+        if (imageCount > ABLITERATION_MAX_IMAGES_PER_REQUEST) return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 export function isEligibleForAbliteratedModel({
   subscription,
   selectedModelOverride,
@@ -72,7 +94,8 @@ export function isEligibleForAbliteratedModel({
     subscription !== "free" &&
     moderationEligible &&
     messages.length > 0 &&
-    !messagesContainUnsupportedFiles(messages)
+    !messagesContainUnsupportedFiles(messages) &&
+    !messagesExceedImageLimit(messages)
   );
 }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -65,6 +65,7 @@ import {
   BudgetMonitor,
   captureBudgetSnapshot,
 } from "@/lib/chat/budget-monitor";
+import { AbliterationVisionError } from "@/lib/chat/abliteration-vision";
 import { UsageTracker } from "@/lib/usage-tracker";
 import { resolveTriggerRunCost } from "@/lib/billing/trigger-run-cost";
 import {
@@ -4569,6 +4570,7 @@ export const agentLongTask = task({
               if (
                 isProviderApiError(error) &&
                 !isInvalidImageInputError(error) &&
+                !(error instanceof AbliterationVisionError) &&
                 !isRetryWithFallback &&
                 (isAutoModel ||
                   shouldRecoverVisionApiError ||
@@ -4790,6 +4792,9 @@ export const agentLongTask = task({
                         providerDisconnectContinuation,
                       );
                       const shouldAttemptProviderRetry =
+                        !(
+                          state.providerError instanceof AbliterationVisionError
+                        ) &&
                         (shouldRetryWithFallback ||
                           shouldRetryWithoutImageToolResults ||
                           shouldRetryWithVisionSummary ||


### PR DESCRIPTION
Fix the confirmed production `media_count_exceeded` failure while **keeping Abliteration for eligible image-heavy requests**. This revision supersedes the initial baseline-bypass design at the user's request.

## Behavior

- Up to four provider-visible images: send native pixels directly to Abliteration.
- More than four: reuse `describeImageWithAuxiliaryVision` (the existing factual vision/OCR helper). Process one image per call, in sequential batches of at most four concurrent calls. Replace every image in the outbound request with its indexed, escaped, explicitly untrusted description/OCR text.
- Count attachments plus persisted/new tool image content together, across the request history. Apply before the initial call and every generation/compaction/recovery send path. Keep the assigned Abliteration route; do not switch providers merely because there are more than four images.
- Preserve original stored/UI images, tool IDs, non-image content and message order. Cache descriptions within the stream using hashed media keys; duplicate images do not incur repeated OCR calls. Existing upstream history/tool-image retention limits still apply.
- Reuse the vision helper's timeout, bounded provider retry, content-safe telemetry and cost callback. Account for successful auxiliary calls even when another image in the batch fails. Respect cancellation, stop before the next batch on failure, and fail clearly without sending the over-limit native payload or automatically restarting failed OCR.

The existing paid/moderation/experiment gates, unsupported-file exclusions, provider-failure policy and **three-generation-step Abliteration ceiling** are unchanged. Baseline-provider requests are not preprocessed by this feature. Separate image dimensions/byte limits are not claimed fixed. No flag, credentials, schema or suppression settings changed. Both Vercel and Trigger need a deployment of the new code.

## Production evidence

Frozen audit: `2026-09-05T20:02:55.718Z`–`2026-09-06T20:02:55.718Z`. Run `run_06g7g3nhcage18251tmkbcmoe1`, Trigger Production `20260906.7`, sent nine files and failed at `2026-09-06T18:50:46.396Z` with the provider's four-image count limit, after #1271.

[PostHog media-policy issue](https://us.posthog.com/project/144137/error_tracking/01a077df-1bef-7cf2-949a-3ba2caa74d10). Its other event is a separate dimensions failure. Revision hypothesis, existing eligible population, metrics/guardrails, exposure, owner, September 13 review and cleanup/rollback plan are recorded in [HAC-99](https://linear.app/hackerai/issue/HAC-99/evaluate-moderation-gated-abliteration-routing-across-paid-model-tiers).

## Validation

Local: 465 Jest suites / 4,897 tests pass; typecheck, changed-file ESLint/Prettier and diff checks pass. Coverage includes 4/5/9/14-image cases, cross-message assignment eligibility, mixed attachment/tool content, binary images, indexed descriptions and filename references, escaped untrusted content, unchanged originals, batch concurrency, duplicate-cache accounting, partial failure and cancellation. Shared-runner tests verify initial/provider-step OCR and retained Abliteration, plus no OCR on baseline providers and no main call after initial OCR failure. Both Ask and Trigger explicitly exclude initial and late OCR errors from generic baseline recovery; the late prepare-step error also propagates without a second OCR attempt.

CI and CodeRabbit must complete again for the revised head. No infrastructure-release paths changed; desktop/sandbox release workflows are not applicable.

## Manual verification (still pending)

First independently verify the branch Preview's Vercel and Trigger runtimes use the designated developer-account Convex Preview; a successful sign-in alone is insufficient proof.

1. On the verified branch Preview, create disposable paid/moderation-eligible/test-assigned Ask and Cloud Agent requests with four small synthetic images. Expect native image input, no auxiliary OCR calls, and the assigned Abliteration model during its existing first three generation steps.
2. Repeat with five and nine images, then a history containing images plus four new uploads. Expect bounded OCR batches, indexed descriptions covering every provider-visible image, and the main response on Abliteration rather than an image-count baseline fallback. Verify completion and reload persistence with originals still accessible.
3. During the first three generation steps, combine four attachments with a file-view image result. Expect summaries before the next Abliteration request; no media-count failure or duplicate tool execution. Confirm step four still follows the existing baseline policy.
4. Simulate an OCR failure or Stop. Expect no over-limit main request, no silent image dropping, no repeated failed batch, and correct auxiliary cost/cancellation accounting. Confirm ordinary baseline requests and <=4-image requests remain unchanged.

Watch after deployment: media-count recurrence, auxiliary failure/latency/cost, description fidelity, actual model attribution, completion and persistence. This revision is not yet proven by an authenticated live image journey.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Abliteration now supports oversized image-based conversations by converting supported images into contextual descriptions while preserving their placement and filenames.
  - Image inputs from attachments and tool results are supported, with processing optimized through batching and reuse.
  - Image descriptions are safely escaped to protect against untrusted content.

- **Bug Fixes**
  - Vision-processing failures now surface directly instead of triggering an inappropriate provider fallback or retry.
  - Image handling remains available across continued conversations and compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->