### PR TITLE
Prevent Agent crashes when tokenizing large terminal output

### DIFF
--- a/lib/__tests__/token-utils.test.ts
+++ b/lib/__tests__/token-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
+import { decode, encode } from "gpt-tokenizer";
 import {
   getMaxTokensForSubscription,
   MAX_TOKENS_FREE,
@@ -21,6 +22,33 @@ describe("getMaxTokensForSubscription", () => {
     expect(getMaxTokensForSubscription("ultra")).toBe(MAX_TOKENS_PAID);
     expect(getMaxTokensForSubscription("team")).toBe(MAX_TOKENS_PAID);
     expect(getMaxTokensForSubscription()).toBe(MAX_TOKENS_PAID);
+  });
+});
+
+describe("large tokenizer batches", () => {
+  it("preserves every token in a split larger than the JS argument limit", () => {
+    // This is one BPE split with 150,000 tokens. gpt-tokenizer's encode()
+    // spreads that batch into push(), which overflows Node's call stack.
+    const content = "\u0001".repeat(150_000);
+    const tokens = safeEncode(content);
+
+    expect(tokens).toHaveLength(safeCountTokens(content));
+    expect(decode(tokens)).toBe(content);
+    expect(safeCountTokens(sliceByTokens(content, 20))).toBe(20);
+    expect(
+      safeCountTokens(truncateContent(content, "[cut]", 40)),
+    ).toBeLessThanOrEqual(40);
+  });
+
+  it.each([
+    "ordinary text and punctuation!\nnext line",
+    "你好 🌍 café\n",
+    "literal <|im_start|> sentinel <|im_end|>",
+    "",
+  ])("keeps exact BPE output for %j", (content) => {
+    expect(safeEncode(content)).toEqual(
+      encode(content, { disallowedSpecial: new Set() }),
+    );
   });
 });
 

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -1,7 +1,7 @@
 import { UIMessage, UIMessagePart } from "ai";
 import {
   countTokens as countGptTokens,
-  encode as encodeGptTokens,
+  encodeGenerator,
   decode,
 } from "gpt-tokenizer";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -15,6 +15,20 @@ export {
 } from "@/lib/token-limits";
 
 const DISALLOWED_SPECIAL_TOKEN_MESSAGE = "Disallowed special token";
