### PR TITLE
HAC-99: Limit Abliteration to the first generation step

### DIFF
--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -16,9 +16,9 @@ Auto uses the base model because its baseline is Standard. The existing moderati
 API must return `shouldUncensorResponse=true`. This signal selects the experiment;
 it does not change moderation thresholds, tool approvals, or authorization gates.
 
-Abliteration is limited to model-generation steps one through three within each
+Abliteration is limited to the first model-generation step within each
 Ask response or Agent run. The shared AI SDK loop uses the assigned Abliteration
-model for zero-based step indexes 0–2, then switches step 4 and every later step to
+model for zero-based step index 0, then switches step 2 and every later step to
 the request's saved OpenRouter baseline. The counter resets for each new response
 or run; an Agent run can continue through its existing 500-step cap. Provider retry
 attempts do not advance the completed-step counter. An Abliteration provider error
@@ -122,6 +122,13 @@ replacement message IDs. Billing and later activity join by authenticated
 
 ## Readout protocol
 
+The one-step phase emits `generation_step_limit=1` on eligibility and provider
+events; the earlier three-step phase emitted `3`. Scope each readout by that
+property on deduplicated eligible requests, then link all outcomes by
+`experiment_request_id`. Compare control/test within the same phase, and do not
+pool phases or treat before/after changes as randomized evidence. Production
+activation starts with the first verified one-step run, not the Git merge time.
+
 1. Freeze the rollout definition and record the first production exposure date.
    Compare randomized control/test users only. Do not compare treatment with all
    unassigned users. Exclude internal tests and report any assignment crossover.
@@ -192,9 +199,9 @@ For release verification on the verified Preview custom URL:
    model for Standard, Pro, and Max while text-only Pro/Max requests use Large v2.
    Unit tests cover deterministic gates; use approved synthetic fixtures for
    integration testing rather than customer content.
-   In Direct Ask and Agent, force one response/run through at least four sequential
-   model-generation steps. Confirm steps 1–3 use the assigned Abliteration route and
-   step 4 onward uses the exact OpenRouter baseline without flag re-evaluation. Start
+   In Direct Ask and Agent, force one response/run through at least three sequential
+   model-generation steps. Confirm step 1 uses the assigned Abliteration route and
+   step 2 onward uses the exact OpenRouter baseline without flag re-evaluation. Start
    a new response/run and confirm its generation-step counter starts again at one.
 3. Force the flag off/control and a provider outage. Verify fallback completes,
    assignment stays unchanged in outcomes/costs, replacement messages can be rated,

--- a/lib/analytics/__tests__/abliterated-model.test.ts
+++ b/lib/analytics/__tests__/abliterated-model.test.ts
@@ -76,18 +76,18 @@ describe("Abliteration stream telemetry", () => {
       finishPart,
     ];
     expect(await consume(telemetry, model(parts))).toEqual(parts);
-    await consume(telemetry, model(parts), 3);
+    await consume(telemetry, model(parts), 1);
     expect(events("abliterated_model_eligible")).toHaveLength(1);
     expect(events("abliterated_model_eligible")[0].properties).toMatchObject({
       assigned_platform_authorization_context: "not_appended",
-      generation_step_limit: 3,
+      generation_step_limit: 1,
     });
     expect(events("abliterated_model_provider_attempt")).toHaveLength(2);
     expect(
       events("abliterated_model_provider_attempt").map(
         (event) => event.properties.generation_step,
       ),
-    ).toEqual([1, 4]);
+    ).toEqual([1, 2]);
     expect(
       events("abliterated_model_provider_attempt").map(
         (event) => event.properties.within_abliteration_step_limit,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2033,7 +2033,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     }
   });
 
