### PR TITLE
Preserve desktop attachment failure exit codes

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -2486,21 +2486,30 @@ describe("CentrifugoSandbox", () => {
       expect(runs[1]).not.toContain("certutil");
     });
 
-    it("keeps a bounded exit status when local file preparation has no output", async () => {
-      const { sandbox } = createWindowsBashSandbox();
-      (sandbox as any).commands.run = jest.fn(async () => ({
-        stdout: "",
-        stderr: "",
-        exitCode: 1,
-      }));
+    it.each([
+      { stdout: "", stderr: "" },
+      { stdout: "The system cannot find the file specified.", stderr: "" },
+      { stdout: "", stderr: "The syntax of the command is incorrect." },
+    ])(
+      "preserves local file preparation exit status with %j",
+      async (output) => {
+        const { sandbox } = createWindowsBashSandbox();
+        (sandbox as any).commands.run = jest.fn(async () => ({
+          ...output,
+          exitCode: 1,
+        }));
 
-      await expect(
-        sandbox.files.copyLocal(
-          "C:\\Users\\alice\\private-report.pdf",
-          "/tmp/hackerai-upload/private-report.pdf",
-        ),
-      ).rejects.toThrow("Failed to prepare local file: exit status 1");
-    });
+        await expect(
+          sandbox.files.copyLocal(
+            "C:\\Users\\alice\\private-report.pdf",
+            "/tmp/hackerai-upload/private-report.pdf",
+          ),
+        ).rejects.toMatchObject({
+          message: `Failed to prepare local file: ${output.stderr || output.stdout || "exit status 1"}`,
+          exitCode: 1,
+        });
+      },
+    );
   });
 
   describe("getSandboxContext", () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1696,7 +1696,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       if (result.exitCode !== 0) {
         const failureDetail =
           result.stderr || result.stdout || `exit status ${result.exitCode}`;
-        throw new Error(`Failed to prepare local file: ${failureDetail}`);
+        throw Object.assign(
+          new Error(`Failed to prepare local file: ${failureDetail}`),
+          { exitCode: result.exitCode },
+        );
       }
     },
 

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -341,6 +341,65 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
+  it("logs the final copy exit status when the fallback upload path also fails", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const copyLocal = jest
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(
+          new Error("Failed to prepare local file: permission denied"),
+          { exitCode: 1 },
+        ),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(
+          new Error("Failed to prepare local file: source missing"),
+          { exitCode: 2 },
+        ),
+      );
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "localPath",
+            path: "/private/report.pdf",
+            localPath: "/tmp/hackerai-upload/report.pdf",
+          },
+        ],
+        async () => ({
+          files: { copyLocal },
+          commands: {
+            run: jest.fn().mockResolvedValue({
+              exitCode: 0,
+              stdout: "/home/alice/hackerai-upload/fallback/report.pdf",
+              stderr: "",
+            }),
+          },
+        }),
+      );
+      expect(copyLocal).toHaveBeenCalledTimes(2);
+      expect(result.failedCount).toBe(1);
+      expect(result.pathRewrites).toEqual([]);
+      expect(
+        JSON.parse(String(consoleErrorSpy.mock.calls[0]?.[0])),
+      ).toMatchObject({
+        event: "sandbox_attachment_staging_failed",
+        failure_exit_code: 2,
+      });
+      expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toContain(
+        "report.pdf",
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
   it("normalizes thrown E2B curl write errors and retries in a writable directory", async () => {
     jest.useFakeTimers();
     const consoleWarnSpy = jest
@@ -1217,7 +1276,12 @@ describe("desktop-local sandbox file helpers", () => {
             copyLocal: jest
               .fn()
               .mockRejectedValue(
-                new Error("Failed to prepare local file: exit status 1"),
+                Object.assign(
+                  new Error(
+                    `Failed to prepare local file: cannot read ${sourcePath}`,
+                  ),
+                  { exitCode: 1 },
+                ),
               ),
           },
         }),

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -54,6 +54,7 @@ type SandboxCommandResult = {
 type SandboxUploadFailureDetail = {
   kind: SandboxFile["kind"];
   error: string;
+  exitCode: number | null;
   reason: SandboxUploadFailureReason;
   transientSandboxCommand: boolean;
   sandboxReadinessReason: SandboxReadinessFailureReason;
@@ -929,8 +930,11 @@ const stageSandboxFile = async (
         fallbackError instanceof Error
           ? fallbackError.message
           : String(fallbackError);
-      throw new Error(
-        `${originalMessage}\nFallback upload path also failed: ${fallbackMessage}`,
+      throw Object.assign(
+        new Error(
+          `${originalMessage}\nFallback upload path also failed: ${fallbackMessage}`,
+        ),
+        { exitCode: extractCommandExitCode(fallbackError) },
       );
     }
 
@@ -987,6 +991,7 @@ const summarizeSandboxUploadFailure = (
   const summary: SandboxUploadFailureDetail = {
     kind: file.kind,
     error: redactSandboxUploadError(file, error),
+    exitCode: extractCommandExitCode(error),
     reason: classifySandboxUploadFailureReason(
       file,
       error,
@@ -1066,7 +1071,7 @@ const uploadSandboxFilesOnce = async (
         ...(primaryFailure.kind === "localPath"
           ? { source_path: "[redacted-local-path]" }
           : {}),
-        failure_exit_code: extractCommandExitCode(primaryFailure.error),
+        failure_exit_code: primaryFailure.exitCode,
         transient_sandbox_command: primaryFailure.transientSandboxCommand,
         sandbox_readiness_reason: primaryFailure.sandboxReadinessReason,
         protocol: primaryFailure.protocol ?? null,


### PR DESCRIPTION
Desktop attachment preparation failures lose their numeric command exit status when the command also returns stdout or stderr. The frozen production audit (2026-09-07T20:02:21Z–2026-09-08T20:02:21Z) found 14 failed Vercel requests across three users/eight chats, all with `failure_exit_code: null`; four requests also contained a Windows syntax classification. The underlying copy failure remains unproven.

This change preserves `exitCode` on the existing copy error, through the redacted upload summary, and through the writable-path fallback failure wrapper. The existing structured event reports the final attempt's numeric exit code. Commands, error messages, retry decisions, routing, attachment storage, and log levels remain unchanged. No additional raw paths, command output, or user content are logged.

Production at collection: `hackerai.co` / Vercel `dpl_FYz7Snhv2LXSHZfvwJD2RXjsohgs`, commit `87138c77`, READY 2026-09-08T19:04:51.532Z. Trigger production `20260908.11/lapciw79`, deployed 19:02:38Z. This diagnostic applies after each runtime deploys the change; historical errors cannot gain the lost status.

Validation: 109 focused tests; full commit hooks passed 474 suites / 5,070 tests, typecheck and staged lint/formatting. Changed-file ESLint, Prettier, dependency isolation and diff checks passed. Adversarial pre-push review covered shared Ask/Agent callers, alternate upload paths, partial progress, retry exhaustion, final completion and deployment compatibility; it caught the fallback wrapper's second loss before push. No persisted schema or task-payload change. Docker image and desktop release workflows are not applicable to these paths. No UI rendering change; no live customer run was triggered or retried.

Manual verification after deployment: in an authorized Preview desktop Agent session, use a disposable local attachment whose source becomes unavailable before preparation. Expect the existing failure behavior and `sandbox_attachment_staging_failed.failure_exit_code` as a number, with paths redacted. Then attach an ordinary small text file, ask Agent to read it, confirm completion, and reload to confirm persistence. Verify Vercel Preview and Trigger Preview target identities independently before that live check.

Other audit findings remain visible: localized Convex query saturation, S2 refused-stream failures, iOS recursion without release attribution, storage quota and payment failures. No error suppression added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Local file preparation errors now include the command’s exit status when available.
  - Fallback upload failures preserve the relevant exit code for more accurate diagnostics.
  - Failure logs retain useful error details while continuing to redact file paths.
  - Error handling now consistently supports cases with empty output, standard output, or standard error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->