### PR TITLE
HAC-99: Reduce Abliteration event volume with request summaries

### DIFF
--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -172,25 +172,51 @@ run; it does not reroute an already-running stream.
 
 All new server events carry `experiment_key`, `experiment_variant`,
 `$feature/abliterated_paid_moderated_v1`, `experiment_request_id`, mode, tier,
-and `generation_step_limit`. Provider-attempt and provider-outcome events also
+and `generation_step_limit`. Provider-outcome events also
 carry the one-based `generation_step` and `within_abliteration_step_limit`.
-Eligibility identifies `assigned_platform_authorization_context`; each provider
-attempt identifies its actual `platform_authorization_context` as `not_appended`
+Eligibility identifies `assigned_platform_authorization_context`; each retained provider
+outcome identifies its actual `platform_authorization_context` as `not_appended`
 for an Abliteration model or `standard` for a control/fallback provider.
 The request ID is the original assistant-message ID and stays stable across
 provider retries. No new event contains prompts, answers, reasoning, targets,
 tool names/arguments, files, raw provider errors, or credentials.
 
-| Event                                  | Meaning                                                                                                                                                                                                                         |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `abliterated_model_eligible`           | Assigned paid/moderation-eligible request before model-priced budget checks; intention-to-treat denominator, including requests blocked by budget or never producing output                                                     |
-| `abliterated_model_provider_attempt`   | Actual provider call; sequential attempt counter includes SDK retries and tool-loop steps                                                                                                                                       |
-| `abliterated_model_exposed`            | First streamed nonempty text or accepted tool call; once per response, including control/fallback with actual model attribution                                                                                                 |
-| `abliterated_model_provider_outcome`   | Per-call completed, empty, error, aborted, incomplete, content-filtered or truncated outcome; duration, first-content latency, text/reasoning lengths, tool-call count, reported token/cache counts and estimated provider cost |
-| `abliterated_model_response_outcome`   | Application-level Ask/Agent outcome, fallback/recovery and budget-abort context                                                                                                                                                 |
-| `abliterated_model_message_linked`     | Maps a replacement fallback message ID back to the original experiment request                                                                                                                                                  |
-| `chat_response_regeneration_requested` | Client regeneration action, with affected message ID and mode; contains no content                                                                                                                                              |
-| `chat_response_stop_requested`         | Client Stop action, with affected message ID and mode; distinct from confirmed cancellation                                                                                                                                     |
+| Event                                  | Meaning                                                                                                                                                                                                                                                  |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `abliterated_model_eligible`           | Assigned paid/moderation-eligible request before model-priced budget checks; intention-to-treat denominator, including requests blocked by budget or never producing output                                                                              |
+| `abliterated_model_provider_attempt`   | Legacy telemetry v1 only; v2 counts calls in the response summary                                                                                                                                                                                        |
+| `abliterated_model_exposed`            | First streamed nonempty text or accepted tool call; once per response, including control/fallback with actual model attribution                                                                                                                          |
+| `abliterated_model_provider_outcome`   | First-step outcomes and every empty, error, aborted, incomplete, content-filtered or truncated outcome at later steps; duration, first-content latency, text/reasoning lengths, tool-call count, reported token/cache counts and estimated provider cost |
+| `abliterated_model_response_outcome`   | Application-level Ask/Agent outcome, fallback/recovery and budget-abort context, plus provider totals in telemetry v2                                                                                                                                    |
+| `abliterated_model_message_linked`     | Maps a replacement fallback message ID back to the original experiment request                                                                                                                                                                           |
+| `chat_response_regeneration_requested` | Client regeneration action, with affected message ID and mode; contains no content                                                                                                                                                                       |
+| `chat_response_stop_requested`         | Client Stop action, with affected message ID and mode; distinct from confirmed cancellation                                                                                                                                                              |
+
+Telemetry v2 removes attempt events and successful continuation events. The
+existing response-outcome event includes request-wide `provider_attempt_count`,
+`provider_outcome_count`, `provider_pending_count`, per-outcome counts, requested
+Abliteration/baseline attempt counts, continuation completion count, duration,
+tool-call count, token/cache/reasoning totals, and `provider_estimated_cost_dollars`.
+Counters remain stable across fallback message replacement and include retries;
+they do not represent unique generation steps. `provider_usage_reported_count`
+counts attempts with both input and output totals available for the cost estimate.
+Missing usage is not an assertion of zero cost. These totals cover the wrapped
+main response providers, not unwrapped subagents or image-summary helper calls.
+
+Eligibility, actual exposure, first-step outcomes for both variants, exceptional
+outcomes at every step, feedback, and final response outcomes remain unsampled.
+A process terminated before final analytics may lose its in-memory summary; retain
+eligible requests without a terminal event in the readout. No new per-step array
+or user content is collected. Normal routing and billing are unchanged.
+
+For charts, do not use the remaining provider-outcome event count as the total
+call denominator. Use sums of v2 response totals, deduplicated by
+`experiment_request_id`. For first-step quality/latency, filter
+`generation_step=1` for both telemetry versions. Historical spend uses v1
+provider-outcome cost; v2 spend uses response-summary cost. Never add v2 detailed
+outcome cost to v2 summary cost, which would double-count first steps and errors.
+The provider-failure chart remains compatible because all exceptional outcomes
+are retained. A drop in diagnostic events at deployment is intentional.
 
 Exposure means content entered the application stream, not confirmed browser
 delivery or task usefulness. Reasoning-only output does not count. A completed

