### PR TITLE
fix: install AI SDK download dependency in Trigger workers

### DIFF
--- a/__tests__/trigger-runtime-packages.test.js
+++ b/__tests__/trigger-runtime-packages.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment-options {"customExportConditions": ["node", "node-addons"]} */
+
+jest.mock("dotenv", () => ({ config: jest.fn() }));
+jest.mock("@trigger.dev/sdk", () => ({ defineConfig: (config) => config }));
+
+const config = require("../trigger.config").default;
+const packageJson = require("../package.json");
+
+describe("Trigger runtime packages", () => {
+  const extension = config.build.extensions.find(
+    (candidate) => candidate.name === "additionalPackages",
+  );
+
+  test("installs the pinned dynamic download dependency in the deployment layer", async () => {
+    const addLayer = jest.fn();
+
+    // Run the actual extension: a declared root dependency alone does not
+    // ensure createRequire can resolve it from an isolated deployed bundle.
+    await extension.onBuildStart({
+      target: "deploy",
+      resolvePath: async (name) => require.resolve(name),
+      logger: { debug: jest.fn(), warn: jest.fn() },
+      addLayer,
+    });
+
+    expect(addLayer).toHaveBeenCalledWith({
+      id: "additionalPackages",
+      dependencies: {
+        "node-pty": expect.any(String),
+        sharp: expect.any(String),
+        undici: packageJson.dependencies.undici,
+      },
+    });
+  });
+
+  test("does not install deployment packages in development", async () => {
+    const addLayer = jest.fn();
+    await extension.onBuildStart({ target: "dev", addLayer });
+    expect(addLayer).not.toHaveBeenCalled();
+  });
+});

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -1,6 +1,7 @@
 import { config } from "dotenv";
 import { defineConfig } from "@trigger.dev/sdk";
 import { additionalPackages } from "@trigger.dev/build/extensions/core";
+import packageJson from "./package.json";
 
 if (process.env.NODE_ENV !== "production") {
   config({ path: ".env.local" });
@@ -38,7 +39,13 @@ export default defineConfig({
     external: ["node-pty", "sharp"],
     extensions: [
       additionalPackages({
-        packages: ["node-pty", "sharp"],
+        // AI SDK's guarded download uses createRequire("undici"), which the
+        // bundler cannot discover. Install the same pinned version as the app.
+        packages: [
+          "node-pty",
+          "sharp",
+          `undici@${packageJson.dependencies.undici}`,
+        ],
       }),
     ],
   },


### PR DESCRIPTION
## Problem and change

Production Agent image downloads began failing after the AI SDK update in #1291. AI SDK 6.0.277's guarded download path dynamically calls `createRequire("undici")`; that dependency exists in the app's pnpm graph but is absent from the bundled Trigger worker filesystem.

Install the app's existing exact `undici` pin through Trigger's `additionalPackages` extension. The change applies to the shared worker image and preserves the SDK download guards, existing bundling, model routing, and recovery behavior.

## Production evidence

Frozen audit: **2026-09-08T20:00:57Z inclusive–2026-09-09T20:00:57Z exclusive**.
- PostHog production: **383 AI_DownloadError events / 62 users**, first **2026-09-09T03:48:56.785Z**. These are events, not terminal-run counts.
- Trigger: four direct `MODULE_NOT_FOUND` terminal errors plus one independently traced terminal 502 that first hit the same missing module: **at least five terminal impacted runs / three users / three chats**.
- Representative `run_06g8ckeepv4fog0i62e92bv3e1`, span `c43a8c2b7b8f047f`: `Cannot find module 'undici'`, require stack `/app/chunk-VGUKZVIA.mjs`, through downloadAssets → convertToLanguageModelPrompt. Overlapping run: `run_06g88peol7u6tm1gef9eb161c1`.
- Affected task version **20260909.1 / 7xy3j1up**, deployed **2026-09-09T03:37:36Z** with #1291. Current audit worker **20260909.3 / ilyhpv91**, deployed **19:55:31Z**. Evaluate this fix only on a newly deployed worker containing this commit; later wall-clock runs can still use older versions.

## Validation

- Real additionalPackages extension regression tests verify the emitted deployment dependency layer and development no-op. Removing the undici entry makes the regression test fail.
- Isolated ESM bundle using Trigger CLI's esbuild and installed ai6.0.277 reproduced the exact missing-module failure outside the checkout.
- Installing undici7.29.1 into that fixture makes real createDownload return correct image bytes/media type with network-disabled MockAgent responses. Private URL and redirect-to-metadata blocking, byte limit, and cancellation checks pass on **Node22.23.2 and Node24.14.0**.
- Typecheck, changed-file ESLint/Prettier, dependency guard and diff check pass.
- Full configured commit hooks: **476 suites / 5,093 tests pass** under Node22. An initial Node24 worker SIGSEGV was followed by a passing isolated 75-test suite and the full successful hook run.
- Pre-push adversarial review covered deployment-level installation, all shared tasks, pinned version resolution, independent Vercel/Trigger versions, and unchanged download security/retry behavior.

## Manual verification

After the PR Preview worker deploys, verify the Vercel Preview and Trigger Preview environment identities independently. In a disposable Agent chat, attach a small PNG, ask for a short description, confirm completion, then reload and confirm persistence. Exercise both initial image input and an image requiring auxiliary vision if available. Confirm the run uses this worker version and has no missing-undici error; cancel a separate request and confirm no new recovery leg starts.

After merge and production deployment, verify the new production worker independently and repeat a bounded image request. Existing failed runs do not change retroactively. The isolated fixture does not claim an authenticated live Agent journey.

Docker sandbox and desktop release checks are not applicable to these paths. No production configuration, secrets, Convex state, retries, suppression rules, or deployment were changed by this audit. Other audit findings (provider billing, S2 persistence burst, payment recovery, browser recursion) remain separate follow-ups.

Reference: [Trigger additionalPackages](https://trigger.dev/docs/config/extensions/additionalPackages).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Improvements**
  - Production deployments now include the required pinned runtime packages, improving compatibility for applications that rely on terminal, image-processing, and HTTP client functionality.
  - Development builds remain unchanged and do not receive an additional deployment package layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->