-  test("Abliteration routing switches to OpenRouter after three generation steps", () => {
+  test("Abliteration routing switches to OpenRouter after the first generation step", () => {
     for (const source of [taskSrc, chatHandlerSrc]) {
       expect(source).toMatch(
         /abliteratedStepRouting:[\s\S]{0,150}baselineModel/,

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -490,6 +490,10 @@ describe("createAgentStream repeated compaction", () => {
     mockDescribeImage
       .mockReset()
       .mockResolvedValue({ description: "Visible image text" });
+    mockRunSummarizationStep.mockResolvedValue({
+      summarizationAttempted: false,
+      needsSummarization: false,
+    });
     mockStreamText.mockImplementation((options) => options);
   });
 
@@ -529,7 +533,7 @@ describe("createAgentStream repeated compaction", () => {
     },
   );
 
-  it("routes only the first three generation steps through Abliteration", async () => {
+  it("routes only the first generation step through Abliteration", async () => {
     const onModelStepSelected = jest.fn();
     const state = initAgentStreamState(
       [uiMessage("initial", "Inspect the authorized lab")],
@@ -564,17 +568,15 @@ describe("createAgentStream repeated compaction", () => {
         messages: [{ role: "user", content: "Continue" }],
       });
 
-    for (const completedSteps of [0, 1, 2]) {
-      const prepared = await prepare(completedSteps);
-      expect(prepared.model.modelId).toBe("model-abliterated");
-      expect(JSON.stringify(prepared.messages)).not.toContain(
-        PLATFORM_AUTHORIZATION_ANNOTATION,
-      );
-    }
+    const firstStep = await prepare(0);
+    expect(firstStep.model.modelId).toBe("model-abliterated");
+    expect(JSON.stringify(firstStep.messages)).not.toContain(
+      PLATFORM_AUTHORIZATION_ANNOTATION,
+    );
 
-    const fourthStep = await prepare(3);
-    expect(fourthStep.model.modelId).toBe("model-deepseek-v4-flash-0731");
-    expect(JSON.stringify(fourthStep.messages)).toContain(
+    const secondStep = await prepare(1);
+    expect(secondStep.model.modelId).toBe("model-deepseek-v4-flash-0731");
+    expect(JSON.stringify(secondStep.messages)).toContain(
       PLATFORM_AUTHORIZATION_ANNOTATION,
     );
     expect(onModelStepSelected).toHaveBeenLastCalledWith(
@@ -671,7 +673,7 @@ describe("createAgentStream repeated compaction", () => {
     expect(mockStreamText).not.toHaveBeenCalled();
   });
 
-  it("propagates late OCR failure instead of retrying the prepare-step fallback", async () => {
+  it("propagates first-step OCR failure instead of retrying the prepare-step fallback", async () => {
     const stream = (await createAgentStream(
       "model-abliterated",
       createTestStreamContext({
@@ -690,7 +692,7 @@ describe("createAgentStream repeated compaction", () => {
     mockDescribeImage.mockRejectedValue(new Error("Auxiliary API failure"));
     await expect(
       stream.prepareStep({
-        stepNumber: 1,
+        stepNumber: 0,
         steps: [],
         messages: [
           {
@@ -734,7 +736,7 @@ describe("createAgentStream repeated compaction", () => {
     expect(mockDescribeImage).not.toHaveBeenCalled();
   });
 
-  it("keeps Abliteration and describes images when tools exceed the request cap", async () => {
+  it("describes persisted tool images on the first step and uses baseline on the next", async () => {
     const stream = (await createAgentStream(
       "model-abliterated",
       createTestStreamContext({
@@ -787,7 +789,7 @@ describe("createAgentStream repeated compaction", () => {
           ],
         },
       ],
-      1,
+      0,
     );
     expect(prepared.model.modelId).toBe("model-abliterated");
     expect(JSON.stringify(prepared.messages)).toContain("image_description");
@@ -795,9 +797,9 @@ describe("createAgentStream repeated compaction", () => {
       PLATFORM_AUTHORIZATION_ANNOTATION,
     );
     expect(
-      (await prepare([{ role: "user", content: "Compacted context" }], 2)).model
+      (await prepare([{ role: "user", content: "Compacted context" }], 1)).model
         .modelId,
-    ).toBe("model-abliterated");
+    ).toBe("model-grok-4.6");
   });
 
   it("preserves the generation-step position across replacement streams", async () => {
@@ -806,7 +808,7 @@ describe("createAgentStream repeated compaction", () => {
       [uiMessage("initial", "Inspect the authorized lab")],
       { usedTokens: 1_000, maxTokens: 128_000 },
     );
-    state.agentStepCount = 3;
+    state.agentStepCount = 1;
 
     const stream = (await createAgentStream(
       "model-abliterated",
@@ -844,7 +846,7 @@ describe("createAgentStream repeated compaction", () => {
       expect.objectContaining({
         model: "model-deepseek-v4-flash-0731",
         source: "prepare_step",
-        step_index: 4,
+        step_index: 2,
       }),
       expect.anything(),
     );

--- a/lib/experiments/__tests__/abliterated-model-steps.test.ts
+++ b/lib/experiments/__tests__/abliterated-model-steps.test.ts
@@ -4,7 +4,7 @@ import {
 } from "../abliterated-model-steps";
 
 describe("resolveAbliterationModelForGenerationStep", () => {
-  it.each([0, 1, 2])(
+  it.each([0])(
     "uses Abliteration for generation step index %i",
     (stepIndex) => {
       expect(
@@ -17,7 +17,7 @@ describe("resolveAbliterationModelForGenerationStep", () => {
     },
   );
 
-  it.each([ABLITERATION_MAX_GENERATION_STEPS, 499])(
+  it.each([ABLITERATION_MAX_GENERATION_STEPS, 2, 3, 499])(
     "uses OpenRouter for generation step index %i",
     (stepIndex) => {
       expect(

--- a/lib/experiments/abliterated-model-steps.ts
+++ b/lib/experiments/abliterated-model-steps.ts
@@ -1,4 +1,4 @@
-export const ABLITERATION_MAX_GENERATION_STEPS = 3;
+export const ABLITERATION_MAX_GENERATION_STEPS = 1;
 
 /**
  * Selects the request-scoped route for one zero-based AI SDK generation step.


### PR DESCRIPTION
Eligible paid requests currently use Abliteration for three generation steps. Reduce this to step 1, then use the saved OpenRouter baseline from step 2 onward to test whether the initial response benefit can be retained at lower cost.

The shared limit covers Ask and Agent, preserves the retry offset and 500-step Agent ceiling, and keeps existing targeting, moderation gates, image handling, and provider fallback. Existing telemetry emits `generation_step_limit=1` so this phase can be analyzed separately. Updated boundary, image, replacement-stream, and telemetry tests; fixed the test summarization stub so those assertions exercise normal preparation.

Validation: typecheck, changed-file ESLint, and all 465 suites / 4,897 tests passed locally.

Manual verification: on the deployed Preview and Production app, use the eligible internal paid account for an isolated lab request with two sequential terminal calls. Confirm step 1 uses Abliteration without the trusted authorization annotation, steps 2–3 use the baseline with standard context, analytics reports limit 1, and the completed response persists after reload. Verify the actual Trigger worker version before drawing conclusions from the run.

Experiment hypothesis, metrics, rollback criteria, and phase readout: https://linear.app/hackerai/issue/HAC-99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Abliteration is now applied only during the first generation step of each Ask response or Agent run.
  - Subsequent generation steps use the standard OpenRouter baseline routing.
  - Agent streaming, multi-step responses, image handling, and OCR-related flows now follow the updated step transition.

- **Documentation**
  - Verification guidance now reflects the one-step Abliteration flow and baseline routing from the second step onward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->