### PR TITLE
Fix Agent provider recovery and oversized tool histories

### DIFF
--- a/docs/provider-error-recovery.md
+++ b/docs/provider-error-recovery.md
@@ -1,0 +1,67 @@
+# Provider error recovery
+
+Agent provider failures may arrive as an HTTP rejection or as an error inside
+an already-open SSE stream. A numeric SSE `code` in the 5xx range is eligible
+for the same bounded disconnect continuation as an HTTP `statusCode`. A bare
+abort without an upstream status remains ineligible; user cancellation always
+wins. Recovery retains completed tool results and removes only the incomplete
+tail. The existing model selection, billing, authorization, and retry limits
+still apply.
+
+A rejection delivered through `streamText.onError` before any output can use
+the existing fallback, including an active Abliteration experiment's baseline
+route. This does not enable replay of arbitrary output-bearing 400 failures.
+The recognized Fireworks image-format rejection uses the existing image-tool
+recovery path. Generic invalid-parameter errors are not assumed to be images.
+
+Storage compaction preserves step boundaries in retained history. For older
+Abliteration histories, request preparation splits assistant batches exceeding
+128 calls only when every call has exactly one adjacent result. Calls, results,
+and their IDs are retained; incomplete or ambiguous batches are left unchanged
+and reported by shape diagnostics. Storage's hard byte limit can still remove
+old parts as before.
+
+## Diagnosing a failure
+
+Inspect the existing `provider_streaming_error` / `provider_stream_terminated`
+event and the primary stream's `provider_recovery_decision` event in the same
+Trigger run. The decision records eligibility or the skip reason, cancellation,
+retry budget state, completed tool count, safe continuation availability, and
+provider correlation IDs. Later recovery attempts/outcomes continue to use
+`agent_provider_disconnect_recovery_attempted` and
+`agent_provider_disconnect_recovery_completed`.
+
+The provider request diagnostics include the maximum calls per assistant,
+unmatched call/result counts, duplicate calls within a batch, and the number of
+oversized batches repaired in that request. Error extraction retains known
+schema parameter paths with numeric indices normalized, when supplied by the
+provider. No new diagnostic includes prompts, tool arguments/results, image
+contents, or signed URLs.
+
+Generic `invalid_request` responses still require an upstream request ID and
+these shape diagnostics to identify the rejected constraint. An image fetch
+403 is not proof of expiration: check storage authorization and URL freshness
+before changing image handling. This change does not refresh signed URLs.
+
+## Verification
+
+Automated regression tests exercise real AI SDK streaming: execute a tool,
+inject an SSE 504, preserve its result, and complete fallback through the UI
+message parser without executing that tool twice. They also exercise an HTTP
+rejection delivered asynchronously, cancellation/retry guards, storage-to-SDK
+round trips, and 148-call legacy histories with complete and ambiguous pairs.
+
+Before promotion, use the PR's Preview with an internal account:
+
+1. Start a disposable Agent chat and ask it to write a short marker to a
+   temporary file, read it, and report completion. Reload the chat; the tool
+   results and final response should remain visible.
+2. Attach a small PNG and request a short description. Confirm completion and
+   that no raw image or signed URL appears in the new diagnostics.
+3. If an upstream failure occurs, inspect the matching Preview Trigger run.
+   It should record recovery eligibility/skip reason, preserve completed work,
+   and obey the existing retry budget. Canceling must prevent a new model leg.
+
+Fault injection is covered locally; do not replay customer runs to manufacture
+these failures. Production verification requires the new Trigger worker
+deployment and new runs; existing failed runs do not change retroactively.

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2042,6 +2042,18 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     }
   });
 
