### PR TITLE
HAC-99: Extend Abliteration pilot to free Agent users

### DIFF
--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -226,12 +226,13 @@ References: [provider models](https://docs.abliteration.ai/models),
 
 ## Free Agent pilot
 
-Free Agent rollout is governed by HAC-99. Preview targets all eligible free Agent
-testers with test assignment. The initial Production free group is 10% enrollment
+Free Agent rollout is governed by HAC-99. Preview flag 869147 was updated on
+2026-09-07 to target all eligible free Agent testers with test assignment. The
+planned initial Production free group is 10% enrollment
 with the existing 50/50 control/test split (approximately 5% treatment); the other
 90% retain baseline without experiment assignment. Existing paid groups and their
-internal override are unchanged. These are the planned settings; record verified
-activation and runtime evidence in HAC-99 before calling the pilot live.
+internal override are unchanged. Record verified Production activation and runtime
+evidence in HAC-99 before calling the pilot live.
 
 Compare free control/test users separately from paid users and from earlier routing
 phases. Prioritize useful results, linked thumbs, and task-outcome ratings only

--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -8,7 +8,7 @@ so base and Large v2 traffic can be checked independently.
 
 ## Routing contract
 
-Paid requests in Ask and Agent may use an Abliteration model at
+Paid requests in Ask and Agent, and free requests in Agent only, may use an Abliteration model at
 `https://api.abliteration.ai/v1`. Auto/Standard routes use `abliterated-model`;
 explicit HackerAI Pro and Max routes use `abliterated-model-large-v2`. Ultra Ask
 Auto also uses Large v2 because its current baseline is Pro, while Ultra Agent
@@ -33,7 +33,10 @@ Explicit free-allowance rescue requests are excluded before assignment. Eligibil
 is recorded before model-priced budget checks so cost-induced blocking cannot
 silently remove treatment users from the denominator.
 
-Free subscriptions and paid daily free-allowance rescue requests are excluded.
+Free Ask and paid daily free-allowance rescue requests are excluded. Free Agent
+treatment uses the base model and preserves its exact free OpenRouter baseline
+for control, later steps and provider recovery. Existing free quota/concurrency
+checks and local-sandbox entitlement still apply; this does not grant cloud access.
 Every control retains its exact existing baseline. Analyze provider model,
 selector, subscription, input modality, and mode separately as well as overall.
 
@@ -64,7 +67,10 @@ Definitions read back on 2026-09-06 after Production enrollment was expanded.
 | Preview     | hackerai-dev / 401167 | 869147  | abliterated_paid_moderated_v1 | Active; 100% of eligible paid users, forced test                         |
 | Production  | HackerAI / 144137     | 869145  | abliterated_paid_moderated_v1 | Active; 100% enrollment, 50/50 control/test, approximately 50% treatment |
 
-Both definitions target `subscription_tier` in `pro`, `pro-plus`, `ultra`, `team`.
+Paid groups target `subscription_tier` in `pro`, `pro-plus`, `ultra`, `team`.
+The free Agent extension adds a separate `subscription_tier=free` group, with the
+mode enforced in code before any flag evaluation. The legacy flag key is retained
+to preserve stable assignment and analytics joins. Free Ask never evaluates it.
 The server supplies the current trusted subscription and enforces the remaining
 eligibility checks. Production evaluates the explicit test-user override first,
 then the broader paid-user experiment group. Keep override traffic out of the
@@ -194,7 +200,7 @@ For release verification on the verified Preview custom URL:
    request. Confirm moderation eligibility, streaming completion, model attribution,
    one exposure, and reload persistence. Repeat in Agent with one bounded tool call.
 2. Confirm benign/unflagged requests, prohibited-category moderation results,
-   moderation failure, free users, PDFs, other unsupported files, and free-allowance
+   moderation failure, free Ask users, PDFs, other unsupported files, and free-allowance
    rescue keep their baseline routes. Confirm image requests use the base Abliteration
    model for Standard, Pro, and Max while text-only Pro/Max requests use Large v2.
    Unit tests cover deterministic gates; use approved synthetic fixtures for
@@ -217,3 +223,31 @@ References: [provider models](https://docs.abliteration.ai/models),
 [AI SDK integration](https://docs.abliteration.ai/integrations/vercel-ai-sdk),
 [PostHog exposure semantics](https://posthog.com/docs/experiments/exposures),
 [PostHog retention](https://posthog.com/docs/product-analytics/retention).
+
+## Free Agent pilot
+
+Free Agent rollout is governed by HAC-99. Preview targets all eligible free Agent
+testers with test assignment. The initial Production free group is 10% enrollment
+with the existing 50/50 control/test split (approximately 5% treatment); the other
+90% retain baseline without experiment assignment. Existing paid groups and their
+internal override are unchanged. These are the planned settings; record verified
+activation and runtime evidence in HAC-99 before calling the pilot live.
+
+Compare free control/test users separately from paid users and from earlier routing
+phases. Prioritize useful results, linked thumbs, and task-outcome ratings only
+where the separate survey flag already permits them. Missing ratings are unknown.
+Track completion, return usage, free-to-paid conversion, quota exhaustion, provider
+fallbacks, tool failures and cost per completed task. Paid churn does not apply to
+free users. Do not widen the survey flag as part of the provider rollout.
+
+Review the free cohort operationally on 2026-09-08 and review quality on 2026-09-14;
+keep uncertainty and mature retention windows explicit. Remove the free flag group
+to roll back just this cohort. No automatic ramp. Full temporary survey removal
+at experiment conclusion remains mandatory under HAC-101.
+
+Verify a free Agent test and control on the designated Preview: completed first
+step, exact free baseline on step two, provider failure recovery, original request
+attribution, unchanged quotas and sandbox permissions, and reload persistence.
+Also verify free Ask never evaluates this experiment and missing/off/unknown flags
+retain baseline. Use a free test account with a connected local sandbox, then
+verify a bounded production free-cohort run before expansion.

--- a/docs/internal/task-outcome-feedback.md
+++ b/docs/internal/task-outcome-feedback.md
@@ -61,7 +61,9 @@ Flag `task_outcome_feedback_v1` is independent from provider assignment:
 | Preview     | hackerai-dev / 401167 | 869527  | Active, 100% eligible test population         |
 | Production  | HackerAI / 144137     | 869525  | Active, only designated internal test account |
 
-Application additionally requires the existing paid/moderation experiment.
+Application additionally requires assignment to the existing moderation-gated
+provider experiment. Free users are eligible only in Agent mode; this does not
+expand the independent Production feedback allowlist.
 Selection checks the server flag; the browser displays only server-reserved
 invitations because browser feature-flag fetching is disabled application-wide.
 Missing or failed evaluation suppresses selection. Turning off the flag stops new

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -2227,6 +2227,11 @@ export const createChatHandler = () => {
                                       generationTimeMs:
                                         Date.now() - fallbackStartTime,
                                       finishReason: state.streamFinishReason,
+                                      abliterationRouting:
+                                        abliteratedTelemetry?.getRoutingMarker(
+                                          !retryAborted &&
+                                            state.streamFinishReason === "stop",
+                                        ),
                                     });
                                   }
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -492,6 +492,7 @@ export const createChatHandler = () => {
         userId,
         selectedModel,
         subscription,
+        mode,
         selectedModelOverride,
         moderationEligible: platformAuthorized,
         messages: processedMessages,

--- a/lib/experiments/__tests__/abliterated-model.test.ts
+++ b/lib/experiments/__tests__/abliterated-model.test.ts
@@ -94,6 +94,7 @@ describe("moderation-gated Abliteration assignment", () => {
     ] as unknown as UIMessage[];
   const defaults = {
     userId: "u",
+    mode: "ask" as const,
     subscription: "pro" as SubscriptionTier,
     selectedModel: "model-deepseek-v4-flash-0731",
     moderationEligible: true,
@@ -155,6 +156,68 @@ describe("moderation-gated Abliteration assignment", () => {
     ).toBeUndefined();
     expect(getFeatureFlag).not.toHaveBeenCalled();
   });
+
+  it.each(["test", "control"] as const)(
+    "routes free Agent %s assignments while retaining their original free baseline",
+    async (variant) => {
+      const getFeatureFlag = jest.fn().mockResolvedValue(variant);
+      const result = await evaluateAbliteratedModel({
+        ...defaults,
+        mode: "agent",
+        subscription: "free",
+        selectedModel: "agent-model-free",
+        posthog: { getFeatureFlag },
+      });
+      expect(result).toMatchObject({
+        variant,
+        modelKey:
+          variant === "test" ? ABLITERATION_MODEL_KEY : "agent-model-free",
+        baselineModel: "agent-model-free",
+      });
+      expect(getFeatureFlag).toHaveBeenCalledWith(
+        ABLITERATED_EXPERIMENT_KEY,
+        "u",
+        {
+          sendFeatureFlagEvents: false,
+          personProperties: { subscription: "free", subscription_tier: "free" },
+        },
+      );
+    },
+  );
+  it.each([
+    { moderationEligible: false },
+    { limitRescue: true },
+    { messages: [] },
+    {
+      messages: [
+        {
+          id: "pdf",
+          role: "user" as const,
+          parts: [
+            {
+              type: "file" as const,
+              mediaType: "application/pdf",
+              url: "https://example.test/lab.pdf",
+            },
+          ],
+        },
+      ],
+    },
+  ])("keeps free Agent safeguards: %j", async (overrides) => {
+    const getFeatureFlag = jest.fn().mockResolvedValue("test");
+    expect(
+      await evaluateAbliteratedModel({
+        ...defaults,
+        mode: "agent",
+        subscription: "free",
+        selectedModel: "agent-model-free",
+        ...overrides,
+        posthog: { getFeatureFlag },
+      }),
+    ).toBeUndefined();
+    expect(getFeatureFlag).not.toHaveBeenCalled();
+  });
+
   it("keeps a request at the Abliteration image limit eligible", async () => {
     const getFeatureFlag = jest.fn().mockResolvedValue("test");
 

--- a/lib/experiments/__tests__/abliterated-model.test.ts
+++ b/lib/experiments/__tests__/abliterated-model.test.ts
@@ -426,6 +426,7 @@ describe("moderation-gated Abliteration assignment", () => {
     { independentAbliterationResponses: 1 },
     { independentAbliterationResponses: NaN },
     { subscription: "free" as SubscriptionTier },
+    { subscription: "free" as SubscriptionTier, mode: "agent" as const },
     { limitRescue: true },
     {
       messages: [

--- a/lib/experiments/abliterated-model.ts
+++ b/lib/experiments/abliterated-model.ts
@@ -108,6 +108,7 @@ export async function evaluateAbliteratedModel({
   limitRescue?: boolean;
 }): Promise<AbliteratedAssignment | undefined> {
   const historyEligible =
+    subscription !== "free" &&
     allowsAbliterationContinuation &&
     Number.isInteger(independentAbliterationResponses) &&
     independentAbliterationResponses >= ABLITERATION_HISTORY_THRESHOLD;

--- a/lib/experiments/abliterated-model.ts
+++ b/lib/experiments/abliterated-model.ts
@@ -1,6 +1,6 @@
 import type { PostHog } from "posthog-node";
 import type { UIMessage } from "ai";
-import type { SelectedModel, SubscriptionTier } from "@/types";
+import type { ChatMode, SelectedModel, SubscriptionTier } from "@/types";
 import type { ModelName } from "@/lib/ai/providers";
 import type { ExperimentAnalyticsContext } from "@/lib/analytics/experiment-context";
 import {
@@ -56,12 +56,14 @@ const messagesContainUnsupportedFiles = (messages: UIMessage[]): boolean =>
 
 export function isEligibleForAbliteratedModel({
   subscription,
+  mode,
   selectedModelOverride,
   moderationEligible,
   messages,
   limitRescue = false,
 }: {
   subscription: SubscriptionTier;
+  mode: ChatMode;
   selectedModelOverride?: SelectedModel;
   moderationEligible: boolean;
   messages: UIMessage[];
@@ -69,7 +71,7 @@ export function isEligibleForAbliteratedModel({
 }): boolean {
   return (
     !limitRescue &&
-    subscription !== "free" &&
+    (subscription !== "free" || mode === "agent") &&
     moderationEligible &&
     messages.length > 0 &&
     !messagesContainUnsupportedFiles(messages)
@@ -81,6 +83,7 @@ export async function evaluateAbliteratedModel({
   userId,
   selectedModel,
   subscription,
+  mode,
   selectedModelOverride,
   moderationEligible,
   messages,
@@ -90,6 +93,7 @@ export async function evaluateAbliteratedModel({
   userId: string;
   selectedModel: ModelName;
   subscription: SubscriptionTier;
+  mode: ChatMode;
   selectedModelOverride?: SelectedModel;
   moderationEligible: boolean;
   messages: UIMessage[];
@@ -100,6 +104,7 @@ export async function evaluateAbliteratedModel({
     !isAbliterationConfigured() ||
     !isEligibleForAbliteratedModel({
       subscription,
+      mode,
       selectedModelOverride,
       moderationEligible,
       messages,

--- a/scripts/test-abliteration.ts
+++ b/scripts/test-abliteration.ts
@@ -31,6 +31,7 @@ async function main() {
       ? "model-deepseek-v4-pro-0813"
       : "model-deepseek-v4-flash-0731",
     subscription: "pro",
+    mode: "agent",
     selectedModelOverride: useLargeV2 ? "hackerai-pro" : "hackerai-standard",
     moderationEligible: true,
     messages: [

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2668,6 +2668,7 @@ export const agentLongTask = task({
         userId,
         selectedModel,
         subscription,
+        mode,
         selectedModelOverride,
         moderationEligible: platformAuthorized,
         messages: processedMessages,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -4522,6 +4522,9 @@ export const agentLongTask = task({
                   generationStartedAt: retryStartTime,
                   generationTimeMs: fallbackGenerationTimeMs,
                   finishReason: state.streamFinishReason,
+                  abliterationRouting: abliteratedTelemetry?.getRoutingMarker(
+                    !retryAborted && state.streamFinishReason === "stop",
+                  ),
                 });
               }
               writer.write({


### PR DESCRIPTION
Free users could not enter the Abliteration experiment even when using Agent mode. Allow moderation-eligible free Agent requests to participate while keeping free Ask on its existing route. Treatment uses `abliterated-model` for the first generation step, then returns to the original free model; fallback, quotas, concurrency, and sandbox permissions remain in place. History continuity remains paid-only, and completed retry messages retain routing provenance.

The existing PostHog key preserves paid assignments. Preview is enabled for 100% of eligible free Agent testers. Production rollout: 10% enrollment split equally between treatment and control (approximately 5% treatment), with paid targeting unchanged. Survey targeting is unchanged. Measurement, rollback, owner, review dates, and removal plans are recorded in HAC-99/HAC-101.

Validation: type checking and all 470 suites / 4,954 tests pass, including free Agent treatment/control, free Ask exclusion, free history-continuity exclusion, and moderation/file/rescue safeguards.

Real Preview verification used the authorized built-in free test account with an isolated local sandbox, without host mounts or Docker socket access. Two Agent runs completed: step 1 used `abliterated-model`; step 2 used `deepseek/deepseek-v4-flash-0731`. PostHog recorded one actual exposure and successful provider outcomes. The latest run, `run_06g7p3icc4e7iuuu2rb98lsme1`, used worker 20260907.3 on `hackerai-klvzrjr6g-hackerai.vercel.app`; its answer persisted after reload. A separate free Ask request completed on `z-ai/glm-5.3-flash`. The final review fixes were verified by the full automated suite.

Environment checks independently confirmed Preview PostHog 401167 in browser and Trigger, branch Convex `gregarious-octopus-971` in the HackerAI Development team, and Production PostHog 144137 in Trigger. Production Convex custom domain `convex.haiusercontent.com` is verified against `greedy-cod-889` in the HackerAI team. No runtime credentials or environment selections were changed.

All three disposable chats, the test survey row, and the temporary sandbox token/connection were deleted. The isolated container and image were removed, and Colima was restored to its original stopped state.

Manual production verification after deployment: start a new eligible free Agent run with a connected local sandbox; verify assigned treatment uses Abliteration on step 1 and the free baseline thereafter. Free Ask should remain on its normal route; existing free usage limits and local-sandbox requirements should remain enforced. Roll back by removing the Production free-tier flag group.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Free-tier Agent requests can now participate in the Abliteration Model pilot.
  - Eligible paid chats can retain treatment across qualifying follow-up responses.
  - Treatment requests preserve baseline behavior, quotas, concurrency checks, and sandbox restrictions.
  - Rollout targeting, evaluation metrics, verification cases, and rollback guidance distinguish free Agent traffic from paid and Ask traffic.

- **Bug Fixes**
  - Free Ask requests and other ineligible traffic remain excluded from the pilot.
  - Agent execution now receives the correct mode for experiment evaluation.
  - Continuation remains blocked when eligibility, moderation, or feature controls are not satisfied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->