### PR TITLE
HAC-99: Ask for task feedback at most once every three days

### DIFF
--- a/convex/__tests__/taskOutcomeSurveys.test.ts
+++ b/convex/__tests__/taskOutcomeSurveys.test.ts
@@ -85,7 +85,7 @@ describe("task outcome feedback", () => {
     jest.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
   });
   afterEach(() => jest.restoreAllMocks());
-  it("reserves before outcomes and enforces rolling cross-device cooldown", async () => {
+  it("reserves before outcomes and enforces a rolling 72-hour cross-device cooldown", async () => {
     const { ctx, rows } = setup();
     expect(await invoke(reserve, ctx, args)).toMatchObject({
       request_id: "run-1",
@@ -93,9 +93,12 @@ describe("task outcome feedback", () => {
     expect(
       await invoke(reserve, ctx, { ...args, request_id: "run-2" }),
     ).toBeNull();
-    jest
-      .mocked(Date.now)
-      .mockReturnValue(rows[0].selected_at + TASK_OUTCOME_COOLDOWN_MS);
+    const nextEligibleAt = rows[0].selected_at + 72 * 60 * 60 * 1000;
+    jest.mocked(Date.now).mockReturnValue(nextEligibleAt - 1);
+    expect(
+      await invoke(reserve, ctx, { ...args, request_id: "run-2" }),
+    ).toBeNull();
+    jest.mocked(Date.now).mockReturnValue(nextEligibleAt);
     expect(
       await invoke(reserve, ctx, { ...args, request_id: "run-2" }),
     ).not.toBeNull();
@@ -120,6 +123,15 @@ describe("task outcome feedback", () => {
       await invoke(record, ctx, { id: row._id, action: "shown" }),
     ).toBeNull();
     expect(rows[0].last_interaction_at).toBe(row.selected_at + 1000);
+    const nextEligibleAt = row.selected_at + 1000 + 72 * 60 * 60 * 1000;
+    jest.mocked(Date.now).mockReturnValue(nextEligibleAt - 1);
+    expect(
+      await invoke(reserve, ctx, { ...args, request_id: "run-2" }),
+    ).toBeNull();
+    jest.mocked(Date.now).mockReturnValue(nextEligibleAt);
+    expect(
+      await invoke(reserve, ctx, { ...args, request_id: "run-2" }),
+    ).not.toBeNull();
   });
   it("preserves assignment while linking a fallback response", async () => {
     const { ctx } = setup();

--- a/docs/internal/task-outcome-feedback.md
+++ b/docs/internal/task-outcome-feedback.md
@@ -7,7 +7,7 @@ of an individual Abliteration call. Existing provider assignment is unchanged.
 ## Quiet interaction
 
 - Select before model-priced budget checks or generation, for both experiment
-  variants. At most one opportunity per authenticated user per rolling seven days,
+  variants. At most one opportunity per authenticated user per rolling three days (72 hours),
   atomically reserved in Convex across concurrent runs/devices.
 - Only the latest assistant response with no newer user message can show it.
   After the run ends (including Stop/error), show immediately when the result
@@ -20,6 +20,8 @@ of an individual Abliteration call. Existing provider assignment is unchanged.
 - Yes / Partly / No; save the answer immediately. Reasons
   are optional and structured, with Skip. Dismiss/answer/view extends cooldown.
   Unshown invitations expire after 48 hours. Existing manual thumbs remain usable.
+  The cooldown is measured from the most recent interaction, including existing
+  invitations; deploying a cadence change does not reset that timestamp.
 - Some failed runs never create a displayable assistant message; they remain in
   the selection denominator as unshown. Never claim the sample covers all failures.
 
@@ -103,7 +105,7 @@ retain their 48-hour expiry). Provider routing stays unchanged.
 
 ## Implementation validation
 
-Automated tests cover weekly cooldown, concurrent reservation/display claims,
+Automated tests cover the 72-hour cooldown boundary, concurrent reservation/display claims,
 owner authorization, expiry, structured reason validation, fallback message
 linkage, visible-tab gating, immediate display, dismissal and no focus stealing. A real
 local Convex backend in the HackerAI Development project verified concurrent

--- a/lib/feedback/task-outcome.ts
+++ b/lib/feedback/task-outcome.ts
@@ -1,5 +1,5 @@
 export const TASK_OUTCOME_FLAG = "task_outcome_feedback_v1";
-export const TASK_OUTCOME_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+export const TASK_OUTCOME_COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000;
 export const TASK_OUTCOME_EXPIRY_MS = 48 * 60 * 60 * 1000;
 export const TASK_OUTCOME_ANSWERS = {
   yes: "Yes",


### PR DESCRIPTION
Feedback opportunities were limited to once every seven days. Shorten the shared server cooldown to 72 hours so returning experiment participants can provide feedback sooner. Selection remains gated by the existing experiment and feedback flag, with one display claim across tabs/devices and the cooldown measured from the latest interaction. Existing records retain their timestamps; no migration or reset is needed.

Validation: type checking and all 470 suites / 4,954 tests pass. Boundary tests reject a new reservation one millisecond before 72 hours and allow it exactly at 72 hours, including after a later display interaction. Documentation now describes the three-day cadence. The prompt UI and provider routing are unchanged.

Deployed Preview validation against `notable-cricket-803` in the verified HackerAI Development project exercised the actual reservation mutation with disposable records under the existing free test account: blocked inside 72 hours, allowed just after 72 hours (before seven days), and blocked again immediately afterward. All created chat and survey records were removed and their absence verified. No real user history or credentials were changed.

Manual verification in Preview: use an existing hardcoded test account from scripts/test-users-config.ts. Complete an eligible request and display or dismiss the feedback prompt; further requests must not reserve another prompt within 72 hours of the latest interaction. After that boundary, the next eligible request may reserve one. Use a disposable backend fixture with controlled timestamps for boundary testing; do not alter real users' survey history. Existing single-display/reload protection should remain in place.

HAC-99 records the authorized cadence change, hypothesis, participation guardrails, review date, and rollback to seven days if annoyance increases. Analyze first selected surveys per user; do not treat missing answers as dissatisfaction. Full experiment cleanup remains tracked in HAC-101.
