### PR TITLE
HAC-103: Compare Abliteration with GLM for free Ask

### DIFF
--- a/convex/__tests__/taskOutcomeSurveys.test.ts
+++ b/convex/__tests__/taskOutcomeSurveys.test.ts
@@ -85,6 +85,33 @@ describe("task outcome feedback", () => {
     jest.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
   });
   afterEach(() => jest.restoreAllMocks());
+  it("retains free Ask experiment attribution through replacement message linkage and feedback", async () => {
+    const { ctx } = setup();
+    const survey = await invoke(reserve, ctx, {
+      ...args,
+      experiment_key: "abliterated_free_ask_moderated_v1",
+      mode: "ask",
+      subscription_tier: "free",
+    });
+    await invoke(linkMessage, ctx, {
+      serviceKey: "test",
+      user_id: "user-1",
+      request_id: "run-1",
+      message_id: "replacement",
+    });
+    await invoke(record, ctx, { id: survey._id, action: "shown" });
+    const answered = await invoke(record, ctx, {
+      id: survey._id,
+      action: "answered",
+      answer: "yes",
+    });
+    expect(answered).toMatchObject({
+      experiment_key: "abliterated_free_ask_moderated_v1",
+      request_id: "run-1",
+      message_id: "replacement",
+      answer: "yes",
+    });
+  });
   it("reserves before outcomes and enforces a rolling 72-hour cross-device cooldown", async () => {
     const { ctx, rows } = setup();
     expect(await invoke(reserve, ctx, args)).toMatchObject({

--- a/convex/taskOutcomeValidators.ts
+++ b/convex/taskOutcomeValidators.ts
@@ -1,4 +1,8 @@
 import { v } from "convex/values";
+import {
+  ABLITERATED_EXPERIMENT_KEY,
+  FREE_ASK_ABLITERATED_EXPERIMENT_KEY,
+} from "../lib/experiments/abliteration-keys";
 export const taskOutcomeAnswer = v.union(
   v.literal("yes"),
   v.literal("partly"),
@@ -21,6 +25,13 @@ export const taskOutcomeContext = {
   request_id: v.string(),
   chat_id: v.string(),
   message_id: v.string(),
+  // Older reservations belong to the original paid/free Agent experiment.
+  experiment_key: v.optional(
+    v.union(
+      v.literal(ABLITERATED_EXPERIMENT_KEY),
+      v.literal(FREE_ASK_ABLITERATED_EXPERIMENT_KEY),
+    ),
+  ),
   experiment_variant: v.union(v.literal("control"), v.literal("test")),
   baseline_model: v.string(),
   assigned_model: v.string(),

--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -6,9 +6,29 @@ The dashboard includes an assigned-model volume diagnostic
 ([insight gRZGMouh](https://us.posthog.com/project/144137/insights/gRZGMouh))
 so base and Large v2 traffic can be checked independently.
 
+## Free rollout phase
+
+The free Agent group of Production flag 869145 enrolls 100% of eligible users
+with control/test 50/50 (50% each, no outside group). Paid criteria are unchanged.
+Preview flag 869147 remains 100% of eligible test users with forced treatment.
+
+The separate free Ask flag enrolls authenticated free users; code additionally
+requires the existing moderation signal and supported inputs. Production is
+prepared with enrollment 100%, control/test 50/50, and remains inactive until the
+free Ask implementation is deployed and verified. Preview enrolls 100%
+for acceptance testing. Record actual flag IDs, activation and cohort boundaries
+in HAC-103. Keep the retired DeepSeek-vs-GLM Ask flag disabled.
+
+Analyze Ask and Agent separately by experiment key and mode. The same user may
+enter both experiments; report overlap for conversion/retention attribution.
+Feedback reservations persist their actual experiment key; old reservations
+without a key remain attributed to the original experiment. The existing
+feedback cooldown and UI stay unchanged. Review health 24h after activation and
+outcomes with equal seven-day follow-up; record inconclusive results honestly.
+
 ## Routing contract
 
-Paid requests in Ask and Agent, and free requests in Agent only, may use an Abliteration model at
+Paid and free requests in Ask and Agent may use an Abliteration model at
 `https://api.abliteration.ai/v1`. Auto/Standard routes use `abliterated-model`;
 explicit HackerAI Pro and Max routes use `abliterated-model-large-v2`. Ultra Ask
 Auto also uses Large v2 because its current baseline is Pro, while Ultra Agent
@@ -44,10 +64,18 @@ Explicit free-allowance rescue requests are excluded before assignment. Eligibil
 is recorded before model-priced budget checks so cost-induced blocking cannot
 silently remove treatment users from the denominator.
 
-Free Ask and paid daily free-allowance rescue requests are excluded. Free Agent
+Paid daily free-allowance rescue requests are excluded. Free Agent
 treatment uses the base model and preserves its exact free OpenRouter baseline
 for control, later steps and provider recovery. Existing free quota/concurrency
 checks and local-sandbox entitlement still apply; this does not grant cloud access.
+Free Ask uses the separate `abliterated_free_ask_moderated_v1` flag
+([HAC-103](https://linear.app/hackerai/issue/HAC-103)). It compares the fixed
+`ask-model-free-glm` baseline (GLM 5.3 Flash low) with base Abliteration, using
+the same moderation, supported-file, first-step and prompt-annotation contract.
+The exact GLM baseline returns on later steps and errors; free Ask keeps low
+reasoning on OpenRouter recovery. Missing/disabled Ask flags never inherit the
+Agent assignment. Free Ask cannot qualify through paid chat-history continuity.
+
 Every control retains its exact existing baseline. Analyze provider model,
 selector, subscription, input modality, and mode separately as well as overall.
 

--- a/docs/internal/abliterated-model-pilot.md
+++ b/docs/internal/abliterated-model-pilot.md
@@ -164,12 +164,15 @@ Do not seed routing markers by editing live user messages.
 
 ## Environment and rollout record
 
-Definitions read back on 2026-09-06 after Production enrollment was expanded.
+Definitions read back on 2026-09-08 after free Agent enrollment was expanded
+and the separate free Ask flags were prepared.
 
-| Environment | PostHog project       | Flag ID | Key                           | Configured rollout                                                       |
-| ----------- | --------------------- | ------- | ----------------------------- | ------------------------------------------------------------------------ |
-| Preview     | hackerai-dev / 401167 | 869147  | abliterated_paid_moderated_v1 | Active; 100% of eligible paid users, forced test                         |
-| Production  | HackerAI / 144137     | 869145  | abliterated_paid_moderated_v1 | Active; 100% enrollment, 50/50 control/test, approximately 50% treatment |
+| Environment | PostHog project       | Flag ID | Key                               | Configured rollout                                                       |
+| ----------- | --------------------- | ------- | --------------------------------- | ------------------------------------------------------------------------ |
+| Preview     | hackerai-dev / 401167 | 869147  | abliterated_paid_moderated_v1     | Active; 100% of eligible paid and free Agent users, forced test          |
+| Production  | HackerAI / 144137     | 869145  | abliterated_paid_moderated_v1     | Active; 100% enrollment, 50/50 control/test, approximately 50% treatment |
+| Preview     | hackerai-dev / 401167 | 872124  | abliterated_free_ask_moderated_v1 | Active; 100% eligible free enrollment, 50/50 control/test                |
+| Production  | HackerAI / 144137     | 872126  | abliterated_free_ask_moderated_v1 | Inactive pending deployment; saved 100% enrollment, 50/50 control/test   |
 
 Paid groups target `subscription_tier` in `pro`, `pro-plus`, `ultra`, `team`.
 The free Agent extension adds a separate `subscription_tier=free` group, with the
@@ -330,7 +333,7 @@ For release verification on the verified Preview custom URL:
    request. Confirm moderation eligibility, streaming completion, model attribution,
    one exposure, and reload persistence. Repeat in Agent with one bounded tool call.
 2. Confirm benign/unflagged requests, prohibited-category moderation results,
-   moderation failure, free Ask users, PDFs, other unsupported files, and free-allowance
+   moderation failure, PDFs, other unsupported files, and free-allowance
    rescue keep their baseline routes. Confirm image requests use the base Abliteration
    model for Standard, Pro, and Max while text-only Pro/Max requests use Large v2.
    Unit tests cover deterministic gates; use approved synthetic fixtures for
@@ -356,13 +359,12 @@ References: [provider models](https://docs.abliteration.ai/models),
 
 ## Free Agent pilot
 
-Free Agent rollout is governed by HAC-99. Preview flag 869147 was updated on
-2026-09-07 to target all eligible free Agent testers with test assignment. The
-planned initial Production free group is 10% enrollment
-with the existing 50/50 control/test split (approximately 5% treatment); the other
-90% retain baseline without experiment assignment. Existing paid groups and their
-internal override are unchanged. Record verified Production activation and runtime
-evidence in HAC-99 before calling the pilot live.
+Free Agent rollout is governed by HAC-99. Production flag 869145 now enrolls
+100% of eligible free users with control/test 50/50, matching the free rollout
+phase above. Existing paid groups and their internal override are unchanged.
+Preview flag 869147 targets all eligible free Agent testers with forced treatment.
+The activation timestamp, previous cohort boundaries, and runtime evidence are
+recorded in HAC-99.
 
 Compare free control/test users separately from paid users and from earlier routing
 phases. Prioritize useful results, linked thumbs, and task-outcome ratings only
@@ -379,6 +381,6 @@ at experiment conclusion remains mandatory under HAC-101.
 Verify a free Agent test and control on the designated Preview: completed first
 step, exact free baseline on step two, provider failure recovery, original request
 attribution, unchanged quotas and sandbox permissions, and reload persistence.
-Also verify free Ask never evaluates this experiment and missing/off/unknown flags
-retain baseline. Use a free test account with a connected local sandbox, then
+Also verify free Ask evaluates only its separate Ask flag and missing/off/unknown
+flags retain baseline. Use a free test account with a connected local sandbox, then
 verify a bounded production free-cohort run before expansion.

--- a/lib/analytics/__tests__/abliterated-model.test.ts
+++ b/lib/analytics/__tests__/abliterated-model.test.ts
@@ -2,6 +2,7 @@ import type { LanguageModel } from "ai";
 import { AbliteratedModelTelemetry } from "../abliterated-model";
 import { guardLanguageModelProviderResponse } from "@/lib/ai/provider-response-guard";
 import { ABLITERATED_EXPERIMENT_KEY } from "@/lib/experiments/abliterated-model";
+import { FREE_ASK_ABLITERATED_EXPERIMENT_KEY } from "@/lib/experiments/abliteration-keys";
 
 const finishPart = {
   type: "finish",
@@ -72,6 +73,43 @@ describe("Abliteration stream telemetry", () => {
   beforeEach(() => capture.mockClear());
   const events = (name: string) =>
     capture.mock.calls.map(([event]) => event).filter((e) => e.event === name);
+  it("attributes free Ask exposure to its own experiment when recovery serves GLM", async () => {
+    const telemetry = new AbliteratedModelTelemetry({ capture }, "user", {
+      assignment: {
+        key: FREE_ASK_ABLITERATED_EXPERIMENT_KEY,
+        variant: "test",
+        modelKey: "model-abliterated",
+        baselineModel: "ask-model-free-glm",
+      },
+      messageId: "message",
+      chatId: "chat",
+      mode: "ask",
+      subscription: "free",
+    });
+    await expect(consume(telemetry, model([], true))).rejects.toThrow();
+    telemetry.setMessageId("replacement");
+    await consume(
+      telemetry,
+      model(
+        [{ type: "text-delta", id: "t", delta: "answer" }, finishPart],
+        false,
+        "z-ai/glm-5.3-flash",
+      ),
+    );
+    expect(events("abliterated_model_exposed")).toHaveLength(1);
+    expect(events("abliterated_model_exposed")[0].properties).toMatchObject({
+      experiment_key: FREE_ASK_ABLITERATED_EXPERIMENT_KEY,
+      experiment_variant: "test",
+      experiment_request_id: "message",
+      message_id: "replacement",
+      response_model: "z-ai/glm-5.3-flash",
+      platform_authorization_context: "standard",
+    });
+    expect(events("abliterated_model_eligible")[0].properties).toMatchObject({
+      assigned_platform_authorization_context: "not_appended",
+      baseline_model: "ask-model-free-glm",
+    });
+  });
   it("aggregates attempts while preserving eligibility and output without leaking content", async () => {
     const telemetry = create();
     expect(events("abliterated_model_exposed")).toHaveLength(0);

--- a/lib/analytics/__tests__/task-outcome.test.ts
+++ b/lib/analytics/__tests__/task-outcome.test.ts
@@ -13,8 +13,27 @@ const row = {
 };
 
 describe("task feedback routing attribution", () => {
+  it("preserves the free Ask experiment for delayed feedback after fallback", () => {
+    expect(
+      taskOutcomeProperties({
+        ...row,
+        experiment_key: "abliterated_free_ask_moderated_v1",
+        mode: "ask",
+        subscription_tier: "free",
+        assigned_model: "model-abliterated",
+        baseline_model: "ask-model-free-glm",
+        answer: "yes",
+      }),
+    ).toMatchObject({
+      experiment_key: "abliterated_free_ask_moderated_v1",
+      experiment_request_id: "original",
+      message_id: "fallback",
+      answer: "yes",
+    });
+  });
   it("preserves legacy three-step reservations across newer frontend deployments", () => {
     expect(taskOutcomeProperties(row)).toMatchObject({
+      experiment_key: "abliterated_paid_moderated_v1",
       generation_step_limit: 3,
       routing_version: "first_three_generation_steps_v1",
       experiment_request_id: "original",

--- a/lib/analytics/task-outcome.ts
+++ b/lib/analytics/task-outcome.ts
@@ -1,4 +1,8 @@
 import { TASK_OUTCOME_FLAG } from "../feedback/task-outcome";
+import {
+  ABLITERATED_EXPERIMENT_KEY,
+  type AbliterationExperimentKey,
+} from "../experiments/abliteration-keys";
 
 /** Shared allowlist: never pass the full database row or user content to PostHog. */
 export function taskOutcomeProperties(row: {
@@ -6,6 +10,7 @@ export function taskOutcomeProperties(row: {
   message_id: string;
   chat_id: string;
   experiment_variant: string;
+  experiment_key?: AbliterationExperimentKey;
   baseline_model: string;
   assigned_model: string;
   mode: string;
@@ -23,7 +28,7 @@ export function taskOutcomeProperties(row: {
     // relabel them with the limit of a newer frontend deployment.
     routing_version: row.routing_version ?? "first_three_generation_steps_v1",
     generation_step_limit: row.generation_step_limit ?? 3,
-    experiment_key: "abliterated_paid_moderated_v1",
+    experiment_key: row.experiment_key ?? ABLITERATED_EXPERIMENT_KEY,
     experiment_variant: row.experiment_variant,
     experiment_request_id: row.request_id,
     message_id: row.message_id,

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -572,56 +572,62 @@ describe("createAgentStream repeated compaction", () => {
     },
   );
 
-  it("routes only the first generation step through Abliteration", async () => {
-    const onModelStepSelected = jest.fn();
-    const state = initAgentStreamState(
-      [uiMessage("initial", "Inspect the authorized lab")],
-      { usedTokens: 1_000, maxTokens: 128_000 },
-    );
-    const stream = (await createAgentStream(
-      "model-abliterated",
-      createTestStreamContext({
-        trackedProvider: {
-          languageModel: (name: string) => ({ modelId: name }),
-        },
-        platformAuthorized: true,
-        abliteratedStepRouting: {
-          baselineModel: "model-deepseek-v4-flash-0731",
-        },
-        onModelStepSelected,
-        summarizationTracker: {
-          hasSummarized: false,
-          summarizationCount: 0,
-        },
-        usageTracker: {},
-      }) as any,
-      state,
-    )) as any;
+  it.each([
+    ["agent", "pro", "model-deepseek-v4-flash-0731"],
+    ["ask", "free", "ask-model-free-glm"],
+  ] as const)(
+    "routes only the first generation step through Abliteration for %s %s",
+    async (mode, subscription, baselineModel) => {
+      const onModelStepSelected = jest.fn();
+      const state = initAgentStreamState(
+        [uiMessage("initial", "Inspect the authorized lab")],
+        { usedTokens: 1_000, maxTokens: 128_000 },
+      );
+      const stream = (await createAgentStream(
+        "model-abliterated",
+        createTestStreamContext({
+          mode,
+          subscription,
+          trackedProvider: {
+            languageModel: (name: string) => ({ modelId: name }),
+          },
+          platformAuthorized: true,
+          abliteratedStepRouting: {
+            baselineModel,
+          },
+          onModelStepSelected,
+          summarizationTracker: {
+            hasSummarized: false,
+            summarizationCount: 0,
+          },
+          usageTracker: {},
+        }) as any,
+        state,
+      )) as any;
 
-    const prepare = (completedSteps: number) =>
-      stream.prepareStep({
-        stepNumber: completedSteps,
-        steps: Array.from({ length: completedSteps }, () => ({
-          toolResults: [],
-        })),
-        messages: [{ role: "user", content: "Continue" }],
-      });
+      const prepare = (completedSteps: number) =>
+        stream.prepareStep({
+          stepNumber: completedSteps,
+          steps: Array.from({ length: completedSteps }, () => ({
+            toolResults: [],
+          })),
+          messages: [{ role: "user", content: "Continue" }],
+        });
 
-    const firstStep = await prepare(0);
-    expect(firstStep.model.modelId).toBe("model-abliterated");
-    expect(JSON.stringify(firstStep.messages)).not.toContain(
-      PLATFORM_AUTHORIZATION_ANNOTATION,
-    );
+      const firstStep = await prepare(0);
+      expect(firstStep.model.modelId).toBe("model-abliterated");
+      expect(JSON.stringify(firstStep.messages)).not.toContain(
+        PLATFORM_AUTHORIZATION_ANNOTATION,
+      );
 
-    const secondStep = await prepare(1);
-    expect(secondStep.model.modelId).toBe("model-deepseek-v4-flash-0731");
-    expect(JSON.stringify(secondStep.messages)).toContain(
-      PLATFORM_AUTHORIZATION_ANNOTATION,
-    );
-    expect(onModelStepSelected).toHaveBeenLastCalledWith(
-      "model-deepseek-v4-flash-0731",
-    );
-  });
+      const secondStep = await prepare(1);
+      expect(secondStep.model.modelId).toBe(baselineModel);
+      expect(JSON.stringify(secondStep.messages)).toContain(
+        PLATFORM_AUTHORIZATION_ANNOTATION,
+      );
+      expect(onModelStepSelected).toHaveBeenLastCalledWith(baselineModel);
+    },
+  );
 
   it.each([
     {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -543,9 +543,13 @@ describe("captureAgentBudgetAbort", () => {
 });
 
 describe("captureAgentCompletionAnalytics", () => {
-  it.each(["ask", "agent"] as const)(
-    "captures %s experiment summaries while preserving assignment through fallback",
-    (mode) => {
+  it.each([
+    ["ask", "abliterated_paid_moderated_v1"],
+    ["agent", "abliterated_paid_moderated_v1"],
+    ["ask", "abliterated_free_ask_moderated_v1"],
+  ] as const)(
+    "captures %s %s summaries while preserving assignment through fallback",
+    (mode, experimentKey) => {
       const capture = jest.fn();
       const providerSummary = {
         telemetry_version: 2,
@@ -561,7 +565,10 @@ describe("captureAgentCompletionAnalytics", () => {
         chatId: "chat",
         endpoint: mode === "agent" ? "/api/agent-long" : "/api/chat",
         mode,
-        subscription: "pro",
+        subscription:
+          experimentKey === "abliterated_free_ask_moderated_v1"
+            ? "free"
+            : "pro",
         outcome: "success",
         selectedModel: "model-abliterated",
         configuredModelId: "abliterated-model",
@@ -570,7 +577,7 @@ describe("captureAgentCompletionAnalytics", () => {
         sandboxInfo: { type: "e2b" },
         chatLogger: {} as any,
         experiment: {
-          key: "abliterated_paid_moderated_v1",
+          key: experimentKey,
           variant: "test",
           requestId: "message",
         },
@@ -582,6 +589,7 @@ describe("captureAgentCompletionAnalytics", () => {
           properties: expect.objectContaining({
             ...providerSummary,
             mode,
+            experiment_key: experimentKey,
             experiment_variant: "test",
             experiment_request_id: "message",
             fallback_served: true,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -36,6 +36,7 @@ import {
 } from "@/lib/analytics/experiment-context";
 import type { AgentStepLimitTelemetry } from "@/lib/analytics/agent-step-limit-telemetry";
 import type { AbliteratedModelTelemetry } from "@/lib/analytics/abliterated-model";
+import { isAbliterationExperimentKey } from "@/lib/experiments/abliteration-keys";
 import { buildAgentPerformanceDiagnostics } from "@/lib/analytics/agent-performance-diagnostics";
 import {
   EXTRA_USAGE_MULTIPLIER,
@@ -1656,7 +1657,7 @@ export function captureAgentCompletionAnalytics(
   args: AgentCompletionAnalyticsArgs,
 ) {
   const { posthog, userId, mode, subscription, sandboxInfo, outcome } = args;
-  if (args.experiment?.key === "abliterated_paid_moderated_v1") {
+  if (isAbliterationExperimentKey(args.experiment?.key)) {
     try {
       posthog?.capture({
         distinctId: userId,

--- a/lib/experiments/__tests__/abliterated-model.test.ts
+++ b/lib/experiments/__tests__/abliterated-model.test.ts
@@ -1,3 +1,4 @@
+import { FREE_ASK_ABLITERATED_EXPERIMENT_KEY } from "../abliteration-keys";
 import {
   evaluateAbliteratedModel,
   ABLITERATED_EXPERIMENT_KEY,
@@ -127,7 +128,6 @@ describe("moderation-gated Abliteration assignment", () => {
     },
   );
   it.each([
-    { subscription: "free" as SubscriptionTier },
     { moderationEligible: false },
     { limitRescue: true },
     { messages: [] },
@@ -159,6 +159,52 @@ describe("moderation-gated Abliteration assignment", () => {
   });
 
   it.each(["test", "control"] as const)(
+    "routes free Ask %s through its separate flag with the exact GLM baseline",
+    async (variant) => {
+      const getFeatureFlag = jest.fn().mockResolvedValue(variant);
+      const result = await evaluateAbliteratedModel({
+        ...defaults,
+        subscription: "free",
+        selectedModel: "ask-model-free-glm",
+        posthog: { getFeatureFlag },
+      });
+      expect(result).toMatchObject({
+        key: FREE_ASK_ABLITERATED_EXPERIMENT_KEY,
+        variant,
+        baselineModel: "ask-model-free-glm",
+        modelKey:
+          variant === "test" ? ABLITERATION_MODEL_KEY : "ask-model-free-glm",
+        selectionSource: "moderation",
+      });
+      expect(getFeatureFlag).toHaveBeenCalledTimes(1);
+      expect(getFeatureFlag).toHaveBeenCalledWith(
+        FREE_ASK_ABLITERATED_EXPERIMENT_KEY,
+        "u",
+        {
+          sendFeatureFlagEvents: false,
+          personProperties: { subscription: "free", subscription_tier: "free" },
+        },
+      );
+    },
+  );
+  it.each([false, undefined, "unknown"])(
+    "leaves free Ask on GLM when its own flag returns %s",
+    async (variant) => {
+      const getFeatureFlag = jest.fn(async (key) =>
+        key === FREE_ASK_ABLITERATED_EXPERIMENT_KEY ? variant : "test",
+      );
+      await expect(
+        evaluateAbliteratedModel({
+          ...defaults,
+          subscription: "free",
+          selectedModel: "ask-model-free-glm",
+          posthog: { getFeatureFlag },
+        }),
+      ).resolves.toBeUndefined();
+      expect(getFeatureFlag).toHaveBeenCalledTimes(1);
+    },
+  );
+  it.each(["test", "control"] as const)(
     "routes free Agent %s assignments while retaining their original free baseline",
     async (variant) => {
       const getFeatureFlag = jest.fn().mockResolvedValue(variant);
@@ -185,38 +231,41 @@ describe("moderation-gated Abliteration assignment", () => {
       );
     },
   );
-  it.each([
-    { moderationEligible: false },
-    { limitRescue: true },
-    { messages: [] },
-    {
-      messages: [
-        {
-          id: "pdf",
-          role: "user" as const,
-          parts: [
-            {
-              type: "file" as const,
-              mediaType: "application/pdf",
-              url: "https://example.test/lab.pdf",
-            },
-          ],
-        },
-      ],
-    },
-  ])("keeps free Agent safeguards: %j", async (overrides) => {
-    const getFeatureFlag = jest.fn().mockResolvedValue("test");
-    expect(
-      await evaluateAbliteratedModel({
-        ...defaults,
-        mode: "agent",
-        subscription: "free",
-        selectedModel: "agent-model-free",
-        ...overrides,
-        posthog: { getFeatureFlag },
-      }),
-    ).toBeUndefined();
-    expect(getFeatureFlag).not.toHaveBeenCalled();
+  describe.each(["ask", "agent"] as const)("free %s safeguards", (mode) => {
+    it.each([
+      { moderationEligible: false },
+      { limitRescue: true },
+      { messages: [] },
+      {
+        messages: [
+          {
+            id: "pdf",
+            role: "user" as const,
+            parts: [
+              {
+                type: "file" as const,
+                mediaType: "application/pdf",
+                url: "https://example.test/lab.pdf",
+              },
+            ],
+          },
+        ],
+      },
+    ])("keeps free routing safeguards: %j", async (overrides) => {
+      const getFeatureFlag = jest.fn().mockResolvedValue("test");
+      expect(
+        await evaluateAbliteratedModel({
+          ...defaults,
+          mode,
+          subscription: "free",
+          selectedModel:
+            mode === "ask" ? "ask-model-free-glm" : "agent-model-free",
+          ...overrides,
+          posthog: { getFeatureFlag },
+        }),
+      ).toBeUndefined();
+      expect(getFeatureFlag).not.toHaveBeenCalled();
+    });
   });
 
   it("keeps a request at the Abliteration image limit eligible", async () => {

--- a/lib/experiments/abliterated-model.ts
+++ b/lib/experiments/abliterated-model.ts
@@ -1,4 +1,10 @@
 import { ABLITERATION_HISTORY_THRESHOLD } from "./abliteration-history";
+import {
+  ABLITERATED_EXPERIMENT_KEY,
+  FREE_ASK_ABLITERATED_EXPERIMENT_KEY,
+  type AbliterationExperimentKey,
+} from "./abliteration-keys";
+export { ABLITERATED_EXPERIMENT_KEY } from "./abliteration-keys";
 import type { PostHog } from "posthog-node";
 import type { UIMessage } from "ai";
 import type { ChatMode, SelectedModel, SubscriptionTier } from "@/types";
@@ -11,10 +17,9 @@ import {
 } from "@/lib/ai/abliteration";
 import { uiMessagesContainImageViewResult } from "@/lib/chat/multimodal-tool-result-recovery";
 
-export const ABLITERATED_EXPERIMENT_KEY = "abliterated_paid_moderated_v1";
 export const ABLITERATION_CONTINUITY_FLAG = "abliteration_chat_continuity_v1";
 export type AbliteratedAssignment = ExperimentAnalyticsContext & {
-  key: typeof ABLITERATED_EXPERIMENT_KEY;
+  key: AbliterationExperimentKey;
   variant: "control" | "test";
   modelKey: ModelName;
   baselineModel: ModelName;
@@ -75,7 +80,6 @@ export function isEligibleForAbliteratedModel({
 }): boolean {
   return (
     !limitRescue &&
-    (subscription !== "free" || mode === "agent") &&
     moderationEligible &&
     messages.length > 0 &&
     !messagesContainUnsupportedFiles(messages)
@@ -126,17 +130,17 @@ export async function evaluateAbliteratedModel({
   )
     return undefined;
 
+  const experimentKey =
+    subscription === "free" && mode === "ask"
+      ? FREE_ASK_ABLITERATED_EXPERIMENT_KEY
+      : ABLITERATED_EXPERIMENT_KEY;
   try {
     // This pinned SDK's evaluateFlags.getFlag emits exposure on access. Use the
     // supported no-event API until it supports deferring exposure explicitly.
-    const variant = await posthog.getFeatureFlag(
-      ABLITERATED_EXPERIMENT_KEY,
-      userId,
-      {
-        sendFeatureFlagEvents: false,
-        personProperties: { subscription, subscription_tier: subscription },
-      },
-    );
+    const variant = await posthog.getFeatureFlag(experimentKey, userId, {
+      sendFeatureFlagEvents: false,
+      personProperties: { subscription, subscription_tier: subscription },
+    });
     if (variant !== "test" && variant !== "control") return undefined;
     if (!moderationEligible) {
       // History is a preference within parent treatment, never an authorization.
@@ -154,7 +158,7 @@ export async function evaluateAbliteratedModel({
     return {
       selectionSource: moderationEligible ? "moderation" : "history",
       independentHistoryCount: independentAbliterationResponses,
-      key: ABLITERATED_EXPERIMENT_KEY,
+      key: experimentKey,
       variant,
       modelKey:
         variant === "test"

--- a/lib/experiments/abliteration-keys.ts
+++ b/lib/experiments/abliteration-keys.ts
@@ -1,0 +1,16 @@
+export const ABLITERATED_EXPERIMENT_KEY = "abliterated_paid_moderated_v1";
+export const FREE_ASK_ABLITERATED_EXPERIMENT_KEY =
+  "abliterated_free_ask_moderated_v1";
+
+export type AbliterationExperimentKey =
+  | typeof ABLITERATED_EXPERIMENT_KEY
+  | typeof FREE_ASK_ABLITERATED_EXPERIMENT_KEY;
+
+export function isAbliterationExperimentKey(
+  key: string | undefined,
+): key is AbliterationExperimentKey {
+  return (
+    key === ABLITERATED_EXPERIMENT_KEY ||
+    key === FREE_ASK_ABLITERATED_EXPERIMENT_KEY
+  );
+}

--- a/lib/feedback/__tests__/select-task-outcome.test.ts
+++ b/lib/feedback/__tests__/select-task-outcome.test.ts
@@ -31,6 +31,31 @@ const row = {
   release: "test",
 };
 describe("survey selection", () => {
+  it("stores the free Ask assignment key and emits matching selection metadata", async () => {
+    const key = "abliterated_free_ask_moderated_v1" as const;
+    mutation.mockResolvedValue({ ...row, experiment_key: key });
+    const posthog = {
+      getFeatureFlag: jest.fn(async () => true),
+      capture: jest.fn(),
+    };
+    await selectTaskOutcomeSurvey({
+      ...base,
+      mode: "ask",
+      subscription: "free",
+      assignment: { ...assignment, key },
+      posthog,
+    });
+    expect(mutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ experiment_key: key }),
+    );
+    expect(posthog.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "task_outcome_survey_selected",
+        properties: expect.objectContaining({ experiment_key: key }),
+      }),
+    );
+  });
   const oldKey = process.env.CONVEX_SERVICE_ROLE_KEY;
   beforeEach(() => {
     jest.clearAllMocks();

--- a/lib/feedback/select-task-outcome.ts
+++ b/lib/feedback/select-task-outcome.ts
@@ -36,6 +36,7 @@ export async function selectTaskOutcomeSurvey(args: {
         chat_id: args.chatId,
         request_id: args.messageId,
         message_id: args.messageId,
+        experiment_key: assignment.key,
         experiment_variant: assignment.variant,
         baseline_model: assignment.baselineModel,
         assigned_model: assignment.modelKey,


### PR DESCRIPTION
Free Ask currently always uses GLM 5.3 Flash low. This adds an independent moderation-gated 50/50 comparison with Abliteration, matching the existing paid treatment: omit only the trusted platform authorization annotation, use Abliteration for the first generation step, then return to the exact GLM baseline for later steps or failure.

The new `abliterated_free_ask_moderated_v1` flag is isolated from Agent assignment. Existing moderation, unsupported-file exclusions, quota and rescue rules remain. Terminal outcomes and delayed feedback retain the actual experiment key; an optional Convex field keeps legacy reservations compatible. The feedback UI/cooldown is unchanged.

Production flag 872126 is prepared inactive with free enrollment 100% and control/test 50/50 until deployment is verified. Preview flag 872124 enrolls 100% for acceptance. Separately, the authorized existing free Agent enrollment has been updated to 100%, yielding 50/50, with paid targeting preserved. Protocol/health warning: https://linear.app/hackerai/issue/HAC-103.

Validation: TypeScript, changed-source ESLint, dependency isolation and 472 suites / 5,025 tests pass. Two concurrent local runs had worker SIGSEGV failures in different unchanged suites; the complete hook passed with one worker and its original configuration was restored.

Live Preview acceptance passed using the existing free test account at https://hackerai-ik85xcuqp-hackerai.vercel.app:

- Moderation-eligible treatment completed with `abliterated-model`, persisted after reload, and emitted `not_appended` authorization context. Exposure, terminal success and submitted feedback retain the new Ask experiment key.
- Identical control request completed with `z-ai/glm-5.3-flash`, low reasoning and standard authorization context. Matching control exposure and terminal success arrived in PostHog.
- Ordinary arithmetic request stayed on GLM low with no experiment assignment, even while treatment was forced.
- Actual browser Convex connection is the designated branch Preview `befitting-ptarmigan-580`; PostHog is development 401167. Vercel and Trigger Preview deployments succeeded. Temporary deterministic assignments restored to enrollment 100%, control/test 50/50.

Automated tests cover first-step switching, exact GLM recovery, delayed feedback attribution and moderation/file/rescue gates. No provider outage was induced during live acceptance. Production Ask remains inactive until merge and deployment verification. After merge, verify the main Vercel/Trigger release and a bounded free Ask request on hackerai.co, then activate Production flag 872126 at the saved 50/50 split. The existing free Agent ramp is already live.

Final commit 4ddc1ab9: all GitHub CI, CodeQL, Vercel, Trigger and CodeRabbit checks pass. The rollout documentation finding is fixed and resolved; the final review has no actionable findings. The generic docstring warning is explicitly answered. Worktree is clean. GitHub requires one approving review before merge; automatic merging is disabled.
