### PR TITLE
HAC-99: Retain Abliteration for qualifying chat continuations

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -794,6 +794,76 @@ describe("getMessagesPageForBackend — is_hidden filtering", () => {
     return paginateMock;
   }
 
+  it("returns routing provenance only for visible assistant messages, outside prompt parts", async () => {
+    const seed = {
+      abliterationRouting: {
+        version: 1,
+        source: "moderation",
+        completed: true,
+      },
+    };
+    setupPaginatedMessages([
+      makeMessage({
+        id: "independent",
+        role: "assistant",
+        finish_reason: "stop",
+        usage: seed,
+      }),
+      makeMessage({
+        id: "hidden",
+        role: "assistant",
+        is_hidden: true,
+        finish_reason: "stop",
+        usage: seed,
+      }),
+      makeMessage({
+        id: "user",
+        role: "user",
+        finish_reason: "stop",
+        usage: seed,
+      }),
+      makeMessage({
+        id: "history",
+        role: "assistant",
+        finish_reason: "stop",
+        usage: {
+          abliterationRouting: {
+            version: 1,
+            source: "history",
+            completed: true,
+          },
+        },
+      }),
+    ]);
+    const { getMessagesPageForBackend } = await import("../messages");
+    const result = await getMessagesPageForBackend.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      paginationOpts: { numItems: 24, cursor: null },
+    });
+    expect(result.abliterationHistory).toEqual([
+      { id: "independent", completed: true, independent: true },
+      { id: "history", completed: true, independent: false },
+    ]);
+    expect(
+      result.page.every((message: any) => message.usage === undefined),
+    ).toBe(true);
+  });
+
+  it("returns no history when chat ownership fails", async () => {
+    mockCtx.runQuery.mockResolvedValue(false);
+    const { getMessagesPageForBackend } = await import("../messages");
+    const result = await getMessagesPageForBackend.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      paginationOpts: { numItems: 24, cursor: null },
+    });
+    expect(result.abliterationHistory).toEqual([]);
+    expect(mockCtx.db.query).not.toHaveBeenCalled();
+  });
+
   it("should filter out hidden messages", async () => {
     const visibleMsg = makeMessage({
       id: "msg-visible",
@@ -891,5 +961,45 @@ describe("getMessagesPageForBackend — is_hidden filtering", () => {
     expect(result.page[0].parts).toEqual([{ type: "file", fileId }]);
     expect(result.fileTokens).toEqual([{ fileId, tokenSize: 321 }]);
     expect(mockCtx.db.get).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("client stop-save routing provenance", () => {
+  it("cannot insert routing evidence through client usage", async () => {
+    const { saveAssistantMessage } = await import("../messages");
+    const insert = jest.fn<any>().mockResolvedValue("doc");
+    const ctx = {
+      auth: {
+        getUserIdentity: jest.fn<any>().mockResolvedValue({ subject: USER_ID }),
+      },
+      runQuery: jest.fn<any>().mockResolvedValue(true),
+      db: {
+        query: jest.fn().mockReturnValue({
+          withIndex: jest.fn().mockReturnValue({
+            first: jest.fn<any>().mockResolvedValue(null),
+          }),
+        }),
+        insert,
+      },
+    };
+    await saveAssistantMessage.handler(ctx as any, {
+      id: "client",
+      chatId: CHAT_ID,
+      role: "assistant",
+      parts: [{ type: "text", text: "ok" }],
+      finishReason: "stop",
+      usage: {
+        inputTokens: 5,
+        abliterationRouting: {
+          version: 1,
+          source: "moderation",
+          completed: true,
+        },
+      },
+    });
+    expect(insert).toHaveBeenCalledWith(
+      "messages",
+      expect.objectContaining({ usage: { inputTokens: 5 } }),
+    );
   });
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,3 +1,7 @@
+import {
+  getAbliterationHistoryEntry,
+  stripClientAbliterationRouting,
+} from "../lib/experiments/abliteration-history";
 import { query, mutation, internalQuery } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { v, ConvexError, getDocumentSize, type Value } from "convex/values";
@@ -640,6 +644,13 @@ export const saveMessage = mutation({
         // Update usage if provided and not already set (e.g., on abort)
         if (args.usage && !existingMessage.usage) {
           patch.usage = args.usage;
+        } else if (args.usage?.abliterationRouting) {
+          // A client stop-save may precede server completion. Only this
+          // service-key mutation can add or replace routing provenance.
+          patch.usage = {
+            ...existingMessage.usage,
+            abliterationRouting: args.usage.abliterationRouting,
+          };
         }
 
         // Update metrics if provided and not already set
@@ -1211,7 +1222,7 @@ export const saveAssistantMessage = mutation({
         generation_started_at: args.generationStartedAt,
         generation_time_ms: args.generationTimeMs,
         finish_reason: args.finishReason,
-        usage: args.usage,
+        usage: stripClientAbliterationRouting(args.usage),
       });
 
       return null;
@@ -1465,6 +1476,13 @@ export const getMessagesPageForBackend = query({
         parts: v.array(v.any()),
       }),
     ),
+    abliterationHistory: v.array(
+      v.object({
+        id: v.string(),
+        completed: v.boolean(),
+        independent: v.boolean(),
+      }),
+    ),
     fileTokens: v.array(
       v.object({
         fileId: v.id("files"),
@@ -1487,7 +1505,13 @@ export const getMessagesPageForBackend = query({
     );
 
     if (!chatExists) {
-      return { page: [], fileTokens: [], isDone: true, continueCursor: "" };
+      return {
+        page: [],
+        abliterationHistory: [],
+        fileTokens: [],
+        isDone: true,
+        continueCursor: "",
+      };
     }
 
     const result = await ctx.db
@@ -1517,6 +1541,9 @@ export const getMessagesPageForBackend = query({
         role: message.role,
         parts: stripUnownedFileParts(message.parts, ownedFileIds),
       })),
+      abliterationHistory: visiblePage
+        .filter((message) => message.role === "assistant")
+        .map(getAbliterationHistoryEntry),
       fileTokens,
       isDone: result.isDone,
       continueCursor: result.continueCursor,

--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -13,8 +13,10 @@ Paid requests in Ask and Agent may use an Abliteration model at
 explicit HackerAI Pro and Max routes use `abliterated-model-large-v2`. Ultra Ask
 Auto also uses Large v2 because its current baseline is Pro, while Ultra Agent
 Auto uses the base model because its baseline is Standard. The existing moderation
-API must return `shouldUncensorResponse=true`. This signal selects the experiment;
-it does not change moderation thresholds, tool approvals, or authorization gates.
+API normally selects the experiment through `shouldUncensorResponse=true`.
+The separately flagged recent-chat preference below can retain the provider when
+the new moderation score falls below the minimum routing threshold; it never
+relaxes forbidden categories, upper score limits, tool approvals, or authorization.
 
 Abliteration is limited to the first model-generation step within each
 Ask response or Agent run. The shared AI SDK loop uses the assigned Abliteration
@@ -54,6 +56,71 @@ default reasoning. OpenRouter options, routing lists, user attribution, and PDF
 plugins are not sent to the direct endpoint. Existing bounded application retries
 use the request's original baseline after an Abliteration failure. Subagents,
 summaries, titles, and approval reviewers retain their existing models.
+
+## Recent-chat continuity
+
+`abliteration_chat_continuity_v1` retains Abliteration for paid parent-treatment
+requests when at least two of the last five completed visible assistant responses
+in the same chat independently used it. A completed response has `finish_reason=stop`;
+a seed additionally requires a successfully finished Abliteration generation and
+no response abort. Failed attempts, empty output, controls, fallback-only output,
+and inherited selections never seed the preference. Two independently selected
+responses are enough even when the chat has fewer than five completed responses.
+
+The new input still runs through moderation. Missing credentials, API failures,
+invalid scores, forbidden categories, and scores above the existing upper bound
+fail closed. This preference only bypasses the lower routing threshold; it does
+not set `platformAuthorized`. Existing plan, rescue, attachment, provider-fallback,
+and one-generation-step restrictions apply. Regenerations do not inherit history.
+
+Provenance is stored as `usage.abliterationRouting` (version, source, completed),
+inside the existing flexible usage object, without a schema migration. The server
+tracks successful Abliteration generation even when later steps use OpenRouter;
+the final saved model alone is insufficient evidence. Client stop-save strips
+this reserved field, and only the service-key save path can persist it. Legacy
+responses without this marker are deliberately not seeds.
+
+History metadata comes from the existing bounded backend page reads, separately
+from model messages and before token truncation or summary projection. No full-chat
+scan or extra database round trip is added. If bounded fetching reaches fewer than
+five completed responses, only available evidence is used; missing evidence does
+not count. As seeds leave the five-response window, inherited responses cannot
+renew them.
+
+Telemetry adds `selection_source` (`moderation` or `history`),
+`independent_history_count`, and `routing_version=2` to the existing eligibility,
+actual exposure, and provider outcome events. `moderation_eligible` reflects the
+independent moderation decision. Compare completion, latency, estimated cost,
+fallback/error/abort rates, and task feedback by routing source, mode and model.
+History traffic is selected from prior treatment: it is not a randomized causal
+comparison against parent controls. Churn and retention need a later user-level
+readout with enough follow-up time. No user content is added to analytics.
+
+Owner: Ross Manko, [HAC-99](https://linear.app/hackerai/issue/HAC-99).
+Review Preview results before Production activation; initial review 2026-09-14.
+Roll back via the continuity flag on completion/feedback regression, elevated
+cost or latency, or any moderation/persistence failure. Remove the continuity
+flag with the parent pilot after an explicit decision.
+
+Definitions verified 2026-09-07:
+
+| Environment | Project               | Flag   | Active | Rollout | Target                                                 |
+| ----------- | --------------------- | ------ | ------ | ------- | ------------------------------------------------------ |
+| Preview     | hackerai-dev / 401167 | 870188 | Yes    | 100%    | Paid tiers; application also requires parent treatment |
+| Production  | HackerAI / 144137     | 870186 | No     | 0%      | Paid tiers; no Production continuity activation        |
+
+Both use `abliteration_chat_continuity_v1` and target `pro`, `pro-plus`, `ultra`,
+and `team`. The parent flag remains unchanged. This implementation requires
+Convex functions, Vercel and Trigger Preview deployments before end-to-end testing;
+subsequent flag changes take effect on a new request/run.
+
+Manual verification in the designated Preview branch: use a disposable paid chat,
+complete two independently moderation-selected responses, then submit a benign
+follow-up below the minimum routing score. Confirm `selection_source=history`,
+completion and reload persistence, and OpenRouter on generation step two. Confirm
+regeneration and an expired history window retain normal routing; check moderation
+failure and forbidden-category exclusions with deterministic automated fixtures.
+Do not seed routing markers by editing live user messages.
 
 ## Environment and rollout record
 

--- a/lib/__tests__/moderation.test.ts
+++ b/lib/__tests__/moderation.test.ts
@@ -106,4 +106,82 @@ describe("getModerationResult", () => {
       moderationInput.indexOf("legal authority"),
     );
   });
+  const request = [
+    {
+      role: "user",
+      parts: [
+        { type: "text", text: "Continue the authorized security assessment." },
+      ],
+    },
+  ];
+  it.each([
+    {
+      score: 0.01,
+      category: "illicit",
+      flagged: false,
+      continuation: true,
+      independent: false,
+    },
+    {
+      score: 0.2,
+      category: "illicit",
+      flagged: true,
+      continuation: true,
+      independent: true,
+    },
+    {
+      score: 0.99,
+      category: "illicit",
+      flagged: true,
+      continuation: false,
+      independent: false,
+    },
+    {
+      score: 0.01,
+      category: "sexual/minors",
+      flagged: true,
+      continuation: false,
+      independent: false,
+    },
+    {
+      score: NaN,
+      category: "illicit",
+      flagged: false,
+      continuation: false,
+      independent: false,
+    },
+  ])(
+    "separates continuity from the lower threshold while retaining restrictions: %j",
+    async ({ score, category, flagged, continuation, independent }) => {
+      mockModerationsCreate.mockResolvedValue({
+        results: [
+          {
+            categories: { [category]: flagged },
+            category_scores: { [category]: score },
+          },
+        ],
+      });
+      expect(await getModerationResult(request, true)).toMatchObject({
+        shouldUncensorResponse: independent,
+        allowsAbliterationContinuation: continuation,
+      });
+      expect(mockModerationsCreate).toHaveBeenCalledTimes(1);
+    },
+  );
+  it("does not authorize continuity on API failure, missing scores or missing credentials", async () => {
+    mockModerationsCreate.mockRejectedValueOnce(new Error("offline"));
+    expect(
+      (await getModerationResult(request, true)).allowsAbliterationContinuation,
+    ).toBe(false);
+    mockModerationsCreate.mockResolvedValueOnce({
+      results: [{ categories: {}, category_scores: {} }],
+    });
+    expect(
+      (await getModerationResult(request, true)).allowsAbliterationContinuation,
+    ).toBe(false);
+    delete process.env.OPENAI_API_KEY;
+    expect(
+      (await getModerationResult(request, true)).allowsAbliterationContinuation,
+    ).toBe(false);
+  });
 });

--- a/lib/analytics/__tests__/abliterated-model.test.ts
+++ b/lib/analytics/__tests__/abliterated-model.test.ts
@@ -207,4 +207,71 @@ describe("Abliteration stream telemetry", () => {
     expect(await consume(create(), model([finishPart]))).toEqual([finishPart]);
     capture.mockReset();
   });
+  it("persists actual successful Abliteration use after later baseline steps", async () => {
+    const telemetry = create();
+    const parts = [{ type: "text-delta", id: "t", delta: "ok" }, finishPart];
+    expect(telemetry.getRoutingMarker(true).completed).toBe(false);
+    await consume(telemetry, model(parts));
+    await consume(
+      telemetry,
+      model([{ type: "response-metadata", modelId: "baseline" }, ...parts]),
+      1,
+    );
+    expect(telemetry.getRoutingMarker(true)).toEqual({
+      version: 1,
+      source: "moderation",
+      completed: true,
+    });
+    expect(telemetry.getRoutingMarker(false).completed).toBe(false);
+    telemetry.setMessageId("retry");
+    expect(telemetry.getRoutingMarker(true).completed).toBe(false);
+  });
+  it("does not persist failed, empty, or fallback output as an independent seed", async () => {
+    for (const parts of [
+      [finishPart],
+      [
+        { type: "text-delta", id: "t", delta: "partial" },
+        { type: "error", error: "failure" },
+      ],
+      [
+        { type: "response-metadata", modelId: "baseline" },
+        { type: "text-delta", id: "t", delta: "ok" },
+        finishPart,
+      ],
+    ]) {
+      const telemetry = create();
+      await consume(telemetry, model(parts));
+      expect(telemetry.getRoutingMarker(true).completed).toBe(false);
+    }
+  });
+  it("retains inherited provenance even when the provider succeeds", async () => {
+    const telemetry = new AbliteratedModelTelemetry({ capture }, "user", {
+      assignment: {
+        key: ABLITERATED_EXPERIMENT_KEY,
+        variant: "test",
+        modelKey: "model-abliterated",
+        baselineModel: "model-deepseek-v4-flash-0731",
+        selectionSource: "history",
+        independentHistoryCount: 2,
+      },
+      messageId: "m",
+      chatId: "c",
+      mode: "agent",
+      subscription: "pro",
+    });
+    await consume(
+      telemetry,
+      model([{ type: "text-delta", id: "t", delta: "ok" }, finishPart]),
+    );
+    expect(telemetry.getRoutingMarker(true)).toEqual({
+      version: 1,
+      source: "history",
+      completed: true,
+    });
+    expect(events("abliterated_model_exposed")[0].properties).toMatchObject({
+      selection_source: "history",
+      moderation_eligible: false,
+      independent_history_count: 2,
+    });
+  });
 });

--- a/lib/analytics/abliterated-model.ts
+++ b/lib/analytics/abliterated-model.ts
@@ -1,3 +1,4 @@
+import type { AbliterationRoutingMarker } from "@/lib/experiments/abliteration-history";
 import {
   wrapLanguageModel,
   type LanguageModel,
@@ -21,6 +22,8 @@ type StreamPart =
 export class AbliteratedModelTelemetry {
   private sequence = 0;
   private exposed = false;
+  private successfulAbliterationGeneration = false;
+  private selectionSource: "moderation" | "history";
   private readonly startedAt = Date.now();
   private readonly properties: Record<string, string | number | boolean>;
 
@@ -36,6 +39,7 @@ export class AbliteratedModelTelemetry {
       selectedModelOverride?: SelectedModel;
     },
   ) {
+    this.selectionSource = args.assignment.selectionSource ?? "moderation";
     this.properties = {
       experiment_key: args.assignment.key,
       experiment_variant: args.assignment.variant,
@@ -49,7 +53,10 @@ export class AbliteratedModelTelemetry {
       baseline_model: args.assignment.baselineModel,
       assigned_model: args.assignment.modelKey,
       generation_step_limit: ABLITERATION_MAX_GENERATION_STEPS,
-      moderation_eligible: true,
+      moderation_eligible: this.selectionSource === "moderation",
+      selection_source: this.selectionSource,
+      independent_history_count: args.assignment.independentHistoryCount ?? 0,
+      routing_version: 2,
       assigned_platform_authorization_context: isAbliterationModel(
         args.assignment.modelKey,
       )
@@ -79,7 +86,16 @@ export class AbliteratedModelTelemetry {
   setMessageId(messageId: string) {
     if (this.properties.message_id === messageId) return;
     this.properties.message_id = messageId;
+    this.successfulAbliterationGeneration = false;
     this.capture("abliterated_model_message_linked", {});
+  }
+
+  getRoutingMarker(completedResponse: boolean): AbliterationRoutingMarker {
+    return {
+      version: 1,
+      source: this.selectionSource,
+      completed: completedResponse && this.successfulAbliterationGeneration,
+    };
   }
 
   wrap(model: LanguageModel, stepIndex: number): LanguageModel {
@@ -115,6 +131,12 @@ export class AbliteratedModelTelemetry {
           ) => {
             if (terminal) return;
             terminal = true;
+            if (
+              outcome === "completed" &&
+              isAbliterationModel(responseModel) &&
+              isAbliterationModel(model.modelId)
+            )
+              this.successfulAbliterationGeneration = true;
             this.capture("abliterated_model_provider_outcome", {
               ...common(),
               outcome,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -458,6 +458,7 @@ export const createChatHandler = () => {
         selectedModel,
         sandboxFiles,
         platformAuthorized,
+        allowsAbliterationContinuation,
       } = await processChatMessages({
         messages: truncatedMessages,
         mode,
@@ -494,6 +495,9 @@ export const createChatHandler = () => {
         subscription,
         selectedModelOverride,
         moderationEligible: platformAuthorized,
+        allowsAbliterationContinuation,
+        independentAbliterationResponses:
+          fetched.independentAbliterationResponses,
         messages: processedMessages,
         limitRescue: Boolean(limitRescue),
       });
@@ -2677,6 +2681,11 @@ export const createChatHandler = () => {
                             generationTimeMs: Date.now() - streamStartTime,
                             finishReason: state.streamFinishReason,
                             usage: resolvedUsage ?? state.streamUsage,
+                            abliterationRouting:
+                              abliteratedTelemetry?.getRoutingMarker(
+                                !isAborted &&
+                                  state.streamFinishReason === "stop",
+                              ),
                             updateOnly: shouldUseUpdateOnlyForAbortedSave({
                               isAborted,
                               isUserInitiatedAbort,

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -788,5 +788,7 @@ export async function processChatMessages({
     selectedModel,
     sandboxFiles,
     platformAuthorized: moderationResult.shouldUncensorResponse,
+    allowsAbliterationContinuation:
+      moderationResult.allowsAbliterationContinuation,
   };
 }

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -1076,6 +1076,70 @@ describe("saveMessage", () => {
 });
 
 describe("getMessagesByChatId", () => {
+  it.each([false, true])(
+    "uses only backend provenance and disables inheritance on regenerate=%s",
+    async (regenerate) => {
+      const { getMessagesByChatId, mockQuery } =
+        await loadSaveMessageWithMocks();
+      const message = {
+        id: "u",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "continue" }],
+      };
+      const evidence = [
+        { id: "a", completed: true, independent: true },
+        { id: "b", completed: true, independent: true },
+      ];
+      mockQuery
+        .mockResolvedValueOnce({ id: "chat-1", user_id: "user-1" })
+        .mockResolvedValueOnce({
+          page: [message],
+          abliterationHistory: evidence,
+          isDone: true,
+          continueCursor: null,
+        });
+      const result = await getMessagesByChatId({
+        chatId: "chat-1",
+        userId: "user-1",
+        subscription: "pro",
+        newMessages: [],
+        regenerate,
+        mode: "agent",
+      });
+      expect(result.independentAbliterationResponses).toBe(regenerate ? 0 : 2);
+      expect(result.truncatedMessages).toEqual([message]);
+      expect(JSON.stringify(result.truncatedMessages)).not.toContain(
+        "independent",
+      );
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    },
+  );
+  it("ignores routing claims in client message metadata", async () => {
+    const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
+    mockQuery.mockResolvedValueOnce(null);
+    const result = await getMessagesByChatId({
+      chatId: "chat-1",
+      userId: "user-1",
+      subscription: "pro",
+      newMessages: [
+        {
+          id: "a",
+          role: "assistant",
+          parts: [{ type: "text", text: "answer" }],
+          metadata: {
+            abliterationRouting: {
+              version: 1,
+              source: "moderation",
+              completed: true,
+            },
+          },
+        },
+      ],
+      mode: "agent",
+    });
+    expect(result.independentAbliterationResponses).toBe(0);
+  });
+
   it("logs empty prompts as warnings instead of errors", async () => {
     const { getMessagesByChatId } = await loadSaveMessageWithMocks();
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -1506,4 +1570,27 @@ describe("deleteAllChatsForBackend", () => {
       errorSpy.mockRestore();
     }
   });
+});
+
+it("persists server routing markers alongside usage only for assistant messages", async () => {
+  const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
+  const marker = {
+    version: 1 as const,
+    source: "moderation" as const,
+    completed: true,
+  };
+  for (const role of ["assistant", "user"] as const) {
+    await saveMessage({
+      chatId: "chat",
+      userId: "user",
+      message: { id: role, role, parts: [{ type: "text", text: "ok" }] },
+      usage: { inputTokens: 12 },
+      abliterationRouting: marker,
+    });
+  }
+  expect(mockMutation.mock.calls[0][1].usage).toEqual({
+    inputTokens: 12,
+    abliterationRouting: marker,
+  });
+  expect(mockMutation.mock.calls[1][1].usage).toEqual({ inputTokens: 12 });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1,4 +1,9 @@
 import "server-only";
+import {
+  countIndependentAbliterationResponses,
+  type AbliterationHistoryEntry,
+  type AbliterationRoutingMarker,
+} from "@/lib/experiments/abliteration-history";
 
 import { api } from "@/convex/_generated/api";
 import { ChatSDKError } from "../errors";
@@ -609,6 +614,7 @@ const databaseError = (
 
 type MessagesPageForBackendResult = {
   page: UIMessage[];
+  abliterationHistory?: AbliterationHistoryEntry[];
   fileTokens?: Array<{ fileId: Id<"files">; tokenSize: number }>;
   isDone: boolean;
   continueCursor: string | null;
@@ -977,6 +983,7 @@ export async function saveMessage({
   isHidden,
   wasAborted,
   wasPreemptiveTimeout,
+  abliterationRouting,
 }: {
   chatId: string;
   userId: string;
@@ -997,6 +1004,7 @@ export async function saveMessage({
   isHidden?: boolean;
   wasAborted?: boolean;
   wasPreemptiveTimeout?: boolean;
+  abliterationRouting?: AbliterationRoutingMarker;
 }) {
   let fixedParts = message.parts;
   let partsForSave = message.parts;
@@ -1076,8 +1084,11 @@ export async function saveMessage({
       ...fileIds,
       ...((extraFileIds || []).filter(Boolean) as string[]),
     ];
-    const usageForSave = sanitizeForConvexValue(usage) as
-      Record<string, unknown> | undefined;
+    const usageForSave = sanitizeForConvexValue(
+      message.role === "assistant" && abliterationRouting
+        ? { ...usage, abliterationRouting }
+        : usage,
+    ) as Record<string, unknown> | undefined;
 
     const mutationArgs = {
       serviceKey,
@@ -1366,6 +1377,7 @@ export async function getMessagesByChatId({
   let chat = undefined;
   let isNewChat = true;
   let existingMessages: UIMessage[] = [];
+  const abliterationHistory: AbliterationHistoryEntry[] = [];
 
   {
     // Check if chat exists first to avoid unnecessary Convex query
@@ -1409,6 +1421,7 @@ export async function getMessagesByChatId({
         while (pagesFetched < MAX_PAGES) {
           const pageResult: {
             page: UIMessage[];
+            abliterationHistory?: AbliterationHistoryEntry[];
             fileTokens?: Array<{
               fileId: Id<"files">;
               tokenSize: number;
@@ -1430,6 +1443,10 @@ export async function getMessagesByChatId({
             continueCursor: nextCursor,
           } = pageResult;
 
+          // Keep provenance outside model messages and token/summary projection.
+          // Regeneration may replace an answer, so it never inherits history.
+          if (!regenerate)
+            abliterationHistory.push(...(pageResult.abliterationHistory ?? []));
           fetchedDesc = fetchedDesc.concat(page);
           pagesFetched++;
 
@@ -1589,6 +1606,8 @@ export async function getMessagesByChatId({
               chat,
               isNewChat,
               fileTokens: fileTokensFromLoop,
+              independentAbliterationResponses:
+                countIndependentAbliterationResponses(abliterationHistory),
             };
           }
 
@@ -1598,6 +1617,8 @@ export async function getMessagesByChatId({
             chat,
             isNewChat,
             fileTokens: fileTokensFromLoop,
+            independentAbliterationResponses:
+              countIndependentAbliterationResponses(abliterationHistory),
           };
         }
       } catch (error) {
@@ -1716,7 +1737,13 @@ export async function getMessagesByChatId({
     );
   }
 
-  return { truncatedMessages, chat, isNewChat, fileTokens };
+  return {
+    truncatedMessages,
+    chat,
+    isNewChat,
+    fileTokens,
+    independentAbliterationResponses: 0,
+  };
 }
 
 export async function getUserCustomization({ userId }: { userId: string }) {

--- a/lib/experiments/__tests__/abliterated-model.test.ts
+++ b/lib/experiments/__tests__/abliterated-model.test.ts
@@ -1,6 +1,7 @@
 import {
   evaluateAbliteratedModel,
   ABLITERATED_EXPERIMENT_KEY,
+  ABLITERATION_CONTINUITY_FLAG,
 } from "../abliterated-model";
 import { ABLITERATION_MAX_IMAGES_PER_REQUEST } from "@/lib/ai/abliteration-media";
 import type { UIMessage } from "ai";
@@ -332,5 +333,97 @@ describe("moderation-gated Abliteration assignment", () => {
       }),
     ).toBeUndefined();
     expect(getFeatureFlag).not.toHaveBeenCalled();
+  });
+  const historyDefaults = {
+    ...defaults,
+    moderationEligible: false,
+    allowsAbliterationContinuation: true,
+    independentAbliterationResponses: 2,
+  };
+  it("uses history only within parent treatment and an explicitly enabled continuity flag", async () => {
+    const getFeatureFlag = jest
+      .fn()
+      .mockImplementation(async (key: string) =>
+        key === ABLITERATION_CONTINUITY_FLAG ? true : "test",
+      );
+    await expect(
+      evaluateAbliteratedModel({
+        ...historyDefaults,
+        posthog: { getFeatureFlag },
+      }),
+    ).resolves.toMatchObject({
+      modelKey: ABLITERATION_MODEL_KEY,
+      selectionSource: "history",
+      independentHistoryCount: 2,
+    });
+    expect(getFeatureFlag).toHaveBeenCalledTimes(2);
+  });
+  it.each([
+    { allowsAbliterationContinuation: false },
+    { independentAbliterationResponses: 1 },
+    { independentAbliterationResponses: NaN },
+    { subscription: "free" as SubscriptionTier },
+    { limitRescue: true },
+    {
+      messages: [
+        {
+          id: "file",
+          role: "user" as const,
+          parts: [
+            {
+              type: "file" as const,
+              mediaType: "application/pdf",
+              url: "https://example.test/a.pdf",
+            },
+          ],
+        },
+      ],
+    },
+  ])("preserves all eligibility gates for history: %j", async (overrides) => {
+    const getFeatureFlag = jest.fn().mockResolvedValue(true);
+    await expect(
+      evaluateAbliteratedModel({
+        ...historyDefaults,
+        ...overrides,
+        posthog: { getFeatureFlag },
+      }),
+    ).resolves.toBeUndefined();
+    expect(getFeatureFlag).not.toHaveBeenCalled();
+  });
+  it.each([false, undefined, "test"])(
+    "fails closed on continuity flag %s",
+    async (value) => {
+      const getFeatureFlag = jest
+        .fn()
+        .mockResolvedValueOnce("test")
+        .mockResolvedValueOnce(value);
+      await expect(
+        evaluateAbliteratedModel({
+          ...historyDefaults,
+          posthog: { getFeatureFlag },
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+  it("does not move parent controls into continuity treatment", async () => {
+    const getFeatureFlag = jest.fn().mockResolvedValue("control");
+    await expect(
+      evaluateAbliteratedModel({
+        ...historyDefaults,
+        posthog: { getFeatureFlag },
+      }),
+    ).resolves.toBeUndefined();
+    expect(getFeatureFlag).toHaveBeenCalledTimes(1);
+  });
+  it("keeps independent moderation selection independent even with enough history", async () => {
+    const getFeatureFlag = jest.fn().mockResolvedValue("test");
+    await expect(
+      evaluateAbliteratedModel({
+        ...historyDefaults,
+        moderationEligible: true,
+        posthog: { getFeatureFlag },
+      }),
+    ).resolves.toMatchObject({ selectionSource: "moderation" });
+    expect(getFeatureFlag).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/experiments/__tests__/abliteration-history.test.ts
+++ b/lib/experiments/__tests__/abliteration-history.test.ts
@@ -1,0 +1,74 @@
+import {
+  countIndependentAbliterationResponses,
+  getAbliterationHistoryEntry,
+  stripClientAbliterationRouting,
+} from "../abliteration-history";
+
+const entry = (
+  id: string,
+  source = "moderation",
+  completed = true,
+  finish_reason = "stop",
+) =>
+  getAbliterationHistoryEntry({
+    id,
+    finish_reason,
+    usage: { abliterationRouting: { version: 1, source, completed } },
+  });
+
+describe("recent Abliteration history", () => {
+  it("counts independent completed responses only, newest first", () => {
+    expect(
+      countIndependentAbliterationResponses([
+        entry("incomplete", "moderation", true, "error"),
+        entry("a"),
+        entry("history", "history"),
+        entry("fallback", "moderation", false),
+        entry("b"),
+      ]),
+    ).toBe(2);
+  });
+  it("expires old seeds and never renews them from inherited responses", () => {
+    expect(
+      countIndependentAbliterationResponses([
+        ...Array.from({ length: 4 }, (_, i) => entry(String(i), "history")),
+        entry("a"),
+        entry("b"),
+      ]),
+    ).toBe(1);
+    expect(
+      countIndependentAbliterationResponses([entry("a"), entry("a")]),
+    ).toBe(1);
+  });
+  it("does not infer independent use from final model or unknown metadata", () => {
+    for (const usage of [
+      undefined,
+      {},
+      {
+        abliterationRouting: {
+          version: 2,
+          source: "moderation",
+          completed: true,
+        },
+      },
+      { abliterationRouting: "moderation" },
+    ]) {
+      expect(
+        getAbliterationHistoryEntry({ id: "a", finish_reason: "stop", usage })
+          .independent,
+      ).toBe(false);
+    }
+  });
+  it("removes client routing claims without losing usage counters", () => {
+    expect(
+      stripClientAbliterationRouting({
+        inputTokens: 12,
+        abliterationRouting: {
+          version: 1,
+          source: "moderation",
+          completed: true,
+        },
+      }),
+    ).toEqual({ inputTokens: 12 });
+  });
+});

--- a/lib/experiments/abliterated-model.ts
+++ b/lib/experiments/abliterated-model.ts
@@ -1,3 +1,4 @@
+import { ABLITERATION_HISTORY_THRESHOLD } from "./abliteration-history";
 import type { PostHog } from "posthog-node";
 import type { UIMessage } from "ai";
 import type { SelectedModel, SubscriptionTier } from "@/types";
@@ -11,11 +12,14 @@ import {
 import { uiMessagesContainImageViewResult } from "@/lib/chat/multimodal-tool-result-recovery";
 
 export const ABLITERATED_EXPERIMENT_KEY = "abliterated_paid_moderated_v1";
+export const ABLITERATION_CONTINUITY_FLAG = "abliteration_chat_continuity_v1";
 export type AbliteratedAssignment = ExperimentAnalyticsContext & {
   key: typeof ABLITERATED_EXPERIMENT_KEY;
   variant: "control" | "test";
   modelKey: ModelName;
   baselineModel: ModelName;
+  selectionSource?: "moderation" | "history";
+  independentHistoryCount?: number;
 };
 
 const LARGE_V2_BASELINE_MODELS = new Set<ModelName>([
@@ -83,6 +87,8 @@ export async function evaluateAbliteratedModel({
   subscription,
   selectedModelOverride,
   moderationEligible,
+  allowsAbliterationContinuation = false,
+  independentAbliterationResponses = 0,
   messages,
   limitRescue = false,
 }: {
@@ -92,16 +98,22 @@ export async function evaluateAbliteratedModel({
   subscription: SubscriptionTier;
   selectedModelOverride?: SelectedModel;
   moderationEligible: boolean;
+  allowsAbliterationContinuation?: boolean;
+  independentAbliterationResponses?: number;
   messages: UIMessage[];
   limitRescue?: boolean;
 }): Promise<AbliteratedAssignment | undefined> {
+  const historyEligible =
+    allowsAbliterationContinuation &&
+    Number.isInteger(independentAbliterationResponses) &&
+    independentAbliterationResponses >= ABLITERATION_HISTORY_THRESHOLD;
   if (
     !posthog ||
     !isAbliterationConfigured() ||
     !isEligibleForAbliteratedModel({
       subscription,
       selectedModelOverride,
-      moderationEligible,
+      moderationEligible: moderationEligible || historyEligible,
       messages,
       limitRescue,
     })
@@ -120,7 +132,22 @@ export async function evaluateAbliteratedModel({
       },
     );
     if (variant !== "test" && variant !== "control") return undefined;
+    if (!moderationEligible) {
+      // History is a preference within parent treatment, never an authorization.
+      if (variant !== "test") return undefined;
+      const continuityEnabled = await posthog.getFeatureFlag(
+        ABLITERATION_CONTINUITY_FLAG,
+        userId,
+        {
+          sendFeatureFlagEvents: false,
+          personProperties: { subscription, subscription_tier: subscription },
+        },
+      );
+      if (continuityEnabled !== true) return undefined;
+    }
     return {
+      selectionSource: moderationEligible ? "moderation" : "history",
+      independentHistoryCount: independentAbliterationResponses,
       key: ABLITERATED_EXPERIMENT_KEY,
       variant,
       modelKey:

--- a/lib/experiments/abliteration-history.ts
+++ b/lib/experiments/abliteration-history.ts
@@ -1,0 +1,67 @@
+/** Server-owned metadata stored inside the existing messages.usage object. */
+export type AbliterationRoutingMarker = {
+  version: 1;
+  source: "moderation" | "history";
+  completed: boolean;
+};
+
+export type AbliterationHistoryEntry = {
+  id: string;
+  completed: boolean;
+  independent: boolean;
+};
+
+export const ABLITERATION_HISTORY_WINDOW = 5;
+export const ABLITERATION_HISTORY_THRESHOLD = 2;
+
+export function getAbliterationHistoryEntry(message: {
+  id: string;
+  finish_reason?: string;
+  usage?: unknown;
+}): AbliterationHistoryEntry {
+  const usage = message.usage;
+  const marker =
+    usage && typeof usage === "object" && "abliterationRouting" in usage
+      ? usage.abliterationRouting
+      : undefined;
+  const completed = message.finish_reason === "stop";
+  return {
+    id: message.id,
+    completed,
+    independent:
+      completed &&
+      !!marker &&
+      typeof marker === "object" &&
+      "version" in marker &&
+      marker.version === 1 &&
+      "source" in marker &&
+      marker.source === "moderation" &&
+      "completed" in marker &&
+      marker.completed === true,
+  };
+}
+
+/** Input is newest-first, fetched by the authenticated backend, never client metadata. */
+export function countIndependentAbliterationResponses(
+  entries: AbliterationHistoryEntry[],
+): number {
+  const seen = new Set<string>();
+  return entries
+    .filter((entry) => {
+      if (seen.has(entry.id)) return false;
+      seen.add(entry.id);
+      return entry.completed;
+    })
+    .slice(0, ABLITERATION_HISTORY_WINDOW)
+    .filter((entry) => entry.independent).length;
+}
+
+/** Client stop-save can preserve usage, but cannot assert routing provenance. */
+export function stripClientAbliterationRouting(usage: unknown): unknown {
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return usage;
+  const { abliterationRouting: _untrusted, ...rest } = usage as Record<
+    string,
+    unknown
+  >;
+  return rest;
+}

--- a/lib/moderation.ts
+++ b/lib/moderation.ts
@@ -6,11 +6,13 @@ const MODERATION_TOKEN_LIMIT = 512;
 
 export type ModerationResult = {
   shouldUncensorResponse: boolean;
+  allowsAbliterationContinuation: boolean;
   moderationText: string;
 };
 
 const emptyModerationResult = (): ModerationResult => ({
   shouldUncensorResponse: false,
+  allowsAbliterationContinuation: false,
   moderationText: "",
 });
 
@@ -45,7 +47,7 @@ export async function getModerationResult(
     // Check if moderation results exist and are not empty
     if (!moderation?.results || moderation.results.length === 0) {
       console.error("Moderation API returned no results");
-      return { shouldUncensorResponse: false, moderationText: input };
+      return { ...emptyModerationResult(), moderationText: input };
     }
 
     const result = moderation.results[0];
@@ -60,7 +62,17 @@ export async function getModerationResult(
       isPaidUser,
     );
 
-    return { shouldUncensorResponse, moderationText: input };
+    const allowsAbliterationContinuation = determineShouldUncensorResponse(
+      moderationLevel,
+      hazardCategories,
+      isPaidUser,
+      0,
+    );
+    return {
+      shouldUncensorResponse,
+      allowsAbliterationContinuation,
+      moderationText: input,
+    };
   } catch (_error: any) {
     return emptyModerationResult();
   }
@@ -167,18 +179,26 @@ function truncateByTokens(content: string): string {
 function calculateModerationLevel(
   categoryScores: OpenAI.Moderations.Moderation.CategoryScores,
 ): number {
-  const maxScore = Math.max(
-    ...Object.values(categoryScores).filter(
-      (score): score is number => typeof score === "number",
-    ),
-  );
-  return Math.min(Math.max(maxScore, 0), 1);
+  const scores = Object.values(categoryScores);
+  if (
+    !scores.length ||
+    scores.some(
+      (score) =>
+        typeof score !== "number" ||
+        !Number.isFinite(score) ||
+        score < 0 ||
+        score > 1,
+    )
+  )
+    return NaN;
+  return Math.max(...scores);
 }
 
 function determineShouldUncensorResponse(
   moderationLevel: number,
   hazardCategories: string[],
   isPaidUser: boolean,
+  minModerationLevel = 0.1,
 ): boolean {
   const forbiddenCategories = [
     "sexual",
@@ -198,7 +218,6 @@ function determineShouldUncensorResponse(
   );
 
   // 0.1 is the minimum moderation level for the model to be used
-  const minModerationLevel = 0.1;
   const maxModerationLevel = isPaidUser ? 0.98 : 0.9;
   return (
     moderationLevel >= minModerationLevel &&

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2636,6 +2636,7 @@ export const agentLongTask = task({
         selectedModel,
         sandboxFiles,
         platformAuthorized,
+        allowsAbliterationContinuation,
       } = await processChatMessages({
         messages: messagesForProcessing,
         mode,
@@ -2670,6 +2671,9 @@ export const agentLongTask = task({
         subscription,
         selectedModelOverride,
         moderationEligible: platformAuthorized,
+        allowsAbliterationContinuation,
+        independentAbliterationResponses:
+          fetched.independentAbliterationResponses,
         messages: processedMessages,
         limitRescue: Boolean(limitRescue),
       });
@@ -5473,6 +5477,11 @@ export const agentLongTask = task({
                             generationTimeMs: finalGenerationTimeMs,
                             finishReason: state.streamFinishReason,
                             usage: resolvedUsage ?? state.streamUsage,
+                            abliterationRouting:
+                              abliteratedTelemetry?.getRoutingMarker(
+                                !isAborted &&
+                                  state.streamFinishReason === "stop",
+                              ),
                             updateOnly: shouldUseUpdateOnlyForAbortedSave({
                               isAborted,
                               isUserInitiatedAbort,


### PR DESCRIPTION
A short follow-up can lose the Abliteration route even after repeated independently selected responses in the same chat. Add a separate continuity flag that retains the provider when at least two of the last five completed visible assistant responses independently used it.

New-input moderation still runs and retains forbidden-category exclusions, upper score limits, and fail-closed errors. Paid targeting, parent control/test assignment, attachment and rescue gates, provider fallback, and the current one-generation-step cap remain intact. Regeneration does not inherit history.

The backend stores versioned provenance inside existing message usage metadata, without a schema migration. Failed/empty/fallback-only responses and inherited selections cannot seed the preference; later OpenRouter steps do not erase earlier successful Abliteration use. Client stop-save strips routing claims. Metadata travels alongside existing bounded history pages, outside prompts and summaries. Analytics distinguish moderation from history routing without user content.

Validation: 470 suites / 4,947 tests pass; TypeScript, ESLint and formatting checks pass. Tests cover expiration, duplicate IDs, inherited provenance, moderation restrictions/failures, parent/continuity flags, server-only persistence, client forgery, regeneration, and provider fallback.

Rollout: `abliteration_chat_continuity_v1` is active at 100% of eligible Preview users in PostHog 401167 (flag 870188), and inactive at 0% in Production 144137 (flag 870186). Parent flags are unchanged. Production activation is held for a separate readout/decision. Owner, metrics, rollback and cleanup are recorded in HAC-99 and the pilot document.

Live Preview verification completed on commit `0d6dcad4` with a disposable paid chat, real moderation and provider calls:

- Two initial conceptual lab questions independently selected Abliteration and persisted as independent seeds. The existing three-user-message moderation context also selected the next two replies independently.
- Once that context expired, a neutral follow-up completed with `selection_source=history`, `moderation_eligible=false`, and four independent recent responses. Its saved marker did not count as independent.
- A bounded terminal `printf` run used `abliterated-model` for generation step 1, then `deepseek/deepseek-v4-flash-0731` through OpenRouter for step 2, and completed successfully.
- Further neutral follow-ups used history at counts three and two. At one remaining independent response, normal OpenRouter routing resumed. All nine runs completed; answers remained visible after reload.
- Convex backend read-back showed the expected independent flags, kept outside prompt messages. No live history markers were inserted or edited for testing.

Verified environment mapping: HackerAI Development / `hackerai-52290` / Preview `woozy-ibex-452`, URL `https://woozy-ibex-452.convex.cloud`; Vercel branch alias below resolves to this commit. Trigger Preview branch `codex/abliteration-chat-continuity`, worker `20260907.1`, receives this Convex URL from the authenticated Vercel request. Vercel and Trigger both use development PostHog 401167 and matching Preview service-key fingerprints. Production configuration was not changed beyond creating the inactive continuity flag.

[Preview test chat](https://hackerai-git-codex-abliteration-chat-continuity-hackerai.vercel.app/c/2f56b8b1-949a-41bc-b26a-7cb2549625d2). The disposable chat and branch deployments are retained for review. Temporary downloaded local credentials were removed.

Manual reviewer check: open the Preview test chat and verify the saved answers and single terminal call. Automated fixtures cover regeneration, client forgery, forbidden categories, API failure, provider failure, and Large v2 routing; those error paths were not induced against the live service. Production remains inactive pending review and a rollout decision.

Refs HAC-99.
