### PR TITLE
Remove unused metadata schema to shrink public-page bundles

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,5 +1,4 @@
 import { UIMessage } from "ai";
-import { z } from "zod";
 import { Id } from "@/convex/_generated/dataModel";
 import type { FileDetails, FilePart } from "./file";
 
@@ -483,16 +482,14 @@ export interface TodoWriteInput {
 
 export type ChatStatus = "submitted" | "streaming" | "ready" | "error";
 
-export const messageMetadataSchema = z.object({
-  feedbackType: z.enum(["positive", "negative"]).optional(),
-  isAutoContinue: z.boolean().optional(),
-  mode: z.enum(["agent", "ask"]).optional(),
-  createdAt: z.number().optional(),
-  generationStartedAt: z.number().optional(),
-  generationTimeMs: z.number().optional(),
-});
-
-export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
+export type MessageMetadata = {
+  feedbackType?: "positive" | "negative";
+  isAutoContinue?: boolean;
+  mode?: "agent" | "ask";
+  createdAt?: number;
+  generationStartedAt?: number;
+  generationTimeMs?: number;
+};
 
 export type ChatMessage = UIMessage<MessageMetadata> & {
   createdAt?: number;


### PR DESCRIPTION
Public pages loaded Zod through `app/layout.tsx → GlobalState → types/chat.ts`, even though `messageMetadataSchema` had no runtime callers and existed only to infer a TypeScript type. Replace that unused schema with the equivalent six-field `MessageMetadata` type, removing Zod initialization from this shared import path.

## Measured impact

Next.js 16.3.4 `corepack pnpm next experimental-analyze --output`, before and after the change on base `2d72252b`:

| Route | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `/privacy-policy` | 425,207 B | 293,835 B | 30.9% |
| `/trust` | 441,328 B | 309,956 B | 29.8% |
| `/pricing` | 444,511 B | 313,139 B | 29.6% |

Each public route removes 131,372 estimated compressed bytes, 393,507 raw bytes, and 88 synchronous client sources. These sum the analyzer's independently compressed JavaScript module estimates, filtering `[client-fs]/` output parts and `[app-client]` module identities reachable before dynamic imports. They are not measured network transfer or Web Vitals. Chat and shared-chat estimates are effectively unchanged because their AI features still use Zod.

Repository-wide tracing found no runtime, namespace, dynamic-import, framework-entrypoint, or package-export consumer of the removed schema. An in-memory TypeScript equality check confirmed the replacement exactly matches the previous inferred type. No runtime validation, files, or tests were removed. No product behavior or rollout changes are introduced.

## Validation

- `corepack pnpm typecheck` — also passed after rebasing onto `fa3dda64`
- `corepack pnpm lint` — no errors, four existing warnings
- `corepack pnpm test --runInBand` — 465 suites / 4,897 tests passed before and after the change; after rebasing onto current main (`fa3dda64`), 469 suites / 4,915 tests passed
- Focused `useAutoContinue` coverage — 16 tests passed
- `corepack pnpm test:user-research-runner` — five tests passed
- `corepack pnpm skills:sync:strix:check` — passed
- `corepack pnpm exec prettier --check types/chat.ts` and `git diff --check` — passed
- `corepack pnpm next experimental-analyze --output` — passed before and after
- `corepack pnpm next build` — production Turbopack build passed
- Repository `format:check` still reports ten pre-existing, untouched files
- Actual Google Chrome against the local production build: Privacy/Trust/Pricing render, client navigation, consent Decline, and yearly pricing selection passed

## Remaining manual verification

Authenticated chat verification remains blocked locally: this worktree's configured Convex backend at `127.0.0.1:3210` is not running, and the intended replacement Preview account/project/deployment mapping is unverified. No environment settings or credentials were changed. Public-page Chrome checks do not establish authenticated chat correctness.

1. In the designated authenticated Preview environment, send a disposable bounded Ask request. Verify response rendering, completion metadata, and persistence after reload.
2. Exercise loading and connection-recovery feedback; existing behavior should remain intact.
3. Recheck Privacy → Trust → Pricing navigation, consent controls, and monthly/yearly display in Chrome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced schema-derived message metadata declarations with an explicit metadata type.
  * Removed the unused validation dependency and the previously exported metadata schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->