+  test("both recovery paths recheck cancellation after awaiting vision recovery", () => {
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      const visionRecoveryIdx = source.indexOf(
+        "await describeImageAttachmentsWithAuxiliaryVision(",
+      );
+      expect(visionRecoveryIdx).toBeGreaterThan(-1);
+      expect(source.slice(visionRecoveryIdx)).toMatch(
+        /if \(\s*shouldAttemptProviderRetry &&\s*!visionSummaryRecoveryFailure &&\s*!userStopSignal\.signal\.aborted\s*\) \{/,
+      );
+    }
+  });
+
   test("Abliteration routing switches to OpenRouter after the first generation step", () => {
     for (const source of [taskSrc, chatHandlerSrc]) {
       expect(source).toMatch(

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2044,14 +2044,49 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
 
   test("both recovery paths recheck cancellation after awaiting vision recovery", () => {
     for (const source of [taskSrc, chatHandlerSrc]) {
-      const visionRecoveryIdx = source.indexOf(
-        "await describeImageAttachmentsWithAuxiliaryVision(",
+      const recoveryCalls = Array.from(
+        source.matchAll(/await describeImageAttachmentsWithAuxiliaryVision\(/g),
       );
-      expect(visionRecoveryIdx).toBeGreaterThan(-1);
-      expect(source.slice(visionRecoveryIdx)).toMatch(
-        /if \(\s*shouldAttemptProviderRetry &&\s*!visionSummaryRecoveryFailure &&\s*!userStopSignal\.signal\.aborted\s*\) \{/,
-      );
+      expect(recoveryCalls).toHaveLength(2);
+      for (const call of recoveryCalls) {
+        const nextStreamIdx = source.indexOf("await createStream(", call.index);
+        expect(nextStreamIdx).toBeGreaterThan(call.index!);
+        const recoveryBlock = source.slice(call.index, nextStreamIdx);
+        if (
+          source.startsWith("await createStream(apiRetryModel)", nextStreamIdx)
+        ) {
+          expect(recoveryBlock).toMatch(
+            /userStopSignal\.signal\.throwIfAborted\(\);\s*result = $/,
+          );
+        } else {
+          const surveyIdx = recoveryBlock.lastIndexOf(
+            "await taskOutcomeSurvey?.linkMessage(",
+          );
+          expect(surveyIdx).toBeGreaterThan(-1);
+          const afterSurvey = recoveryBlock.slice(surveyIdx);
+          expect(afterSurvey).toMatch(
+            /if \(\s*shouldAttemptProviderRetry &&\s*!visionSummaryRecoveryFailure &&\s*!userStopSignal\.signal\.aborted\s*\) \{/,
+          );
+          if (source === taskSrc) {
+            // Trigger also persists completed work inside the recovery block.
+            expect(afterSurvey).toMatch(
+              /if \(userStopSignal\.signal\.aborted\) \{\s*isAborted = true;\s*break primaryProviderRecovery;\s*\}\s*const retryResult = $/,
+            );
+          } else {
+            // No later async work may open a cancellation race after this guard.
+            expect(afterSurvey.slice(afterSurvey.indexOf(") {"))).not.toMatch(
+              /\bawait\b/,
+            );
+          }
+        }
+      }
     }
+  });
+
+  test("the final Trigger recovery finalizes cancellation after linking its message", () => {
+    expect(taskSrc).toMatch(
+      /await taskOutcomeSurvey\?\.linkMessage\(\s*finalRetryMessageId,?\s*\);\s*if \(userStopSignal\.signal\.aborted\) \{\s*await finalizeRetryStream\(\{\s*retryMessages,\s*retryAborted: true,\s*retryMessageId,\s*retryStartTime: fallbackStartTime,?\s*\}\);\s*return;\s*\}\s*const finalRetryResult =\s*await createStream\(finalRetryModel\)/,
+    );
   });
 
   test("Abliteration routing switches to OpenRouter after the first generation step", () => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1558,7 +1558,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       /hasTerminalProviderStreamError\s*&&\s*isRetriableProviderStreamDisconnectError\(\s*state\.providerError/,
     );
     expect(taskSrc).toMatch(
-      /shouldContinueAfterProviderDisconnect\)\s*&&\s*!isRetryWithFallback/,
+      /decideProviderRecovery\(\{[\s\S]{0,300}alreadyRetried: isRetryWithFallback/,
     );
     expect(taskSrc).toMatch(
       /state\.finalMessages\s*=\s*\[\s*\.\.\.state\.finalMessages,\s*\.\.\.providerDisconnectContinuation\.messages/,
@@ -2027,9 +2027,18 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   test("OCR preprocessing failures never trigger generic baseline recovery", () => {
     for (const source of [taskSrc, chatHandlerSrc]) {
       expect(source).toMatch(/!\(error instanceof AbliterationVisionError\)/);
-      expect(source).toMatch(
-        /const shouldAttemptProviderRetry\s*=\s*!\(\s*state\.providerError instanceof AbliterationVisionError\s*\)\s*&&/,
-      );
+      if (source === taskSrc) {
+        expect(source).toMatch(
+          /unrecoverableVision:\s*state\.providerError instanceof\s*AbliterationVisionError/,
+        );
+        expect(source).toMatch(
+          /const shouldAttemptProviderRetry\s*=\s*providerRecoveryDecision\.attempt/,
+        );
+      } else {
+        expect(source).toMatch(
+          /const shouldAttemptProviderRetry\s*=\s*!\(\s*state\.providerError instanceof AbliterationVisionError\s*\)\s*&&/,
+        );
+      }
     }
   });
 

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -503,6 +503,74 @@ describe("createAgentStream repeated compaction", () => {
     mockGetProviderPromptPressure.mockReset();
   });
 
+  it("repairs legacy oversized Abliteration batches in initial and later requests and records counts", async () => {
+    const calls = Array.from({ length: 148 }, (_, i) => ({
+      type: "tool-call" as const,
+      toolCallId: `call-${i}`,
+      toolName: "file",
+      input: {},
+    }));
+    const legacy: ModelMessage[] = [
+      { role: "assistant", content: calls },
+      {
+        role: "tool",
+        content: calls.map((call) => ({
+          type: "tool-result" as const,
+          toolCallId: call.toolCallId,
+          toolName: "file",
+          output: { type: "text" as const, value: "ok" },
+        })),
+      },
+      { role: "user", content: "continue" },
+    ];
+    jest.requireMock("ai").convertToModelMessages.mockResolvedValueOnce(legacy);
+    const recordProviderRequestDiagnostics = jest.fn();
+    const stream = (await createAgentStream(
+      "model-abliterated",
+      createTestStreamContext({
+        trackedProvider: {
+          languageModel: (name: string) => ({ modelId: name }),
+        },
+        chatLogger: { recordProviderRequestDiagnostics },
+        summarizationTracker: { hasSummarized: false, summarizationCount: 0 },
+        usageTracker: {},
+      }) as any,
+      initAgentStreamState([uiMessage("initial", "continue")], {
+        usedTokens: 1000,
+        maxTokens: 128000,
+      }),
+    )) as any;
+    expect(stream.messages.map((m: ModelMessage) => m.role)).toEqual([
+      "assistant",
+      "tool",
+      "assistant",
+      "tool",
+      "user",
+    ]);
+    expect(recordProviderRequestDiagnostics).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        max_tool_calls_per_assistant: 128,
+        unmatched_tool_call_count: 0,
+        unmatched_tool_result_count: 0,
+        tool_call_batches_split: 1,
+      }),
+    );
+    const step = await stream.prepareStep({
+      stepNumber: 0,
+      steps: [],
+      messages: legacy,
+    });
+    expect(
+      step.messages.filter((m: ModelMessage) => m.role === "assistant"),
+    ).toHaveLength(2);
+    expect(recordProviderRequestDiagnostics).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        max_tool_calls_per_assistant: 128,
+        tool_call_batches_split: 1,
+      }),
+    );
+  });
+
   it.each([
     ["agent", 0, true],
     ["agent", 1, false],

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -6,6 +6,10 @@ import {
   createAbliterationVisionPreprocessor,
 } from "@/lib/chat/abliteration-vision";
 import { createAbliterationMediaRecovery } from "@/lib/chat/abliteration-media-recovery";
+import {
+  getProviderToolCallDiagnostics,
+  splitProviderToolCallBatches,
+} from "@/lib/chat/provider-tool-call-batches";
 /**
  * Shared streamText factory for the agent loop.
  *
@@ -614,6 +618,7 @@ const buildProviderRequestDiagnostics = (args: {
     active_tools_mode: args.activeTools ? "subset" : "all",
     ...summarizeProviderOptions(args.providerOptions),
     has_multimodal_tool_results: args.hasMultimodalToolResults,
+    ...getProviderToolCallDiagnostics(args.messages),
   };
 };
 
@@ -1062,13 +1067,18 @@ export async function createAgentStream(
     preprocessAbliterationImages,
     abortSignal,
   );
+  let latestToolCallBatchSplitCount = 0;
   const prepareProviderMessages = async (
     messages: ModelMessage[],
     effectiveModelName = getEffectiveModelName(),
   ): Promise<ModelMessage[]> => {
+    const toolCallRepair = isAbliterationModel(effectiveModelName)
+      ? splitProviderToolCallBatches(messages)
+      : { messages, splitCount: 0 };
+    latestToolCallBatchSplitCount = toolCallRepair.splitCount;
     const visionMessages = isAbliterationModel(effectiveModelName)
-      ? await preprocessAbliterationImages(messages)
-      : messages;
+      ? await preprocessAbliterationImages(toolCallRepair.messages)
+      : toolCallRepair.messages;
     const providerMessages = providerPdfAttachmentsDisabled
       ? omitPdfFilePartsFromModelMessages(visionMessages)
       : visionMessages;
@@ -1126,6 +1136,8 @@ export async function createAgentStream(
       maxOutputTokens,
       hasMultimodalToolResults: streamHasImageViewResults,
     });
+    latestProviderRequestDiagnostics.tool_call_batches_split =
+      latestToolCallBatchSplitCount;
     ctx.chatLogger?.recordProviderRequestDiagnostics(
       latestProviderRequestDiagnostics,
     );

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -2837,7 +2837,38 @@ export const createChatHandler = () => {
               }),
             );
           } catch (error) {
-            await releaseFreeRunLockOnce();
+            // execute errors are consumed by createUIMessageStream, so the
+            // outer request catch and stream onFinish cannot clean them up.
+            preemptiveTimeout?.clear();
+            const cleanupOperations = [
+              [
+                "stop_subscriber",
+                async () => {
+                  if (!subscriberStopped) {
+                    await cancellationSubscriber.stop();
+                    subscriberStopped = true;
+                  }
+                },
+              ],
+              ["refund_usage", () => usageRefundTracker.refund()],
+              ["close_pty_sessions", () => ptySessionManager.closeAll(chatId)],
+              ["release_run_lock", () => releaseFreeRunLockOnce()],
+            ] as const;
+            const cleanupResults = await Promise.allSettled(
+              cleanupOperations.map(async ([, cleanup]) => cleanup()),
+            );
+            const failedOperations = cleanupOperations
+              .filter((_, index) => cleanupResults[index].status === "rejected")
+              .map(([operation]) => operation);
+            if (failedOperations.length > 0) {
+              phLogger.warn("Chat stream setup cleanup failed", {
+                event: "chat_stream_setup_cleanup_failed",
+                chatId,
+                endpoint,
+                failed_operations: failedOperations,
+              });
+            }
+            shutdownPostHog(posthog);
             throw error;
           }
         },

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1880,7 +1880,13 @@ export const createChatHandler = () => {
                           state.providerError instanceof AbliterationVisionError
                         ) &&
                         (!isAborted || stoppedDueToAssistantContentLoop) &&
+                        !userStopSignal.signal.aborted &&
                         (isAutoModel ||
+                          (hasTerminalProviderStreamError &&
+                            shouldRetryAbliterationApiError(
+                              activeAbliteratedExperiment,
+                              state.providerError,
+                            )) ||
                           shouldRetryWithVisionSummary ||
                           providerContentBlocked ||
                           shouldRetryWithoutImageToolResults ||

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1991,7 +1991,8 @@ export const createChatHandler = () => {
                       // after replacing image outputs with text placeholders.
                       if (
                         shouldAttemptProviderRetry &&
-                        !visionSummaryRecoveryFailure
+                        !visionSummaryRecoveryFailure &&
+                        !userStopSignal.signal.aborted
                       ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1713,6 +1713,7 @@ export const createChatHandler = () => {
                     throw error;
                   }
                 }
+                userStopSignal.signal.throwIfAborted();
                 result = await createStream(apiRetryModel);
               } else {
                 throw error;
@@ -1989,6 +1990,16 @@ export const createChatHandler = () => {
                       // incomplete, or reasoning-only terminal provider streams.
                       // For image-tool rejection, retry the same selected model
                       // after replacing image outputs with text placeholders.
+                      const retryMessageId = generateId();
+                      if (
+                        shouldAttemptProviderRetry &&
+                        !visionSummaryRecoveryFailure &&
+                        !userStopSignal.signal.aborted
+                      ) {
+                        await taskOutcomeSurvey?.linkMessage(retryMessageId);
+                      }
+                      isAborted ||= userStopSignal.signal.aborted;
+
                       if (
                         shouldAttemptProviderRetry &&
                         !visionSummaryRecoveryFailure &&
@@ -2035,9 +2046,7 @@ export const createChatHandler = () => {
                           usageTracker.resetModelLeg();
                         }
 
-                        const retryMessageId = generateId();
                         abliteratedTelemetry?.setMessageId(retryMessageId);
-                        await taskOutcomeSurvey?.linkMessage(retryMessageId);
                         const retryResult = await createStream(
                           retryModel,
                           blockedProviderModel

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -1,5 +1,7 @@
 import {
   createAssistantContentLoopMonitor,
+  decideProviderRecovery,
+  getProviderOutputDiagnostics,
   detectAssistantContentLoopFromText,
   getNextDeepSeekProDisconnectRetryModel,
   prepareProviderDisconnectContinuation,
@@ -429,12 +431,12 @@ describe("shouldRetryAgentLongWithFallback", () => {
     ).toBe(false);
   });
 
-  it("does not retry empty assistant output", () => {
+  it("retries a terminal provider error before any assistant output", () => {
     expect(
       shouldRetryAgentLongWithFallback([], {
         hasTerminalProviderStreamError: true,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it.each([
@@ -625,5 +627,62 @@ describe("assistant content loop detection", () => {
     }
 
     expect(detected).toBe(false);
+  });
+});
+
+describe("provider recovery decisions", () => {
+  const eligible = {
+    userCancelled: false,
+    unrecoverableVision: false,
+    alreadyRetried: false,
+    streamAborted: false,
+    loopRecovery: false,
+    hasCandidate: true,
+    modelEligible: true,
+  };
+  it.each([
+    [{ userCancelled: true, loopRecovery: true }, "user_cancelled"],
+    [{ unrecoverableVision: true }, "vision_recovery_unavailable"],
+    [{ alreadyRetried: true }, "retry_budget_exhausted"],
+    [{ streamAborted: true }, "stream_aborted"],
+    [{ hasCandidate: false }, "no_safe_recovery"],
+    [{ modelEligible: false }, "model_not_eligible"],
+  ])("explains why recovery is blocked: %s", (overrides, reason) => {
+    expect(decideProviderRecovery({ ...eligible, ...overrides })).toEqual({
+      attempt: false,
+      reason,
+    });
+  });
+  it("allows eligible recovery and internal loop recovery", () => {
+    expect(decideProviderRecovery(eligible)).toEqual({
+      attempt: true,
+      reason: "eligible",
+    });
+    expect(
+      decideProviderRecovery({
+        ...eligible,
+        streamAborted: true,
+        loopRecovery: true,
+      }).attempt,
+    ).toBe(true);
+  });
+  it("records output shape without content", () => {
+    const diagnostics = getProviderOutputDiagnostics([
+      { type: "step-start" },
+      { type: "text", text: "private answer" },
+      {
+        type: "tool-file",
+        state: "output-available",
+        input: "private input",
+        output: "private output",
+      },
+    ]);
+    expect(diagnostics).toEqual({
+      part_count: 3,
+      completed_tool_count: 1,
+      has_durable_output: true,
+      has_step_boundary: true,
+    });
+    expect(JSON.stringify(diagnostics)).not.toContain("private");
   });
 });

--- a/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
+++ b/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
@@ -164,3 +164,18 @@ describe("multimodal tool result recovery", () => {
     ).toBe(false);
   });
 });
+
+it("recognizes the Fireworks image format rejection without broadening generic 400s", () => {
+  expect(
+    isProviderMultimodalToolResultRejectionError({
+      code: 400,
+      message: "图片输入格式/解析错误",
+    }),
+  ).toBe(true);
+  expect(
+    isProviderMultimodalToolResultRejectionError({
+      code: 400,
+      message: "Invalid API parameter, please check the documentation.",
+    }),
+  ).toBe(false);
+});

--- a/lib/chat/__tests__/provider-recovery-stream.test.ts
+++ b/lib/chat/__tests__/provider-recovery-stream.test.ts
@@ -1,0 +1,200 @@
+import {
+  convertToModelMessages,
+  readUIMessageStream,
+  stepCountIs,
+  streamText,
+  tool,
+  type LanguageModel,
+  type UIMessage,
+} from "ai";
+import { WritableStream } from "node:stream/web";
+import { z } from "zod";
+import { isRetriableProviderStreamDisconnectError } from "@/lib/utils/error-utils";
+import {
+  decideProviderRecovery,
+  prepareProviderDisconnectContinuation,
+  shouldRetryProviderStreamWithFallback,
+} from "../agent-long-provider-retry";
+import { getProviderToolCallDiagnostics } from "../provider-tool-call-batches";
+
+const descriptors = ["WritableStream", "structuredClone"].map(
+  (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
+);
+beforeAll(() => {
+  Object.defineProperty(globalThis, "WritableStream", {
+    configurable: true,
+    value: WritableStream,
+  });
+  Object.defineProperty(globalThis, "structuredClone", {
+    configurable: true,
+    value: (v: unknown) => JSON.parse(JSON.stringify(v)),
+  });
+});
+afterAll(() => {
+  for (const [key, descriptor] of descriptors) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+});
+const usage = {
+  inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 5, text: 5, reasoning: 0 },
+};
+const finish = (reason: string) => ({
+  type: "finish",
+  finishReason: { unified: reason, raw: reason },
+  usage,
+});
+const model = (doStream: jest.Mock): LanguageModel =>
+  ({
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "test",
+    supportedUrls: {},
+    doStream,
+    doGenerate: jest.fn(),
+  }) as LanguageModel;
+const response = (parts: unknown[]) => ({
+  stream: new ReadableStream({
+    start(controller) {
+      parts.forEach((part) => controller.enqueue(part));
+      controller.close();
+    },
+  }),
+});
+
+it("recovers a 504 after tool execution through real SDK/UI streams without executing the tool twice", async () => {
+  const execute = jest.fn(async () => ({ saved: true }));
+  const tools = { save: tool({ inputSchema: z.object({}), execute }) };
+  const upstreamError = { code: 504, message: "The operation was aborted" };
+  const primary = jest
+    .fn()
+    .mockResolvedValueOnce(
+      response([
+        {
+          type: "tool-call",
+          toolCallId: "saved-once",
+          toolName: "save",
+          input: "{}",
+        },
+        finish("tool-calls"),
+      ]),
+    )
+    .mockResolvedValueOnce(
+      response([
+        { type: "text-start", id: "partial" },
+        { type: "text-delta", id: "partial", delta: "incomplete" },
+        { type: "error", error: upstreamError },
+      ]),
+    );
+  let failure: unknown;
+  const initial = streamText({
+    model: model(primary),
+    messages: [{ role: "user", content: "save and report" }],
+    tools,
+    stopWhen: stepCountIs(3),
+    maxRetries: 0,
+    onError: ({ error }) => {
+      failure = error;
+    },
+  });
+  let partial: UIMessage | undefined;
+  for await (const message of readUIMessageStream({
+    stream: initial.toUIMessageStream(),
+    onError: () => {},
+  }))
+    partial = message;
+  expect(execute).toHaveBeenCalledTimes(1);
+  expect(isRetriableProviderStreamDisconnectError(failure)).toBe(true);
+  const continuation = prepareProviderDisconnectContinuation([partial!]);
+  expect(continuation?.preservedCompletedToolCount).toBe(1);
+  const messages = await convertToModelMessages(continuation!.messages, {
+    tools,
+  });
+  expect(getProviderToolCallDiagnostics(messages)).toMatchObject({
+    unmatched_tool_call_count: 0,
+    unmatched_tool_result_count: 0,
+  });
+  expect(JSON.stringify(messages)).not.toContain("incomplete");
+  const fallback = jest
+    .fn()
+    .mockResolvedValue(
+      response([
+        { type: "text-start", id: "done" },
+        { type: "text-delta", id: "done", delta: "Saved successfully." },
+        { type: "text-end", id: "done" },
+        finish("stop"),
+      ]),
+    );
+  const recovered = streamText({
+    model: model(fallback),
+    messages,
+    tools,
+    maxRetries: 0,
+  });
+  let final: UIMessage | undefined;
+  const parseErrors: unknown[] = [];
+  for await (const message of readUIMessageStream({
+    stream: recovered.toUIMessageStream(),
+    onError: (e) => parseErrors.push(e),
+  }))
+    final = message;
+  expect(parseErrors).toEqual([]);
+  expect(final?.parts).toContainEqual({
+    type: "text",
+    text: "Saved successfully.",
+    state: "done",
+  });
+  expect(execute).toHaveBeenCalledTimes(1);
+  expect(
+    fallback.mock.calls[0][0].prompt.some(
+      (message: { role: string }) => message.role === "tool",
+    ),
+  ).toBe(true);
+});
+
+it("recognizes HTTP rejection delivered asynchronously before any content, with cancellation and retry limits intact", async () => {
+  let failure: unknown;
+  const rejected = streamText({
+    model: model(
+      jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error("Invalid request"), { statusCode: 400 }),
+        ),
+    ),
+    prompt: "test",
+    maxRetries: 0,
+    onError: ({ error }) => {
+      failure = error;
+    },
+  });
+  let last: UIMessage | undefined;
+  for await (const message of readUIMessageStream({
+    stream: rejected.toUIMessageStream(),
+    onError: () => {},
+  }))
+    last = message;
+  expect(failure).toBeDefined();
+  const hasCandidate = shouldRetryProviderStreamWithFallback(
+    last?.parts ?? [],
+    { hasTerminalProviderStreamError: true },
+  );
+  expect(hasCandidate).toBe(true);
+  const eligible = {
+    hasCandidate,
+    modelEligible: true,
+    userCancelled: false,
+    unrecoverableVision: false,
+    alreadyRetried: false,
+    streamAborted: false,
+    loopRecovery: false,
+  };
+  expect(decideProviderRecovery(eligible).attempt).toBe(true);
+  expect(
+    decideProviderRecovery({ ...eligible, userCancelled: true }).attempt,
+  ).toBe(false);
+  expect(
+    decideProviderRecovery({ ...eligible, alreadyRetried: true }).attempt,
+  ).toBe(false);
+});

--- a/lib/chat/__tests__/provider-tool-call-batches.test.ts
+++ b/lib/chat/__tests__/provider-tool-call-batches.test.ts
@@ -1,0 +1,166 @@
+import { convertToModelMessages, type ModelMessage, type UIMessage } from "ai";
+import {
+  getProviderToolCallDiagnostics,
+  splitProviderToolCallBatches,
+} from "../provider-tool-call-batches";
+import { compactMessageForStorage } from "../compaction/prune-tool-outputs";
+
+function history(count: number): ModelMessage[] {
+  return [
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "private notes" },
+        ...Array.from({ length: count }, (_, i) => ({
+          type: "tool-call" as const,
+          toolCallId: `call-${i}`,
+          toolName: "file",
+          input: { path: "private path" },
+        })),
+      ],
+    },
+    {
+      role: "tool",
+      content: Array.from({ length: count }, (_, i) => ({
+        type: "tool-result" as const,
+        toolCallId: `call-${i}`,
+        toolName: "file",
+        output: { type: "text" as const, value: `private output ${i}` },
+      })),
+    },
+    { role: "user", content: "continue" },
+  ];
+}
+
+describe("provider tool-call batches", () => {
+  it("repairs a legacy 148-call turn without dropping or repeating any calls/results", () => {
+    const input = history(148);
+    const original = JSON.parse(JSON.stringify(input));
+    const repaired = splitProviderToolCallBatches(input);
+    expect(repaired.splitCount).toBe(1);
+    expect(repaired.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "tool",
+      "assistant",
+      "tool",
+      "user",
+    ]);
+    expect(getProviderToolCallDiagnostics(repaired.messages)).toEqual({
+      max_tool_calls_per_assistant: 128,
+      unmatched_tool_call_count: 0,
+      unmatched_tool_result_count: 0,
+      duplicate_tool_call_count: 0,
+    });
+    for (const role of ["assistant", "tool"]) {
+      const parts = (messages: ModelMessage[]) =>
+        messages.filter((m) => m.role === role).flatMap((m) => m.content);
+      expect(parts(repaired.messages)).toEqual(parts(input));
+    }
+    expect(input).toEqual(original);
+    expect(splitProviderToolCallBatches(repaired.messages).messages).toBe(
+      repaired.messages,
+    );
+  });
+
+  it("preserves valid batches and multiple tool-result message metadata", () => {
+    const small = history(128);
+    expect(splitProviderToolCallBatches(small).messages).toBe(small);
+    const input = history(129);
+    const tool = input[1] as Extract<ModelMessage, { role: "tool" }>;
+    input.splice(
+      1,
+      1,
+      {
+        ...tool,
+        content: tool.content.slice(0, 100),
+        providerOptions: { test: { marker: "a" } },
+      },
+      {
+        ...tool,
+        content: tool.content.slice(100),
+        providerOptions: { test: { marker: "b" } },
+      },
+    );
+    const output = splitProviderToolCallBatches(input).messages;
+    expect(
+      output.filter((m) => m.role === "tool").map((m) => m.providerOptions),
+    ).toEqual([
+      { test: { marker: "a" } },
+      { test: { marker: "b" } },
+      { test: { marker: "b" } },
+    ]);
+    expect(
+      getProviderToolCallDiagnostics(output).unmatched_tool_result_count,
+    ).toBe(0);
+  });
+
+  it.each(["missing", "duplicate", "unmatched"])(
+    "does not guess how to repair %s results",
+    (problem) => {
+      const input = history(129);
+      const tool = input[1] as Extract<ModelMessage, { role: "tool" }>;
+      if (problem === "missing") tool.content.pop();
+      if (problem === "duplicate") tool.content[128] = tool.content[0];
+      if (problem === "unmatched")
+        tool.content[128] = {
+          ...tool.content[128],
+          toolCallId: "orphan",
+        } as (typeof tool.content)[number];
+      expect(splitProviderToolCallBatches(input)).toEqual({
+        messages: input,
+        splitCount: 0,
+      });
+    },
+  );
+
+  it("reports invalid pairing using counts only", () => {
+    const input = history(2);
+    const tool = input[1] as Extract<ModelMessage, { role: "tool" }>;
+    tool.content.pop();
+    tool.content.push({
+      type: "tool-result",
+      toolCallId: "private-orphan",
+      toolName: "file",
+      output: { type: "text", value: "private output" },
+    });
+    const diagnostics = getProviderToolCallDiagnostics(input);
+    expect(diagnostics).toMatchObject({
+      unmatched_tool_call_count: 1,
+      unmatched_tool_result_count: 1,
+    });
+    expect(JSON.stringify(diagnostics)).not.toContain("private");
+  });
+
+  it("preserves step boundaries through storage compaction and real SDK serialization", async () => {
+    const message: UIMessage = {
+      id: "assistant",
+      role: "assistant",
+      parts: Array.from({ length: 148 }, (_, i) => [
+        { type: "step-start" as const },
+        {
+          type: "tool-file" as const,
+          toolCallId: `call-${i}`,
+          state: "output-available" as const,
+          input: {},
+          output: "ok",
+        },
+      ]).flat(),
+    };
+    message.parts.unshift({
+      type: "data-summarization",
+      data: { text: "x".repeat(100_000) },
+    });
+    const compaction = compactMessageForStorage(message, {
+      softLimitBytes: 50_000,
+    });
+    expect(compaction.compacted).toBe(true);
+    const stored = compaction.message;
+    const serialized = await convertToModelMessages([stored]);
+    expect(serialized.filter((m) => m.role === "assistant")).toHaveLength(148);
+    expect(getProviderToolCallDiagnostics(serialized)).toMatchObject({
+      max_tool_calls_per_assistant: 1,
+      unmatched_tool_call_count: 0,
+      unmatched_tool_result_count: 0,
+    });
+  });
+});

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -96,6 +96,39 @@ const hasDurableAssistantPart = (parts: unknown[]): boolean =>
     return isCompletedToolPart(part);
   });
 
+export const getProviderOutputDiagnostics = (parts: unknown[]) => ({
+  part_count: parts.length,
+  completed_tool_count: parts.filter(isCompletedToolPart).length,
+  has_durable_output: hasDurableAssistantPart(parts),
+  has_step_boundary: parts.some((part) => getPartType(part) === "step-start"),
+});
+
+/** Shared eligibility and skip reason so telemetry cannot drift from behavior. */
+export function decideProviderRecovery(options: {
+  userCancelled: boolean;
+  unrecoverableVision: boolean;
+  alreadyRetried: boolean;
+  streamAborted: boolean;
+  loopRecovery: boolean;
+  hasCandidate: boolean;
+  modelEligible: boolean;
+}) {
+  const reason = options.userCancelled
+    ? "user_cancelled"
+    : options.unrecoverableVision
+      ? "vision_recovery_unavailable"
+      : options.alreadyRetried
+        ? "retry_budget_exhausted"
+        : options.streamAborted && !options.loopRecovery
+          ? "stream_aborted"
+          : !options.hasCandidate
+            ? "no_safe_recovery"
+            : !options.modelEligible
+              ? "model_not_eligible"
+              : "eligible";
+  return { attempt: reason === "eligible", reason };
+}
+
 export type ProviderDisconnectContinuation = {
   messages: UIMessage[];
   removedPartCount: number;
@@ -374,6 +407,14 @@ export const shouldRetryProviderStreamWithFallback = (
   // configured fallback model; the caller's bounded retry guard keeps a second
   // content-filter finish terminal.
   if (options.providerContentBlocked) return true;
+
+  // An HTTP rejection can arrive via streamText.onError without emitting a
+  // step-start. Metadata/empty text is also non-durable and safe to retry.
+  if (
+    options.hasTerminalProviderStreamError &&
+    parts.every(isFallbackSafeProviderPart)
+  )
+    return true;
 
   // A provider can consume the entire output allowance as hidden reasoning
   // and return no text or completed tool call. Treat that as a failed model

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -436,10 +436,9 @@ const compactReasoningParts = (
 };
 
 const stripStorageOnlyParts = (parts: UIMessage["parts"]): UIMessage["parts"] =>
-  parts.filter(
-    (part) =>
-      part?.type !== "step-start" && part?.type !== "data-summarization",
-  );
+  // step-start is a provider serialization boundary, not just UI metadata.
+  // Removing it merges every tool call in a saved turn into one request batch.
+  parts.filter((part) => part?.type !== "data-summarization");
 
 const compactToolPartsToByteLimit = (
   parts: UIMessage["parts"],

--- a/lib/chat/multimodal-tool-result-recovery.ts
+++ b/lib/chat/multimodal-tool-result-recovery.ts
@@ -104,6 +104,7 @@ export const omitTrailingStepStartAssistantMessage = (
 };
 
 const MULTIMODAL_REJECTION_PATTERNS = [
+  /图片输入格式\/解析错误/,
   /image[-_\s]?data/i,
   /input[_\s-]?image/i,
   /image(?:\s+content|\s+input|\s+part|\s+block|\s+tool|\s+output)/i,

--- a/lib/chat/provider-tool-call-batches.ts
+++ b/lib/chat/provider-tool-call-batches.ts
@@ -1,0 +1,108 @@
+import type { AssistantModelMessage, ModelMessage, ToolModelMessage } from "ai";
+
+export const MAX_ASSISTANT_TOOL_CALLS = 128;
+
+/** Counts only: never put tool IDs, arguments, results, or user text in logs. */
+export function getProviderToolCallDiagnostics(messages: ModelMessage[]) {
+  let maxCalls = 0;
+  let unmatchedResults = 0;
+  let unmatchedCalls = 0;
+  let duplicateCalls = 0;
+  const pending = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "tool") {
+      unmatchedCalls += pending.size;
+      pending.clear();
+    }
+    if (!Array.isArray(message.content)) continue;
+    let count = 0;
+    for (const part of message.content) {
+      if (part.type === "tool-call") {
+        count++;
+        if (pending.has(part.toolCallId)) duplicateCalls++;
+        pending.add(part.toolCallId);
+      } else if (part.type === "tool-result") {
+        if (!pending.delete(part.toolCallId)) unmatchedResults++;
+      }
+    }
+    maxCalls = Math.max(maxCalls, count);
+  }
+  return {
+    max_tool_calls_per_assistant: maxCalls,
+    unmatched_tool_call_count: unmatchedCalls + pending.size,
+    unmatched_tool_result_count: unmatchedResults,
+    duplicate_tool_call_count: duplicateCalls,
+  };
+}
+
+/**
+ * Old stored turns may have lost their step-start boundaries, collapsing a
+ * long tool history into one assistant message. Split only complete batches;
+ * never drop calls/results or guess how an ambiguous history should be paired.
+ * This changes the provider transcript only and never executes a tool.
+ */
+export function splitProviderToolCallBatches(messages: ModelMessage[]) {
+  const result: ModelMessage[] = [];
+  let splitCount = 0;
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      result.push(message);
+      continue;
+    }
+    const calls = message.content.filter((part) => part.type === "tool-call");
+    if (calls.length <= MAX_ASSISTANT_TOOL_CALLS) {
+      result.push(message);
+      continue;
+    }
+    const toolMessages: ToolModelMessage[] = [];
+    for (let next = index + 1; messages[next]?.role === "tool"; next++) {
+      toolMessages.push(messages[next] as ToolModelMessage);
+    }
+    const ids = new Set(calls.map((call) => call.toolCallId));
+    const results = toolMessages.flatMap((tool) => tool.content);
+    const resultIds = new Set(
+      results.map((part) =>
+        part.type === "tool-result" ? part.toolCallId : undefined,
+      ),
+    );
+    if (
+      ids.size !== calls.length ||
+      results.length !== calls.length ||
+      resultIds.size !== calls.length ||
+      results.some(
+        (part) => part.type !== "tool-result" || !ids.has(part.toolCallId),
+      )
+    ) {
+      result.push(message);
+      continue;
+    }
+
+    let content: Exclude<AssistantModelMessage["content"], string> = [];
+    let batchIds = new Set<string>();
+    const flush = () => {
+      result.push({ ...message, content });
+      for (const tool of toolMessages) {
+        const batchResults = tool.content.filter(
+          (part) =>
+            part.type === "tool-result" && batchIds.has(part.toolCallId),
+        );
+        if (batchResults.length)
+          result.push({ ...tool, content: batchResults });
+      }
+      content = [];
+      batchIds = new Set();
+    };
+    for (const part of message.content) {
+      if (part.type === "tool-call") {
+        if (batchIds.size === MAX_ASSISTANT_TOOL_CALLS) flush();
+        batchIds.add(part.toolCallId);
+      }
+      content.push(part);
+    }
+    flush();
+    splitCount++;
+    index += toolMessages.length;
+  }
+  return { messages: splitCount ? result : messages, splitCount };
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -38,6 +38,11 @@ export interface ProviderRequestDiagnostics {
   fallback_model_slugs?: string[];
   has_user_attribution: boolean;
   has_multimodal_tool_results: boolean;
+  max_tool_calls_per_assistant?: number;
+  unmatched_tool_call_count?: number;
+  unmatched_tool_result_count?: number;
+  duplicate_tool_call_count?: number;
+  tool_call_batches_split?: number;
 }
 
 export interface ProviderRequestRetentionDiagnostics {

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -688,3 +688,45 @@ describe("provider error classification", () => {
     expect(getUserFriendlyProviderError(err)).toContain("context limit");
   });
 });
+
+describe("SSE upstream abort recovery", () => {
+  it.each([502, 503, 504, "504"])(
+    "recovers code=%s even with aborted wording",
+    (code) => {
+      const error = { code, message: "The operation was aborted" };
+      expect(getProviderStatusCode(extractErrorDetails(error))).toBe(
+        Number(code),
+      );
+      expect(isRetriableProviderStreamDisconnectError(error)).toBe(true);
+    },
+  );
+  it("keeps bare cancellation and HTTP 400 terminal", () => {
+    expect(
+      isRetriableProviderStreamDisconnectError(
+        new DOMException("The operation was aborted", "AbortError"),
+      ),
+    ).toBe(false);
+    expect(
+      isRetriableProviderStreamDisconnectError({
+        code: 400,
+        message: "The operation was aborted",
+      }),
+    ).toBe(false);
+  });
+  it("normalizes allowlisted error parameter paths without logging arbitrary values", () => {
+    const error = (param: string) => ({
+      responseBody: JSON.stringify({
+        error: { code: "invalid_request", message: "Invalid request", param },
+      }),
+    });
+    expect(
+      extractErrorDetails(error("messages[123].tool_calls")),
+    ).toHaveProperty("providerErrorParam", "messages[].tool_calls");
+    expect(extractErrorDetails(error("private prompt"))).not.toHaveProperty(
+      "providerErrorParam",
+    );
+    expect(
+      extractErrorDetails(error("messages[1].private_payload")),
+    ).not.toHaveProperty("providerErrorParam");
+  });
+});

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -175,6 +175,19 @@ const getOpenRouterProviderInfo = (
     const nested = isRecord(payload.error) ? payload.error : undefined;
     if (!nested) continue;
 
+    // Parameter paths can otherwise echo arbitrary request data. Retain only
+    // known schema paths and normalize numeric indices to avoid cardinality.
+    if (typeof nested.param === "string") {
+      const param = nested.param.replace(/\[\d+\]/g, "[]");
+      if (
+        /^(?:model|messages(?:\[\])?(?:\.(?:role|content|tool_calls|tool_call_id|type|image_url|url|function|name|arguments)(?:\[\])?)*|tools(?:\[\])?(?:\.function(?:\.(?:name|parameters))?)?|tool_choice|max_tokens|temperature|reasoning)$/.test(
+          param,
+        )
+      ) {
+        details.providerErrorParam ??= param;
+      }
+    }
+
     if (
       details.providerErrorCode === undefined &&
       (typeof nested.code === "number" || typeof nested.code === "string")
@@ -507,6 +520,12 @@ export const isRetriableProviderStreamDisconnectError = (
 ): boolean => {
   const details = extractErrorDetails(error);
   const category = getProviderErrorCategory(details);
+  // SSE errors use `code`, while HTTP errors use `statusCode`. Preserve the
+  // stable error category, but honor an upstream 5xx regardless of wording.
+  // A bare AbortError still must not turn user cancellation into a retry.
+  const statusCode = getProviderStatusCode(details);
+  if (category === "content_blocked") return false;
+  if (statusCode != null && statusCode >= 500 && statusCode <= 599) return true;
   if (category === "timeout" || category === "provider_5xx") return true;
   return (
     category === "stream_terminated" &&

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -257,7 +257,9 @@ import {
   PREEMPTIVE_TIMEOUT_FINISH_REASON,
 } from "@/lib/chat/stop-conditions";
 import {
+  decideProviderRecovery,
   detectAssistantContentLoopFromParts,
+  getProviderOutputDiagnostics,
   getNextDeepSeekProDisconnectRetryModel,
   prepareProviderDisconnectContinuation,
   shouldRetryProviderStreamAfterNonDurableOutputLimit,
@@ -4814,17 +4816,26 @@ export const agentLongTask = task({
                       const shouldContinueAfterProviderDisconnect = Boolean(
                         providerDisconnectContinuation,
                       );
-                      const shouldAttemptProviderRetry =
-                        !(
-                          state.providerError instanceof AbliterationVisionError
-                        ) &&
-                        (shouldRetryWithFallback ||
+                      const providerRecoveryDecision = decideProviderRecovery({
+                        userCancelled: userStopSignal.signal.aborted,
+                        unrecoverableVision:
+                          state.providerError instanceof
+                          AbliterationVisionError,
+                        alreadyRetried: isRetryWithFallback,
+                        streamAborted: isAborted,
+                        loopRecovery: stoppedDueToAssistantContentLoop,
+                        hasCandidate:
+                          shouldRetryWithFallback ||
                           shouldRetryWithoutImageToolResults ||
                           shouldRetryWithVisionSummary ||
-                          shouldContinueAfterProviderDisconnect) &&
-                        !isRetryWithFallback &&
-                        (!isAborted || stoppedDueToAssistantContentLoop) &&
-                        (isAutoModel ||
+                          shouldContinueAfterProviderDisconnect,
+                        modelEligible:
+                          isAutoModel ||
+                          (hasTerminalProviderStreamError &&
+                            shouldRetryAbliterationApiError(
+                              activeAbliteratedExperiment,
+                              state.providerError,
+                            )) ||
                           shouldRetryWithVisionSummary ||
                           providerContentBlocked ||
                           shouldRetryWithoutImageToolResults ||
@@ -4832,7 +4843,10 @@ export const agentLongTask = task({
                           state.stoppedDueToDoomLoop ||
                           shouldRetryInterruptedToolInput ||
                           shouldRetryExplicitDeepSeekProReasoning ||
-                          shouldContinueAfterProviderDisconnect);
+                          shouldContinueAfterProviderDisconnect,
+                      });
+                      const shouldAttemptProviderRetry =
+                        providerRecoveryDecision.attempt;
                       let recoveredVisionMessages:
                         typeof state.finalMessages | undefined;
                       let visionSummaryRecoveryFailure: unknown;
@@ -4881,9 +4895,57 @@ export const agentLongTask = task({
                         }
                       }
 
+                      if (hasTerminalProviderStreamError) {
+                        const failure = wrapProviderTerminalError(
+                          state.providerError,
+                          {
+                            model: selectedModel,
+                            openRouterMetadata: state.openRouterMetadata,
+                          },
+                        );
+                        triggerLogger.info("Provider recovery decision", {
+                          event: "provider_recovery_decision",
+                          service: "agent-long",
+                          environment: ctx.environment.type,
+                          run_id: ctx.run.id,
+                          chat_id: chatId,
+                          decision:
+                            shouldAttemptProviderRetry &&
+                            !visionSummaryRecoveryFailure &&
+                            !userStopSignal.signal.aborted
+                              ? "attempt"
+                              : "skip",
+                          reason: userStopSignal.signal.aborted
+                            ? "user_cancelled"
+                            : visionSummaryRecoveryFailure
+                              ? "vision_summary_failed"
+                              : providerRecoveryDecision.reason,
+                          category: failure.category,
+                          status_code: failure.statusCode,
+                          configured_model: selectedModel,
+                          served_model:
+                            state.openRouterMetadata
+                              ?.openrouter_selected_model ??
+                            state.responseModel,
+                          provider: failure.provider,
+                          provider_request_id: failure.openrouterRequestId,
+                          provider_generation_id:
+                            failure.openrouterGenerationId,
+                          retry_already_used: isRetryWithFallback,
+                          user_cancelled: userStopSignal.signal.aborted,
+                          stream_aborted: isAborted,
+                          has_safe_continuation:
+                            shouldContinueAfterProviderDisconnect,
+                          ...getProviderOutputDiagnostics(
+                            lastAssistantMessageParts,
+                          ),
+                        });
+                      }
+
                       if (
                         shouldAttemptProviderRetry &&
-                        !visionSummaryRecoveryFailure
+                        !visionSummaryRecoveryFailure &&
+                        !userStopSignal.signal.aborted
                       ) {
                         const retryReason = shouldRetryWithVisionSummary
                           ? "vision_summary_recovery"

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -4669,6 +4669,7 @@ export const agentLongTask = task({
                     throw error;
                   }
                 }
+                userStopSignal.signal.throwIfAborted();
                 result = await createStream(apiRetryModel);
               } else {
                 throw error;
@@ -4942,7 +4943,17 @@ export const agentLongTask = task({
                         });
                       }
 
+                      const retryMessageId = generateId();
                       if (
+                        shouldAttemptProviderRetry &&
+                        !visionSummaryRecoveryFailure &&
+                        !userStopSignal.signal.aborted
+                      ) {
+                        await taskOutcomeSurvey?.linkMessage(retryMessageId);
+                      }
+                      isAborted ||= userStopSignal.signal.aborted;
+
+                      primaryProviderRecovery: if (
                         shouldAttemptProviderRetry &&
                         !visionSummaryRecoveryFailure &&
                         !userStopSignal.signal.aborted
@@ -5096,9 +5107,11 @@ export const agentLongTask = task({
                             });
                           }
                         }
-                        const retryMessageId = generateId();
                         abliteratedTelemetry?.setMessageId(retryMessageId);
-                        await taskOutcomeSurvey?.linkMessage(retryMessageId);
+                        if (userStopSignal.signal.aborted) {
+                          isAborted = true;
+                          break primaryProviderRecovery;
+                        }
                         const retryResult = await createStream(
                           retryModel,
                           blockedProviderModel
@@ -5224,6 +5237,15 @@ export const agentLongTask = task({
                                     await taskOutcomeSurvey?.linkMessage(
                                       finalRetryMessageId,
                                     );
+                                    if (userStopSignal.signal.aborted) {
+                                      await finalizeRetryStream({
+                                        retryMessages,
+                                        retryAborted: true,
+                                        retryMessageId,
+                                        retryStartTime: fallbackStartTime,
+                                      });
+                                      return;
+                                    }
                                     const finalRetryResult =
                                       await createStream(finalRetryModel);
                                     writer.merge(


### PR DESCRIPTION
Agent runs can fail without attempting the existing recovery when an upstream sends `{ code: 504, message: "The operation was aborted" }` inside SSE. Saved long tool histories can also reach Abliteration as a single assistant message exceeding its 128-call limit.

This change:
- Honors upstream 5xx codes in disconnect recovery while preserving cancellation, completed tool results, and existing retry/model/billing limits.
- Handles asynchronous provider rejection before any durable output, including the active Abliteration experiment's baseline fallback.
- Preserves step boundaries during storage compaction and repairs older oversized Abliteration batches only when every call has exactly one adjacent result. No calls/results are dropped or executed by the repair.
- Recognizes the observed Fireworks image-format error and records recovery decisions, tool-call shape counts, and allowlisted error parameter paths without user content or signed URLs.

Generic invalid-request responses still need upstream diagnosis. Image URL refresh is not included: the observed fetch 403 does not prove expiration. No flags or runtime configuration were changed. These are correctness fixes, so no new rollout flag is introduced.

Validation: 474 suites / 5,035 tests passed, plus type checking, lint, and formatting. New tests use real AI SDK and UI streams to execute a tool, inject a 504, recover, and verify the tool executes only once. Coverage also includes asynchronous HTTP rejection, cancellation/retry limits, 148-call legacy batches, malformed pairing, and storage serialization. The pre-commit suite had one worker SIGSEGV on its first run; the complete rerun passed.

Manual verification before promotion:
1. In this PR's Preview, create a disposable Agent chat; write/read a short marker in a temporary file and verify completion and persisted tool results after reload.
2. Attach a small PNG and request a short description; verify completion and that new diagnostics contain no raw image or signed URL.
3. If an upstream failure occurs, inspect its Preview Trigger run: recovery should preserve completed work, explain attempts/skips, respect its retry budget, and stop when canceled. Fault injection is covered locally; do not replay customer runs.

The full operating notes are in `docs/provider-error-recovery.md`. Production recovery requires deploying the updated Trigger worker and starting new runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from provider disconnects, stream failures, supported image-format errors, and eligible server errors.
  * Prevented retries after cancellation and avoided duplicate tool execution or malformed messages.
  * Split oversized tool-call batches while preserving results and conversation step boundaries.
  * Empty or fallback-safe provider responses can retry when eligible.

* **Improvements**
  * Added privacy-safe provider and tool-call diagnostics.
  * Preserved serialization boundaries during conversation compaction.

* **Documentation**
  * Added guidance for provider error recovery, diagnostics, privacy, and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->