--- a/lib/analytics/__tests__/abliterated-model.test.ts
+++ b/lib/analytics/__tests__/abliterated-model.test.ts
@@ -11,11 +11,15 @@ const finishPart = {
     outputTokens: { total: 5, reasoning: 1 },
   },
 };
-function model(parts: unknown[], fails = false): LanguageModel {
+function model(
+  parts: unknown[],
+  fails = false,
+  modelId = "abliterated-model",
+): LanguageModel {
   return {
     specificationVersion: "v3",
     provider: "test",
-    modelId: "abliterated-model",
+    modelId,
     supportedUrls: {},
     doGenerate: jest.fn(),
     doStream: jest.fn(async () => {
@@ -68,7 +72,7 @@ describe("Abliteration stream telemetry", () => {
   beforeEach(() => capture.mockClear());
   const events = (name: string) =>
     capture.mock.calls.map(([event]) => event).filter((e) => e.event === name);
-  it("distinguishes eligibility, attempts and actual output, without leaking content", async () => {
+  it("aggregates attempts while preserving eligibility and output without leaking content", async () => {
     const telemetry = create();
     expect(events("abliterated_model_exposed")).toHaveLength(0);
     const parts = [
@@ -82,17 +86,14 @@ describe("Abliteration stream telemetry", () => {
       assigned_platform_authorization_context: "not_appended",
       generation_step_limit: 1,
     });
-    expect(events("abliterated_model_provider_attempt")).toHaveLength(2);
-    expect(
-      events("abliterated_model_provider_attempt").map(
-        (event) => event.properties.generation_step,
-      ),
-    ).toEqual([1, 2]);
-    expect(
-      events("abliterated_model_provider_attempt").map(
-        (event) => event.properties.within_abliteration_step_limit,
-      ),
-    ).toEqual([true, false]);
+    expect(events("abliterated_model_provider_attempt")).toHaveLength(0);
+    expect(events("abliterated_model_provider_outcome")).toHaveLength(1);
+    expect(telemetry.getSummary()).toMatchObject({
+      telemetry_version: 2,
+      provider_attempt_count: 2,
+      provider_completed_count: 2,
+      provider_pending_count: 0,
+    });
     expect(events("abliterated_model_exposed")).toHaveLength(1);
     expect(
       events("abliterated_model_provider_outcome")[0].properties,
@@ -102,8 +103,125 @@ describe("Abliteration stream telemetry", () => {
       output_tokens: 5,
       cache_read_tokens: 2,
       platform_authorization_context: "not_appended",
+      generation_step: 1,
+      within_abliteration_step_limit: true,
     });
     expect(JSON.stringify(capture.mock.calls)).not.toContain("private answer");
+  });
+  it.each(["test", "control"] as const)(
+    "keeps event volume constant across 500 successful steps for %s",
+    async (variant) => {
+      const telemetry = new AbliteratedModelTelemetry({ capture }, "user", {
+        assignment: {
+          key: ABLITERATED_EXPERIMENT_KEY,
+          variant,
+          modelKey:
+            variant === "test"
+              ? "model-abliterated"
+              : "model-deepseek-v4-flash-0731",
+          baselineModel: "model-deepseek-v4-flash-0731",
+        },
+        messageId: "message",
+        chatId: "chat",
+        mode: "agent",
+        subscription: "free",
+      });
+      const parts = [
+        { type: "text-delta", id: "t", delta: "private answer" },
+        finishPart,
+      ];
+      for (let step = 0; step < 500; step++) {
+        const source = model(
+          parts,
+          false,
+          step === 0 && variant === "test"
+            ? "abliterated-model"
+            : "deepseek/deepseek-v4-flash-0731",
+        );
+        expect(await consume(telemetry, source, step)).toEqual(parts);
+      }
+      expect(capture).toHaveBeenCalledTimes(3); // eligibility, exposure, first outcome
+      expect(
+        events("abliterated_model_provider_outcome")[0].properties,
+      ).toMatchObject({
+        generation_step: 1,
+        experiment_variant: variant,
+        outcome: "completed",
+      });
+      expect(telemetry.getSummary()).toMatchObject({
+        provider_attempt_count: 500,
+        provider_outcome_count: 500,
+        provider_completed_count: 500,
+        provider_pending_count: 0,
+        provider_continuation_completed_count: 499,
+        provider_abliteration_attempt_count: variant === "test" ? 1 : 0,
+        provider_baseline_attempt_count: variant === "test" ? 499 : 500,
+        provider_usage_reported_count: 500,
+        provider_input_tokens: 5000,
+        provider_output_tokens: 2500,
+        provider_cache_read_tokens: 1000,
+        provider_reasoning_tokens: 500,
+      });
+      expect(
+        telemetry.getSummary().provider_estimated_cost_dollars,
+      ).toBeGreaterThan(0);
+      expect(JSON.stringify(capture.mock.calls)).not.toContain(
+        "private answer",
+      );
+    },
+  );
+  it.each([
+    ["length", "truncated"],
+    ["content-filter", "content_filter"],
+    ["error", "error"],
+    ["stop", "empty"],
+  ])("retains later-step %s diagnostics", async (reason, outcome) => {
+    const telemetry = create();
+    await consume(
+      telemetry,
+      model([
+        { ...finishPart, finishReason: { unified: reason, raw: reason } },
+      ]),
+      499,
+    );
+    expect(
+      events("abliterated_model_provider_outcome")[0].properties,
+    ).toMatchObject({ generation_step: 500, outcome });
+    expect(telemetry.getSummary()).toMatchObject({
+      provider_attempt_count: 1,
+      provider_outcome_count: 1,
+      [`provider_${outcome}_count`]: 1,
+    });
+  });
+  it("retains late failures and totals across fallback message replacement", async () => {
+    const telemetry = create();
+    await expect(consume(telemetry, model([], true), 4)).rejects.toThrow();
+    telemetry.setMessageId("fallback-message");
+    await consume(
+      telemetry,
+      model(
+        [{ type: "text-delta", id: "t", delta: "ok" }, finishPart],
+        false,
+        "deepseek/deepseek-v4-flash-0731",
+      ),
+      4,
+    );
+    expect(events("abliterated_model_provider_outcome")).toHaveLength(1);
+    expect(
+      events("abliterated_model_provider_outcome")[0].properties,
+    ).toMatchObject({ generation_step: 5, outcome: "error" });
+    expect(
+      events("abliterated_model_message_linked")[0].properties,
+    ).toMatchObject({
+      experiment_request_id: "message",
+      message_id: "fallback-message",
+    });
+    expect(telemetry.getSummary()).toMatchObject({
+      provider_attempt_count: 2,
+      provider_error_count: 1,
+      provider_completed_count: 1,
+      provider_usage_reported_count: 1,
+    });
   });
   it("retains failed attempts without inventing exposure, then records fallback exposure", async () => {
     const telemetry = create();
@@ -125,6 +243,54 @@ describe("Abliteration stream telemetry", () => {
     expect(JSON.stringify(capture.mock.calls)).not.toContain(
       "private provider error",
     );
+  });
+  it("counts an error followed by finish only once", async () => {
+    const telemetry = create();
+    await consume(
+      telemetry,
+      model([{ type: "error", error: "private error" }, finishPart]),
+      3,
+    );
+    expect(events("abliterated_model_provider_outcome")).toHaveLength(1);
+    expect(telemetry.getSummary()).toMatchObject({
+      provider_outcome_count: 1,
+      provider_error_count: 1,
+      provider_completed_count: 0,
+      provider_pending_count: 0,
+    });
+  });
+  it("retains incomplete continuation outcomes", async () => {
+    const telemetry = create();
+    await consume(telemetry, model([]), 2);
+    expect(
+      events("abliterated_model_provider_outcome")[0].properties.outcome,
+    ).toBe("incomplete");
+    expect(telemetry.getSummary().provider_incomplete_count).toBe(1);
+  });
+  it("propagates cancellation and retains the aborted continuation outcome", async () => {
+    const telemetry = create();
+    const source = model([]);
+    if (typeof source === "string") throw new Error("unexpected model");
+    const cancel = jest.fn();
+    source.doStream = jest.fn(async () => ({
+      stream: new ReadableStream({ cancel }),
+    }));
+    const wrapped = telemetry.wrap(source, 4);
+    if (typeof wrapped === "string") throw new Error("unexpected model");
+    const result = await wrapped.doStream({ prompt: [] });
+    const pending = telemetry.getSummary();
+    expect(pending.provider_pending_count).toBe(1);
+    await result.stream.cancel("stop");
+    expect(cancel).toHaveBeenCalledWith("stop");
+    expect(
+      events("abliterated_model_provider_outcome")[0].properties,
+    ).toMatchObject({ generation_step: 5, outcome: "aborted" });
+    expect(telemetry.getSummary()).toMatchObject({
+      provider_aborted_count: 1,
+      provider_pending_count: 0,
+      provider_outcome_count: 1,
+    });
+    expect(pending.provider_pending_count).toBe(1); // snapshots cannot change after capture
   });
   it("does not call reasoning-only output a successful answer", async () => {
     await consume(
@@ -165,6 +331,7 @@ describe("Abliteration stream telemetry", () => {
           finishReason: { unified: "content-filter", raw: "content-filter" },
         },
       ]),
+      0,
     );
     const output = await consumeModel(
       guardLanguageModelProviderResponse(telemetryModel),

--- a/lib/analytics/abliterated-model.ts
+++ b/lib/analytics/abliterated-model.ts
@@ -18,9 +18,39 @@ type StreamResult = Awaited<ReturnType<StreamOptions["doStream"]>>;
 type StreamPart =
   StreamResult["stream"] extends ReadableStream<infer P> ? P : never;
 
+type ProviderOutcome =
+  | "completed"
+  | "error"
+  | "aborted"
+  | "incomplete"
+  | "content_filter"
+  | "truncated"
+  | "empty";
+
 /** One instance per assistant response; shared across retries and model switches. */
 export class AbliteratedModelTelemetry {
   private sequence = 0;
+  private readonly totals = {
+    provider_outcome_count: 0,
+    provider_completed_count: 0,
+    provider_error_count: 0,
+    provider_aborted_count: 0,
+    provider_incomplete_count: 0,
+    provider_content_filter_count: 0,
+    provider_truncated_count: 0,
+    provider_empty_count: 0,
+    provider_abliteration_attempt_count: 0,
+    provider_baseline_attempt_count: 0,
+    provider_continuation_completed_count: 0,
+    provider_usage_reported_count: 0,
+    provider_input_tokens: 0,
+    provider_output_tokens: 0,
+    provider_cache_read_tokens: 0,
+    provider_reasoning_tokens: 0,
+    provider_estimated_cost_dollars: 0,
+    provider_duration_ms: 0,
+    provider_tool_call_count: 0,
+  };
   private exposed = false;
   private successfulAbliterationGeneration = false;
   private selectionSource: "moderation" | "history";
@@ -62,7 +92,7 @@ export class AbliteratedModelTelemetry {
       )
         ? "not_appended"
         : "standard",
-      telemetry_version: 1,
+      telemetry_version: 2,
       $process_person_profile: false,
     };
     this.capture("abliterated_model_eligible", {});
@@ -98,6 +128,17 @@ export class AbliteratedModelTelemetry {
     };
   }
 
+  /** Request totals include retries and replacement messages; no per-step array. */
+  getSummary() {
+    return {
+      telemetry_version: 2,
+      provider_attempt_count: this.sequence,
+      provider_pending_count:
+        this.sequence - this.totals.provider_outcome_count,
+      ...this.totals,
+    };
+  }
+
   wrap(model: LanguageModel, stepIndex: number): LanguageModel {
     if (typeof model === "string" || model.specificationVersion !== "v3")
       return model;
@@ -107,6 +148,9 @@ export class AbliteratedModelTelemetry {
         specificationVersion: "v3",
         wrapStream: async ({ doStream, params }) => {
           const attempt = ++this.sequence;
+          if (isAbliterationModel(model.modelId))
+            this.totals.provider_abliteration_attempt_count++;
+          else this.totals.provider_baseline_attempt_count++;
           const start = Date.now();
           let terminal = false;
           let textCharacters = 0;
@@ -126,21 +170,48 @@ export class AbliteratedModelTelemetry {
               : "standard",
           });
           const finish = (
-            outcome: string,
+            outcome: ProviderOutcome,
             properties: Record<string, unknown> = {},
           ) => {
             if (terminal) return;
             terminal = true;
+            const duration = Date.now() - start;
+            this.totals.provider_outcome_count++;
+            this.totals[`provider_${outcome}_count`]++;
+            this.totals.provider_duration_ms += duration;
+            this.totals.provider_tool_call_count += toolCalls;
+            if (outcome === "completed" && stepIndex > 0)
+              this.totals.provider_continuation_completed_count++;
+            if (
+              typeof properties.estimated_provider_cost_dollars === "number"
+            ) {
+              this.totals.provider_usage_reported_count++;
+              this.totals.provider_estimated_cost_dollars +=
+                properties.estimated_provider_cost_dollars;
+            }
+            for (const key of [
+              "input_tokens",
+              "output_tokens",
+              "cache_read_tokens",
+              "reasoning_tokens",
+            ] as const) {
+              const value = properties[key];
+              if (typeof value === "number")
+                this.totals[`provider_${key}`] += value;
+            }
             if (
               outcome === "completed" &&
               isAbliterationModel(responseModel) &&
               isAbliterationModel(model.modelId)
             )
               this.successfulAbliterationGeneration = true;
+            // Keep first-step comparisons and every exceptional outcome. Normal
+            // continuation successes are represented by the final run summary.
+            if (stepIndex > 0 && outcome === "completed") return;
             this.capture("abliterated_model_provider_outcome", {
               ...common(),
               outcome,
-              duration_ms: Date.now() - start,
+              duration_ms: duration,
               first_content_ms: firstContentMs,
               text_characters: textCharacters,
               reasoning_characters: reasoningCharacters,
@@ -159,7 +230,6 @@ export class AbliteratedModelTelemetry {
               exposure_surface: "stream_content",
             });
           };
-          this.capture("abliterated_model_provider_attempt", common());
           let result: StreamResult;
           try {
             result = await doStream();

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -541,7 +541,15 @@ describe("captureAgentBudgetAbort", () => {
 describe("captureAgentCompletionAnalytics", () => {
   it("captures Ask experiment outcomes while preserving assignment through fallback", () => {
     const capture = jest.fn();
+    const providerSummary = {
+      telemetry_version: 2,
+      provider_attempt_count: 500,
+      provider_completed_count: 499,
+      provider_error_count: 1,
+      provider_estimated_cost_dollars: 0.12,
+    };
     captureAgentCompletionAnalytics({
+      abliteratedProviderSummary: providerSummary,
       posthog: { capture } as any,
       userId: "user",
       chatId: "chat",
@@ -566,6 +574,7 @@ describe("captureAgentCompletionAnalytics", () => {
       expect.objectContaining({
         event: "abliterated_model_response_outcome",
         properties: expect.objectContaining({
+          ...providerSummary,
           mode: "ask",
           experiment_variant: "test",
           experiment_request_id: "message",

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -2114,6 +2114,8 @@ export const createChatHandler = () => {
                                     ? "error"
                                     : "success";
                                 captureAgentCompletionAnalytics({
+                                  abliteratedProviderSummary:
+                                    abliteratedTelemetry?.getSummary(),
                                   posthog,
                                   userId,
                                   chatId,
@@ -2439,6 +2441,8 @@ export const createChatHandler = () => {
                         ? "error"
                         : "success";
                     captureAgentCompletionAnalytics({
+                      abliteratedProviderSummary:
+                        abliteratedTelemetry?.getSummary(),
                       posthog,
                       userId,
                       chatId,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -35,6 +35,7 @@ import {
   type ExperimentAnalyticsContext,
 } from "@/lib/analytics/experiment-context";
 import type { AgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
+import type { AbliteratedModelTelemetry } from "@/lib/analytics/abliterated-model";
 import { buildAgentPerformanceDiagnostics } from "@/lib/analytics/agent-performance-diagnostics";
 import {
   EXTRA_USAGE_MULTIPLIER,
@@ -1249,6 +1250,9 @@ export function resolveAgentAbortSource({
 }
 
 type AgentCompletionAnalyticsArgs = {
+  abliteratedProviderSummary?: ReturnType<
+    AbliteratedModelTelemetry["getSummary"]
+  >;
   posthog: PostHog | null;
   userId: string;
   chatId: string;
@@ -1643,6 +1647,7 @@ export function captureAgentCompletionAnalytics(
         distinctId: userId,
         event: "abliterated_model_response_outcome",
         properties: {
+          ...args.abliteratedProviderSummary,
           ...getExperimentAnalyticsProperties(args.experiment),
           chat_id: args.chatId,
           mode,


### PR DESCRIPTION
Abliteration telemetry emitted an attempt and outcome for every generation step, including successful OpenRouter continuations. At September 7 traffic, removing the redundant attempt and continuation-success events would save roughly 204,000 events/day.

This change counts provider calls in memory and attaches attempts, outcomes, usage, estimated cost, and continuation totals to the existing response-outcome event. First-step outcomes for both experiment variants, all exceptional outcomes, eligibility, exposure, feedback, and final run outcomes remain unsampled. Routing, billing, and rollout assignments are unchanged.

Telemetry is versioned as v2. The production PostHog spend chart now separates historical v1 per-call estimates from v2 response totals to prevent double counting. Preview has no corresponding saved insight. Request totals include replacement-message retries; missing usage and processes that exit before final analytics remain explicit measurement limitations.

Validation:
- TypeScript and ESLint passed; all 4,986 tests across 471 suites passed locally.
- GitHub CI, CodeQL, Vercel Preview, Trigger Preview, and CodeRabbit completed successfully; CodeRabbit reported no actionable findings.
- Focused stream, handler, Agent-loop and completion analytics tests passed, including 500-step runs for both variants, later failures, fallback message replacement, cancellation, incomplete streams, and duplicate terminal chunks.
- A successful 500-step run now emits three provider-experiment diagnostic events before its existing final summary, instead of 1,002.
- Updated PostHog spend insight executes and retains historical data.

Post-deployment verification:
1. Use the hardcoded test accounts in Preview for an eligible Ask request and a multi-step Agent run; confirm successful completion and reload the chat.
2. In PostHog project 401167, verify telemetry_version=2, no provider-attempt events from the new worker, first-step detail only for successful runs, and response totals covering all calls. Check errors/fallbacks retain their detail.
3. After both Vercel and Trigger Production deploy, repeat the aggregate volume/outcome-coverage check in project 144137. Older in-flight runs may still emit v1. No environment variables or feature-flag edits are required.

Tracks HAC-99; existing HAC-101 experiment and feedback cleanup remains required.
