### PR TITLE
HAC-99: Include provider summaries in Trigger Agent outcomes

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -539,54 +539,58 @@ describe("captureAgentBudgetAbort", () => {
 });
 
 describe("captureAgentCompletionAnalytics", () => {
-  it("captures Ask experiment outcomes while preserving assignment through fallback", () => {
-    const capture = jest.fn();
-    const providerSummary = {
-      telemetry_version: 2,
-      provider_attempt_count: 500,
-      provider_completed_count: 499,
-      provider_error_count: 1,
-      provider_estimated_cost_dollars: 0.12,
-    };
-    captureAgentCompletionAnalytics({
-      abliteratedProviderSummary: providerSummary,
-      posthog: { capture } as any,
-      userId: "user",
-      chatId: "chat",
-      endpoint: "/api/chat",
-      mode: "ask",
-      subscription: "pro",
-      outcome: "success",
-      selectedModel: "model-abliterated",
-      configuredModelId: "abliterated-model",
-      responseModel: "deepseek/deepseek-v4-flash-0731",
-      fallbackServed: true,
-      sandboxInfo: { type: "e2b" },
-      chatLogger: {} as any,
-      experiment: {
-        key: "abliterated_paid_moderated_v1",
-        variant: "test",
-        requestId: "message",
-      },
-    });
-    expect(capture).toHaveBeenCalledTimes(1);
-    expect(capture).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: "abliterated_model_response_outcome",
-        properties: expect.objectContaining({
-          ...providerSummary,
-          mode: "ask",
-          experiment_variant: "test",
-          experiment_request_id: "message",
-          fallback_served: true,
+  it.each(["ask", "agent"] as const)(
+    "captures %s experiment summaries while preserving assignment through fallback",
+    (mode) => {
+      const capture = jest.fn();
+      const providerSummary = {
+        telemetry_version: 2,
+        provider_attempt_count: 500,
+        provider_completed_count: 499,
+        provider_error_count: 1,
+        provider_estimated_cost_dollars: 0.12,
+      };
+      captureAgentCompletionAnalytics({
+        abliteratedProviderSummary: providerSummary,
+        posthog: { capture } as any,
+        userId: "user",
+        chatId: "chat",
+        endpoint: mode === "agent" ? "/api/agent-long" : "/api/chat",
+        mode,
+        subscription: "pro",
+        outcome: "success",
+        selectedModel: "model-abliterated",
+        configuredModelId: "abliterated-model",
+        responseModel: "deepseek/deepseek-v4-flash-0731",
+        fallbackServed: true,
+        sandboxInfo: { type: "e2b" },
+        chatLogger: {} as any,
+        experiment: {
+          key: "abliterated_paid_moderated_v1",
+          variant: "test",
+          requestId: "message",
+        },
+      });
+      expect(capture).toHaveBeenCalledTimes(mode === "agent" ? 2 : 1);
+      expect(capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "abliterated_model_response_outcome",
+          properties: expect.objectContaining({
+            ...providerSummary,
+            mode,
+            experiment_variant: "test",
+            experiment_request_id: "message",
+            fallback_served: true,
+          }),
         }),
-      }),
-    );
-  });
+      );
+    },
+  );
   it("uses the existing agent completion event for successful free Agent activation", () => {
     const capture = jest.fn();
 
     captureAgentCompletionAnalytics({
+      abliteratedProviderSummary: undefined,
       posthog: { capture } as any,
       userId: "user_123",
       chatId: "chat_123",
@@ -625,6 +629,7 @@ describe("captureAgentCompletionAnalytics", () => {
     const capture = jest.fn();
 
     captureAgentCompletionAnalytics({
+      abliteratedProviderSummary: undefined,
       posthog: { capture } as any,
       userId: "user_123",
       chatId: "chat_123",

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1250,9 +1250,9 @@ export function resolveAgentAbortSource({
 }
 
 type AgentCompletionAnalyticsArgs = {
-  abliteratedProviderSummary?: ReturnType<
-    AbliteratedModelTelemetry["getSummary"]
-  >;
+  // Every completion path must explicitly forward its request telemetry.
+  abliteratedProviderSummary:
+    ReturnType<AbliteratedModelTelemetry["getSummary"]> | undefined;
   posthog: PostHog | null;
   userId: string;
   chatId: string;
@@ -1358,7 +1358,10 @@ export function captureAgentRun({
   providerRecoveryAttempts,
   providerRecoveryModels,
   providerRecoverySucceeded,
-}: Omit<AgentCompletionAnalyticsArgs, "endpoint" | "chatLogger">) {
+}: Omit<
+  AgentCompletionAnalyticsArgs,
+  "endpoint" | "chatLogger" | "abliteratedProviderSummary"
+>) {
   if (mode !== "agent") return;
   const performanceDiagnostics = buildAgentPerformanceDiagnostics({
     triggerUsageDurationMs,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -4419,6 +4419,7 @@ export const agentLongTask = task({
                   ? "error"
                   : "success";
               captureAgentCompletionAnalytics({
+                abliteratedProviderSummary: abliteratedTelemetry?.getSummary(),
                 posthog,
                 userId,
                 chatId,
@@ -5264,6 +5265,8 @@ export const agentLongTask = task({
                           ? "error"
                           : "success";
                       captureAgentCompletionAnalytics({
+                        abliteratedProviderSummary:
+                          abliteratedTelemetry?.getSummary(),
                         posthog,
                         userId,
                         chatId,


### PR DESCRIPTION
Production verification of #1284 found that new Agent runs correctly stopped emitting per-step attempts, but their final response events lacked provider totals. Trigger has two completion paths separate from the Vercel chat handler, and neither forwarded the new summary.

Forward request totals from both the normal and fallback Trigger completion paths. Make the completion summary argument required (explicitly undefined outside the experiment) so TypeScript catches omitted callers. Extend the completion-event test to cover both Ask and Agent. Routing, budgets, retries, and feedback behavior stay unchanged.

Observed production evidence: 14 v2 Agent requests had matching final outcomes (12 success, 2 aborted), but none included telemetry_version or the new summary totals. Final response tracking and the event-volume reduction worked; aggregate provider totals for the affected worker version 20260908.1 are missing and must not be treated as zero cost.

Validation:
- All 4,987 tests across 471 suites, TypeScript, and lint passed.
- CI, CodeQL, Vercel Preview, Trigger Preview, and CodeRabbit passed. No actionable review findings.
- Normal and fallback Trigger paths now forward the same request-wide summary used by the model wrapper.

Deployment verification:
- After Vercel and Trigger Production deploy and the worker-linked Vercel redeploy is Ready, wait for eligible Agent requests on the new worker.
- In PostHog project 144137, verify final response events include telemetry_version=2 and provider_attempt_count/provider_outcome_count totals; counts reconcile, successful later-step events and attempt events remain absent, and first-step/error outcomes remain present.
- Check the updated spend insight includes v2 totals; preserve the known missing-summary interval from worker 20260908.1 when reading historical data.

Tracks HAC-99. Corrects the deployment issue found while verifying #1284.
