### PR TITLE
Recover Abliteration image dimension and format rejections

### DIFF
--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -31,6 +31,15 @@ the multimodal base `abliterated-model` for every selector, including Pro and Ma
 PDFs, files without an image media type, and other unsupported file inputs retain
 their original HackerAI route.
 
+Requests with more than four provider-visible images use batched auxiliary
+descriptions/OCR. Smaller requests keep native images unless Abliteration rejects
+them before streaming with `media_dimensions_too_large` (413) or
+`media_type_unsupported` (415). Those two rejections activate the same OCR path
+and one retry on the selected Abliteration model. Original stored images remain
+unchanged. Failed OCR is not restarted; moderation blocks, generic errors and
+errors after streaming starts do not activate this recovery. Provider-attempt
+telemetry retains the rejection and the subsequent outcome separately.
+
 Explicit free-allowance rescue requests are excluded before assignment. Eligibility
 is recorded before model-priced budget checks so cost-induced blocking cannot
 silently remove treatment users from the denominator.

--- a/lib/ai/abliteration-media.ts
+++ b/lib/ai/abliteration-media.ts
@@ -1,10 +1,15 @@
-import type { ModelMessage } from "ai";
+import type { LanguageModelMiddleware, ModelMessage } from "ai";
+
+type ProviderPrompt = Parameters<
+  NonNullable<LanguageModelMiddleware["wrapStream"]>
+>[0]["params"]["prompt"];
+export type AbliterationImageMessages = ModelMessage[] | ProviderPrompt;
 
 export const ABLITERATION_MAX_IMAGES_PER_REQUEST = 4;
 
 /** Counts attachments and tool images together at the provider request boundary. */
 export function exceedsAbliterationImageLimit(
-  messages: ModelMessage[],
+  messages: AbliterationImageMessages,
 ): boolean {
   let imageCount = 0;
   const isImage = (part: { type: string; mediaType?: string }) =>

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1500,7 +1500,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
 
   test("content-filter finishes retry once on a different model and remain terminal on fallback", () => {
     expect(agentStreamRunnerSrc).toMatch(
-      /const telemetryModel =\s*ctx\.abliteratedTelemetry\?\.wrap\(languageModel, stepIndex\) \?\? languageModel;[\s\S]{0,150}guardLanguageModelProviderResponse\(telemetryModel/,
+      /const telemetryModel =\s*ctx\.abliteratedTelemetry\?\.wrap\(languageModel, stepIndex\) \?\? languageModel;\s*const recoveryModel = recoverAbliterationMedia\(telemetryModel\);[\s\S]{0,150}guardLanguageModelProviderResponse\(recoveryModel/,
     );
     expect(agentStreamRunnerSrc).toMatch(
       /isProviderContentBlockedFinishReasonError\(error\)/,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -5,6 +5,7 @@ import {
   AbliterationVisionError,
   createAbliterationVisionPreprocessor,
 } from "@/lib/chat/abliteration-vision";
+import { createAbliterationMediaRecovery } from "@/lib/chat/abliteration-media-recovery";
 /**
  * Shared streamText factory for the agent loop.
  *
@@ -863,7 +864,8 @@ export async function createAgentStream(
   ): LanguageModel => {
     const telemetryModel =
       ctx.abliteratedTelemetry?.wrap(languageModel, stepIndex) ?? languageModel;
-    const guardedModel = guardLanguageModelProviderResponse(telemetryModel, {
+    const recoveryModel = recoverAbliterationMedia(telemetryModel);
+    const guardedModel = guardLanguageModelProviderResponse(recoveryModel, {
       onToolCallsDropped: ({ droppedToolCallCount, maxToolCalls }) => {
         console.warn("[agent-stream] provider tool calls bounded", {
           event: "provider_tool_call_guard_applied",
@@ -1053,6 +1055,10 @@ export async function createAgentStream(
       ctx.chatLogger?.getBuilder().addToolCost(cost);
     },
   });
+  const recoverAbliterationMedia = createAbliterationMediaRecovery(
+    preprocessAbliterationImages,
+    abortSignal,
+  );
   const prepareProviderMessages = async (
     messages: ModelMessage[],
     effectiveModelName = getEffectiveModelName(),

--- a/lib/chat/__tests__/abliteration-media-recovery.test.ts
+++ b/lib/chat/__tests__/abliteration-media-recovery.test.ts
@@ -1,0 +1,363 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import {
+  WritableStream as NodeWritableStream,
+  TextDecoderStream as NodeTextDecoderStream,
+} from "node:stream/web";
+import {
+  streamText,
+  type LanguageModel,
+  type LanguageModelMiddleware,
+} from "ai";
+import { createAbliterationMediaRecovery } from "../abliteration-media-recovery";
+import { createAbliterationVisionPreprocessor } from "../abliteration-vision";
+
+jest.mock("server-only", () => ({}));
+jest.mock("../auxiliary-vision", () => ({
+  describeImageWithAuxiliaryVision: jest.fn(),
+}));
+
+const originalWritableStream = globalThis.WritableStream;
+const originalTextDecoderStream = globalThis.TextDecoderStream;
+const originalResponse = globalThis.Response;
+const originalHeaders = globalThis.Headers;
+const edgeFetchPrimitives = jest.requireActual(
+  "next/dist/compiled/@edge-runtime/primitives/fetch",
+);
+beforeAll(() => {
+  Object.defineProperty(globalThis, "TextDecoderStream", {
+    configurable: true,
+    value: NodeTextDecoderStream,
+  });
+  Object.defineProperty(globalThis, "WritableStream", {
+    configurable: true,
+    value: NodeWritableStream,
+  });
+  globalThis.Response = edgeFetchPrimitives.Response;
+  globalThis.Headers = edgeFetchPrimitives.Headers;
+});
+afterAll(() => {
+  Object.defineProperty(globalThis, "TextDecoderStream", {
+    configurable: true,
+    value: originalTextDecoderStream,
+  });
+  Object.defineProperty(globalThis, "WritableStream", {
+    configurable: true,
+    value: originalWritableStream,
+  });
+  globalThis.Response = originalResponse;
+  globalThis.Headers = originalHeaders;
+});
+
+type Params = Parameters<
+  NonNullable<LanguageModelMiddleware["wrapStream"]>
+>[0]["params"];
+const mediaError = (code = "media_dimensions_too_large", statusCode = 413) =>
+  Object.assign(new Error("media rejected"), {
+    statusCode,
+    responseBody: JSON.stringify({ error: { code } }),
+  });
+const prompt = (): Params["prompt"] => [
+  { role: "system", content: "trusted instruction" },
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "Read the image" },
+      {
+        type: "file",
+        data: new URL("https://example.test/image.png"),
+        mediaType: "image/png",
+        filename: "screenshot.png",
+      },
+    ],
+  },
+];
+const success = () => ({
+  stream: new ReadableStream({
+    start(c) {
+      c.close();
+    },
+  }),
+});
+const setup = () => {
+  const controller = new AbortController();
+  const onCost = jest.fn();
+  const describe = jest.fn(async (args) => {
+    args.onCost(0.01);
+    return {
+      description: "Visible <text>",
+      inputTokens: 1,
+      outputTokens: 1,
+      durationMs: 1,
+      model: "vision",
+    };
+  });
+  const preprocess = createAbliterationVisionPreprocessor({
+    userId: "user",
+    chatId: "chat",
+    abortSignal: controller.signal,
+    onCost,
+    describe,
+  });
+  const wrap = createAbliterationMediaRecovery(preprocess, controller.signal);
+  const doStream = jest.fn(async (_params: Params) => success());
+  const model = {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "abliterated-model",
+    supportedUrls: {},
+    doStream,
+    doGenerate: jest.fn(),
+  } as const;
+  const wrapped = wrap(model);
+  if (typeof wrapped === "string") throw new Error("Expected model object");
+  return { controller, onCost, describe, wrap, doStream, model, wrapped };
+};
+
+it.each([
+  ["media_dimensions_too_large", 413],
+  ["media_type_unsupported", 415],
+])("recovers %s once with OCR on the same model", async (code, status) => {
+  const { doStream, wrapped, describe, onCost } = setup();
+  doStream.mockRejectedValueOnce(mediaError(String(code), Number(status)));
+  const original = prompt();
+  const params: Params = {
+    prompt: original,
+    maxOutputTokens: 123,
+    temperature: 0.5,
+  };
+  await wrapped.doStream(params);
+
+  expect(wrapped.modelId).toBe("abliterated-model");
+  expect(doStream).toHaveBeenCalledTimes(2);
+  expect(doStream.mock.calls[0][0].prompt).toBe(original);
+  const recovered = doStream.mock.calls[1][0];
+  expect(recovered).toMatchObject({ maxOutputTokens: 123, temperature: 0.5 });
+  expect(recovered.prompt[0]).toEqual(original[0]);
+  expect(JSON.stringify(recovered.prompt)).toContain("Visible &lt;text&gt;");
+  expect(JSON.stringify(recovered.prompt)).toContain("screenshot.png");
+  expect(JSON.stringify(recovered.prompt)).not.toContain(
+    "https://example.test",
+  );
+  expect(original[1].content[1]).toHaveProperty("type", "file");
+  expect(describe).toHaveBeenCalledTimes(1);
+  expect(onCost).toHaveBeenCalledWith(0.01);
+});
+
+it("keeps native input on success", async () => {
+  const { wrapped, doStream, describe } = setup();
+  const original = prompt();
+  await wrapped.doStream({ prompt: original });
+  expect(doStream).toHaveBeenCalledTimes(1);
+  expect(doStream.mock.calls[0][0].prompt).toBe(original);
+  expect(describe).not.toHaveBeenCalled();
+});
+
+it("describes provider tool images with their IDs and surrounding text intact", async () => {
+  const { wrapped, doStream, describe } = setup();
+  doStream.mockRejectedValueOnce(mediaError());
+  const messages = prompt();
+  messages.push({
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: "view-1",
+        toolName: "file",
+        output: {
+          type: "content",
+          value: [
+            { type: "text", text: "tool context" },
+            { type: "image-data", data: "AQID", mediaType: "image/png" },
+          ],
+        },
+      },
+    ],
+  });
+  await wrapped.doStream({ prompt: messages });
+  expect(describe).toHaveBeenCalledTimes(2);
+  expect(describe).toHaveBeenLastCalledWith(
+    expect.objectContaining({ source: "file_view", image: "AQID" }),
+  );
+  expect(doStream.mock.calls[1][0].prompt[2]).toMatchObject({
+    role: "tool",
+    content: [
+      {
+        toolCallId: "view-1",
+        toolName: "file",
+        output: {
+          value: [{ type: "text", text: "tool context" }, { type: "text" }],
+        },
+      },
+    ],
+  });
+  expect(messages[2].content[0]).toHaveProperty(
+    "output.value.1.type",
+    "image-data",
+  );
+});
+
+it.each([
+  ["moderation_blocked", 400],
+  ["invalid_request", 400],
+  ["media_dimensions_too_large", 500],
+  ["media_type_unsupported", 400],
+  ["unknown", 413],
+])("does not recover %s status %s", async (code, status) => {
+  const { wrapped, doStream, describe } = setup();
+  const error = mediaError(String(code), Number(status));
+  doStream.mockRejectedValue(error);
+  await expect(wrapped.doStream({ prompt: prompt() })).rejects.toBe(error);
+  expect(doStream).toHaveBeenCalledTimes(1);
+  expect(describe).not.toHaveBeenCalled();
+});
+
+it("does not alter baseline providers or retry text-only input", async () => {
+  const { wrap, model, wrapped, doStream, describe } = setup();
+  const baseline = { ...model, modelId: "baseline" };
+  expect(wrap(baseline)).toBe(baseline);
+  const error = mediaError();
+  doStream.mockRejectedValue(error);
+  await expect(
+    wrapped.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    }),
+  ).rejects.toBe(error);
+  expect(doStream).toHaveBeenCalledTimes(1);
+  expect(describe).not.toHaveBeenCalled();
+});
+
+it("shares activation and cached summaries across wrappers and retries", async () => {
+  const { wrap, model, wrapped, doStream, describe } = setup();
+  const error = mediaError();
+  doStream.mockRejectedValue(error);
+  const params = { prompt: prompt() };
+  await expect(wrapped.doStream(params)).rejects.toBe(error);
+  const another = wrap(model) as Exclude<LanguageModel, string>;
+  await expect(another.doStream(params)).rejects.toBe(error);
+  expect(doStream).toHaveBeenCalledTimes(3);
+  expect(describe).toHaveBeenCalledTimes(1);
+  expect(JSON.stringify(doStream.mock.calls[2][0].prompt)).not.toContain(
+    '"type":"file"',
+  );
+});
+
+it("fails closed on OCR failure without replaying its failed batch", async () => {
+  const { wrapped, doStream, describe } = setup();
+  doStream.mockRejectedValue(mediaError());
+  describe.mockRejectedValue(new Error("private provider response"));
+  const params = { prompt: prompt() };
+  await expect(wrapped.doStream(params)).rejects.toHaveProperty(
+    "name",
+    "AbliterationVisionError",
+  );
+  await expect(wrapped.doStream(params)).rejects.toHaveProperty(
+    "name",
+    "AbliterationVisionError",
+  );
+  expect(doStream).toHaveBeenCalledTimes(1);
+  expect(describe).toHaveBeenCalledTimes(1);
+});
+
+it("honors cancellation during OCR and never makes a second provider request", async () => {
+  const { controller, wrapped, doStream, describe } = setup();
+  doStream.mockRejectedValueOnce(mediaError());
+  describe.mockImplementationOnce(async () => {
+    controller.abort();
+    return {
+      description: "text",
+      inputTokens: 1,
+      outputTokens: 1,
+      durationMs: 1,
+      model: "vision",
+    };
+  });
+  await expect(wrapped.doStream({ prompt: prompt() })).rejects.toHaveProperty(
+    "name",
+    "AbortError",
+  );
+  expect(doStream).toHaveBeenCalledTimes(1);
+});
+
+it("does not start a request or OCR for an already-canceled SDK attempt", async () => {
+  const { wrapped, doStream, describe } = setup();
+  const canceled = new AbortController();
+  canceled.abort();
+  await expect(
+    wrapped.doStream({ prompt: prompt(), abortSignal: canceled.signal }),
+  ).rejects.toHaveProperty("name", "AbortError");
+  expect(doStream).not.toHaveBeenCalled();
+  expect(describe).not.toHaveBeenCalled();
+});
+
+it("does not replay an error after the provider returned a stream", async () => {
+  const { wrapped, doStream, describe } = setup();
+  const error = mediaError();
+  doStream.mockResolvedValueOnce({
+    stream: new ReadableStream({
+      start(c) {
+        c.error(error);
+      },
+    }),
+  });
+  const result = await wrapped.doStream({ prompt: prompt() });
+  await expect(result.stream.getReader().read()).rejects.toBe(error);
+  expect(doStream).toHaveBeenCalledTimes(1);
+  expect(describe).not.toHaveBeenCalled();
+});
+
+it("completes through the real OpenAI-compatible adapter after HTTP 413", async () => {
+  const { wrap, describe } = setup();
+  const bodies: Array<Record<string, any>> = [];
+  const provider = createOpenAICompatible({
+    name: "abliteration",
+    baseURL: "https://provider.test/v1",
+    apiKey: "synthetic-test-key",
+    fetch: async (_url, init) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      if (bodies.length === 1)
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "Image dimensions exceed the project media policy.",
+              code: "media_dimensions_too_large",
+            },
+          }),
+          { status: 413, headers: { "content-type": "application/json" } },
+        );
+      return new Response(
+        'data: {"id":"test","model":"abliterated-model","choices":[{"index":0,"delta":{"content":"Recovered answer"},"finish_reason":null}]}\n\ndata: {"id":"test","model":"abliterated-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+  const result = streamText({
+    model: wrap(provider("abliterated-model")),
+    maxRetries: 0,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Read image" },
+          {
+            type: "image",
+            image: new Uint8Array([1, 2, 3]),
+            mediaType: "image/png",
+          },
+        ],
+      },
+    ],
+  });
+  expect(await result.text).toBe("Recovered answer");
+  expect(bodies).toHaveLength(2);
+  expect(bodies.map((b) => b.model)).toEqual([
+    "abliterated-model",
+    "abliterated-model",
+  ]);
+  expect(bodies[0].messages[0].content).toEqual(
+    expect.arrayContaining([expect.objectContaining({ type: "image_url" })]),
+  );
+  expect(JSON.stringify(bodies[1].messages)).not.toContain("image_url");
+  expect(describe).toHaveBeenCalledWith(
+    expect.objectContaining({ image: "AQID", mediaType: "image/png" }),
+  );
+});

--- a/lib/chat/abliteration-media-recovery.ts
+++ b/lib/chat/abliteration-media-recovery.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import { wrapLanguageModel, type LanguageModel } from "ai";
+import { isAbliterationModel } from "@/lib/ai/abliteration";
+import { extractErrorDetails } from "@/lib/utils/error-utils";
+import type { createAbliterationVisionPreprocessor } from "./abliteration-vision";
+
+/** Retries a rejected native-image request once, preserving its selected model. */
+export function createAbliterationMediaRecovery(
+  preprocess: ReturnType<typeof createAbliterationVisionPreprocessor>,
+  abortSignal: AbortSignal,
+) {
+  // Shared by every model wrapper in this response/run, including SDK retries.
+  let activated = false;
+
+  const canRecover = (error: unknown): boolean => {
+    if (activated || abortSignal.aborted) return false;
+    const details = extractErrorDetails(error);
+    return (
+      (details.statusCode === 413 &&
+        details.providerErrorCode === "media_dimensions_too_large") ||
+      (details.statusCode === 415 &&
+        details.providerErrorCode === "media_type_unsupported")
+    );
+  };
+
+  return (model: LanguageModel): LanguageModel => {
+    if (
+      typeof model === "string" ||
+      model.specificationVersion !== "v3" ||
+      !isAbliterationModel(model.modelId)
+    )
+      return model;
+
+    return wrapLanguageModel({
+      model,
+      middleware: {
+        specificationVersion: "v3",
+        wrapStream: async ({ params }) => {
+          abortSignal.throwIfAborted();
+          params.abortSignal?.throwIfAborted();
+          const prompt = activated
+            ? await preprocess(params.prompt, { force: true })
+            : params.prompt;
+          try {
+            return await model.doStream({ ...params, prompt });
+          } catch (error) {
+            // Only an HTTP rejection before a stream exists is replayable.
+            // Never replay text/tool output or handle moderation as media error.
+            if (params.abortSignal?.aborted || !canRecover(error)) throw error;
+            activated = true;
+            const recovered = await preprocess(prompt, { force: true });
+            if (recovered === prompt) throw error;
+            abortSignal.throwIfAborted();
+            params.abortSignal?.throwIfAborted();
+            return model.doStream({ ...params, prompt: recovered });
+          }
+        },
+      },
+    });
+  };
+}

--- a/lib/chat/abliteration-vision.ts
+++ b/lib/chat/abliteration-vision.ts
@@ -1,8 +1,10 @@
 import "server-only";
 
 import { createHash } from "node:crypto";
-import type { ModelMessage } from "ai";
-import { exceedsAbliterationImageLimit } from "@/lib/ai/abliteration-media";
+import {
+  exceedsAbliterationImageLimit,
+  type AbliterationImageMessages,
+} from "@/lib/ai/abliteration-media";
 import { describeImageWithAuxiliaryVision } from "./auxiliary-vision";
 
 export class AbliterationVisionError extends Error {
@@ -67,8 +69,12 @@ export function createAbliterationVisionPreprocessor({
   // Store only summaries/hashes, not duplicate image payloads. Retain rejected
   // promises too so error recovery cannot repeat an already failed OCR batch.
   const cache = new Map<string, Promise<string>>();
-  return async (messages: ModelMessage[]): Promise<ModelMessage[]> => {
-    if (!exceedsAbliterationImageLimit(messages)) return messages;
+  return async <T extends AbliterationImageMessages>(
+    messages: T,
+    options?: { force?: boolean },
+  ): Promise<T> => {
+    if (!options?.force && !exceedsAbliterationImageLimit(messages))
+      return messages;
     const tasks: Array<{
       position: string;
       input: ImageInput;
@@ -93,6 +99,7 @@ export function createAbliterationVisionPreprocessor({
         }
       }
     }
+    if (tasks.length === 0) return messages;
     const replacements = new Map<string, { type: "text"; text: string }>();
     for (let start = 0; start < tasks.length; start += 4) {
       abortSignal.throwIfAborted();
@@ -155,7 +162,7 @@ export function createAbliterationVisionPreprocessor({
           }
           return replacements.get(`${mi}:${pi}`) ?? part;
         }),
-      } as ModelMessage;
-    });
+      };
+    }) as T;
   };
 }


### PR DESCRIPTION
Abliteration image-policy errors currently terminate otherwise eligible Ask/Agent requests, including a single oversized image. Recover those specific pre-stream rejections by reusing the existing auxiliary image descriptions/OCR, then retrying the **same selected Abliteration model once**.

## Evidence and behavior

- Confirmed production dimensions failure: `run_06g7fnnr2aoi89n7242a7pbie1`, Trigger 20260906.6, span 29af9514a544a856: HTTP 413, `media_dimensions_too_large`, `Image dimensions exceed the project media policy.`.
- Current unsupported-format burst: five runs on 20260907.6 / one user/chat, representative `run_06g7qqugu1tcp0gle6mkvo6ee1`, HTTP 415 `media_type_unsupported`, with two provider file parts. These are separate from the >4-image count fix in #1273.
- Supported ≤4-image requests stay native. Existing >4-image preprocessing remains intact.
- Exact code/status allowlist only: dimensions 413 and unsupported-format 415. Unknown errors, generic 400, moderation blocks and any error after a stream exists are not handled by this recovery.
- Reuse the existing OCR batch limit, hashed request-local cache, cost accounting, cancellation and escaped/untrusted descriptions. Process attachment and serialized tool image representations together; preserve filenames, tool identity, stored/UI originals and non-image content.
- Share recovery activation across model wrappers/SDK attempts in one shared stream. A failed batch is cached and never automatically restarted. Existing `AbliterationVisionError` guards in both Ask and Trigger prevent generic fallback from restarting failed OCR.
- Keep provider-attempt telemetry inside recovery, so the original rejection and retry outcome remain visible. This is recovery from provider rejection, not suppression or a guarantee that malformed image data can be decoded.
- Preserve existing moderation/authorization gates, plan targeting, first-generation-step ceiling, provider-failure policy and original baseline. Correctness fix; no feature flag, schema, credential, configuration or dependency change.

The provider [documents formats and file size](https://docs.abliteration.ai/capabilities/images), but no exact project dimension ceiling. Using its precise rejection code avoids guessing a destructive resize threshold.

## Validation and adversarial review

- 200 focused tests covering recovery, overflow preprocessing, runner paths, telemetry and Ask/Trigger contracts.
- Full configured commit hooks: 471 suites / 4,970 tests; typecheck, changed-file ESLint/Prettier and diff check pass.
- Real OpenAI-compatible adapter + mocked HTTP 413/SSE integration: original native request rejects, exactly one description-based request to the same model completes with streamed text.
- Coverage includes both exact errors, SDK file bytes/URLs and tool images, preserved message/tool identity, unchanged originals, cost callback, cache reuse across wrappers, retry exhaustion, OCR failure, cancellation and no midstream replay.
- Adversarial review checked the actual HTTP request boundary, all shared-runner call sites, retained content-filter guard/namespace ordering, first-step routing and outer Ask/Trigger error recovery. No protocol change across Vercel/Trigger revisions; each runtime needs its own deploy.
- No infrastructure/desktop paths changed. Docker and desktop release checks are not applicable. No visual layout changes.

## Manual verification

On an independently verified branch Preview:
1. Create disposable Ask and Agent chats using the test-assigned route. Retry an image previously rejected for dimensions or format.
2. Expect one native rejection, bounded auxiliary OCR, then a completed answer on the same Abliteration model. Confirm originals remain accessible and reload preserves the response.
3. Try an ordinary supported image: expect native input without extra OCR. Stop during OCR: expect cancellation with no resumed batch/main request.
4. Verify moderation rejection remains terminal and does not activate this recovery.

The adapter/stream integration is automated; an authenticated live image journey remains manual. No production jobs were triggered or retried. All ten registered checks are green on `2b44005fd0f2ecf875e73b86831457f417c66425`: tests, CodeQL aggregate/actions/JavaScript-TypeScript/Rust, Vercel, Trigger Preview jsj3a5bb, Preview Comments, GitSync and CodeRabbit. Latest-head CodeRabbit completed with no actionable comments or inline threads. Verified 2026-09-07T22:08:43Z. Human review and the listed live image verification remain.

This PR is independent of tokenizer PR #1281.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic image recovery for supported AI model requests.
  * Requests containing more than four images can use batched descriptions and OCR processing.
  * Certain media-size or unsupported-format errors now trigger OCR preprocessing and one retry.
  * Original images remain unchanged during recovery.

* **Bug Fixes**
  * Improved handling of provider tool images, cancellation, and streaming errors.
  * Recovery is limited to eligible media errors; unrelated failures and moderation blocks are not retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->