### PR TITLE
Prefer EU model endpoints for European users with global fallback

### DIFF
--- a/docs/openrouter-eu-routing.md
+++ b/docs/openrouter-eu-routing.md
@@ -1,0 +1,63 @@
+# Europe-first OpenRouter routing
+
+For European users, Ask and Agent can prefer EU inference endpoints while
+retaining global availability. This is a regional preference, not an EU-only
+data-residency guarantee.
+
+The trusted Vercel `x-vercel-ip-continent: EU` header determines eligibility.
+Agent jobs carry that decision in `isEuropeanUser`; the worker's region does
+not determine the user's location. Missing geography and older queued jobs use
+global routing.
+
+The server-side PostHog flag `openrouter_eu_routing_v1` must also evaluate to
+`true`. Missing, disabled, failed, or slow flag evaluation uses global routing.
+Evaluation is bounded to one second. The production flag starts disabled at 0%;
+configure an explicit internal allowlist before activation.
+
+## Request behavior
+
+- Cache the public EU model catalog for five minutes, with a two-second lookup
+  timeout and a thirty-second backoff after lookup failure.
+- If the primary model is absent from the catalog, send the original request
+  directly to global, even if one of its fallback models is EU-eligible.
+- Otherwise send it to `https://eu.openrouter.ai/api/v1/chat/completions`.
+- On a pre-stream no-endpoint/no-allowed-provider 404 or provider-unavailable
+  503, retry the original request once through the global endpoint.
+- Keep model order, provider restrictions, headers, request repairs, and abort
+  signals. Never replay an accepted stream, a network failure with unknown
+  inference status, or auth, billing, and guardrail failures.
+
+The request-scoped provider is used by the main Ask/Agent inference loops.
+Standalone helpers using `myProvider` directly, including titles and automatic
+approval review, continue to use global routing.
+
+## Measurement and rollback
+
+`openrouter_eu_routing_exposed` fires once per chat request when an EU inference
+request is actually attempted. Assignment and catalog lookup are not exposure.
+`openrouter_eu_routing_global_fallback` records endpoint-unavailable fallback.
+These events carry only the user identifier, flag value, and fixed route outcome.
+Use completion/error events and existing model attribution to assess reliability,
+latency, and cost. OpenRouter's reported region is diagnostic metadata, not proof
+that a global request was constrained to EU providers.
+
+Disable the flag to roll back subsequent requests. Review the internal canary
+before expanding the rollout. Owner, review date, guardrails, and flag cleanup
+are tracked in [HAC-105](https://linear.app/hackerai/issue/HAC-105).
+
+## Manual verification
+
+1. On a preview deployment, allowlist an internal user and make an Ask request
+   from Europe. For an EU-eligible model, verify an EU attempt and a normal
+   response. Repeat with Agent, checking the job's `isEuropeanUser` value.
+2. Select a model absent from the current EU catalog. Verify a normal global
+   response with the same selected model and no EU exposure event.
+3. For an EU model without an allowed regional provider, verify EU then global
+   and a normal response. Preserve the account's provider restrictions.
+4. Repeat from outside Europe and with the flag disabled. Both should use global
+   without an EU catalog lookup or exposure event.
+5. Cancel a request and verify that no global replay follows cancellation. A
+   started stream must never be replayed after an error.
+
+OpenRouter Business or Enterprise access is required for in-region routing.
+See [OpenRouter's documentation](https://openrouter.ai/docs/guides/features/in-region-routing).

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -14,20 +14,22 @@ global.TextDecoder = TextDecoder;
 global.ReadableStream = ReadableStream;
 global.TransformStream = TransformStream;
 
-// Mock window.matchMedia
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: jest.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
+// Mock window.matchMedia only for browser tests.
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // Deprecated
+      removeListener: jest.fn(), // Deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
 
 // Global test utilities
 global.beforeEach(() => {

--- a/lib/ai/__tests__/openrouter-region.test.ts
+++ b/lib/ai/__tests__/openrouter-region.test.ts
@@ -1,0 +1,317 @@
+/** @jest-environment node */
+import { jest } from "@jest/globals";
+import { generateText } from "ai";
+import { createTrackedProvider, myProvider } from "../providers";
+import {
+  createEuModelCatalog,
+  createOpenRouterRegionFetch,
+  isEuropeanRequest,
+} from "../openrouter-region";
+
+const globalUrl = "https://openrouter.ai/api/v1/chat/completions";
+const euUrl = "https://eu.openrouter.ai/api/v1/chat/completions";
+const init: RequestInit = {
+  method: "POST",
+  headers: {
+    Authorization: "Bearer test",
+    "X-OpenRouter-Experimental-Metadata": "enabled",
+  },
+  body: JSON.stringify({
+    model: "z-ai/glm-5.2",
+    models: ["x-ai/grok-4.5"],
+    messages: [{ role: "user", content: "test" }],
+    stream: true,
+    provider: { ignore: ["example"] },
+  }),
+};
+
+describe("European user detection", () => {
+  it.each([
+    ["EU", true],
+    [" eu ", true],
+    ["NA", false],
+    ["AS", false],
+    ["", false],
+  ])("handles continent %s", (continent, expected) => {
+    expect(
+      isEuropeanRequest({
+        headers: new Headers({ "x-vercel-ip-continent": String(continent) }),
+      }),
+    ).toBe(expected);
+  });
+  it("defaults missing geography to global", () => {
+    expect(isEuropeanRequest({ headers: new Headers() })).toBe(false);
+  });
+});
+
+describe("OpenRouter regional transport", () => {
+  const inference = jest.fn<typeof fetch>();
+  const catalog = jest.fn<() => Promise<Set<string> | null>>();
+  const onRoute = jest.fn();
+  const success = () =>
+    new Response("data: [DONE]\n\n", {
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  let transport: typeof fetch;
+  beforeEach(() => {
+    inference.mockReset().mockImplementation(async () => success());
+    catalog.mockReset().mockResolvedValue(new Set(["z-ai/glm-5.2"]));
+    onRoute.mockReset();
+    transport = createOpenRouterRegionFetch(
+      inference,
+      { preferEurope: true, onRoute },
+      catalog,
+    );
+  });
+
+  it("sends eligible models to EU without modifying body, headers, or signal", async () => {
+    const requestInit = { ...init, signal: new AbortController().signal };
+    const result = await transport(globalUrl, requestInit);
+    expect(String(inference.mock.calls[0][0])).toBe(euUrl);
+    expect(inference.mock.calls[0][1]).toBe(requestInit);
+    expect(result.bodyUsed).toBe(false);
+    expect(inference).toHaveBeenCalledTimes(1);
+    expect(onRoute).toHaveBeenCalledWith("eu");
+  });
+
+  it("uses global when disabled without fetching the catalog", async () => {
+    await createOpenRouterRegionFetch(inference, {}, catalog)(globalUrl, init);
+    expect(inference).toHaveBeenCalledWith(globalUrl, init);
+    expect(catalog).not.toHaveBeenCalled();
+  });
+
+  it.each([null, new Set<string>()])(
+    "uses global when the catalog has no EU endpoint",
+    async (models) => {
+      catalog.mockResolvedValue(models);
+      await transport(globalUrl, init);
+      expect(inference).toHaveBeenCalledWith(globalUrl, init);
+      expect(onRoute).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps the primary model global even if a fallback is EU-eligible", async () => {
+    const body = JSON.stringify({
+      model: "x-ai/grok-4.5",
+      models: ["z-ai/glm-5.2"],
+    });
+    await transport(globalUrl, { ...init, body });
+    expect(inference.mock.calls[0][0]).toBe(globalUrl);
+  });
+
+  it.each([404, 503])(
+    "retries an EU endpoint availability error (%s) globally exactly once",
+    async (status) => {
+      inference.mockResolvedValueOnce(
+        Response.json(
+          {
+            error: {
+              code: status,
+              message: "No endpoints found for this model",
+            },
+          },
+          { status },
+        ),
+      );
+      await transport(globalUrl, init);
+      expect(inference).toHaveBeenCalledTimes(2);
+      expect(String(inference.mock.calls[0][0])).toBe(euUrl);
+      expect(inference.mock.calls[1]).toEqual([globalUrl, init]);
+      expect(onRoute.mock.calls).toEqual([["eu"], ["global_no_eu_endpoint"]]);
+    },
+  );
+
+  it("falls back when the account has no allowed provider in EU", async () => {
+    inference.mockResolvedValueOnce(
+      Response.json(
+        {
+          error: {
+            code: 404,
+            message:
+              "No allowed providers are available for the selected model. Providers serving this model: mistral, but your account's allowed-providers setting permits only: z-ai.",
+          },
+        },
+        { status: 404 },
+      ),
+    );
+    await transport(globalUrl, init);
+    expect(inference).toHaveBeenCalledTimes(2);
+    expect(inference.mock.calls[1]).toEqual([globalUrl, init]);
+  });
+
+  it.each([400, 401, 402, 403, 404, 429, 500, 502])(
+    "preserves unrelated HTTP %s failures and their readable bodies",
+    async (status) => {
+      const response = Response.json(
+        { error: { message: "Unrelated failure" } },
+        { status },
+      );
+      inference.mockResolvedValueOnce(response);
+      expect(await transport(globalUrl, init)).toBe(response);
+      expect(await response.json()).toEqual({
+        error: { message: "Unrelated failure" },
+      });
+      expect(inference).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("never replays SSE errors in an accepted stream", async () => {
+    const response = new Response('data: {"error":{"code":503}}\n\n');
+    inference.mockResolvedValueOnce(response);
+    expect(await transport(globalUrl, init)).toBe(response);
+    expect(response.bodyUsed).toBe(false);
+    expect(inference).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not forward requests for other hosts or endpoints to EU", async () => {
+    for (const url of [
+      "https://example.com/api/v1/chat/completions",
+      "https://openrouter.ai/api/v1/models",
+    ]) {
+      await transport(url, init);
+      expect(inference).toHaveBeenLastCalledWith(url, init);
+    }
+    expect(catalog).not.toHaveBeenCalled();
+  });
+
+  it("honors cancellation during catalog lookup without sending inference", async () => {
+    const controller = new AbortController();
+    catalog.mockImplementation(async () => {
+      controller.abort();
+      return new Set(["z-ai/glm-5.2"]);
+    });
+    await expect(
+      transport(globalUrl, { ...init, signal: controller.signal }),
+    ).rejects.toThrow();
+    expect(inference).not.toHaveBeenCalled();
+  });
+
+  it("never retries a network failure with unknown inference status", async () => {
+    inference.mockRejectedValueOnce(new Error("Network failure"));
+    await expect(transport(globalUrl, init)).rejects.toThrow("Network failure");
+    expect(inference).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let analytics failures block inference", async () => {
+    onRoute.mockImplementation(() => {
+      throw new Error("Analytics failure");
+    });
+    await expect(transport(globalUrl, init)).resolves.toBeInstanceOf(Response);
+  });
+});
+
+describe("EU model catalog", () => {
+  afterEach(() => jest.restoreAllMocks());
+  it("deduplicates concurrent reads and refreshes after five minutes", async () => {
+    let now = 100;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    const fetchCatalog = jest
+      .fn<typeof fetch>()
+      .mockImplementation(async () =>
+        Response.json({ data: [{ id: "model-a" }] }),
+      );
+    const load = createEuModelCatalog(fetchCatalog);
+    expect(await Promise.all([load(), load(), load()])).toEqual([
+      new Set(["model-a"]),
+      new Set(["model-a"]),
+      new Set(["model-a"]),
+    ]);
+    expect(fetchCatalog).toHaveBeenCalledTimes(1);
+    await load();
+    expect(fetchCatalog).toHaveBeenCalledTimes(1);
+    now += 5 * 60_000;
+    await load();
+    expect(fetchCatalog).toHaveBeenCalledTimes(2);
+    expect(fetchCatalog.mock.calls[0][1]).toEqual({
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it.each([null, { data: [null] }, { data: [{ name: "missing-id" }] }])(
+    "falls back on malformed catalogs and backs off retries",
+    async (body) => {
+      const fetchCatalog = jest
+        .fn<typeof fetch>()
+        .mockImplementation(async () => Response.json(body));
+      const load = createEuModelCatalog(fetchCatalog);
+      expect(await load()).toBeNull();
+      expect(await load()).toBeNull();
+      expect(fetchCatalog).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("recovers from a failed catalog lookup after thirty seconds", async () => {
+    let now = 100;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    const fetchCatalog = jest
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("Timeout"))
+      .mockResolvedValueOnce(Response.json({ data: [{ id: "model-a" }] }));
+    const load = createEuModelCatalog(fetchCatalog);
+    expect(await load()).toBeNull();
+    now += 30_000;
+    expect(await load()).toEqual(new Set(["model-a"]));
+  });
+});
+
+describe("OpenRouter SDK integration", () => {
+  it("preserves direct-provider models when creating an EU-aware provider", () => {
+    const provider = createTrackedProvider({ preferEurope: true });
+    for (const key of ["model-abliterated", "model-abliterated-large-v2"]) {
+      expect(provider.languageModel(key)).toBe(myProvider.languageModel(key));
+    }
+  });
+  it("applies EU fallback and existing request repairs through the registered provider", async () => {
+    const originalKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "test-key";
+    const fetchMock = jest
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (url) => {
+        if (String(url).includes("/models?region=eu")) {
+          return Response.json({ data: [{ id: "z-ai/glm-5.2" }] });
+        }
+        if (String(url).startsWith("https://eu.openrouter.ai/")) {
+          return Response.json(
+            { error: { code: 404, message: "No endpoints found" } },
+            { status: 404 },
+          );
+        }
+        return Response.json({
+          id: "gen-test",
+          model: "z-ai/glm-5.2",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "Done" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        });
+      });
+    try {
+      const provider = createTrackedProvider({ preferEurope: true });
+      const result = await generateText({
+        model: provider.languageModel("model-glm-5.2"),
+        prompt: "Test",
+        maxRetries: 0,
+      });
+      expect(result.text).toBe("Done");
+      const calls = fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes("/chat/completions"),
+      );
+      expect(calls.map(([url]) => String(url))).toEqual([euUrl, globalUrl]);
+      expect(calls[0][1]?.body).toBe(calls[1][1]?.body);
+      expect(
+        new Headers(calls[1][1]?.headers).get("X-OpenRouter-Metadata"),
+      ).toBe("enabled");
+      expect(new Headers(calls[1][1]?.headers).get("Authorization")).toBe(
+        "Bearer test-key",
+      );
+    } finally {
+      fetchMock.mockRestore();
+      if (originalKey === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = originalKey;
+    }
+  });
+});

--- a/lib/ai/openrouter-region.ts
+++ b/lib/ai/openrouter-region.ts
@@ -1,0 +1,136 @@
+const GLOBAL_ORIGIN = "https://openrouter.ai";
+const EU_ORIGIN = "https://eu.openrouter.ai";
+const CATALOG_TTL_MS = 5 * 60_000;
+const CATALOG_FAILURE_TTL_MS = 30_000;
+
+export type OpenRouterRegionOutcome = "eu" | "global_no_eu_endpoint";
+
+export type OpenRouterRegionOptions = {
+  preferEurope?: boolean;
+  onRoute?: (outcome: OpenRouterRegionOutcome) => void;
+};
+
+export function isEuropeanRequest(request: { headers: Headers }): boolean {
+  return (
+    request.headers.get("x-vercel-ip-continent")?.trim().toUpperCase() === "EU"
+  );
+}
+
+// The public catalog contains model metadata only. Never send auth or prompts.
+export function createEuModelCatalog(
+  fetchCatalog: typeof fetch = (...args) => globalThis.fetch(...args),
+): () => Promise<Set<string> | null> {
+  let cached: Set<string> | null = null;
+  let expiresAt = 0;
+  let pending: Promise<Set<string> | null> | undefined;
+
+  return async () => {
+    if (Date.now() < expiresAt) return cached;
+    if (pending) return pending;
+    pending = (async () => {
+      try {
+        const response = await fetchCatalog(
+          `${GLOBAL_ORIGIN}/api/v1/models?region=eu`,
+          {
+            signal: AbortSignal.timeout(2_000),
+          },
+        );
+        if (!response.ok) throw new Error("EU model catalog unavailable");
+        const body = await response.json();
+        if (
+          !Array.isArray(body?.data) ||
+          !body.data.every(
+            (model: unknown) =>
+              typeof model === "object" &&
+              model !== null &&
+              "id" in model &&
+              typeof model.id === "string",
+          )
+        )
+          throw new Error("Invalid EU model catalog");
+        cached = new Set(body.data.map((model: { id: string }) => model.id));
+        expiresAt = Date.now() + CATALOG_TTL_MS;
+      } catch {
+        cached = null;
+        expiresAt = Date.now() + CATALOG_FAILURE_TTL_MS;
+      }
+      return cached;
+    })();
+    try {
+      return await pending;
+    } finally {
+      pending = undefined;
+    }
+  };
+}
+
+const getEuModels = createEuModelCatalog();
+
+export function createOpenRouterRegionFetch(
+  fetchInference: typeof fetch,
+  options: OpenRouterRegionOptions,
+  loadEuModels = getEuModels,
+): typeof fetch {
+  return async (input, init) => {
+    // The SDK sends replayable JSON strings. Leave other fetch surfaces alone.
+    if (
+      !options.preferEurope ||
+      input instanceof Request ||
+      init?.method?.toUpperCase() !== "POST" ||
+      typeof init.body !== "string"
+    ) {
+      return fetchInference(input, init);
+    }
+    const url = new URL(input);
+    if (
+      url.origin !== GLOBAL_ORIGIN ||
+      url.pathname !== "/api/v1/chat/completions"
+    ) {
+      return fetchInference(input, init);
+    }
+    let model: unknown;
+    try {
+      model = JSON.parse(init.body)?.model;
+    } catch {
+      return fetchInference(input, init);
+    }
+    init.signal?.throwIfAborted();
+    const models = typeof model === "string" ? await loadEuModels() : null;
+    init.signal?.throwIfAborted();
+    if (!models || typeof model !== "string" || !models.has(model)) {
+      return fetchInference(input, init);
+    }
+
+    const recordRoute = (outcome: OpenRouterRegionOutcome) => {
+      try {
+        options.onRoute?.(outcome);
+      } catch {
+        /* Analytics must not affect inference. */
+      }
+    };
+    const euUrl = new URL(url);
+    euUrl.hostname = new URL(EU_ORIGIN).hostname;
+    recordRoute("eu");
+    const response = await fetchInference(euUrl, init);
+    // Only replay pre-stream endpoint-availability failures. Successful streams,
+    // auth/guardrail errors, billing errors, and cancellations are never replayed.
+    if (response.status !== 404 && response.status !== 503) return response;
+    if (response.status === 404) {
+      const body = await response
+        .clone()
+        .json()
+        .catch(() => null);
+      if (
+        typeof body?.error?.message !== "string" ||
+        !/^no (?:(?:available )?(?:endpoints|providers)\b|allowed providers are available\b)/i.test(
+          body.error.message,
+        )
+      )
+        return response;
+    }
+    await response.body?.cancel();
+    init.signal?.throwIfAborted();
+    recordRoute("global_no_eu_endpoint");
+    return fetchInference(input, init);
+  };
+}

--- a/lib/ai/openrouter-region.ts
+++ b/lib/ai/openrouter-region.ts
@@ -10,13 +10,14 @@ export type OpenRouterRegionOptions = {
   onRoute?: (outcome: OpenRouterRegionOutcome) => void;
 };
 
+/** Uses trusted ingress geography; absent location keeps the global default. */
 export function isEuropeanRequest(request: { headers: Headers }): boolean {
   return (
     request.headers.get("x-vercel-ip-continent")?.trim().toUpperCase() === "EU"
   );
 }
 
-// The public catalog contains model metadata only. Never send auth or prompts.
+/** Shares bounded public catalog lookups without sending auth or prompts. */
 export function createEuModelCatalog(
   fetchCatalog: typeof fetch = (...args) => globalThis.fetch(...args),
 ): () => Promise<Set<string> | null> {
@@ -66,6 +67,7 @@ export function createEuModelCatalog(
 
 const getEuModels = createEuModelCatalog();
 
+/** Prefers EU for eligible models, replaying only pre-stream availability errors. */
 export function createOpenRouterRegionFetch(
   fetchInference: typeof fetch,
   options: OpenRouterRegionOptions,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -9,6 +9,10 @@ import {
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { ChatMode, SelectedModel } from "@/types/chat";
 import { openrouterAttributionHeaders } from "@/lib/ai/openrouter-attribution";
+import {
+  createOpenRouterRegionFetch,
+  type OpenRouterRegionOptions,
+} from "@/lib/ai/openrouter-region";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -1449,4 +1453,26 @@ export const myProvider = customProvider({
   languageModels: baseProviders,
 });
 
-export const createTrackedProvider = () => myProvider;
+export const createTrackedProvider = (
+  options: OpenRouterRegionOptions = {},
+) => {
+  if (!options.preferEurope) return myProvider;
+  return customProvider({
+    languageModels: {
+      ...baseProviders,
+      ...buildProviderMap(
+        createOpenRouter({
+          // Choose the region after request repairs have resolved the actual
+          // outgoing model, including forced-tool-choice model fallback.
+          fetch: createOpenRouterPatchFetch(
+            createOpenRouterRegionFetch(
+              (...args) => globalThis.fetch(...args),
+              options,
+            ),
+          ),
+          headers: openrouterAttributionHeaders,
+        }),
+      ),
+    },
+  });
+};

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1453,6 +1453,7 @@ export const myProvider = customProvider({
   languageModels: baseProviders,
 });
 
+/** Builds request-scoped OpenRouter routing while retaining direct providers. */
 export const createTrackedProvider = (
   options: OpenRouterRegionOptions = {},
 ) => {

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -4,6 +4,7 @@ import { createHash } from "crypto";
 import { tasks, auth, idempotencyKeys, sessions } from "@trigger.dev/sdk";
 import type { agentLongTask } from "@/trigger/agent-long";
 import { geolocation } from "@vercel/functions";
+import { isEuropeanRequest } from "@/lib/ai/openrouter-region";
 import type { UIMessage } from "ai";
 
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
@@ -700,6 +701,7 @@ export const createAgentTriggerPost =
         autoReviewAssignment,
         userLocation,
         triggerRegion,
+        isEuropeanUser: isEuropeanRequest(req),
         isAutoContinue,
         isAutomaticContinuation,
         regenerate,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -446,6 +446,13 @@ export const createChatHandler = () => {
         projectId: projectContext.projectId,
       });
 
+      posthog ??= PostHogClient();
+      const openRouterRegionOptionsPromise = resolveOpenRouterRegionOptions({
+        posthog,
+        userId,
+        isEuropeanUser: isEuropeanRequest(req),
+      });
+
       const regionalFreeLimits = await evaluateRegionalFreeLimits({
         posthog: (posthog ??= PostHogClient()),
         userId,
@@ -1018,11 +1025,7 @@ export const createChatHandler = () => {
               : Promise.resolve(undefined);
 
             const trackedProvider = createTrackedProvider(
-              await resolveOpenRouterRegionOptions({
-                posthog,
-                userId,
-                isEuropeanUser: isEuropeanRequest(req),
-              }),
+              await openRouterRegionOptionsPromise,
             );
 
             let currentSystemPrompt = await systemPrompt(

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -148,6 +148,8 @@ import {
   drainBackgroundWork,
 } from "@/lib/chat/background-work-drain";
 import { createTrackedProvider } from "@/lib/ai/providers";
+import { isEuropeanRequest } from "@/lib/ai/openrouter-region";
+import { resolveOpenRouterRegionOptions } from "@/lib/experiments/openrouter-eu-routing";
 import {
   getSandboxUploadFailureMetadata,
   getSandboxUploadUserMessage,
@@ -1015,7 +1017,13 @@ export const createChatHandler = () => {
                 )
               : Promise.resolve(undefined);
 
-            const trackedProvider = createTrackedProvider();
+            const trackedProvider = createTrackedProvider(
+              await resolveOpenRouterRegionOptions({
+                posthog,
+                userId,
+                isEuropeanUser: isEuropeanRequest(req),
+              }),
+            );
 
             let currentSystemPrompt = await systemPrompt(
               userId,

--- a/lib/experiments/__tests__/openrouter-eu-routing.test.ts
+++ b/lib/experiments/__tests__/openrouter-eu-routing.test.ts
@@ -1,0 +1,85 @@
+import {
+  resolveOpenRouterRegionOptions,
+  OPENROUTER_EU_ROUTING_FLAG,
+} from "../openrouter-eu-routing";
+import type { PostHog } from "posthog-node";
+
+describe("Europe routing assignment and exposure", () => {
+  const evaluateFlags = jest.fn();
+  const capture = jest.fn();
+  const posthog = { evaluateFlags, capture } as unknown as Pick<
+    PostHog,
+    "evaluateFlags" | "capture"
+  >;
+  const args = { posthog, userId: "test-user", isEuropeanUser: true };
+  beforeEach(() => {
+    jest.useFakeTimers();
+    evaluateFlags.mockReset().mockResolvedValue({ getFlag: () => true });
+    capture.mockReset();
+  });
+  afterEach(() => jest.useRealTimers());
+
+  it("never enables EU routing for users outside Europe", async () => {
+    expect(
+      await resolveOpenRouterRegionOptions({ ...args, isEuropeanUser: false }),
+    ).toEqual({});
+    expect(evaluateFlags).not.toHaveBeenCalled();
+  });
+
+  it.each([false, undefined, "true"])(
+    "uses global for a missing or disabled flag (%s)",
+    async (value) => {
+      evaluateFlags.mockResolvedValue({ getFlag: () => value });
+      expect(await resolveOpenRouterRegionOptions(args)).toEqual({});
+      expect(capture).not.toHaveBeenCalled();
+    },
+  );
+
+  it("records exposure only when EU inference is attempted, once per request", async () => {
+    const options = await resolveOpenRouterRegionOptions(args);
+    expect(options.preferEurope).toBe(true);
+    expect(capture).not.toHaveBeenCalled();
+    options.onRoute?.("eu");
+    options.onRoute?.("eu");
+    options.onRoute?.("global_no_eu_endpoint");
+    expect(capture.mock.calls).toEqual([
+      [
+        {
+          distinctId: "test-user",
+          event: "openrouter_eu_routing_exposed",
+          properties: {
+            [`$feature/${OPENROUTER_EU_ROUTING_FLAG}`]: true,
+            route_outcome: "eu",
+            $process_person_profile: false,
+          },
+        },
+      ],
+      [
+        {
+          distinctId: "test-user",
+          event: "openrouter_eu_routing_global_fallback",
+          properties: {
+            [`$feature/${OPENROUTER_EU_ROUTING_FLAG}`]: true,
+            route_outcome: "global_no_eu_endpoint",
+            $process_person_profile: false,
+          },
+        },
+      ],
+    ]);
+  });
+
+  it("uses global on missing analytics or flag errors", async () => {
+    expect(
+      await resolveOpenRouterRegionOptions({ ...args, posthog: null }),
+    ).toEqual({});
+    evaluateFlags.mockRejectedValue(new Error("Flag service unavailable"));
+    expect(await resolveOpenRouterRegionOptions(args)).toEqual({});
+  });
+
+  it("bounds the flag lookup to one second", async () => {
+    evaluateFlags.mockReturnValue(new Promise(() => {}));
+    const result = resolveOpenRouterRegionOptions(args);
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(await result).toEqual({});
+  });
+});

--- a/lib/experiments/openrouter-eu-routing.ts
+++ b/lib/experiments/openrouter-eu-routing.ts
@@ -3,6 +3,7 @@ import type { OpenRouterRegionOptions } from "@/lib/ai/openrouter-region";
 
 export const OPENROUTER_EU_ROUTING_FLAG = "openrouter_eu_routing_v1";
 
+/** Resolves rollout assignment; exposure is deferred until actual EU inference. */
 export async function resolveOpenRouterRegionOptions({
   posthog,
   userId,

--- a/lib/experiments/openrouter-eu-routing.ts
+++ b/lib/experiments/openrouter-eu-routing.ts
@@ -1,0 +1,52 @@
+import type { PostHog } from "posthog-node";
+import type { OpenRouterRegionOptions } from "@/lib/ai/openrouter-region";
+
+export const OPENROUTER_EU_ROUTING_FLAG = "openrouter_eu_routing_v1";
+
+export async function resolveOpenRouterRegionOptions({
+  posthog,
+  userId,
+  isEuropeanUser,
+}: {
+  posthog: Pick<PostHog, "evaluateFlags" | "capture"> | null;
+  userId: string;
+  isEuropeanUser: boolean;
+}): Promise<OpenRouterRegionOptions> {
+  if (!isEuropeanUser || !posthog) return {};
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const flags = await Promise.race([
+      posthog.evaluateFlags(userId, {
+        flagKeys: [OPENROUTER_EU_ROUTING_FLAG],
+      }),
+      new Promise<null>((resolve) => {
+        timeout = setTimeout(() => resolve(null), 1_000);
+      }),
+    ]);
+    if (flags?.getFlag(OPENROUTER_EU_ROUTING_FLAG) !== true) return {};
+    let exposed = false;
+    return {
+      preferEurope: true,
+      onRoute(outcome) {
+        if (outcome === "eu" && exposed) return;
+        if (outcome === "eu") exposed = true;
+        posthog.capture({
+          distinctId: userId,
+          event:
+            outcome === "eu"
+              ? "openrouter_eu_routing_exposed"
+              : "openrouter_eu_routing_global_fallback",
+          properties: {
+            [`$feature/${OPENROUTER_EU_ROUTING_FLAG}`]: true,
+            route_outcome: outcome,
+            $process_person_profile: false,
+          },
+        });
+      },
+    };
+  } catch {
+    return {};
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -36,6 +36,7 @@ import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { createTrackedProvider } from "@/lib/ai/providers";
+import { resolveOpenRouterRegionOptions } from "@/lib/experiments/openrouter-eu-routing";
 import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
 import { cacheAuxiliaryVisionDescription } from "@/lib/utils/file-transform-utils";
 import {
@@ -2267,6 +2268,8 @@ export type AgentLongPayload = {
   autoReviewAssignment?: AgentAutoReviewAssignment;
   userLocation: Geo;
   triggerRegion?: TriggerRunRegion;
+  /** Trusted ingress geography; older jobs default to global routing. */
+  isEuropeanUser?: boolean;
   isAutoContinue?: boolean;
   isAutomaticContinuation?: boolean;
   regenerate?: boolean;
@@ -2356,6 +2359,7 @@ export const agentLongTask = task({
       autoReviewAssignment,
       userLocation,
       triggerRegion = "us-east-1",
+      isEuropeanUser = false,
       isAutoContinue,
       isAutomaticContinuation,
       regenerate,
@@ -3609,7 +3613,13 @@ export const agentLongTask = task({
               subscription,
               shouldIncludeNotes: userCustomization?.include_notes ?? true,
             };
-            const trackedProvider = createTrackedProvider();
+            const trackedProvider = createTrackedProvider(
+              await resolveOpenRouterRegionOptions({
+                posthog,
+                userId,
+                isEuropeanUser,
+              }),
+            );
             const [currentSystemPrompt, messagesWithNotes] = await Promise.all([
               systemPrompt(
                 userId,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2632,6 +2632,11 @@ export const agentLongTask = task({
         selectedModelOverride,
       });
       const posthog = PostHogClient();
+      const openRouterRegionOptionsPromise = resolveOpenRouterRegionOptions({
+        posthog,
+        userId,
+        isEuropeanUser,
+      });
       const regionalFreeLimits = await evaluateRegionalFreeLimits({
         posthog,
         userId,
@@ -3614,11 +3619,7 @@ export const agentLongTask = task({
               shouldIncludeNotes: userCustomization?.include_notes ?? true,
             };
             const trackedProvider = createTrackedProvider(
-              await resolveOpenRouterRegionOptions({
-                posthog,
-                userId,
-                isEuropeanUser,
-              }),
+              await openRouterRegionOptionsPromise,
             );
             const [currentSystemPrompt, messagesWithNotes] = await Promise.all([
               systemPrompt(


### PR DESCRIPTION
European users currently send model requests through the global OpenRouter endpoint. This adds Europe-first routing to the main Ask and Agent inference loops: use the EU endpoint when the primary model is listed in the EU catalog, otherwise keep that model on global. A pre-stream EU endpoint-availability failure retries the same request globally without changing provider restrictions or replaying an accepted stream.

Eligibility comes from the trusted Vercel continent header, is preserved in Agent payloads, and also requires the server-side `openrouter_eu_routing_v1` flag. The production flag is **disabled at 0%**, pending an internal allowlist canary. This is a regional preference, not an EU-only residency guarantee; direct providers and standalone global-provider helpers remain unchanged.

Validation:
- Focused routing, rollout, provider, fallback, and Agent contract suites: 339 tests passed.
- Full suite on current main: 478 suites / 5,155 tests passed.
- Typecheck, ESLint, and formatting passed.
- Live authenticated test: EU GLM 5.2 returned a no-allowed-provider 404; this transport retried globally and received HTTP 200, the same model, and `OK.`.
- Added real AI SDK transport coverage and native Fetch/stream tests; browser setup is now skipped for Node test environments.

Manual canary verification:
1. Allowlist an internal user on preview and make Ask/Agent requests from Europe. An EU-eligible model should attempt EU; an unsupported model should go directly global.
2. Confirm an EU no-provider error falls back globally with the same model and existing provider restrictions.
3. Repeat outside Europe and with the flag off; both should stay global. Cancel a request and confirm no replay follows cancellation.

[Rollout and cleanup plan: HAC-105](https://linear.app/hackerai/issue/HAC-105)
[Disabled production flag](https://us.posthog.com/project/144137/feature_flags/875897)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Europe-first OpenRouter routing for eligible requests from Europe.
  * European requests can use EU-supported models and automatically fall back to global routing when EU routing is unavailable.
  * Added feature-flag controls and routing outcome tracking.
  * Preserved existing provider behavior for non-European requests and direct-provider configurations.

* **Documentation**
  * Added setup, access requirements, verification, monitoring, and rollback guidance for Europe-first routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->