### PR TITLE
Hide monthly warnings when prepaid Extra Usage is available

### DIFF
--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -1,5 +1,7 @@
 import { X } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { redirectToPricing } from "../hooks/usePricingDialog";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
@@ -176,6 +178,22 @@ export const RateLimitWarning = ({
   data,
   onDismiss,
 }: RateLimitWarningProps) => {
+  const isPersonalMonthlyWarning =
+    data.warningType === "token-bucket" &&
+    ["pro", "pro-plus", "ultra"].includes(data.subscription) &&
+    !data.cutOff &&
+    (data.capReason === "monthly_near_limit" ||
+      (!data.capReason && data.remainingPercent > 0));
+  // Reuse the live personal-wallet entitlement so an already visible warning
+  // reacts to purchases, the Extra Usage toggle, and spending-cap changes.
+  const extraUsage = useQuery(
+    api.extraUsage.getMaxModelExtraUsageEntitlement,
+    isPersonalMonthlyWarning ? {} : "skip",
+  );
+  const hideMonthlyWarning =
+    isPersonalMonthlyWarning &&
+    (extraUsage === undefined ||
+      (extraUsage?.extraUsageAvailable === true && extraUsage.hasBalance));
   const capturedUpgradeImpressionRef = useRef(false);
   const capturedAddCreditImpressionRef = useRef(false);
   const timeString = formatTimeUntil(data.resetTime);
@@ -187,7 +205,7 @@ export const RateLimitWarning = ({
       ? undefined
       : data.capReason;
   const extraUsageCta =
-    data.warningType === "token-bucket"
+    data.warningType === "token-bucket" && !hideMonthlyWarning
       ? getExtraUsageLimitCta({
           subscription: data.subscription,
           capReason,
@@ -197,6 +215,7 @@ export const RateLimitWarning = ({
     data.warningType === "extra-usage-active" ||
     data.warningType === "paid-daily-free-allowance";
   const showUpgrade =
+    !hideMonthlyWarning &&
     data.warningType !== "agent-run-spend-cap" &&
     data.warningType !== "extra-usage-active" &&
     data.warningType !== "paid-daily-free-allowance" &&
@@ -254,6 +273,8 @@ export const RateLimitWarning = ({
       cta_text: extraUsageCta.analyticsText,
     });
   }, [capReason, data.subscription, extraUsageCta, limitSeverity, limitType]);
+
+  if (hideMonthlyWarning) return null;
 
   return (
     <div

--- a/app/components/__tests__/RateLimitWarning.test.tsx
+++ b/app/components/__tests__/RateLimitWarning.test.tsx
@@ -1,7 +1,18 @@
 import "@testing-library/jest-dom";
 import { describe, expect, it, jest, beforeEach } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
-import { RateLimitWarning } from "../RateLimitWarning";
+import { setMockQueryResult } from "@/__mocks__/convex-react";
+
+const monthlyWarning = {
+  warningType: "token-bucket" as const,
+  bucketType: "monthly" as const,
+  remainingPercent: 3,
+  resetTime: new Date(Date.now() + 9 * 24 * 60 * 60_000),
+  subscription: "pro-plus" as const,
+  capReason: "monthly_near_limit",
+  usedDollars: 57.99,
+  limitDollars: 60,
+};
 
 jest.mock("@/lib/analytics/client", () => ({
   captureAddCreditCtaClick: jest.fn(),
@@ -13,10 +24,125 @@ jest.mock("@/lib/utils/settings-dialog", () => ({
   openSettingsDialog: jest.fn(),
 }));
 
+const { RateLimitWarning } = require("../RateLimitWarning");
+const {
+  captureAddCreditCtaImpression,
+  captureUpgradeCtaImpression,
+} = require("@/lib/analytics/client");
+
 describe("RateLimitWarning", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setMockQueryResult(null);
   });
+
+  it("removes an existing monthly warning as soon as purchased credit becomes usable", () => {
+    const { rerender } = render(
+      <RateLimitWarning data={monthlyWarning} onDismiss={jest.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: "Add Credits" })).toBeVisible();
+
+    setMockQueryResult({ extraUsageAvailable: true, hasBalance: true });
+    rerender(<RateLimitWarning data={monthlyWarning} onDismiss={jest.fn()} />);
+    expect(screen.queryByTestId("rate-limit-warning")).not.toBeInTheDocument();
+
+    setMockQueryResult({ extraUsageAvailable: false, hasBalance: false });
+    rerender(<RateLimitWarning data={monthlyWarning} onDismiss={jest.fn()} />);
+    expect(screen.getByRole("button", { name: "Add Credits" })).toBeVisible();
+  });
+
+  it.each(["pro", "pro-plus", "ultra"] as const)(
+    "hides the near-limit banner and purchase impressions for %s with usable credit",
+    (subscription) => {
+      setMockQueryResult({ extraUsageAvailable: true, hasBalance: true });
+      render(
+        <RateLimitWarning
+          data={{ ...monthlyWarning, subscription }}
+          onDismiss={jest.fn()}
+        />,
+      );
+      expect(
+        screen.queryByTestId("rate-limit-warning"),
+      ).not.toBeInTheDocument();
+      expect(captureAddCreditCtaImpression).not.toHaveBeenCalled();
+      expect(captureUpgradeCtaImpression).not.toHaveBeenCalled();
+    },
+  );
+
+  it("waits for the wallet query without flashing a purchase CTA", () => {
+    setMockQueryResult(undefined);
+    const { rerender } = render(
+      <RateLimitWarning data={monthlyWarning} onDismiss={jest.fn()} />,
+    );
+    expect(screen.queryByTestId("rate-limit-warning")).not.toBeInTheDocument();
+    expect(captureAddCreditCtaImpression).not.toHaveBeenCalled();
+    setMockQueryResult({ extraUsageAvailable: false, hasBalance: false });
+    rerender(<RateLimitWarning data={monthlyWarning} onDismiss={jest.fn()} />);
+    expect(screen.getByRole("button", { name: "Add Credits" })).toBeVisible();
+    expect(captureAddCreditCtaImpression).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { reason: "disabled", extraUsageAvailable: false, hasBalance: true },
+    {
+      reason: "monthly_cap_exhausted",
+      extraUsageAvailable: false,
+      hasBalance: true,
+    },
+    { reason: "empty", extraUsageAvailable: false, hasBalance: false },
+    { reason: "available", extraUsageAvailable: true, hasBalance: false },
+  ])(
+    "keeps the warning without usable prepaid credit: $reason / balance $hasBalance",
+    (wallet) => {
+      setMockQueryResult(wallet);
+      render(<RateLimitWarning data={monthlyWarning} onDismiss={jest.fn()} />);
+      expect(screen.getByTestId("rate-limit-warning")).toBeVisible();
+    },
+  );
+
+  it("hides mid-stream near-limit warnings without a cap reason", () => {
+    setMockQueryResult({ extraUsageAvailable: true, hasBalance: true });
+    render(
+      <RateLimitWarning
+        data={{ ...monthlyWarning, capReason: undefined, midStream: true }}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("rate-limit-warning")).not.toBeInTheDocument();
+  });
+
+  it.each(["monthly_exhausted", "extra_usage_cap", "team_member_cap"])(
+    "preserves actual cutoff warnings even with personal credit: %s",
+    (capReason) => {
+      setMockQueryResult({ extraUsageAvailable: true, hasBalance: true });
+      render(
+        <RateLimitWarning
+          data={{
+            ...monthlyWarning,
+            remainingPercent: 0,
+            capReason,
+            cutOff: true,
+          }}
+          onDismiss={jest.fn()}
+        />,
+      );
+      expect(screen.getByText(/this response was cut off/i)).toBeVisible();
+    },
+  );
+
+  it.each(["free", "team"] as const)(
+    "preserves %s warnings regardless of personal credit",
+    (subscription) => {
+      setMockQueryResult({ extraUsageAvailable: true, hasBalance: true });
+      render(
+        <RateLimitWarning
+          data={{ ...monthlyWarning, subscription }}
+          onDismiss={jest.fn()}
+        />,
+      );
+      expect(screen.getByTestId("rate-limit-warning")).toBeVisible();
+    },
+  );
 
   it("uses generic copy for free monthly exhaustion", () => {
     render(


### PR DESCRIPTION
A paid user can buy Extra Usage and still see the monthly near-limit banner asking them to add credits. The banner reports only the included monthly allowance and does not react to the prepaid wallet, making a successful top-up look ineffective.

Subscribe to the existing personal Extra Usage entitlement while a monthly near-limit warning is present. Hide the warning and its purchase/upgrade impressions when Extra Usage is enabled, has a positive prepaid balance, and has spending-cap headroom. Wait for the wallet result before showing purchase CTAs, and react immediately to purchases, toggle changes, and balance exhaustion. Preserve cutoff, spending-cap, free-plan, team, and active-Extra-Usage notices.

Validation:
- Component tests cover live top-up and exhaustion, all personal paid tiers, loading, disabled/empty/capped wallets, mid-stream warnings, cutoff preservation, and free/team isolation.
- TypeScript, ESLint, and formatting checks.
- Desktop and mobile visual checks of the real component with a simulated wallet: the banner disappears after a top-up; spending-cap warnings remain visible without horizontal overflow.
- This is a correctness fix; no staged feature flag is needed.

Manual verification:
1. On a paid personal account near its included monthly limit, open a chat with the warning visible.
2. Purchase Extra Usage in test billing and leave it enabled with a positive balance and available spending-cap headroom. The warning should disappear without reloading the chat.
3. Disable Extra Usage or exhaust its balance; the near-limit warning should return. Verify actual spending-cap and response-cutoff notices remain visible.

Account-specific payment verification is not part of this patch; live Stripe access currently requires reauthentication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-limit warnings now accurately reflect extra-usage eligibility and available prepaid credit.
  * Warnings and upgrade prompts remain hidden while entitlement information is loading, preventing misleading flashes.
  * Existing warnings continue to appear for unsupported account states, free accounts, team accounts, and applicable cutoff scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->