### PR TITLE
Test reduced free allowances in India, Pakistan, and Bangladesh

### DIFF
--- a/docs/internal/regional-free-limits-experiment.md
+++ b/docs/internal/regional-free-limits-experiment.md
@@ -1,0 +1,121 @@
+# Regional free allowance experiment
+
+Owner and decision record: [HAC-104](https://linear.app/hackerai/issue/HAC-104/experiment-regional-free-allowance-for-india-pakistan-and-bangladesh).
+
+Hypothesis: a smaller free allowance in India, Pakistan and Bangladesh lowers
+serving cost per exposed account without losing enough paid conversion/revenue
+to outweigh the savings. This is a hypothesis, not a conclusion from traffic or
+cancellation data. Initial review is September 23, 2026, with a conversion
+follow-up September 30. Leave the issue open until the readout is reviewed.
+
+## Eligibility and treatment
+
+Only authenticated free accounts with a Vercel ingress country of `IN`, `PK`,
+or `BD` and analytics allowed are eligible. Vercel sets `x-vercel-ip-country`;
+client JSON and `cf-ipcountry` cannot enroll an account. Outside Vercel,
+unknown country, declined consent, paid tiers and failed/disabled flag lookup
+all retain normal limits. Location reflects the current connection, not
+residence; VPNs and travel affect eligibility.
+
+`regional_free_limits_v1` assigns by WorkOS user ID, independently of the
+existing model-routing experiments. Assignment is stable across new requests
+and the web/Trigger services. The web route forwards only the eligible coarse
+country to the trusted worker; the worker evaluates its own PostHog project.
+
+| Variant | Daily shared Ask/Agent requests          | Calendar-month provider/tool cost        |
+| ------- | ---------------------------------------- | ---------------------------------------- |
+| control | Configured normal allowance (default 10) | Configured normal budget (default $0.25) |
+| test    | At most 3                                | At most $0.10                            |
+
+Existing stricter configuration takes precedence. Both variants use the same
+identity-scoped usage counters, UTC resets and earned referral bonuses. Joining
+the test does not clear prior usage: accounts already above the treatment budget
+hit the limit immediately. Cost enforcement uses the existing usage accounting
+and budget checkpoints; in-flight calls can exceed a nominal budget. Paid
+entitlements, model eligibility and moderation behavior remain unchanged.
+
+Agent preflight, post-approval revalidation and delegated child starts receive
+the same policy. The country and assignment are never accepted from client
+request bodies. Child/continued runs receive only the parent's internal policy.
+
+## Measurement
+
+The `regional_free_limits_exposed` event fires when quota enforcement is
+encountered, including rejected attempts. It does not fire merely because a
+flag is evaluated. Properties include `$feature/regional_free_limits_v1`,
+`regional_free_variant`, `regional_free_country`, both applied limits and mode.
+There are no IP addresses, prompts, answers or written customer feedback.
+
+Existing `hackerai-usage_cost` events receive these additional dimensions without
+overwriting model-routing experiment properties. PostHog's custom exposure
+configuration attributes later outcomes by the same user ID, including users
+with no subsequent usage (zero-cost participants). Do not divide costs by usage
+events: that would omit users blocked by the policy and bias the comparison.
+
+Production [experiment 462736](https://us.posthog.com/project/144137/experiments/462736):
+
+- Primary: free serving cost per exposed account, sum of `cost_dollars` where
+  `subscription_tier=free`.
+- Guardrail: `subscription_started` with `conversion_type=free_to_paid`.
+- Guardrail: attributed subscription revenue per exposed account from the same
+  conversion event's `attributed_revenue_dollars` (not total lifetime revenue).
+- Operational readout: assignment ratio and country coverage, existing
+  `limit_hit`, `hackerai-agent_run` success, errors and request completions.
+
+Compare matched follow-up windows, inspect the country breakdown and report
+sample sizes. Do not decide from fewer requests alone. Stop for any paid or
+out-of-country restriction, broken chat/Agent flow, inconsistent enforcement,
+or clear conversion/revenue harm that exceeds savings. Review exposure loss
+from consent, unknown geography and flag failures separately from control.
+
+## Environment and rollout
+
+| Environment | PostHog project       | Flag ID | Enrollment                            | Split                  |
+| ----------- | --------------------- | ------- | ------------------------------------- | ---------------------- |
+| Preview     | hackerai-dev / 401167 | 875174  | 100% code-eligible QA population      | Forced test            |
+| Production  | HackerAI / 144137     | 875171  | 100% eligible population after launch | 50% control / 50% test |
+
+Production flag stays disabled until the PR and deployment pass verification.
+Vercel project `hackerai` belongs to the HackerAI team and is connected to
+`hackerai-tech/hackerai`. Trigger project is `proj_fixirhycbcnfdpicejfb`.
+Verified environment boundaries:
+
+- Preview: Convex team `hackerai-development`, project `hackerai-52290`,
+  designated deployment `diligent-blackbird-710`,
+  `https://diligent-blackbird-710.convex.cloud`. Both Vercel Preview and Trigger
+  Preview use this URL and the PostHog 401167 key.
+- Production: Convex team/project `hackerai`, designated deployment
+  `greedy-cod-889`, `https://greedy-cod-889.convex.cloud`, with the registered
+  Convex Cloud custom domain `https://convex.haiusercontent.com`. Both Vercel
+  Production and Trigger Production use the custom domain. The user-facing
+  production domain is `https://hackerai.co`.
+
+This change needs new Vercel and Trigger deployments. No Convex schema or
+configuration change is required. Flag updates affect new requests/runs;
+already-running tasks retain their policy snapshot. Disable the production flag
+to restore normal limits on new requests, without clearing usage counters.
+
+## Verification and cleanup
+
+Automated tests cover each target country, excluded countries, all paid tiers,
+consent denial, missing/error/disabled flags, stricter overrides, shared
+Ask/Agent counters, monthly existing-spend handling and rollback without reset.
+
+Manual verification on the PR Preview URL:
+
+1. Use a disposable free account connecting from IN/PK/BD with analytics allowed.
+   Send three short Ask/local-Agent requests; the next request must show the
+   existing upgrade/reset message, unless earned referral credits remain.
+2. Reload and retry. Usage must remain exhausted; changing mode must not reset it.
+3. Verify a paid account and an account outside the target countries can complete
+   a chat, reload its response and continue normally.
+4. Confirm Preview exposure and usage events have the test variant and country;
+   compare displayed limits with the actual enforcement. Exercise an Agent run
+   and approval/resume when a connected local sandbox is available.
+5. After production launch, verify both control and test exposure, 50/50 expected
+   assignment, country coverage and conversion attribution. Do not manufacture
+   purchases or customer activity to populate the readout.
+
+After the reviewed decision, remove the code and both flags if unsuccessful,
+or replace them with an explicitly approved permanent policy. Do not ship a
+winning variant or expand targeting automatically.

--- a/lib/ai/subagents/billing.ts
+++ b/lib/ai/subagents/billing.ts
@@ -1,3 +1,4 @@
+import type { FreeLimitPolicy } from "@/lib/rate-limit/free-config";
 import {
   checkFreeMonthlyCostLimit,
   checkRateLimitCapacity,
@@ -13,6 +14,7 @@ type SubagentBillingCapacityInput = {
   organizationId?: string;
   subscription: SubscriptionTier;
   freeQuotaSubject?: string;
+  freeLimits?: FreeLimitPolicy;
   extraUsageConfig?: ExtraUsageConfig;
   modelName: string;
 };
@@ -39,6 +41,7 @@ export const checkSubagentBillingCapacity = async (
   if (input.subscription === "free") {
     await dependencies.checkFreeMonthlyCostLimit(
       input.freeQuotaSubject ?? input.userId,
+      ...(input.freeLimits ? [input.freeLimits] : []),
     );
     return undefined;
   }

--- a/lib/ai/tools/subagent-tools.ts
+++ b/lib/ai/tools/subagent-tools.ts
@@ -1,3 +1,4 @@
+import type { FreeLimitPolicy } from "@/lib/rate-limit/free-config";
 import {
   idempotencyKeys,
   logger as triggerLogger,
@@ -74,6 +75,7 @@ export type SubagentToolsRuntimeConfig = {
   permissionMode: AgentPermissionMode;
   subscription: SubscriptionTier;
   freeQuotaSubject?: string;
+  regionalFreeLimits?: FreeLimitPolicy;
   triggerRegion?: TriggerRunRegion;
 };
 
@@ -325,6 +327,7 @@ export const createDelegateTaskTool = (
               subagentId,
               convexUrl: getConvexUrl(),
               triggerRegion: config.triggerRegion,
+              regionalFreeLimits: config.regionalFreeLimits,
             },
             {
               idempotencyKey: key,
@@ -462,6 +465,7 @@ export const createContinueAgentTool = (
             subagentId: row.subagent_id,
             convexUrl: getConvexUrl(),
             triggerRegion: config.triggerRegion,
+            regionalFreeLimits: config.regionalFreeLimits,
           },
           {
             idempotencyKey: key,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2307,10 +2307,14 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(
       /acquireFreeRunConcurrencyLock\(\s*freeUsageSubject/,
     );
-    expect(taskSrc).toMatch(/checkFreeMonthlyCostLimit\(freeUsageSubject\)/);
+    expect(taskSrc).toMatch(
+      /checkFreeMonthlyCostLimit\(\s*freeUsageSubject,\s*regionalFreeLimits,?\s*\)/,
+    );
     expect(
-      taskSrc.match(/checkFreeMonthlyCostLimit\(freeUsageSubject\)/g),
-    ).toHaveLength(3);
+      taskSrc.match(
+        /checkFreeMonthlyCostLimit\(\s*freeUsageSubject,\s*regionalFreeLimits,?\s*\)/g,
+      ),
+    ).toHaveLength(4);
     expect(taskSrc).not.toMatch(
       /checkFreeMonthlyCostLimit\(freeUsageSubject,\s*userId/,
     );

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -2295,6 +2295,20 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   });
 
   test("agent-long carries free quota subject into Trigger.dev enforcement", () => {
+    const lockIndex = taskSrc.indexOf(
+      "const lock = await acquireFreeRunConcurrencyLock(",
+    );
+    const monthlyIndex = taskSrc.indexOf(
+      "await checkFreeMonthlyCostLimit(",
+      lockIndex,
+    );
+    const consumeIndex = taskSrc.indexOf(
+      "rateLimitInfo = await checkRateLimit(",
+      lockIndex,
+    );
+    expect(lockIndex).toBeGreaterThan(-1);
+    expect(monthlyIndex).toBeGreaterThan(lockIndex);
+    expect(consumeIndex).toBeGreaterThan(monthlyIndex);
     expect(routeSrc).toMatch(/freeQuotaSubject/);
     expect(routeSrc).toMatch(
       /const agentPayload\s*=\s*{[\s\S]*freeQuotaSubject/,

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -1,3 +1,4 @@
+import { regionalFreeCountryFromRequest } from "@/lib/experiments/regional-free-limits-request";
 import { NextRequest, NextResponse } from "next/server";
 import { createHash } from "crypto";
 import { tasks, auth, idempotencyKeys, sessions } from "@trigger.dev/sdk";
@@ -684,6 +685,10 @@ export const createAgentTriggerPost =
         subscription,
         organizationId,
         freeQuotaSubject,
+        regionalFreeCountry:
+          subscription === "free"
+            ? regionalFreeCountryFromRequest(req)
+            : undefined,
         messages: messagesForPayload,
         localDesktopAttachmentsPrepared,
         baseTodos: Array.isArray(todos) ? todos : [],

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1,4 +1,9 @@
 import {
+  evaluateRegionalFreeLimits,
+  captureRegionalFreeLimitsExposure,
+} from "@/lib/experiments/regional-free-limits";
+import { regionalFreeCountryFromRequest } from "@/lib/experiments/regional-free-limits-request";
+import {
   prepareProviderDisconnectContinuation,
   PROVIDER_DISCONNECT_CONTINUATION_PROMPT,
 } from "@/lib/chat/agent-long-provider-retry";
@@ -439,6 +444,26 @@ export const createChatHandler = () => {
         projectId: projectContext.projectId,
       });
 
+      const regionalFreeLimits = await evaluateRegionalFreeLimits({
+        posthog: (posthog ??= PostHogClient()),
+        userId,
+        subscription,
+        country: regionalFreeCountryFromRequest(req),
+      });
+      await captureRegionalFreeLimitsExposure(
+        posthog,
+        regionalFreeLimits,
+        userId,
+        mode,
+      );
+      const freeMonthlyBudgetSnapshot =
+        subscription === "free"
+          ? await checkFreeMonthlyCostLimit(
+              freeUsageSubject,
+              regionalFreeLimits,
+            )
+          : null;
+
       // Free ask: pre-flight rate-limit before any token counting/model work.
       const freeAskRateLimitInfo =
         mode === "ask" && subscription === "free"
@@ -451,6 +476,7 @@ export const createChatHandler = () => {
               undefined,
               undefined,
               freeQuotaSubject,
+              regionalFreeLimits,
             )
           : null;
 
@@ -595,6 +621,7 @@ export const createChatHandler = () => {
             selectedModel,
             organizationId,
             freeQuotaSubject,
+            regionalFreeLimits,
           ));
       } catch (error) {
         if (!(error instanceof ChatSDKError)) {
@@ -713,11 +740,6 @@ export const createChatHandler = () => {
           getDeepSeekV4Pro0813ExperimentContext(
             activeDeepSeekV4Pro0813Experiment,
           ));
-
-      const freeMonthlyBudgetSnapshot =
-        subscription === "free"
-          ? await checkFreeMonthlyCostLimit(freeUsageSubject)
-          : null;
 
       usageRefundTracker.recordDeductions(rateLimitInfo);
 
@@ -1319,6 +1341,7 @@ export const createChatHandler = () => {
                   });
                 }
                 captureUsageCost({
+                  regionalFreeLimits,
                   posthog,
                   userId,
                   subscription,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1,3 +1,7 @@
+import {
+  regionalFreeLimitsProperties,
+  type RegionalFreeLimitsAssignment,
+} from "@/lib/experiments/regional-free-limits";
 /**
  * Chat Handler Wide Event Logger
  *
@@ -1767,6 +1771,7 @@ export function captureUsageCost({
   analyticsRequestContext,
   fallbackServed,
   experiment,
+  regionalFreeLimits,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1794,6 +1799,7 @@ export function captureUsageCost({
   analyticsRequestContext?: AnalyticsRequestContext;
   fallbackServed?: boolean;
   experiment?: ExperimentAnalyticsContext;
+  regionalFreeLimits?: RegionalFreeLimitsAssignment;
 }) {
   if (!posthog) return;
   const includedUsageValueDollars =
@@ -1895,6 +1901,7 @@ export function captureUsageCost({
           paidDailyFreeAllowance.resetTimestamp,
       }),
       ...getExperimentAnalyticsProperties(experiment),
+      ...regionalFreeLimitsProperties(regionalFreeLimits),
     },
   });
 }

--- a/lib/experiments/__tests__/regional-free-limits.test.ts
+++ b/lib/experiments/__tests__/regional-free-limits.test.ts
@@ -20,6 +20,7 @@ describe("regional free allowance", () => {
   });
   afterEach(() => {
     process.env = { ...savedEnv };
+    jest.useRealTimers();
   });
 
   it.each(["IN", "PK", "BD"])(
@@ -162,6 +163,7 @@ describe("regional free allowance", () => {
     ).toBeUndefined();
   });
   it("emits exposure only explicitly at enforcement and preserves other experiment dimensions", async () => {
+    jest.useFakeTimers();
     const capture = jest.fn();
     const flush = jest.fn().mockResolvedValue(undefined);
     const assignment = await evaluateRegionalFreeLimits({
@@ -191,6 +193,7 @@ describe("regional free allowance", () => {
       "experiment_key",
     );
     expect(flush).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
     capture.mockClear();
     await captureRegionalFreeLimitsExposure(
       { capture, flush },
@@ -199,5 +202,37 @@ describe("regional free allowance", () => {
       "ask",
     );
     expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("bounds a stalled exposure flush and handles its late rejection", async () => {
+    jest.useFakeTimers();
+    const assignment = await evaluateRegionalFreeLimits({
+      posthog,
+      userId: "test-user",
+      subscription: "free",
+      country: "IN",
+    });
+    let rejectFlush!: (error: Error) => void;
+    const flush = jest.fn().mockImplementation(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejectFlush = reject;
+        }),
+    );
+    const enforced = jest.fn();
+    const pending = captureRegionalFreeLimitsExposure(
+      { capture: jest.fn(), flush },
+      assignment,
+      "test-user",
+      "ask",
+    ).then(enforced);
+    await jest.advanceTimersByTimeAsync(749);
+    expect(enforced).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1);
+    await pending;
+    expect(enforced).toHaveBeenCalledTimes(1);
+    rejectFlush(new Error("late network failure"));
+    await jest.advanceTimersByTimeAsync(0);
+    expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/lib/experiments/__tests__/regional-free-limits.test.ts
+++ b/lib/experiments/__tests__/regional-free-limits.test.ts
@@ -1,0 +1,203 @@
+import {
+  evaluateRegionalFreeLimits,
+  captureRegionalFreeLimitsExposure,
+  regionalFreeLimitsProperties,
+  REGIONAL_FREE_LIMITS_KEY,
+} from "../regional-free-limits";
+import { regionalFreeCountryFromRequest } from "../regional-free-limits-request";
+import type { NextRequest } from "next/server";
+
+describe("regional free allowance", () => {
+  const getFeatureFlag = jest.fn();
+  const posthog = { getFeatureFlag };
+  const savedEnv = { ...process.env };
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.VERCEL = "1";
+    delete process.env.FREE_RATE_LIMIT_REQUESTS;
+    delete process.env.FREE_MONTHLY_COST_LIMIT_USD;
+    getFeatureFlag.mockResolvedValue("test");
+  });
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it.each(["IN", "PK", "BD"])(
+    "uses a stable account flag and reduced limits for %s",
+    async (country) => {
+      const result = await evaluateRegionalFreeLimits({
+        posthog,
+        userId: "test-user",
+        subscription: "free",
+        country,
+      });
+      expect(result).toMatchObject({
+        country,
+        variant: "test",
+        dailyRequests: 3,
+        monthlyCostDollars: 0.1,
+      });
+      expect(getFeatureFlag).toHaveBeenCalledWith(
+        REGIONAL_FREE_LIMITS_KEY,
+        "test-user",
+        {
+          sendFeatureFlagEvents: false,
+          personProperties: {
+            regional_free_country: country,
+            subscription: "free",
+          },
+        },
+      );
+    },
+  );
+
+  it.each(["pro", "pro-plus", "ultra", "team"])(
+    "never changes %s limits",
+    async (subscription) => {
+      expect(
+        await evaluateRegionalFreeLimits({
+          posthog,
+          userId: "test-user",
+          subscription,
+          country: "IN",
+        }),
+      ).toBeUndefined();
+      expect(getFeatureFlag).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([undefined, "US", "XX", "", "India"])(
+    "excludes non-target/unknown country %s",
+    async (country) => {
+      expect(
+        await evaluateRegionalFreeLimits({
+          posthog,
+          userId: "test-user",
+          subscription: "free",
+          country,
+        }),
+      ).toBeUndefined();
+      expect(getFeatureFlag).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps configured control limits and never raises a stricter existing cap", async () => {
+    process.env.FREE_RATE_LIMIT_REQUESTS = "8";
+    process.env.FREE_MONTHLY_COST_LIMIT_USD = "0.20";
+    getFeatureFlag.mockResolvedValue("control");
+    expect(
+      await evaluateRegionalFreeLimits({
+        posthog,
+        userId: "test-user",
+        subscription: "free",
+        country: "IN",
+      }),
+    ).toMatchObject({ dailyRequests: 8, monthlyCostDollars: 0.2 });
+    process.env.FREE_RATE_LIMIT_REQUESTS = "2";
+    process.env.FREE_MONTHLY_COST_LIMIT_USD = "0.05";
+    getFeatureFlag.mockResolvedValue("test");
+    expect(
+      await evaluateRegionalFreeLimits({
+        posthog,
+        userId: "test-user",
+        subscription: "free",
+        country: "IN",
+      }),
+    ).toMatchObject({ dailyRequests: 2, monthlyCostDollars: 0.05 });
+  });
+
+  it.each([false, true, undefined, "unexpected"])(
+    "does not enroll disabled or invalid flag value %s",
+    async (value) => {
+      getFeatureFlag.mockResolvedValue(value);
+      expect(
+        await evaluateRegionalFreeLimits({
+          posthog,
+          userId: "test-user",
+          subscription: "free",
+          country: "IN",
+        }),
+      ).toBeUndefined();
+    },
+  );
+  it("fails open to normal limits on flag lookup errors", async () => {
+    getFeatureFlag.mockRejectedValue(new Error("offline"));
+    expect(
+      await evaluateRegionalFreeLimits({
+        posthog,
+        userId: "test-user",
+        subscription: "free",
+        country: "IN",
+      }),
+    ).toBeUndefined();
+  });
+  it("requires trusted ingress and respects declined consent", () => {
+    const req = (headers: Record<string, string>) =>
+      ({
+        headers: new Headers(headers),
+        cookies: {
+          get: () =>
+            headers.cookie
+              ? { value: headers.cookie.split("=")[1] }
+              : undefined,
+        },
+      }) as unknown as NextRequest;
+    expect(
+      regionalFreeCountryFromRequest(req({ "x-vercel-ip-country": "IN" })),
+    ).toBe("IN");
+    expect(
+      regionalFreeCountryFromRequest(
+        req({
+          "x-vercel-ip-country": "IN",
+          cookie: "hackerai_analytics_consent=declined",
+        }),
+      ),
+    ).toBeUndefined();
+    expect(
+      regionalFreeCountryFromRequest(req({ "cf-ipcountry": "IN" })),
+    ).toBeUndefined();
+    delete process.env.VERCEL;
+    expect(
+      regionalFreeCountryFromRequest(req({ "x-vercel-ip-country": "IN" })),
+    ).toBeUndefined();
+  });
+  it("emits exposure only explicitly at enforcement and preserves other experiment dimensions", async () => {
+    const capture = jest.fn();
+    const flush = jest.fn().mockResolvedValue(undefined);
+    const assignment = await evaluateRegionalFreeLimits({
+      posthog,
+      userId: "test-user",
+      subscription: "free",
+      country: "IN",
+    });
+    expect(capture).not.toHaveBeenCalled();
+    await captureRegionalFreeLimitsExposure(
+      { capture, flush },
+      assignment,
+      "test-user",
+      "ask",
+    );
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "regional_free_limits_exposed",
+        properties: expect.objectContaining({
+          regional_free_variant: "test",
+          regional_free_country: "IN",
+          $geoip_disable: true,
+        }),
+      }),
+    );
+    expect(regionalFreeLimitsProperties(assignment)).not.toHaveProperty(
+      "experiment_key",
+    );
+    expect(flush).toHaveBeenCalledTimes(1);
+    capture.mockClear();
+    await captureRegionalFreeLimitsExposure(
+      { capture, flush },
+      undefined,
+      "test-user",
+      "ask",
+    );
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/lib/experiments/regional-free-limits-request.ts
+++ b/lib/experiments/regional-free-limits-request.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+import {
+  ANALYTICS_CONSENT_COOKIE_NAME,
+  getAnalyticsConsentDecision,
+} from "@/lib/privacy/analytics-consent";
+import {
+  isRegionalFreeCountry,
+  type RegionalFreeCountry,
+} from "./regional-free-limits";
+
+/** Vercel overwrites this header at ingress. Never trust client country/body fields. */
+export function regionalFreeCountryFromRequest(
+  req: NextRequest,
+): RegionalFreeCountry | undefined {
+  if (process.env.VERCEL !== "1") return;
+  const country = req.headers.get("x-vercel-ip-country")?.trim().toUpperCase();
+  if (!isRegionalFreeCountry(country)) return;
+  const { analyticsAllowed } = getAnalyticsConsentDecision({
+    cookieValue: req.cookies.get(ANALYTICS_CONSENT_COOKIE_NAME)?.value,
+    countryCode: country,
+    failClosed: true,
+  });
+  return analyticsAllowed ? country : undefined;
+}

--- a/lib/experiments/regional-free-limits.ts
+++ b/lib/experiments/regional-free-limits.ts
@@ -95,6 +95,7 @@ export async function captureRegionalFreeLimitsExposure(
   mode: string,
 ) {
   if (!posthog || !assignment) return;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     posthog.capture({
       distinctId: userId,
@@ -109,9 +110,18 @@ export async function captureRegionalFreeLimitsExposure(
       },
     });
     // Rejected preflight never reaches normal completion telemetry. Flush before
-    // returning so zero-usage exposed accounts remain in the denominator.
-    await posthog.flush();
+    // returning so zero-usage exposed accounts remain in the denominator. Bound
+    // the wait so analytics outages cannot hold up quota enforcement. The race
+    // also handles a flush rejection after the timeout has already won.
+    await Promise.race([
+      posthog.flush(),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, 750);
+      }),
+    ]);
   } catch {
     /* Analytics must not prevent quota enforcement. */
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
   }
 }

--- a/lib/experiments/regional-free-limits.ts
+++ b/lib/experiments/regional-free-limits.ts
@@ -1,0 +1,117 @@
+import type { PostHog } from "posthog-node";
+import {
+  getFreeMonthlyCostLimitDollars,
+  getFreeRequestLimit,
+  type FreeLimitPolicy,
+} from "@/lib/rate-limit/free-config";
+
+export const REGIONAL_FREE_LIMITS_KEY = "regional_free_limits_v1";
+export const REGIONAL_FREE_LIMITS_EXPOSURE = "regional_free_limits_exposed";
+export const REGIONAL_FREE_COUNTRIES = ["IN", "PK", "BD"] as const;
+export type RegionalFreeCountry = (typeof REGIONAL_FREE_COUNTRIES)[number];
+export type RegionalFreeLimitsAssignment = FreeLimitPolicy & {
+  key: typeof REGIONAL_FREE_LIMITS_KEY;
+  variant: "control" | "test";
+  country: RegionalFreeCountry;
+};
+
+export function isRegionalFreeCountry(
+  value: unknown,
+): value is RegionalFreeCountry {
+  return REGIONAL_FREE_COUNTRIES.some((country) => country === value);
+}
+
+/** Only server-derived country and consent may reach this evaluator. */
+export async function evaluateRegionalFreeLimits({
+  posthog,
+  userId,
+  subscription,
+  country,
+}: {
+  posthog: Pick<PostHog, "getFeatureFlag"> | null;
+  userId: string;
+  subscription: string;
+  country?: string;
+}): Promise<RegionalFreeLimitsAssignment | undefined> {
+  if (
+    !posthog ||
+    !userId ||
+    subscription !== "free" ||
+    !isRegionalFreeCountry(country)
+  )
+    return;
+  try {
+    const variant = await posthog.getFeatureFlag(
+      REGIONAL_FREE_LIMITS_KEY,
+      userId,
+      {
+        sendFeatureFlagEvents: false,
+        personProperties: {
+          regional_free_country: country,
+          subscription: "free",
+        },
+      },
+    );
+    // Disabled, missing and failed evaluations preserve the established allowance
+    // and are not mislabeled as experiment controls.
+    if (variant !== "control" && variant !== "test") return;
+    return {
+      key: REGIONAL_FREE_LIMITS_KEY,
+      variant,
+      country,
+      dailyRequests:
+        variant === "test"
+          ? Math.min(3, getFreeRequestLimit())
+          : getFreeRequestLimit(),
+      monthlyCostDollars:
+        variant === "test"
+          ? Math.min(0.1, getFreeMonthlyCostLimitDollars())
+          : getFreeMonthlyCostLimitDollars(),
+    };
+  } catch {
+    return;
+  }
+}
+
+export function regionalFreeLimitsProperties(
+  assignment?: RegionalFreeLimitsAssignment,
+) {
+  return assignment
+    ? {
+        [`$feature/${REGIONAL_FREE_LIMITS_KEY}`]: assignment.variant,
+        regional_free_variant: assignment.variant,
+        regional_free_country: assignment.country,
+        regional_free_daily_requests: assignment.dailyRequests,
+        regional_free_monthly_cost_dollars: assignment.monthlyCostDollars,
+      }
+    : {};
+}
+
+/** Called at quota enforcement, including requests rejected by the quota. */
+export async function captureRegionalFreeLimitsExposure(
+  posthog: Pick<PostHog, "capture" | "flush"> | null,
+  assignment: RegionalFreeLimitsAssignment | undefined,
+  userId: string,
+  mode: string,
+) {
+  if (!posthog || !assignment) return;
+  try {
+    posthog.capture({
+      distinctId: userId,
+      event: REGIONAL_FREE_LIMITS_EXPOSURE,
+      properties: {
+        ...regionalFreeLimitsProperties(assignment),
+        subscription_tier: "free",
+        mode,
+        exposure_surface: "quota_enforcement",
+        $geoip_disable: true,
+        $process_person_profile: false,
+      },
+    });
+    // Rejected preflight never reaches normal completion telemetry. Flush before
+    // returning so zero-usage exposed accounts remain in the denominator.
+    await posthog.flush();
+  } catch {
+    /* Analytics must not prevent quota enforcement. */
+  }
+}

--- a/lib/rate-limit/__tests__/free-monthly-cost.test.ts
+++ b/lib/rate-limit/__tests__/free-monthly-cost.test.ts
@@ -59,6 +59,22 @@ describe("free monthly cost limit", () => {
     expect(snapshot.extraUsageAutoReload).toBe(false);
   });
 
+  it("enforces the treatment cap against existing spend and restores control without clearing it", async () => {
+    mockCreateRedisClient.mockReturnValue({ get: mockGet, eval: mockEval });
+    mockGet.mockResolvedValue(1000);
+    const { checkFreeMonthlyCostLimit } = getIsolatedModule();
+    await expect(
+      checkFreeMonthlyCostLimit("quota", {
+        dailyRequests: 3,
+        monthlyCostDollars: 0.1,
+      }),
+    ).rejects.toMatchObject({ type: "rate_limit" });
+    const control = await checkFreeMonthlyCostLimit("quota");
+    expect(control.monthlyRemainingAtStart).toBe(1500);
+    expect(mockGet.mock.calls[0]).toEqual(mockGet.mock.calls[1]);
+    expect(mockEval).not.toHaveBeenCalled();
+  });
+
   it("throws a rate-limit error when the monthly free cost cap is exhausted", async () => {
     process.env.FREE_MONTHLY_COST_LIMIT_USD = "0.01";
     mockCreateRedisClient.mockReturnValue({ get: mockGet, eval: mockEval });

--- a/lib/rate-limit/__tests__/sliding-window.test.ts
+++ b/lib/rate-limit/__tests__/sliding-window.test.ts
@@ -32,6 +32,44 @@ describe("sliding-window", () => {
   };
 
   describe("checkFreeUserRateLimit", () => {
+    it("shares a reduced daily allowance between Ask and Agent without resetting usage", async () => {
+      const {
+        checkFreeUserRateLimit,
+        checkFreeAgentRateLimit,
+        checkFreeAgentRateLimitCapacity,
+      } = getIsolatedModule();
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      const policy = { dailyRequests: 3, monthlyCostDollars: 0.1 };
+      mockEvalFn
+        .mockResolvedValueOnce([1, 2])
+        .mockResolvedValueOnce([1, 1])
+        .mockResolvedValueOnce([1, 0])
+        .mockResolvedValueOnce([0, 0])
+        .mockResolvedValueOnce(0);
+      await checkFreeUserRateLimit("quota", 1, policy);
+      await checkFreeAgentRateLimit("quota", policy);
+      await checkFreeUserRateLimit("quota", 1, policy);
+      await expect(
+        checkFreeAgentRateLimit("quota", policy),
+      ).rejects.toMatchObject({ type: "rate_limit" });
+      await expect(
+        checkFreeAgentRateLimitCapacity("quota", policy),
+      ).rejects.toMatchObject({ type: "rate_limit" });
+      const keys = mockEvalFn.mock.calls.map((call) => call[1]);
+      expect(
+        keys.every((key) => JSON.stringify(key) === JSON.stringify(keys[0])),
+      ).toBe(true);
+      expect(
+        mockEvalFn.mock.calls
+          .slice(0, 4)
+          .every((call) => (call[2] as number[])[0] === 3),
+      ).toBe(true);
+      expect(mockEvalFn.mock.calls[4][2]).toEqual([3]);
+      mockEvalFn.mockResolvedValueOnce([1, 6]);
+      expect((await checkFreeUserRateLimit("quota")).limit).toBe(10);
+      expect(mockEvalFn.mock.calls[5][1]).toEqual(keys[0]);
+    });
+
     it("should skip rate limiting when Redis unavailable", async () => {
       const { checkFreeUserRateLimit } = getIsolatedModule();
 

--- a/lib/rate-limit/free-config.ts
+++ b/lib/rate-limit/free-config.ts
@@ -6,19 +6,38 @@ export const FREE_RATE_LIMIT_REQUESTS_DEFAULT = 10;
 export const FREE_ASK_REQUEST_COST = 1;
 export const FREE_AGENT_REQUEST_COST = 1;
 
-export const getFreeRequestLimit = (): number => {
+export type FreeLimitPolicy = {
+  dailyRequests: number;
+  monthlyCostDollars: number;
+};
+
+export const getFreeRequestLimit = (policy?: FreeLimitPolicy): number => {
   const configuredLimit = parseInt(
     process.env.FREE_RATE_LIMIT_REQUESTS || "",
     10,
   );
-  return Number.isFinite(configuredLimit) && configuredLimit > 0
-    ? configuredLimit
-    : FREE_RATE_LIMIT_REQUESTS_DEFAULT;
+  const normal =
+    Number.isFinite(configuredLimit) && configuredLimit > 0
+      ? configuredLimit
+      : FREE_RATE_LIMIT_REQUESTS_DEFAULT;
+  return policy &&
+    Number.isFinite(policy.dailyRequests) &&
+    policy.dailyRequests >= 1
+    ? Math.min(normal, Math.floor(policy.dailyRequests))
+    : normal;
 };
 
-export const getFreeMonthlyCostLimitDollars = (): number => {
+export const getFreeMonthlyCostLimitDollars = (
+  policy?: FreeLimitPolicy,
+): number => {
   const configuredLimit = Number(process.env.FREE_MONTHLY_COST_LIMIT_USD);
-  return Number.isFinite(configuredLimit) && configuredLimit > 0
-    ? configuredLimit
-    : FREE_MONTHLY_COST_LIMIT_USD_DEFAULT;
+  const normal =
+    Number.isFinite(configuredLimit) && configuredLimit > 0
+      ? configuredLimit
+      : FREE_MONTHLY_COST_LIMIT_USD_DEFAULT;
+  return policy &&
+    Number.isFinite(policy.monthlyCostDollars) &&
+    policy.monthlyCostDollars > 0
+    ? Math.min(normal, policy.monthlyCostDollars)
+    : normal;
 };

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -1,5 +1,8 @@
 import { ChatSDKError } from "@/lib/errors";
-import { getFreeMonthlyCostLimitDollars } from "./free-config";
+import {
+  type FreeLimitPolicy,
+  getFreeMonthlyCostLimitDollars,
+} from "./free-config";
 import { POINTS_PER_DOLLAR } from "./token-bucket";
 import { createRedisClient } from "./redis";
 import { getLimitPressureContext } from "@/lib/limit-pressure";
@@ -64,8 +67,11 @@ const getLimitMessage = (reset: number) =>
 /** Enforce the configured monthly cost cap for a free quota subject. */
 export async function checkFreeMonthlyCostLimit(
   quotaSubject: string,
+  freeLimits?: FreeLimitPolicy,
 ): Promise<FreeMonthlyCostSnapshot> {
-  const limitPoints = dollarsToPoints(getFreeMonthlyCostLimitDollars());
+  const limitPoints = dollarsToPoints(
+    getFreeMonthlyCostLimitDollars(freeLimits),
+  );
   const { bucket, reset } = getCurrentUtcMonthWindow();
   const redis = createRedisClient();
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -1,3 +1,4 @@
+import type { FreeLimitPolicy } from "./free-config";
 /**
  * Rate Limiting Module
  *
@@ -141,15 +142,16 @@ export const checkRateLimit = async (
   modelName?: string,
   organizationId?: string,
   freeQuotaSubject?: string,
+  freeLimits?: FreeLimitPolicy,
 ): Promise<RateLimitInfo> => {
   // Free users: fixed daily window
   if (subscription === "free") {
     const quotaSubject = freeQuotaSubject ?? userId;
     if (isAgentMode(mode)) {
       // Free agent mode shares the daily free budget and consumes 1 unit.
-      return checkFreeAgentRateLimit(quotaSubject);
+      return checkFreeAgentRateLimit(quotaSubject, freeLimits);
     }
-    return checkFreeUserRateLimit(quotaSubject);
+    return checkFreeUserRateLimit(quotaSubject, undefined, freeLimits);
   }
 
   // Paid users: token bucket (same budget for both modes)
@@ -175,12 +177,13 @@ export const checkRateLimitCapacity = async (
   modelName?: string,
   organizationId?: string,
   freeQuotaSubject?: string,
+  freeLimits?: FreeLimitPolicy,
 ): Promise<RateLimitInfo> => {
   if (subscription === "free") {
     const quotaSubject = freeQuotaSubject ?? userId;
     return isAgentMode(mode)
-      ? checkFreeAgentRateLimitCapacity(quotaSubject)
-      : checkFreeUserRateLimitCapacity(quotaSubject);
+      ? checkFreeAgentRateLimitCapacity(quotaSubject, freeLimits)
+      : checkFreeUserRateLimitCapacity(quotaSubject, undefined, freeLimits);
   }
 
   const current = await checkTokenBucketLimit(

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -1,3 +1,4 @@
+import type { FreeLimitPolicy } from "./free-config";
 /**
  * Fixed Window Rate Limiting (Free Users)
  *
@@ -199,10 +200,11 @@ export const grantFreeReferralBonusUnits = async (
 export const checkFreeUserRateLimit = async (
   userId: string,
   requestCost = FREE_ASK_REQUEST_COST,
+  freeLimits?: FreeLimitPolicy,
 ): Promise<RateLimitInfo> => {
   const redis = createRedisClient();
 
-  const requestLimit = getFreeRequestLimit();
+  const requestLimit = getFreeRequestLimit(freeLimits);
   const cost = Math.max(1, Math.trunc(requestCost));
   const { bucket, reset, ttlMs } = getCurrentUtcDayWindow();
 
@@ -269,16 +271,18 @@ export const checkFreeUserRateLimit = async (
  */
 export const checkFreeAgentRateLimit = async (
   userId: string,
+  freeLimits?: FreeLimitPolicy,
 ): Promise<RateLimitInfo> => {
-  return checkFreeUserRateLimit(userId, FREE_AGENT_REQUEST_COST);
+  return checkFreeUserRateLimit(userId, FREE_AGENT_REQUEST_COST, freeLimits);
 };
 
 export const checkFreeUserRateLimitCapacity = async (
   userId: string,
   requestCost = FREE_ASK_REQUEST_COST,
+  freeLimits?: FreeLimitPolicy,
 ): Promise<RateLimitInfo> => {
   const redis = createRedisClient();
-  const requestLimit = getFreeRequestLimit();
+  const requestLimit = getFreeRequestLimit(freeLimits);
   const cost = Math.max(1, Math.trunc(requestCost));
   const { bucket, reset } = getCurrentUtcDayWindow();
 
@@ -343,5 +347,6 @@ export const checkFreeUserRateLimitCapacity = async (
 
 export const checkFreeAgentRateLimitCapacity = async (
   userId: string,
+  freeLimits?: FreeLimitPolicy,
 ): Promise<RateLimitInfo> =>
-  checkFreeUserRateLimitCapacity(userId, FREE_AGENT_REQUEST_COST);
+  checkFreeUserRateLimitCapacity(userId, FREE_AGENT_REQUEST_COST, freeLimits);

--- a/trigger/__tests__/agent-long-post-wait-authorization.test.ts
+++ b/trigger/__tests__/agent-long-post-wait-authorization.test.ts
@@ -170,7 +170,7 @@ describe("agent-long post-wait authorization contract", () => {
     const resume = taskSource.indexOf("activeRuntimeBudget.resume()", wait);
     const capacity = taskSource.indexOf("await checkRateLimitCapacity(");
     const monthlyCost = taskSource.indexOf(
-      "await checkFreeMonthlyCostLimit(freeUsageSubject)",
+      "await checkFreeMonthlyCostLimit(",
       capacity,
     );
     const reacquire = taskSource.indexOf(

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2933,6 +2933,14 @@ export const agentLongTask = task({
               releaseFreeRunLock = lock.release;
             }
 
+            const freeMonthlyBudgetSnapshot =
+              subscription === "free"
+                ? await checkFreeMonthlyCostLimit(
+                    freeUsageSubject,
+                    regionalFreeLimits,
+                  )
+                : null;
+
             try {
               rateLimitInfo = await checkRateLimit(
                 userId,
@@ -3056,14 +3064,6 @@ export const agentLongTask = task({
                 getDeepSeekV4Pro0813ExperimentContext(
                   activeDeepSeekV4Pro0813Experiment,
                 ));
-
-            const freeMonthlyBudgetSnapshot =
-              subscription === "free"
-                ? await checkFreeMonthlyCostLimit(
-                    freeUsageSubject,
-                    regionalFreeLimits,
-                  )
-                : null;
 
             usageRefundTracker.recordDeductions(rateLimitInfo);
             chatLogger?.setRateLimit(

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1,3 +1,7 @@
+import {
+  evaluateRegionalFreeLimits,
+  captureRegionalFreeLimitsExposure,
+} from "@/lib/experiments/regional-free-limits";
 import { createRecoverableProviderErrorFilter } from "@/lib/chat/provider-error-stream";
 import { selectTaskOutcomeSurvey } from "@/lib/feedback/select-task-outcome";
 import { evaluateAbliteratedModel } from "@/lib/experiments/abliterated-model";
@@ -2251,6 +2255,7 @@ export type AgentLongPayload = {
   subscription: SubscriptionTier;
   organizationId?: string;
   freeQuotaSubject?: string;
+  regionalFreeCountry?: string;
   messages: UIMessage[];
   localDesktopAttachmentsPrepared?: boolean;
   baseTodos: Todo[];
@@ -2623,6 +2628,33 @@ export const agentLongTask = task({
         selectedModelOverride,
       });
       const posthog = PostHogClient();
+      const regionalFreeLimits = await evaluateRegionalFreeLimits({
+        posthog,
+        userId,
+        subscription,
+        country: payload.regionalFreeCountry,
+      });
+      // Check capacity before moderation/model work, then consume the daily
+      // request atomically under the free-run lock when execution starts.
+      await captureRegionalFreeLimitsExposure(
+        posthog,
+        regionalFreeLimits,
+        userId,
+        mode,
+      );
+      if (subscription === "free") {
+        await checkRateLimitCapacity(
+          userId,
+          mode,
+          subscription,
+          undefined,
+          undefined,
+          organizationId,
+          freeQuotaSubject,
+          regionalFreeLimits,
+        );
+        await checkFreeMonthlyCostLimit(freeUsageSubject, regionalFreeLimits);
+      }
       const cloudSandboxProvider = "e2b" as const;
 
       const baseTodos: Todo[] = getBaseTodosForRequest(
@@ -2911,6 +2943,7 @@ export const agentLongTask = task({
                 selectedModel,
                 organizationId,
                 freeQuotaSubject,
+                regionalFreeLimits,
               );
             } catch (error) {
               if (!(error instanceof ChatSDKError)) throw error;
@@ -3026,7 +3059,10 @@ export const agentLongTask = task({
 
             const freeMonthlyBudgetSnapshot =
               subscription === "free"
-                ? await checkFreeMonthlyCostLimit(freeUsageSubject)
+                ? await checkFreeMonthlyCostLimit(
+                    freeUsageSubject,
+                    regionalFreeLimits,
+                  )
                 : null;
 
             usageRefundTracker.recordDeductions(rateLimitInfo);
@@ -3161,9 +3197,13 @@ export const agentLongTask = task({
                 selectedModel,
                 authorization.organizationId,
                 freeQuotaSubject,
+                regionalFreeLimits,
               );
               if (authorization.subscription === "free") {
-                await checkFreeMonthlyCostLimit(freeUsageSubject);
+                await checkFreeMonthlyCostLimit(
+                  freeUsageSubject,
+                  regionalFreeLimits,
+                );
                 const lock = await acquireFreeRunConcurrencyLock(
                   freeUsageSubject,
                   FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS,
@@ -3248,9 +3288,13 @@ export const agentLongTask = task({
                 selectedModel,
                 currentEntitlement.organizationId,
                 freeQuotaSubject,
+                regionalFreeLimits,
               );
               if (currentEntitlement.subscription === "free") {
-                await checkFreeMonthlyCostLimit(freeUsageSubject);
+                await checkFreeMonthlyCostLimit(
+                  freeUsageSubject,
+                  regionalFreeLimits,
+                );
               }
             };
             let approvalSandboxManager: SandboxManager | undefined;
@@ -3369,6 +3413,7 @@ export const agentLongTask = task({
                           permissionMode: agentPermissionMode,
                           subscription,
                           freeQuotaSubject,
+                          regionalFreeLimits,
                           triggerRegion,
                         }),
                         continue_agent: createContinueAgentTool(toolContext, {
@@ -3377,6 +3422,7 @@ export const agentLongTask = task({
                           permissionMode: agentPermissionMode,
                           subscription,
                           freeQuotaSubject,
+                          regionalFreeLimits,
                           triggerRegion,
                         }),
                         list_agents: createListAgentsTool(toolContext),
@@ -3859,6 +3905,7 @@ export const agentLongTask = task({
                   });
                 }
                 captureUsageCost({
+                  regionalFreeLimits,
                   posthog,
                   userId,
                   subscription,

--- a/trigger/subagent.ts
+++ b/trigger/subagent.ts
@@ -1,3 +1,4 @@
+import type { FreeLimitPolicy } from "@/lib/rate-limit/free-config";
 import {
   logger as triggerLogger,
   metadata,
@@ -137,6 +138,7 @@ const loadPersistedTerminalOutput = async (
 };
 
 type SubagentTaskPayload = {
+  regionalFreeLimits?: FreeLimitPolicy;
   subagentId: string;
   convexUrl?: string;
   triggerRegion?: TriggerRunRegion;
@@ -608,6 +610,7 @@ export const subagentTask = task({
         organizationId: row.organization_id,
         subscription: row.subscription,
         freeQuotaSubject: row.free_quota_subject,
+        freeLimits: payload.regionalFreeLimits,
         extraUsageConfig,
         modelName: selectedModel,
       });


### PR DESCRIPTION
Free accounts connecting from India, Pakistan, and Bangladesh can now enter a PostHog experiment comparing the normal 10 requests/day and $0.25/month budget with 3 requests/day and $0.10/month. Production launched September 9, 2026 at 20:07 UTC with a stable 50/50 control/test split; Preview forces the treatment for eligible QA accounts.

The server derives country from Vercel ingress and respects analytics consent. Paid accounts, other/unknown countries and unavailable flags retain normal limits. Ask, Agent, approval rechecks and delegated starts share the policy and existing usage counters; earned referral credits and model eligibility are preserved. Quota exposure includes blocked users and gets a bounded 750 ms flush before preflight can return. Usage telemetry adds the regional dimensions without replacing model-routing experiment attribution.

Tracks [HAC-104](https://linear.app/hackerai/issue/HAC-104/experiment-regional-free-allowance-for-india-pakistan-and-bangladesh), which stays open for the readout. [Production experiment](https://us.posthog.com/project/144137/experiments/462736) measures free serving cost per exposed account, paid conversion and attributed subscription revenue.

Validation: typecheck; ESLint; 476 Jest suites / 5,114 tests plus 5 research-runner checks passed. The final review fixes also passed the full test suite and typecheck in commit hooks. Exposure delivery is bounded to 750 ms; the locked monthly check precedes daily credit consumption. Separate Preview/Production Convex and PostHog mappings verified for Vercel and Trigger. No Convex schema/configuration changes.

Deployed verification: Preview Ask returned the expected short response and persisted after reload; the disposable chat was deleted. Actual Trigger Preview key evaluations returned test for IN/PK/BD free accounts and false for US/free and IN/pro. Final Preview commit b47ef840 deployed to Vercel and Trigger worker 20260909.2. Production commit a541be06 is live on hackerai.co with Trigger worker 20260909.4. A Pro cloud Agent request completed and persisted after reload; the disposable production chat was deleted. Live production SDK checks returned both variants, stable across IN/PK/BD, and excluded US/free, IN/pro and PK/team. Initial real exposures are arriving in PostHog.

Remaining manual verification: on the PR Preview URL, use an eligible free QA account to exhaust three requests across Ask/local Agent, reload and confirm the upgrade/reset response persists. Paid production Agent completion/reload and Preview free Ask completion/reload passed. Check exposure and cost events against the enforced allowance. Geographic treatment UI verification requires an eligible connection and is still pending.

Operational notes: existing monthly spend is retained, so treatment accounts already above $0.10 hit the limit immediately. Existing accounting checkpoints allow in-flight cost overshoot. Rollback disables the flag for new requests/runs; in-flight tasks retain their snapshot. New Vercel and Trigger builds are required; this PR does not touch sandbox image build paths.
