### PR TITLE
HAC-98: Make GLM Flash low the free Ask default

### DIFF
--- a/docs/internal/flash-routing-experiment.md
+++ b/docs/internal/flash-routing-experiment.md
@@ -1,8 +1,30 @@
-# Flash routing experiment (HAC-98)
+# Flash routing decisions (HAC-98)
 
 Owner and decision record: [HAC-98](https://linear.app/hackerai/issue/HAC-98).
-This is a reversible comparison, not evidence that the model caused a business
-decline. Opening or merging the PR does not authorize a production ramp.
+
+## Free Ask closeout — September 8, 2026
+
+Free Ask now selects `ask-model-free-glm` (`z-ai/glm-5.3-flash`) directly,
+with low reasoning through the existing provider/fallback policy. No PostHog
+assignment is consulted or free Flash experiment exposure emitted. Existing
+media routes, authenticated tier checks, limits and cost accounting remain in
+place. The `ask-model-free` DeepSeek alias remains for paid allowance rescue.
+
+This is an explicit product decision; the conversion result was inconclusive.
+The preliminary readout and limitations are recorded in HAC-98, with historical
+events retained. Retire `free_ask_flash_conversion_v1` in Preview 401167
+(flag 868788) and Production 144137 (flag 868786) after this code is deployed.
+Disabling that retired flag no longer changes routing; rollback requires a code
+change. Verify a new free Ask request on the deployment, completion/reload,
+configured GLM model, low reasoning and no experiment attribution.
+
+The paid Agent flag remains disabled by the separate Agent decision in HAC-98.
+Its routing and the Abliteration experiment are unchanged by this cleanup.
+
+## Historical experiment design
+
+The remaining sections describe the original experiment, not current rollout
+instructions. Consult HAC-98 for dated allocations and final decisions.
 
 ## Routes
 

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -126,6 +126,10 @@ describe("provider registry", () => {
         .modelId,
     ).toBe("deepseek/deepseek-v4-flash-0731");
     expect(
+      (myProvider.languageModel("ask-model-free-glm") as { modelId: string })
+        .modelId,
+    ).toBe("z-ai/glm-5.3-flash");
+    expect(
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
     ).toBe("deepseek/deepseek-v4-flash-0731");
@@ -283,8 +287,12 @@ describe("provider registry", () => {
     expect(isDeepSeekModel("agent-auto-review-model")).toBe(true);
   });
 
-  it("keeps tracked free Ask and Agent on the current Flash revision", () => {
+  it("keeps tracked free Ask on GLM and Agent/rescue on DeepSeek", () => {
     const provider = createTrackedProvider();
+    expect(
+      (provider.languageModel("ask-model-free-glm") as { modelId: string })
+        .modelId,
+    ).toBe("z-ai/glm-5.3-flash");
     expect(
       (provider.languageModel("ask-model-free") as { modelId: string }).modelId,
     ).toBe("deepseek/deepseek-v4-flash-0731");

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1233,8 +1233,8 @@ export const getOpenRouterProviderRoutingForModel = (
 
 const buildProviderMap = (
   or: OpenRouterInstance,
-  // DeepSeek V4 Flash requires reasoning. Free Ask uses the same current model
-  // as Free Agent, with a lower reasoning effort set per request.
+  // Preserve the DeepSeek alias used by paid daily free allowance rescue.
+  // Regular free Ask uses ask-model-free-glm with low reasoning per request.
   freeAskModelSlug = DEEPSEEK_V4_FLASH_SLUG,
   freeAgentModelSlug = DEEPSEEK_V4_FLASH_SLUG,
 ) =>

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -76,7 +76,7 @@ describe("buildProviderOptions fallback chain", () => {
       }
     },
   );
-  it("keeps the free GLM treatment at low reasoning with billed, retryable fallbacks", () => {
+  it("keeps the free Ask default at low reasoning with billed, retryable fallbacks", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -362,8 +362,10 @@ describe("selectModel", () => {
       );
     });
 
-    it("should return ask-model-free for ask mode (free)", () => {
-      expect(selectModel("ask", "free")).toBe("ask-model-free");
+    it.each([false, true])("keeps free Ask on GLM with PDF=%s", (hasPdf) => {
+      expect(selectModel("ask", "free", "auto", false, hasPdf)).toBe(
+        "ask-model-free-glm",
+      );
     });
 
     it("should return DeepSeek V4 Pro 0813 for ultra subscription with no image/PDF", () => {
@@ -533,12 +535,14 @@ describe("selectModel", () => {
     });
 
     it("should ignore tier override for free users in ask mode", () => {
-      expect(selectModel("ask", "free", "hackerai-pro")).toBe("ask-model-free");
+      expect(selectModel("ask", "free", "hackerai-pro")).toBe(
+        "ask-model-free-glm",
+      );
     });
 
     it("should keep free ask Standard on the free GLM Flash route", () => {
       expect(selectModel("ask", "free", "hackerai-standard")).toBe(
-        "ask-model-free",
+        "ask-model-free-glm",
       );
     });
   });

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -98,7 +98,7 @@ export function selectModel(
         ? "model-grok-4.5"
         : paidAutoTextModel
     : isFreeAsk
-      ? "ask-model-free"
+      ? "ask-model-free-glm"
       : paidAskMediaModel;
 
   // Free users always route through the auto router; paid users may pick an

--- a/lib/experiments/__tests__/flash-routing.test.ts
+++ b/lib/experiments/__tests__/flash-routing.test.ts
@@ -2,7 +2,6 @@ import {
   evaluateFlashRouting,
   getActiveFlashRoutingAssignment,
   createFlashRoutingExposureRecorder,
-  FREE_ASK_FLASH_CONVERSION_KEY,
   PAID_AGENT_FLASH_RETURN_KEY,
   FLASH_ROUTING_EXPOSURE_EVENT,
 } from "@/lib/experiments/flash-routing";
@@ -11,7 +10,7 @@ const free = {
   userId: "test-user",
   subscription: "free" as const,
   mode: "ask" as const,
-  selectedModel: "ask-model-free",
+  selectedModel: "ask-model-free-glm",
   hasImages: false,
 };
 const paid = {
@@ -26,8 +25,6 @@ const flags = (variant: unknown) => ({
 
 describe("Flash routing experiments", () => {
   it.each([
-    [free, "control", FREE_ASK_FLASH_CONVERSION_KEY, "ask-model-free"],
-    [free, "test", FREE_ASK_FLASH_CONVERSION_KEY, "ask-model-free-glm"],
     [
       paid,
       "control",
@@ -59,6 +56,8 @@ describe("Flash routing experiments", () => {
   );
 
   it.each([
+    free,
+    { ...free, selectedModel: "ask-model-free" },
     { ...paid, mode: "ask" as const },
     { ...paid, subscription: "free" as const },
     { ...paid, selectedModel: "model-deepseek-v4-pro-0813" },
@@ -81,7 +80,7 @@ describe("Flash routing experiments", () => {
     async (variant) => {
       expect(
         await evaluateFlashRouting({
-          ...free,
+          ...paid,
           posthog: flags(variant) as never,
         }),
       ).toBeUndefined();
@@ -90,11 +89,11 @@ describe("Flash routing experiments", () => {
 
   it("fails closed on missing client or flag service failure", async () => {
     expect(
-      await evaluateFlashRouting({ ...free, posthog: null }),
+      await evaluateFlashRouting({ ...paid, posthog: null }),
     ).toBeUndefined();
     expect(
       await evaluateFlashRouting({
-        ...free,
+        ...paid,
         posthog: {
           evaluateFlags: jest.fn().mockRejectedValue(new Error("unavailable")),
         } as never,
@@ -131,12 +130,12 @@ describe("Flash routing experiments", () => {
 
   it("records only the first matching provider request, with an explicit property allowlist", async () => {
     const assignment = await evaluateFlashRouting({
-      ...free,
+      ...paid,
       posthog: flags("test") as never,
     });
     const capture = jest.fn();
     const record = createFlashRoutingExposureRecorder({
-      ...free,
+      ...paid,
       posthog: { capture } as never,
       assignment,
       requestId: "request-1",
@@ -152,13 +151,13 @@ describe("Flash routing experiments", () => {
       distinctId: "test-user",
       event: FLASH_ROUTING_EXPOSURE_EVENT,
       properties: {
-        experiment_key: FREE_ASK_FLASH_CONVERSION_KEY,
+        experiment_key: PAID_AGENT_FLASH_RETURN_KEY,
         experiment_variant: "test",
-        [`$feature/${FREE_ASK_FLASH_CONVERSION_KEY}`]: "test",
-        subscription: "free",
-        subscription_tier: "free",
-        mode: "ask",
-        selected_model: "ask-model-free-glm",
+        [`$feature/${PAID_AGENT_FLASH_RETURN_KEY}`]: "test",
+        subscription: "pro",
+        subscription_tier: "pro",
+        mode: "agent",
+        selected_model: "model-glm-5.3-flash-agent",
         configured_model: "z-ai/glm-5.3-flash",
         request_id: "request-1",
         exposure_surface: "provider_request",
@@ -169,11 +168,11 @@ describe("Flash routing experiments", () => {
 
   it("does not fail generation when capture throws", async () => {
     const assignment = await evaluateFlashRouting({
-      ...free,
+      ...paid,
       posthog: flags("test") as never,
     });
     const record = createFlashRoutingExposureRecorder({
-      ...free,
+      ...paid,
       assignment,
       requestId: "request-1",
       posthog: {

--- a/lib/experiments/flash-routing.ts
+++ b/lib/experiments/flash-routing.ts
@@ -4,18 +4,16 @@ import { getExperimentAnalyticsProperties } from "@/lib/analytics/experiment-con
 import type { ChatMode, SubscriptionTier } from "@/types";
 
 export const PAID_AGENT_FLASH_RETURN_KEY = "paid_agent_glm_flash_return_v1";
-export const FREE_ASK_FLASH_CONVERSION_KEY = "free_ask_flash_conversion_v1";
 export const FLASH_ROUTING_EXPOSURE_EVENT = "flash_routing_experiment_exposed";
 
 export type FlashRoutingAssignment = {
-  key:
-    typeof PAID_AGENT_FLASH_RETURN_KEY | typeof FREE_ASK_FLASH_CONVERSION_KEY;
+  key: typeof PAID_AGENT_FLASH_RETURN_KEY;
   variant: "control" | "test";
   modelKey: ModelName;
   configuredModel: string;
 };
 
-/** Only already-authorized standard routes participate; media and rescue do not. */
+/** Only paid Agent standard routes participate; free Ask uses a fixed model. */
 export async function evaluateFlashRouting({
   posthog,
   userId,
@@ -33,15 +31,11 @@ export async function evaluateFlashRouting({
 }): Promise<FlashRoutingAssignment | undefined> {
   if (!posthog || !userId || hasImages) return undefined;
   const key =
-    mode === "ask" &&
-    subscription === "free" &&
-    selectedModel === "ask-model-free"
-      ? FREE_ASK_FLASH_CONVERSION_KEY
-      : mode === "agent" &&
-          subscription !== "free" &&
-          selectedModel === "model-deepseek-v4-flash-0731"
-        ? PAID_AGENT_FLASH_RETURN_KEY
-        : undefined;
+    mode === "agent" &&
+    subscription !== "free" &&
+    selectedModel === "model-deepseek-v4-flash-0731"
+      ? PAID_AGENT_FLASH_RETURN_KEY
+      : undefined;
   if (!key) return undefined;
 
   try {
@@ -52,11 +46,7 @@ export async function evaluateFlashRouting({
       key,
       variant,
       modelKey:
-        variant === "control"
-          ? selectedModel
-          : key === FREE_ASK_FLASH_CONVERSION_KEY
-            ? "ask-model-free-glm"
-            : "model-glm-5.3-flash-agent",
+        variant === "control" ? selectedModel : "model-glm-5.3-flash-agent",
       configuredModel:
         variant === "test"
           ? "z-ai/glm-5.3-flash"


### PR DESCRIPTION
Free Ask still depended on a PostHog allocation to choose between DeepSeek and GLM. It now always selects the existing GLM 5.3 Flash route with low reasoning, and no longer evaluates or emits exposure for the free Ask experiment.

Keeps model-specific fallback/accounting, media routing, paid allowance rescue, and Agent behavior intact. Records the inconclusive experiment closeout in the runbook and HAC-98. Retire the free flag in both PostHog projects after deployment; retain historical data.

Validation: TypeScript, changed-source ESLint, dependency isolation, and all 472 suites / 5,011 tests pass, including routing, low reasoning/retries, pricing, and rescue coverage.

Manual verification: On the branch Preview, sign in with the existing free test account, submit a short Ask request, verify completion and reload, GLM attribution and low reasoning, and no free experiment attribution. Verify the same model default after deployment and flag retirement. Preview acceptance passed on e40707e: the existing free test account completed a disposable Ask request with free_ask_flash_conversion_v1 disabled. Vercel runtime evidence shows configured ask-model-free-glm, served z-ai/glm-5.3-flash, reasoning_effort=low, HTTP 200, finish_reason=stop, outcome=success. Response survived reload. The branch uses HackerAI Developer / hackerai-development / hackerai-52290 / bright-walrus-473; the browser actually connects to that backend and its analytics key fingerprint matches Preview project 401167. Production retirement follows deployment. All CI and CodeRabbit passed with no actionable comments. Preview PostHog confirms GLM, successful usage accounting and no experiment attribution; zero custom experiment exposures.


Merge status: GitHub requires an approving review and automatic merge is disabled. Production has been set to 100% GLM / 0% control using the existing free Ask flag so the comparison is no longer allocating users between models. After this PR is approved, merged and deployed, deactivate production free_ask_flash_conversion_v1 (project 144137, flag 868786). Preview counterpart (401167, 868788) is already inactive. Do not deactivate production before deployment: old code would restore DeepSeek.