+
+/** Collects exact BPE tokens without spreading a large batch into call arguments. */
+const encodeGptTokens = (
+  content: string,
+  options?: Parameters<typeof encodeGenerator>[1],
+): number[] => {
+  const tokens: number[] = [];
+  for (const batch of encodeGenerator(content, options)) {
+    // A single tokenizer split can exceed the JavaScript argument-count limit.
+    for (const token of batch) tokens.push(token);
+  }
+  return tokens;
+};
+
 const TOKENIZE_SPECIAL_TOKENS_AS_TEXT: NonNullable<
   Parameters<typeof encodeGptTokens>[1]
 > = {

--- a/lib/utils/__tests__/terminal-executor.test.ts
+++ b/lib/utils/__tests__/terminal-executor.test.ts
@@ -1,6 +1,36 @@
 import { createTerminalHandler } from "../terminal-executor";
+import { safeCountTokens, TOOL_DEFAULT_MAX_TOKENS } from "@/lib/token-utils";
 
 describe("createTerminalHandler", () => {
+  test("returns bounded head/tail output after a large-output timeout", async () => {
+    jest.useFakeTimers();
+    const content = `start\n${"\u0001".repeat(150_000)}\nend`;
+    let result:
+      | ReturnType<ReturnType<typeof createTerminalHandler>["getResult"]>
+      | undefined;
+    const handler = createTerminalHandler(() => {}, {
+      timeoutSeconds: 1,
+      onTimeout: () => {
+        result = handler.getResult(123, { timeoutMessage: "\npaused session" });
+      },
+    });
+    try {
+      handler.stdout(content);
+      await jest.advanceTimersByTimeAsync(1000);
+
+      expect(result?.output).toContain("start");
+      expect(result?.output).toContain("end\npaused session");
+      expect(safeCountTokens(result!.output!)).toBeLessThanOrEqual(
+        TOOL_DEFAULT_MAX_TOKENS,
+      );
+      expect(handler.wasTruncated()).toBe(true);
+      expect(handler.getFullOutput()).toBe(content);
+    } finally {
+      handler.cleanup();
+      jest.useRealTimers();
+    }
+  });
+
   test("does not buffer output that arrives after timeout", async () => {
     const writes: string[] = [];
     const onTimeout = jest.fn();


### PR DESCRIPTION
Large terminal output can crash an Agent run while its timeout handler prepares the final result. The tokenizer spreads every token from one BPE split into `Array.push(...tokens)`; sufficiently large splits exceed JavaScript's call-argument limit.

This change collects the tokenizer's exact generator batches using one-token pushes. It preserves token order, counts, special-token handling, head/tail truncation, saved full output and existing limits. The shared helper covers terminal completion/timeouts, slicing, moderation and summary callers. No schema, configuration, dependency, retry, suppression or routing changes.

## Production evidence

Frozen audit: **2026-09-06T21:21:15Z–2026-09-07T21:21:15Z**.
Trigger Production `run_06g7pa4sjh195gi75bjbfd9te1` failed at approximately 16:20 UTC on worker `20260907.6` / deployment `1eukaza7`, deployed 16:03:38 UTC. Exact stack: `BytePairEncodingCore.encodeNative → safeEncode → truncateContent → truncateTerminalOutput → getResult → run-terminal-cmd onTimeout`. This is an application exception, despite the generic Trigger trace wrapper.

The same dependency failure reproduces locally with one 150,000-token synthetic split. The generator produces the same tokens without the failing variadic call.

Audit context: Vercel 11 unique production error requests; PostHog 1,085 issue-summed occurrences; Trigger 47 engineering failures / 18,064 terminal engineering runs (0.2602%). No observed recurrence of the previous image-count signature after the final OCR fix. Sandbox placement, provider media errors, persistence failures, browser transports and worker OOM remain visible and outside this patch.

## Validation and adversarial review

- 86 focused tests across token utilities, terminal timeout, command/session tools and moderation.
- Full configured commit hooks: 470 suites / 4,960 tests; typecheck, ESLint and Prettier pass.
- Exact-token equivalence for ordinary, multilingual and sentinel input; oversized split round-trip/count, bounded slicing/truncation and timeout result regression.
- Reviewed every shared-helper caller and the dependency generator implementation. The fix removes the argument expansion at the actual platform-limit scope without arbitrary chunking or altered BPE boundaries.
- No wire-format changes across Vercel/Trigger revisions. Each runtime needs its own deployment for protection. This does not claim to solve memory exhaustion or worst-case tokenizer CPU cost.
- Docker sandbox and desktop release checks are not applicable: no matching workflow paths.

## Manual verification

On an independently verified Preview with this branch's Vercel and Trigger worker:
1. Create a disposable Agent chat. Run a bounded synthetic terminal command that emits one long tokenizable segment and then pauses past the command timeout.
2. Expect a normal timed-out tool result with bounded head/tail output and the correct paused-session marker; the Agent run must remain alive. Verify saved output remains available, follow up in the session, then reload and confirm message persistence.
3. Run a short ordinary terminal command and confirm unchanged completion.

The local regression exercises the affected timeout handler with real tokenization. An authenticated live Agent journey remains manual; no production jobs were triggered or retried.

All ten registered checks passed on `1745cb52492dccb4982c64463459aa42146fd4da`: tests, CodeQL aggregate/actions/JavaScript-TypeScript/Rust, Vercel, Trigger Preview, Vercel Preview Comments, GitSync and CodeRabbit. CodeRabbit completed its latest-head review with no actionable comments, review submissions or inline threads. Verified 2026-09-07T21:37:04Z. The branch is clean and synchronized; human review and the listed manual Agent verification remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very large text inputs during token encoding, preserving token counts and truncation behavior.
  * Ensured oversized terminal output remains within configured limits while retaining representative beginning and ending content.
* **Tests**
  * Added coverage for large batches, Unicode, empty input, exact encoding, token limits, and truncated terminal output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->