### PR TITLE
Fix allowance concurrency and pause deletion races

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -241,6 +241,7 @@ describe("POST /api/delete-account", () => {
       {
         serviceKey: "service_key",
         userId: "user_123",
+        preservedOrganizationIds: ["org_team"],
       },
     );
     expect(mockDeleteOrganizationMembership).toHaveBeenCalledWith(
@@ -324,6 +325,7 @@ describe("POST /api/delete-account", () => {
       {
         serviceKey: "service_key",
         userId: "user_123",
+        preservedOrganizationIds: [],
       },
     );
     expect(mockListSubscriptions).toHaveBeenCalledWith({
@@ -370,6 +372,7 @@ describe("POST /api/delete-account", () => {
       {
         serviceKey: "service_key",
         userId: "user_123",
+        preservedOrganizationIds: [],
       },
     );
     expect(mockConvexMutation.mock.invocationCallOrder[2]).toBeLessThan(
@@ -561,6 +564,7 @@ describe("POST /api/delete-account", () => {
       {
         serviceKey: "service_key",
         userId: "user_123",
+        preservedOrganizationIds: [],
       },
     );
     expect(mockConvexMutation).toHaveBeenNthCalledWith(
@@ -569,6 +573,7 @@ describe("POST /api/delete-account", () => {
       {
         serviceKey: "service_key",
         userId: "user_123",
+        preservedOrganizationIds: [],
       },
     );
     expect(mockConvexMutation.mock.invocationCallOrder[3]).toBeLessThan(
@@ -700,6 +705,7 @@ describe("POST /api/delete-account", () => {
       {
         serviceKey: "service_key",
         userId: "user_123",
+        preservedOrganizationIds: ["org_team"],
       },
     );
   });

--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -8,8 +8,11 @@ import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
 import { cancelSubagentsForUserDeletion } from "@/lib/db/subagents";
 import { terminateCloudSandboxesForUser } from "@/lib/ai/tools/utils/cloud-sandbox";
 import { logger } from "@/lib/logger";
+import { acquireTeamInvitationLock } from "@/lib/billing/team-invitation-lock";
 
 const mockConvexMutation = jest.fn();
+const mockMembershipLockAssertOwned = jest.fn();
+const mockMembershipLockRelease = jest.fn();
 
 jest.mock("next/server", () => ({
   NextResponse: {
@@ -58,6 +61,11 @@ jest.mock("@/lib/logger", () => ({
   },
 }));
 
+jest.mock("@/lib/billing/team-invitation-lock", () => ({
+  acquireTeamInvitationLock: jest.fn(),
+  TeamInvitationLockUnavailableError: class extends Error {},
+}));
+
 jest.mock("@/convex/_generated/api", () => ({
   api: {
     accountIdentities: {
@@ -67,6 +75,10 @@ jest.mock("@/convex/_generated/api", () => ({
       beginUserDataDeletionByService:
         "userDeletion.beginUserDataDeletionByService",
       deleteAllUserDataByService: "userDeletion.deleteAllUserDataByService",
+    },
+    subscriptionPauses: {
+      deleteForDeletedOrganization:
+        "subscriptionPauses.deleteForDeletedOrganization",
     },
   },
 }));
@@ -87,6 +99,7 @@ jest.mock("../../workos", () => ({
   workos: {
     userManagement: {
       listOrganizationMemberships: jest.fn(),
+      listInvitations: jest.fn(),
       deleteOrganizationMembership: jest.fn(),
       deleteUser: jest.fn(),
     },
@@ -109,6 +122,14 @@ const mockListOrganizationMemberships = workos.userManagement
   .listOrganizationMemberships as jest.MockedFunction<
   typeof workos.userManagement.listOrganizationMemberships
 >;
+const mockListInvitations = workos.userManagement
+  .listInvitations as jest.MockedFunction<
+  typeof workos.userManagement.listInvitations
+>;
+const mockAcquireTeamInvitationLock =
+  acquireTeamInvitationLock as jest.MockedFunction<
+    typeof acquireTeamInvitationLock
+  >;
 const mockDeleteOrganizationMembership = workos.userManagement
   .deleteOrganizationMembership as jest.MockedFunction<
   typeof workos.userManagement.deleteOrganizationMembership
@@ -170,6 +191,13 @@ describe("POST /api/delete-account", () => {
       freeQuotaSubject: "free_quota:v1:identity_hash",
     });
     mockDeleteUserRateLimitKeys.mockResolvedValue(undefined);
+    mockListInvitations.mockResolvedValue({ data: [] } as never);
+    mockMembershipLockAssertOwned.mockResolvedValue(undefined);
+    mockMembershipLockRelease.mockResolvedValue(undefined);
+    mockAcquireTeamInvitationLock.mockResolvedValue({
+      assertOwned: mockMembershipLockAssertOwned,
+      release: mockMembershipLockRelease,
+    });
     mockFenceAndGetActiveAgentResourcesForUser.mockResolvedValue({
       resources: [],
       hasMore: false,
@@ -187,11 +215,17 @@ describe("POST /api/delete-account", () => {
       killed: 0,
       alreadyGone: 0,
     });
-    mockConvexMutation.mockImplementation(async (functionReference) =>
-      functionReference === "userDeletion.deleteAllUserDataByService"
-        ? { hasMore: false }
-        : null,
-    );
+    mockConvexMutation.mockImplementation(async (functionReference) => {
+      if (functionReference === "userDeletion.deleteAllUserDataByService") {
+        return { hasMore: false };
+      }
+      if (
+        functionReference === "subscriptionPauses.deleteForDeletedOrganization"
+      ) {
+        return { deletedCount: 0, hasMore: false };
+      }
+      return null;
+    });
     mockDeleteOrganizationMembership.mockResolvedValue(undefined as never);
     mockDeleteUser.mockResolvedValue(undefined as never);
     mockDeleteOrganization.mockResolvedValue(undefined as never);
@@ -325,7 +359,7 @@ describe("POST /api/delete-account", () => {
       {
         serviceKey: "service_key",
         userId: "user_123",
-        preservedOrganizationIds: [],
+        preservedOrganizationIds: ["org_solo"],
       },
     );
     expect(mockListSubscriptions).toHaveBeenCalledWith({
@@ -336,9 +370,84 @@ describe("POST /api/delete-account", () => {
     expect(mockCancelSubscription).toHaveBeenCalledWith("sub_1");
     expect(mockCancelSubscription).toHaveBeenCalledWith("sub_2");
     expect(mockDeleteCustomer).toHaveBeenCalledWith("cus_123");
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "subscriptionPauses.deleteForDeletedOrganization",
+      {
+        serviceKey: "service_key",
+        organizationId: "org_solo",
+      },
+    );
     expect(mockDeleteOrganization).toHaveBeenCalledWith("org_solo");
     expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
     expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+    expect(mockAcquireTeamInvitationLock).toHaveBeenCalledWith("org_solo");
+    expect(mockMembershipLockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a solo-admin deletion while an invitation can become active", async () => {
+    const callerMembership = {
+      id: "membership_user",
+      organizationId: "org_solo",
+      userId: "user_123",
+      role: { slug: "admin" },
+    };
+
+    mockListOrganizationMemberships
+      .mockResolvedValueOnce({ data: [callerMembership] } as never)
+      .mockResolvedValueOnce({ data: [callerMembership] } as never);
+    mockListInvitations.mockResolvedValueOnce({
+      data: [{ id: "invitation_1", state: "pending" }],
+    } as never);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("last admin");
+    expect(mockListInvitations.mock.invocationCallOrder[0]).toBeLessThan(
+      mockListOrganizationMemberships.mock.invocationCallOrder[1],
+    );
+    expect(mockConvexMutation).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockMembershipLockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries when an invitation mutation owns the organization lock", async () => {
+    const callerMembership = {
+      id: "membership_user",
+      organizationId: "org_solo",
+      userId: "user_123",
+      role: { slug: "admin" },
+    };
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [callerMembership],
+    } as never);
+    mockAcquireTeamInvitationLock.mockResolvedValueOnce(null);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      code: "account_cleanup_in_progress",
+    });
+    expect(mockListInvitations).not.toHaveBeenCalled();
+    expect(mockConvexMutation).not.toHaveBeenCalled();
+  });
+
+  it("retries before identity cleanup while a billing resume is authorized", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    mockConvexMutation.mockResolvedValueOnce(false);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      code: "account_cleanup_in_progress",
+    });
+    expect(mockConvexMutation).toHaveBeenCalledTimes(1);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 
   it("marks identity and runs Convex cleanup before deleting a WorkOS user with no memberships", async () => {

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -172,6 +172,7 @@ async function deleteConvexUserData(
   userId: string,
   serviceKey: string,
   requestId: string,
+  preservedOrganizationIds: string[],
 ): Promise<boolean> {
   const convex = getConvexClient();
   let progressStatsBatches = 0;
@@ -187,6 +188,7 @@ async function deleteConvexUserData(
       {
         serviceKey,
         userId,
+        preservedOrganizationIds,
       },
     );
 
@@ -269,6 +271,9 @@ export const POST = async (req: NextRequest) => {
         { status: 400 },
       );
     }
+    const preservedOrganizationIds = membershipDeletionPlans
+      .filter((plan) => !plan.deleteOrganization)
+      .map((plan) => plan.membership.organizationId);
 
     const serviceKey = getConvexServiceKey();
     stage = "begin_user_data_deletion";
@@ -323,6 +328,7 @@ export const POST = async (req: NextRequest) => {
       userId,
       serviceKey,
       requestId,
+      preservedOrganizationIds,
     );
     if (!cleanupComplete) {
       return NextResponse.json(

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -12,6 +12,11 @@ import { closeAndCancelAgentResources } from "@/lib/api/agent-deletion-cleanup";
 import { cancelSubagentsForUserDeletion } from "@/lib/db/subagents";
 import { terminateCloudSandboxesForUser } from "@/lib/ai/tools/utils/cloud-sandbox";
 import { ACCOUNT_CLEANUP_IN_PROGRESS_CODE } from "@/lib/account-deletion";
+import {
+  acquireTeamInvitationLock,
+  TeamInvitationLockUnavailableError,
+  type TeamInvitationLock,
+} from "@/lib/billing/team-invitation-lock";
 
 type OrganizationMembership = Awaited<
   ReturnType<typeof workos.userManagement.listOrganizationMemberships>
@@ -24,6 +29,7 @@ type MembershipDeletionPlan = {
 };
 
 const MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES = 50;
+const MAX_CONVEX_ORGANIZATION_CLEANUP_BATCHES = 50;
 
 type ConvexCleanupProgress = {
   deletedDocuments: number;
@@ -104,11 +110,23 @@ async function getMembershipDeletionPlan(
   membership: OrganizationMembership,
 ): Promise<MembershipDeletionPlan> {
   try {
+    // Read invitations first. If one is accepted between these two reads, it
+    // remains represented either as pending here or as active below. The
+    // shared organization lock prevents a new invitation from being sent
+    // after this snapshot begins.
+    const invitationsPage = await workos.userManagement.listInvitations({
+      organizationId: membership.organizationId,
+      limit: 100,
+    });
     const activeMembershipsPage =
       await workos.userManagement.listOrganizationMemberships({
         organizationId: membership.organizationId,
         statuses: ["active"],
+        limit: 100,
       });
+    const hasPendingInvitation = invitationsPage.data.some(
+      (invitation) => invitation.state === "pending",
+    );
     const activeMemberships = activeMembershipsPage.data;
     const activeCallerMembership = activeMemberships.find(
       (activeMembership) => activeMembership.id === membership.id,
@@ -123,7 +141,11 @@ async function getMembershipDeletionPlan(
       (activeMembership) => activeMembership.role?.slug === "admin",
     ).length;
 
-    if (!isSoleActiveMember && isAdmin && activeAdminCount <= 1) {
+    if (
+      isAdmin &&
+      activeAdminCount <= 1 &&
+      (!isSoleActiveMember || hasPendingInvitation)
+    ) {
       return {
         membership,
         deleteOrganization: false,
@@ -134,7 +156,8 @@ async function getMembershipDeletionPlan(
 
     return {
       membership,
-      deleteOrganization: isSoleActiveMember && isAdmin,
+      deleteOrganization:
+        isSoleActiveMember && isAdmin && !hasPendingInvitation,
     };
   } catch (e) {
     console.warn(
@@ -173,6 +196,7 @@ async function deleteConvexUserData(
   serviceKey: string,
   requestId: string,
   preservedOrganizationIds: string[],
+  assertMembershipLocksOwned: () => Promise<void>,
 ): Promise<boolean> {
   const convex = getConvexClient();
   let progressStatsBatches = 0;
@@ -183,6 +207,7 @@ async function deleteConvexUserData(
   let lastProgress: ConvexCleanupProgress | undefined;
 
   for (let batch = 0; batch < MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES; batch++) {
+    await assertMembershipLocksOwned();
     const result = await convex.mutation(
       api.userDeletion.deleteAllUserDataByService,
       {
@@ -233,12 +258,42 @@ async function deleteConvexUserData(
   return false;
 }
 
+async function deleteDeletedOrganizationPauseRows(
+  organizationId: string,
+  serviceKey: string,
+  assertMembershipLocksOwned: () => Promise<void>,
+) {
+  for (
+    let batch = 0;
+    batch < MAX_CONVEX_ORGANIZATION_CLEANUP_BATCHES;
+    batch++
+  ) {
+    await assertMembershipLocksOwned();
+    const result = await getConvexClient().mutation(
+      api.subscriptionPauses.deleteForDeletedOrganization,
+      { serviceKey, organizationId },
+    );
+    if (!result.hasMore) return;
+  }
+
+  throw new Error(
+    "Organization cleanup exceeded its safety bound. Please retry account deletion.",
+  );
+}
+
 export const POST = async (req: NextRequest) => {
   let stage = "authenticate";
   let userIdForLog: string | undefined;
   let membershipCount: number | undefined;
   let freeQuotaSubjectPresent: boolean | undefined;
   const requestId = req.headers.get("x-vercel-id") ?? "unknown";
+  const membershipLocks: TeamInvitationLock[] = [];
+
+  const assertMembershipLocksOwned = async () => {
+    for (const lock of membershipLocks) {
+      await lock.assertOwned();
+    }
+  };
 
   try {
     // Enforce recent login (10-minute window) before any destructive action
@@ -257,6 +312,23 @@ export const POST = async (req: NextRequest) => {
     );
     membershipCount = memberships.data.length;
 
+    stage = "coordinate_membership_deletions";
+    const organizationIds = [
+      ...new Set(
+        memberships.data.map((membership) => membership.organizationId),
+      ),
+    ].sort();
+    for (const organizationId of organizationIds) {
+      const lock = await acquireTeamInvitationLock(organizationId);
+      if (!lock) {
+        return NextResponse.json(
+          { code: ACCOUNT_CLEANUP_IN_PROGRESS_CODE },
+          { status: 409 },
+        );
+      }
+      membershipLocks.push(lock);
+    }
+
     stage = "plan_membership_deletions";
     const membershipDeletionPlans = await Promise.all(
       memberships.data.map(getMembershipDeletionPlan),
@@ -271,19 +343,33 @@ export const POST = async (req: NextRequest) => {
         { status: 400 },
       );
     }
-    const preservedOrganizationIds = membershipDeletionPlans
-      .filter((plan) => !plan.deleteOrganization)
-      .map((plan) => plan.membership.organizationId);
+    // Keep all organization-owned pause rows until the organization has been
+    // deleted. This makes cleanup continuation safe even if team membership
+    // changes between requests; solo-organization rows are purged below while
+    // the same membership snapshot and lock are still authoritative.
+    const preservedOrganizationIds = membershipDeletionPlans.map(
+      (plan) => plan.membership.organizationId,
+    );
 
     const serviceKey = getConvexServiceKey();
     stage = "begin_user_data_deletion";
-    await getConvexClient().mutation(
+    await assertMembershipLocksOwned();
+    const deletionFenceStarted = await getConvexClient().mutation(
       api.userDeletion.beginUserDataDeletionByService,
       {
         serviceKey,
         userId,
       },
     );
+    // A resume that has already crossed its Stripe side-effect barrier must
+    // finish before deletion can safely own the account. Older deployments
+    // returned null, so only an explicit false is treated as contention.
+    if (deletionFenceStarted === false) {
+      return NextResponse.json(
+        { code: ACCOUNT_CLEANUP_IN_PROGRESS_CODE },
+        { status: 409 },
+      );
+    }
     stage = "mark_account_identity_deleted";
     await markAccountIdentityDeleted(userId, freeQuotaSubject, serviceKey);
 
@@ -329,6 +415,7 @@ export const POST = async (req: NextRequest) => {
       serviceKey,
       requestId,
       preservedOrganizationIds,
+      assertMembershipLocksOwned,
     );
     if (!cleanupComplete) {
       return NextResponse.json(
@@ -340,6 +427,7 @@ export const POST = async (req: NextRequest) => {
     // Process each organization from memberships. Only delete org-level billing
     // and identity resources after proving this user is the sole active admin.
     stage = "delete_memberships_and_organizations";
+    await assertMembershipLocksOwned();
     await Promise.all(
       membershipDeletionPlans.map(
         async ({ membership, deleteOrganization }) => {
@@ -393,6 +481,12 @@ export const POST = async (req: NextRequest) => {
             }
           }
 
+          await deleteDeletedOrganizationPauseRows(
+            orgId,
+            serviceKey,
+            assertMembershipLocksOwned,
+          );
+
           // Delete the WorkOS organization only for verified single-member orgs.
           try {
             await workos.organizations.deleteOrganization(orgId);
@@ -431,6 +525,12 @@ export const POST = async (req: NextRequest) => {
 
     return NextResponse.json({ ok: true });
   } catch (error) {
+    if (error instanceof TeamInvitationLockUnavailableError) {
+      return NextResponse.json(
+        { error: "Account deletion coordination is temporarily unavailable" },
+        { status: 503 },
+      );
+    }
     if (error instanceof ChatSDKError) {
       return error.toResponse();
     }
@@ -456,5 +556,20 @@ export const POST = async (req: NextRequest) => {
       },
     );
     return NextResponse.json({ error: message }, { status: 500 });
+  } finally {
+    for (const lock of membershipLocks.reverse()) {
+      try {
+        await lock.release();
+      } catch (error) {
+        logger.warn("account_deletion_membership_lock_release_failed", {
+          event: "account_deletion_membership_lock_release_failed",
+          service: "hackerai-web",
+          environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+          request_id: requestId,
+          user_id: userIdForLog,
+          error_name: error instanceof Error ? error.name : "UnknownError",
+        });
+      }
+    }
   }
 };

--- a/convex/__tests__/subscriptionPauses.test.ts
+++ b/convex/__tests__/subscriptionPauses.test.ts
@@ -24,6 +24,16 @@ jest.mock("../lib/utils", () => ({
   validateServiceKey: jest.fn(),
 }));
 
+jest.mock("../lib/userDeletionFence", () => ({
+  isUserDeletionFenced: jest.fn(async () => false),
+}));
+
+const mockIsUserDeletionFenced = jest.requireMock<{
+  isUserDeletionFenced: jest.MockedFunction<
+    (db: unknown, userId: string) => Promise<boolean>
+  >;
+}>("../lib/userDeletionFence").isUserDeletionFenced;
+
 type Row = Record<string, any>;
 
 /** Minimal in-memory stand-in for the subscription_pauses table. */
@@ -108,6 +118,7 @@ function pauseRow(overrides: Row = {}): Row {
 describe("subscription pause lifecycle", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsUserDeletionFenced.mockResolvedValue(false);
   });
 
   it("claims a due pause once and rejects a second automatic claim", async () => {
@@ -247,6 +258,52 @@ describe("subscription pause lifecycle", () => {
 
     expect(result).toEqual({ pauseId: "pause_1", created: false });
     expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a new scheduled pause after account deletion is fenced", async () => {
+    const { recordScheduledPause } = await import("../subscriptionPauses");
+    const rows: Row[] = [];
+    const db = buildDb(rows);
+    mockIsUserDeletionFenced.mockResolvedValueOnce(true);
+
+    await expect(
+      (recordScheduledPause as any).handler(
+        { db },
+        {
+          serviceKey: "k",
+          userId: "user_1",
+          stripeCustomerId: "cus_1",
+          stripeSubscriptionId: "sub_1",
+          stripePriceId: "price_1",
+          quantity: 1,
+          pauseMonths: 2,
+          requestedAt: 5_000,
+          pauseEffectiveAt: 6_000,
+          resumeAt: 7_000,
+        },
+      ),
+    ).rejects.toThrow("Account deletion is in progress");
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("cancels a resumable pause instead of claiming it after deletion is fenced", async () => {
+    const { claimResume } = await import("../subscriptionPauses");
+    const rows = [pauseRow({ status: "paused" })];
+    const db = buildDb(rows);
+    mockIsUserDeletionFenced.mockResolvedValueOnce(true);
+
+    await expect(
+      (claimResume as any).handler(
+        { db },
+        { serviceKey: "k", pauseId: "pause_1", now: 5_000, maxAttempts: 3 },
+      ),
+    ).resolves.toBeNull();
+    expect(rows[0]).toMatchObject({
+      status: "canceled",
+      canceled_at: 5_000,
+      updated_at: 5_000,
+    });
+    expect(rows[0].resume_claimed_at).toBeUndefined();
   });
 
   it("only exposes the caller's own active pause", async () => {

--- a/convex/__tests__/subscriptionPauses.test.ts
+++ b/convex/__tests__/subscriptionPauses.test.ts
@@ -86,6 +86,11 @@ function buildDb(rows: Row[]) {
       const row = byId.get(id);
       if (row) Object.assign(row, patch);
     }),
+    delete: jest.fn(async (id: string) => {
+      const index = rows.findIndex((row) => row._id === id);
+      if (index !== -1) rows.splice(index, 1);
+      byId.delete(id);
+    }),
     insert: jest.fn(async (_table: string, row: Row) => {
       const id = `pause_${rows.length + 1}`;
       const inserted = { _id: id, ...row };
@@ -134,6 +139,8 @@ describe("subscription pause lifecycle", () => {
       id: "pause_1",
       status: "resuming",
       resumeAttemptCount: 1,
+      resumeClaimedAt: 5_000,
+      resumeClaimVersion: 2,
     });
 
     const second = await (claimResume as any).handler(
@@ -306,6 +313,70 @@ describe("subscription pause lifecycle", () => {
     expect(rows[0].resume_claimed_at).toBeUndefined();
   });
 
+  it("authorizes a claimed resume before external Stripe work", async () => {
+    const { authorizeResumeSideEffect } = await import("../subscriptionPauses");
+    const rows = [
+      pauseRow({
+        status: "resuming",
+        resume_claimed_at: 5_000,
+        resume_claim_version: 2,
+        resume_attempt_count: 1,
+      }),
+    ];
+    const db = buildDb(rows);
+
+    await expect(
+      (authorizeResumeSideEffect as any).handler(
+        { db },
+        {
+          serviceKey: "k",
+          pauseId: "pause_1",
+          resumeClaimedAt: 5_000,
+          resumeAttemptCount: 1,
+          authorizedAt: 5_001,
+        },
+      ),
+    ).resolves.toBe(true);
+    expect(rows[0]).toMatchObject({
+      status: "resuming",
+      resume_side_effect_authorized_at: 5_001,
+    });
+  });
+
+  it("cancels a claimed resume when deletion wins before authorization", async () => {
+    const { authorizeResumeSideEffect } = await import("../subscriptionPauses");
+    const rows = [
+      pauseRow({
+        status: "resuming",
+        resume_claimed_at: 5_000,
+        resume_claim_version: 2,
+        resume_attempt_count: 1,
+      }),
+    ];
+    const db = buildDb(rows);
+    mockIsUserDeletionFenced.mockResolvedValueOnce(true);
+
+    await expect(
+      (authorizeResumeSideEffect as any).handler(
+        { db },
+        {
+          serviceKey: "k",
+          pauseId: "pause_1",
+          resumeClaimedAt: 5_000,
+          resumeAttemptCount: 1,
+          authorizedAt: 5_001,
+        },
+      ),
+    ).resolves.toBe(false);
+    expect(rows[0]).toMatchObject({
+      status: "canceled",
+      canceled_at: 5_001,
+    });
+    expect(rows[0].resume_claimed_at).toBeUndefined();
+    expect(rows[0].resume_claim_version).toBeUndefined();
+    expect(rows[0].resume_side_effect_authorized_at).toBeUndefined();
+  });
+
   it("only exposes the caller's own active pause", async () => {
     const { getMyActivePause } = await import("../subscriptionPauses");
     const rows = [
@@ -330,5 +401,23 @@ describe("subscription pause lifecycle", () => {
       auth: { getUserIdentity: async () => ({ subject: "user_1" }) },
     });
     expect(mine).toMatchObject({ id: "pause_mine", status: "paused" });
+  });
+
+  it("deletes pause rows only for an organization being torn down", async () => {
+    const { deleteForDeletedOrganization } =
+      await import("../subscriptionPauses");
+    const rows = [
+      pauseRow({ _id: "pause_deleted_org", organization_id: "org_deleted" }),
+      pauseRow({ _id: "pause_shared_org", organization_id: "org_shared" }),
+    ];
+    const db = buildDb(rows);
+
+    await expect(
+      (deleteForDeletedOrganization as any).handler(
+        { db },
+        { serviceKey: "k", organizationId: "org_deleted" },
+      ),
+    ).resolves.toEqual({ deletedCount: 1, hasMore: false });
+    expect(rows.map((row) => row._id)).toEqual(["pause_shared_org"]);
   });
 });

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -961,21 +961,96 @@ describe("userDeletion", () => {
     tables.user_deletion_fences = [];
     const { ctx, db } = createMockCtx(tables);
 
-    await beginUserDataDeletionByService.handler(ctx as any, {
+    const first = await beginUserDataDeletionByService.handler(ctx as any, {
       serviceKey: "service_key",
       userId: "user_123",
     });
-    await beginUserDataDeletionByService.handler(ctx as any, {
+    const second = await beginUserDataDeletionByService.handler(ctx as any, {
       serviceKey: "service_key",
       userId: "user_123",
     });
 
+    expect(first).toBe(true);
+    expect(second).toBe(true);
     expect(tables.user_deletion_fences).toHaveLength(1);
     expect(tables.user_deletion_fences[0]).toMatchObject({
       user_id: "user_123",
       started_at: expect.any(Number),
     });
     expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an unapproved resume claim in the deletion-fence transaction", async () => {
+    const { beginUserDataDeletionByService } = await import("../userDeletion");
+    const tables = seedTables();
+    tables.user_deletion_fences = [];
+    tables.subscription_pauses[0] = {
+      ...tables.subscription_pauses[0],
+      status: "resuming",
+      resume_claimed_at: 5_000,
+      resume_claim_version: 2,
+      resume_attempt_count: 1,
+    };
+    const { ctx } = createMockCtx(tables);
+
+    const started = await beginUserDataDeletionByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
+
+    expect(started).toBe(true);
+    expect(tables.subscription_pauses[0]).toMatchObject({
+      status: "canceled",
+      canceled_at: expect.any(Number),
+    });
+    expect(tables.subscription_pauses[0].resume_claimed_at).toBeUndefined();
+    expect(tables.subscription_pauses[0].resume_claim_version).toBeUndefined();
+    expect(tables.user_deletion_fences).toHaveLength(1);
+  });
+
+  it("waits for an authorized Stripe resume before inserting the deletion fence", async () => {
+    const { beginUserDataDeletionByService } = await import("../userDeletion");
+    const tables = seedTables();
+    tables.user_deletion_fences = [];
+    tables.subscription_pauses[0] = {
+      ...tables.subscription_pauses[0],
+      status: "resuming",
+      resume_claimed_at: 5_000,
+      resume_claim_version: 2,
+      resume_side_effect_authorized_at: 5_001,
+      resume_attempt_count: 1,
+    };
+    const { ctx } = createMockCtx(tables);
+
+    const started = await beginUserDataDeletionByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
+
+    expect(started).toBe(false);
+    expect(tables.subscription_pauses[0].status).toBe("resuming");
+    expect(tables.user_deletion_fences).toHaveLength(0);
+  });
+
+  it("fails closed for a rolling-deployment resume claim", async () => {
+    const { beginUserDataDeletionByService } = await import("../userDeletion");
+    const tables = seedTables();
+    tables.user_deletion_fences = [];
+    tables.subscription_pauses[0] = {
+      ...tables.subscription_pauses[0],
+      status: "resuming",
+      resume_claimed_at: 5_000,
+      resume_attempt_count: 1,
+    };
+    const { ctx } = createMockCtx(tables);
+
+    const started = await beginUserDataDeletionByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
+
+    expect(started).toBe(false);
+    expect(tables.user_deletion_fences).toHaveLength(0);
   });
 
   it("rejects service-key cleanup with an invalid key", async () => {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -298,6 +298,40 @@ function seedTables(userId = "user_123", otherUserId = "user_other"): Tables {
         updated_at: 1,
       },
     ],
+    subscription_pauses: [
+      {
+        _id: "pause-user",
+        user_id: userId,
+        organization_id: "org_personal",
+        stripe_customer_id: "cus_user",
+        stripe_subscription_id: "sub_user",
+        stripe_price_id: "price_user",
+        quantity: 1,
+        pause_months: 1,
+        requested_at: 1,
+        pause_effective_at: 2,
+        resume_at: 3,
+        status: "paused",
+        resume_attempt_count: 0,
+        updated_at: 1,
+      },
+      {
+        _id: "pause-other",
+        user_id: otherUserId,
+        organization_id: "org_other",
+        stripe_customer_id: "cus_other",
+        stripe_subscription_id: "sub_other",
+        stripe_price_id: "price_other",
+        quantity: 1,
+        pause_months: 1,
+        requested_at: 1,
+        pause_effective_at: 2,
+        resume_at: 3,
+        status: "paused",
+        resume_attempt_count: 0,
+        updated_at: 1,
+      },
+    ],
     local_sandbox_tokens: [
       { _id: "token-user", user_id: userId, token: "secret" },
       { _id: "token-other", user_id: otherUserId, token: "keep" },
@@ -677,6 +711,8 @@ describe("userDeletion", () => {
     expect(row(tables, "chats", "chat-other")).toBeTruthy();
     expect(row(tables, "feedback", "feedback-other")).toBeTruthy();
     expect(row(tables, "files", "file-other")).toBeTruthy();
+    expect(row(tables, "subscription_pauses", "pause-user")).toBeUndefined();
+    expect(row(tables, "subscription_pauses", "pause-other")).toBeTruthy();
     expect(
       row(tables, "research_user_profiles", "research-profile-user"),
     ).toBeUndefined();
@@ -825,6 +861,98 @@ describe("userDeletion", () => {
     });
 
     expect(row(tables, "chats", "chat-doc")).toBeUndefined();
+  });
+
+  it("keeps cleanup fenced while a subscription resume is in flight", async () => {
+    const { deleteAllUserDataByService } = await import("../userDeletion");
+    const tables: Tables = {
+      subscription_pauses: [
+        {
+          _id: "pause-resuming",
+          user_id: "user_123",
+          status: "resuming",
+          requested_at: 1,
+        },
+      ],
+    };
+    const { ctx } = createMockCtx(tables);
+
+    const activeCleanup = await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
+    expect(activeCleanup.hasMore).toBe(true);
+    expect(row(tables, "subscription_pauses", "pause-resuming")).toBeTruthy();
+
+    tables.subscription_pauses[0].status = "resumed";
+    const settledCleanup = await deleteAllUserDataByService.handler(
+      ctx as any,
+      { serviceKey: "service_key", userId: "user_123" },
+    );
+    expect(settledCleanup.hasMore).toBe(false);
+    expect(
+      row(tables, "subscription_pauses", "pause-resuming"),
+    ).toBeUndefined();
+  });
+
+  it("deletes every non-running subscription pause lifecycle state", async () => {
+    const { deleteAllUserDataByService } = await import("../userDeletion");
+    const statuses = [
+      "scheduled",
+      "paused",
+      "resume_failed",
+      "resumed",
+      "canceled",
+      "superseded",
+    ];
+    const tables: Tables = {
+      subscription_pauses: statuses.map((status) => ({
+        _id: `pause-${status}`,
+        user_id: "user_123",
+        status,
+        requested_at: 1,
+      })),
+    };
+    const { ctx } = createMockCtx(tables);
+
+    const cleanup = await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+    });
+
+    expect(cleanup.hasMore).toBe(false);
+    expect(tables.subscription_pauses).toHaveLength(0);
+  });
+
+  it("anonymizes a shared-organization pause without removing its resume schedule", async () => {
+    const { deleteAllUserDataByService, DELETED_USER_ID } =
+      await import("../userDeletion");
+    const tables: Tables = {
+      subscription_pauses: [
+        {
+          _id: "pause-shared",
+          user_id: "user_123",
+          organization_id: "org_shared",
+          status: "scheduled",
+          requested_at: 1,
+          updated_at: 1,
+        },
+      ],
+    };
+    const { ctx } = createMockCtx(tables);
+
+    const cleanup = await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "user_123",
+      preservedOrganizationIds: ["org_shared"],
+    });
+
+    expect(cleanup.hasMore).toBe(false);
+    expect(row(tables, "subscription_pauses", "pause-shared")).toMatchObject({
+      user_id: DELETED_USER_ID,
+      organization_id: "org_shared",
+      status: "scheduled",
+    });
   });
 
   it("creates an idempotent deletion fence before lifecycle cleanup", async () => {

--- a/convex/__tests__/userDeletionFence.test.ts
+++ b/convex/__tests__/userDeletionFence.test.ts
@@ -34,6 +34,7 @@ describe("user deletion fence", () => {
     const chats = read("convex/chats.ts");
     const subagents = read("convex/subagents.ts");
     const subscriptionPauses = read("convex/subscriptionPauses.ts");
+    const pauseResume = read("lib/billing/pause-resume.ts");
 
     expect(
       accountRoute.indexOf('stage = "begin_user_data_deletion"'),
@@ -58,5 +59,11 @@ describe("user deletion fence", () => {
     expect(subscriptionPauses).toMatch(
       /claimResume = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, row\.user_id\)/,
     );
+    expect(subscriptionPauses).toMatch(
+      /authorizeResumeSideEffect = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, row\.user_id\)/,
+    );
+    expect(
+      pauseResume.indexOf("api.subscriptionPauses.authorizeResumeSideEffect"),
+    ).toBeLessThan(pauseResume.lastIndexOf("findLiveSubscription("));
   });
 });

--- a/convex/__tests__/userDeletionFence.test.ts
+++ b/convex/__tests__/userDeletionFence.test.ts
@@ -33,6 +33,7 @@ describe("user deletion fence", () => {
     const accountRoute = read("app/api/delete-account/route.ts");
     const chats = read("convex/chats.ts");
     const subagents = read("convex/subagents.ts");
+    const subscriptionPauses = read("convex/subscriptionPauses.ts");
 
     expect(
       accountRoute.indexOf('stage = "begin_user_data_deletion"'),
@@ -50,6 +51,12 @@ describe("user deletion fence", () => {
     );
     expect(subagents).toMatch(
       /resumeForBackend = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, args\.userId\)/,
+    );
+    expect(subscriptionPauses).toMatch(
+      /recordScheduledPause = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, args\.userId\)/,
+    );
+    expect(subscriptionPauses).toMatch(
+      /claimResume = mutation[\s\S]*?isUserDeletionFenced\(ctx\.db, row\.user_id\)/,
     );
   });
 });

--- a/convex/lib/subscriptionPauseResume.ts
+++ b/convex/lib/subscriptionPauseResume.ts
@@ -1,0 +1,5 @@
+/**
+ * Resume claims at or above this version participate in the deletion barrier.
+ * Older in-flight claims fail closed during rolling deployments.
+ */
+export const DELETION_COORDINATED_RESUME_CLAIM_VERSION = 2;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -419,6 +419,8 @@ export default defineSchema({
     paused_at: v.optional(v.number()),
     resume_attempt_count: v.number(),
     resume_claimed_at: v.optional(v.number()),
+    resume_claim_version: v.optional(v.number()),
+    resume_side_effect_authorized_at: v.optional(v.number()),
     last_resume_attempt_at: v.optional(v.number()),
     last_resume_error: v.optional(v.string()),
     resumed_at: v.optional(v.number()),
@@ -427,6 +429,8 @@ export default defineSchema({
     updated_at: v.number(),
   })
     .index("by_user_requested", ["user_id", "requested_at"])
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_organization_requested", ["organization_id", "requested_at"])
     .index("by_stripe_subscription_id", ["stripe_subscription_id"])
     .index("by_status_resume_at", ["status", "resume_at"]),
 

--- a/convex/subscriptionPauses.ts
+++ b/convex/subscriptionPauses.ts
@@ -2,6 +2,7 @@ import { mutation, query, type QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import { validateServiceKey } from "./lib/utils";
+import { isUserDeletionFenced } from "./lib/userDeletionFence";
 
 const MAX_DUE_RESUMES = 50;
 const MAX_USER_PAUSE_ROWS = 20;
@@ -135,6 +136,9 @@ export const recordScheduledPause = mutation({
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
+    if (await isUserDeletionFenced(ctx.db, args.userId)) {
+      throw new Error("Account deletion is in progress");
+    }
 
     const existing = await ctx.db
       .query("subscription_pauses")
@@ -353,6 +357,15 @@ export const claimResume = mutation({
       row.resume_claimed_at !== undefined &&
       args.now - row.resume_claimed_at >= STALE_RESUME_CLAIM_MS;
     if (!RESUMABLE_PAUSE_STATUSES.has(row.status) && !staleClaim) {
+      return null;
+    }
+    if (await isUserDeletionFenced(ctx.db, row.user_id)) {
+      await ctx.db.patch(row._id, {
+        status: "canceled",
+        canceled_at: args.now,
+        resume_claimed_at: undefined,
+        updated_at: args.now,
+      });
       return null;
     }
     if (

--- a/convex/subscriptionPauses.ts
+++ b/convex/subscriptionPauses.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import { validateServiceKey } from "./lib/utils";
 import { isUserDeletionFenced } from "./lib/userDeletionFence";
+import { DELETION_COORDINATED_RESUME_CLAIM_VERSION } from "./lib/subscriptionPauseResume";
 
 const MAX_DUE_RESUMES = 50;
 const MAX_USER_PAUSE_ROWS = 20;
@@ -47,6 +48,8 @@ export const subscriptionPauseValidator = v.object({
   resumeAt: v.number(),
   status: pauseStatusValidator,
   resumeAttemptCount: v.number(),
+  resumeClaimedAt: v.optional(v.number()),
+  resumeClaimVersion: v.optional(v.number()),
   lastResumeError: v.optional(v.string()),
   resumedAt: v.optional(v.number()),
   resumedStripeSubscriptionId: v.optional(v.string()),
@@ -87,6 +90,8 @@ export function toSubscriptionPause(row: Doc<"subscription_pauses">) {
     resumeAt: row.resume_at,
     status: row.status,
     resumeAttemptCount: row.resume_attempt_count,
+    resumeClaimedAt: row.resume_claimed_at,
+    resumeClaimVersion: row.resume_claim_version,
     lastResumeError: row.last_resume_error,
     resumedAt: row.resumed_at,
     resumedStripeSubscriptionId: row.resumed_stripe_subscription_id,
@@ -379,6 +384,8 @@ export const claimResume = mutation({
     await ctx.db.patch(row._id, {
       status: "resuming",
       resume_claimed_at: args.now,
+      resume_claim_version: DELETION_COORDINATED_RESUME_CLAIM_VERSION,
+      resume_side_effect_authorized_at: undefined,
       last_resume_attempt_at: args.now,
       resume_attempt_count: row.resume_attempt_count + 1,
       updated_at: args.now,
@@ -386,6 +393,54 @@ export const claimResume = mutation({
 
     const claimed = await ctx.db.get(row._id);
     return claimed ? toSubscriptionPause(claimed) : null;
+  },
+});
+
+/**
+ * Establish the deletion barrier before any Stripe reads or writes occur.
+ * Convex serializes this mutation with deletion-fence creation: either the
+ * claim is authorized and deletion waits, or deletion fences the user and the
+ * claim is canceled.
+ */
+export const authorizeResumeSideEffect = mutation({
+  args: {
+    serviceKey: v.string(),
+    pauseId: v.id("subscription_pauses"),
+    resumeClaimedAt: v.number(),
+    resumeAttemptCount: v.number(),
+    authorizedAt: v.number(),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const row = await ctx.db.get(args.pauseId);
+    if (
+      !row ||
+      row.status !== "resuming" ||
+      row.resume_claim_version !== DELETION_COORDINATED_RESUME_CLAIM_VERSION ||
+      row.resume_claimed_at !== args.resumeClaimedAt ||
+      row.resume_attempt_count !== args.resumeAttemptCount
+    ) {
+      return false;
+    }
+
+    if (await isUserDeletionFenced(ctx.db, row.user_id)) {
+      await ctx.db.patch(row._id, {
+        status: "canceled",
+        canceled_at: args.authorizedAt,
+        resume_claimed_at: undefined,
+        resume_claim_version: undefined,
+        resume_side_effect_authorized_at: undefined,
+        updated_at: args.authorizedAt,
+      });
+      return false;
+    }
+
+    await ctx.db.patch(row._id, {
+      resume_side_effect_authorized_at: args.authorizedAt,
+      updated_at: args.authorizedAt,
+    });
+    return true;
   },
 });
 
@@ -406,6 +461,8 @@ export const markResumeSucceeded = mutation({
       resumed_stripe_subscription_id: args.resumedStripeSubscriptionId,
       last_resume_error: undefined,
       resume_claimed_at: undefined,
+      resume_claim_version: undefined,
+      resume_side_effect_authorized_at: undefined,
       updated_at: resumedAt,
     });
     return null;
@@ -430,6 +487,8 @@ export const markResumeFailed = mutation({
       ...(args.retryAt !== undefined && { resume_at: args.retryAt }),
       last_resume_error: normalizeResumeError(args.error),
       resume_claimed_at: undefined,
+      resume_claim_version: undefined,
+      resume_side_effect_authorized_at: undefined,
       updated_at: failedAt,
     });
     return null;
@@ -452,8 +511,39 @@ export const markPauseSuperseded = mutation({
       status: "superseded",
       resumed_stripe_subscription_id: args.stripeSubscriptionId,
       resume_claimed_at: undefined,
+      resume_claim_version: undefined,
+      resume_side_effect_authorized_at: undefined,
       updated_at: supersededAt,
     });
     return null;
+  },
+});
+
+/** Remove retained pause state during coordinated organization teardown. */
+export const deleteForDeletedOrganization = mutation({
+  args: {
+    serviceKey: v.string(),
+    organizationId: v.string(),
+  },
+  returns: v.object({
+    deletedCount: v.number(),
+    hasMore: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const rows = await ctx.db
+      .query("subscription_pauses")
+      .withIndex("by_organization_requested", (q) =>
+        q.eq("organization_id", args.organizationId),
+      )
+      .take(MAX_SUBSCRIPTION_PAUSE_ROWS + 1);
+    const batch = rows.slice(0, MAX_SUBSCRIPTION_PAUSE_ROWS);
+    for (const row of batch) {
+      await ctx.db.delete(row._id);
+    }
+    return {
+      deletedCount: batch.length,
+      hasMore: rows.length > MAX_SUBSCRIPTION_PAUSE_ROWS,
+    };
   },
 });

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { fileCountAggregate } from "./fileAggregate";
 import { validateServiceKey } from "./lib/utils";
+import { DELETION_COORDINATED_RESUME_CLAIM_VERSION } from "./lib/subscriptionPauseResume";
 
 export const DELETED_USER_ID = "__deleted_user__";
 
@@ -70,6 +71,7 @@ type OrphanSubagentTable = "subagent_events" | "subagent_work_items";
 // deletion route already repeats the mutation while `hasMore` is true.
 const MAX_CLEANUP_DOCS_PER_MUTATION = 100;
 const MAX_RESIDUE_USER_IDS_PER_MUTATION = 1;
+const MAX_RESUME_CLAIMS_PER_DELETION_START = 20;
 
 type ReadBudget = {
   remaining: number;
@@ -1021,7 +1023,7 @@ export const beginUserDataDeletionByService = mutation({
     serviceKey: v.string(),
     userId: v.string(),
   },
-  returns: v.null(),
+  returns: v.boolean(),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
     const existing = await ctx.db
@@ -1029,12 +1031,45 @@ export const beginUserDataDeletionByService = mutation({
       .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
       .unique();
     if (!existing) {
+      const resumingPauses = await ctx.db
+        .query("subscription_pauses")
+        .withIndex("by_user_status", (q) =>
+          q.eq("user_id", args.userId).eq("status", "resuming"),
+        )
+        .take(MAX_RESUME_CLAIMS_PER_DELETION_START + 1);
+
+      if (
+        resumingPauses.length > MAX_RESUME_CLAIMS_PER_DELETION_START ||
+        resumingPauses.some(
+          (pause) =>
+            pause.resume_claim_version !==
+              DELETION_COORDINATED_RESUME_CLAIM_VERSION ||
+            pause.resume_side_effect_authorized_at !== undefined,
+        )
+      ) {
+        return false;
+      }
+
+      // These versioned claims have not crossed the Stripe side-effect
+      // barrier, so canceling them and inserting the fence in this same
+      // transaction safely gives deletion ownership of the user.
+      const canceledAt = Date.now();
+      for (const pause of resumingPauses) {
+        await ctx.db.patch(pause._id, {
+          status: "canceled",
+          canceled_at: canceledAt,
+          resume_claimed_at: undefined,
+          resume_claim_version: undefined,
+          resume_side_effect_authorized_at: undefined,
+          updated_at: canceledAt,
+        });
+      }
       await ctx.db.insert("user_deletion_fences", {
         user_id: args.userId,
-        started_at: Date.now(),
+        started_at: canceledAt,
       });
     }
-    return null;
+    return true;
   },
 });
 

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -20,6 +20,9 @@ export const USER_DELETION_TABLE_POLICY = {
     "user_customization",
     "extra_usage",
     "team_member_usage",
+    // Shared-organization rows are anonymized in place so the organization's
+    // automatic resume remains intact; all other pause rows are deleted.
+    "subscription_pauses",
     "local_sandbox_tokens",
     "local_sandbox_connections",
     "cancellation_reason_details",
@@ -351,6 +354,7 @@ async function cleanupUserDataForUser(
   ctx: MutationCtx,
   userId: string,
   mode: CleanupMode,
+  options: { preservedOrganizationIds?: string[] } = {},
 ) {
   const stats = createStats();
   const now = Date.now();
@@ -451,6 +455,11 @@ async function cleanupUserDataForUser(
   >(ctx, budget, "team_member_usage", "by_user_id", (q) =>
     q.eq("user_id", userId),
   );
+  const subscriptionPausesBatch = await collectByIndexBatch<
+    Doc<"subscription_pauses">
+  >(ctx, budget, "subscription_pauses", "by_user_requested", (q) =>
+    q.eq("user_id", userId),
+  );
   const cancellationReasonDetailsBatch = await collectByIndexBatch<
     Doc<"cancellation_reason_details">
   >(
@@ -506,6 +515,7 @@ async function cleanupUserDataForUser(
     localSandboxConnectionsBatch,
     extraUsageBatch,
     teamMemberUsageBatch,
+    subscriptionPausesBatch,
     cancellationReasonDetailsBatch,
     researchRunMembersBatch,
     researchUserProfilesBatch,
@@ -524,6 +534,7 @@ async function cleanupUserDataForUser(
   const localSandboxConnections = localSandboxConnectionsBatch.docs;
   const extraUsage = extraUsageBatch.docs;
   const teamMemberUsage = teamMemberUsageBatch.docs;
+  const subscriptionPauses = subscriptionPausesBatch.docs;
   const cancellationReasonDetails = cancellationReasonDetailsBatch.docs;
   const researchRunMembers = researchRunMembersBatch.docs;
   const researchUserProfiles = researchUserProfilesBatch.docs;
@@ -541,6 +552,30 @@ async function cleanupUserDataForUser(
       ? []
       : chats.filter((chat) => !incompleteChatIds.has(chat.id));
   if (chatsReadyToDelete.length < chats.length) {
+    stats.hasMore = true;
+  }
+
+  const preservedOrganizationIds = new Set(
+    options.preservedOrganizationIds ?? [],
+  );
+  const subscriptionPausesToAnonymize = subscriptionPauses.filter(
+    (pause) =>
+      pause.organization_id !== undefined &&
+      preservedOrganizationIds.has(pause.organization_id),
+  );
+  const subscriptionPausesReadyToDelete = subscriptionPauses.filter(
+    (pause) =>
+      !subscriptionPausesToAnonymize.includes(pause) &&
+      pause.status !== "resuming",
+  );
+  const heldSubscriptionPauses =
+    subscriptionPauses.length -
+    subscriptionPausesToAnonymize.length -
+    subscriptionPausesReadyToDelete.length;
+  // A resume worker may already be creating a new Stripe subscription. Keep
+  // the deletion fence and this row until that worker settles, then a later
+  // cleanup pass can safely remove the terminal row.
+  if (heldSubscriptionPauses > 0) {
     stats.hasMore = true;
   }
 
@@ -579,6 +614,21 @@ async function cleanupUserDataForUser(
   );
   await deleteDocs(ctx, stats, "extra_usage", extraUsage, mode);
   await deleteDocs(ctx, stats, "team_member_usage", teamMemberUsage, mode);
+  await deleteDocs(
+    ctx,
+    stats,
+    "subscription_pauses",
+    subscriptionPausesReadyToDelete,
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "subscription_pauses",
+    subscriptionPausesToAnonymize,
+    () => ({ user_id: DELETED_USER_ID, updated_at: now }),
+    mode,
+  );
   await deleteDocs(
     ctx,
     stats,
@@ -992,11 +1042,14 @@ export const deleteAllUserDataByService = mutation({
   args: {
     serviceKey: v.string(),
     userId: v.string(),
+    preservedOrganizationIds: v.optional(v.array(v.string())),
   },
   returns: cleanupStatsValidator,
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
-    return await cleanupUserDataForUser(ctx, args.userId, "execute");
+    return await cleanupUserDataForUser(ctx, args.userId, "execute", {
+      preservedOrganizationIds: args.preservedOrganizationIds,
+    });
   },
 });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -943,6 +943,25 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(chatHandlerSrc).toMatch(
       /selected_model:\s*selectedModel,\s*response_model:\s*state\.responseModel,/,
     );
+
+    const askSetupCleanup = chatHandlerSrc.indexOf(
+      "execute errors are consumed by createUIMessageStream",
+    );
+    expect(askSetupCleanup).toBeGreaterThan(-1);
+    expect(
+      chatHandlerSrc.slice(askSetupCleanup, askSetupCleanup + 1_000),
+    ).toContain("releasePaidDailyFreeAllowanceReservation");
+
+    const triggerCancelCleanup = taskSrc.slice(
+      taskSrc.indexOf("onCancel: async"),
+      taskSrc.indexOf("run: async"),
+    );
+    expect(triggerCancelCleanup).toContain(
+      "releasePaidDailyFreeAllowanceReservation",
+    );
+    expect(
+      taskSrc.match(/await releasePaidDailyFreeAllowanceReservation\(\)/g),
+    ).toHaveLength(3);
   });
 
   test("uses a turn-scoped Trigger idempotency key for agent runs", () => {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -260,6 +260,34 @@ export const createChatHandler = () => {
     let outerChatId: string | undefined;
     let posthog: ReturnType<typeof PostHogClient> = null;
     let releaseFreeRunLock: (() => Promise<void>) | undefined;
+    let paidDailyFreeAllowanceUserId: string | undefined;
+    let paidDailyFreeAllowanceReservation:
+      PaidDailyFreeAllowanceReservation | undefined;
+    let paidDailyFreeAllowanceFinalized = false;
+    let paidDailyFreeAllowanceUsageTracker: UsageTracker | undefined;
+    const releasePaidDailyFreeAllowanceReservation = async () => {
+      if (
+        !paidDailyFreeAllowanceUserId ||
+        !paidDailyFreeAllowanceReservation ||
+        paidDailyFreeAllowanceFinalized
+      ) {
+        return;
+      }
+      const result = await recordPaidDailyFreeAllowanceCost(
+        paidDailyFreeAllowanceUserId,
+        0,
+        paidDailyFreeAllowanceReservation,
+      );
+      paidDailyFreeAllowanceFinalized = result.recorded;
+      if (!result.recorded) {
+        phLogger.warn("Paid daily free allowance lease release failed", {
+          userId: paidDailyFreeAllowanceUserId,
+          chatId: outerChatId,
+          endpoint,
+          cost_record_failure_reason: result.unavailableReason,
+        });
+      }
+    };
     const releaseFreeRunLockOnce = async () => {
       const release = releaseFreeRunLock;
       if (!release) return;
@@ -324,6 +352,7 @@ export const createChatHandler = () => {
 
       const { userId, subscription, organizationId, freeQuotaSubject } =
         await getUserIDAndPro(req);
+      paidDailyFreeAllowanceUserId = userId;
       const freeUsageSubject = freeQuotaSubject ?? userId;
       let selectedModelOverride: SelectedModel | undefined =
         normalizeSelectedModelOverrideForSubscription(
@@ -605,8 +634,6 @@ export const createChatHandler = () => {
       };
       chatLogger.setChat(chatLogContext, selectedModel);
 
-      let paidDailyFreeAllowanceReservation:
-        PaidDailyFreeAllowanceReservation | undefined;
       let rateLimitInfo: RateLimitInfo;
 
       try {
@@ -791,6 +818,7 @@ export const createChatHandler = () => {
         execute: async ({ writer }) => {
           try {
             const usageTracker = new UsageTracker();
+            paidDailyFreeAllowanceUsageTracker = usageTracker;
             const auxiliaryVision = directGlmVisionEnabled
               ? {
                   isEnabled: visionSummaryRecovery.isEnabled,
@@ -1165,7 +1193,12 @@ export const createChatHandler = () => {
                 }
 
                 if (!usageTracker.hasUsage) {
-                  // No usage data reported — skip deduction
+                  // Release an unused rescue lease so a failed provider start
+                  // does not block the user's next sequential rescue.
+                  if (paidDailyFreeAllowanceReservation) {
+                    await releasePaidDailyFreeAllowanceReservation();
+                    hasRecordedUsage = paidDailyFreeAllowanceFinalized;
+                  }
                   return;
                 }
                 hasRecordedUsage = true;
@@ -1194,7 +1227,10 @@ export const createChatHandler = () => {
                     await recordPaidDailyFreeAllowanceCost(
                       userId,
                       usageCostRecord.costDollars,
+                      paidDailyFreeAllowanceReservation,
                     );
+                  paidDailyFreeAllowanceFinalized =
+                    allowanceCostRecord.recorded;
                   if (!allowanceCostRecord.recorded) {
                     phLogger.warn(
                       "Paid daily free allowance cost recording failed",
@@ -2926,6 +2962,9 @@ export const createChatHandler = () => {
             // execute errors are consumed by createUIMessageStream, so the
             // outer request catch and stream onFinish cannot clean them up.
             preemptiveTimeout?.clear();
+            if (!paidDailyFreeAllowanceUsageTracker?.hasUsage) {
+              await releasePaidDailyFreeAllowanceReservation();
+            }
             const cleanupOperations = [
               [
                 "stop_subscriber",
@@ -2988,6 +3027,9 @@ export const createChatHandler = () => {
     } catch (error) {
       // Clear timeout if error occurs before onFinish
       preemptiveTimeout?.clear();
+      if (!paidDailyFreeAllowanceUsageTracker?.hasUsage) {
+        await releasePaidDailyFreeAllowanceReservation();
+      }
       await releaseFreeRunLockOnce();
       shutdownPostHog(posthog);
 

--- a/lib/billing/__tests__/pause-resume.test.ts
+++ b/lib/billing/__tests__/pause-resume.test.ts
@@ -44,6 +44,7 @@ jest.mock("@/convex/_generated/api", () => ({
   api: {
     subscriptionPauses: {
       claimResume: "subscriptionPauses.claimResume",
+      authorizeResumeSideEffect: "subscriptionPauses.authorizeResumeSideEffect",
       markPauseSuperseded: "subscriptionPauses.markPauseSuperseded",
       markResumeFailed: "subscriptionPauses.markResumeFailed",
       markResumeSucceeded: "subscriptionPauses.markResumeSucceeded",
@@ -99,8 +100,13 @@ describe("resumePausedSubscription", () => {
         return pauseRecord({
           status: "resuming",
           resumeAttemptCount: 1,
+          resumeClaimedAt: NOW,
+          resumeClaimVersion: 2,
           id: args.pauseId,
         });
+      }
+      if (name === "subscriptionPauses.authorizeResumeSideEffect") {
+        return true;
       }
       return null;
     }) as never);
@@ -138,6 +144,14 @@ describe("resumePausedSubscription", () => {
     expect(mockConvexMutation).toHaveBeenCalledWith(
       "subscriptionPauses.claimResume",
       expect.objectContaining({ pauseId: "pause_1", manual: false, now: NOW }),
+    );
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "subscriptionPauses.authorizeResumeSideEffect",
+      expect.objectContaining({
+        pauseId: "pause_1",
+        resumeClaimedAt: NOW,
+        resumeAttemptCount: 1,
+      }),
     );
     expect(mockCreateSubscription).toHaveBeenCalledWith(
       {
@@ -181,6 +195,34 @@ describe("resumePausedSubscription", () => {
         now: NOW,
       }),
     ).resolves.toEqual({ outcome: "not_claimable" });
+    expect(mockCreateSubscription).not.toHaveBeenCalled();
+  });
+
+  it("does no Stripe work when deletion wins before side-effect authorization", async () => {
+    mockConvexMutation.mockImplementation((async (name: string) => {
+      if (name === "subscriptionPauses.claimResume") {
+        return pauseRecord({
+          status: "resuming",
+          resumeAttemptCount: 1,
+          resumeClaimedAt: NOW,
+          resumeClaimVersion: 2,
+        });
+      }
+      if (name === "subscriptionPauses.authorizeResumeSideEffect") {
+        return false;
+      }
+      return null;
+    }) as never);
+    const { resumePausedSubscription } = await import("../pause-resume");
+
+    await expect(
+      resumePausedSubscription(pauseRecord() as never, {
+        trigger: "cron",
+        now: NOW,
+      }),
+    ).resolves.toEqual({ outcome: "not_claimable" });
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockRetrievePaymentMethod).not.toHaveBeenCalled();
     expect(mockCreateSubscription).not.toHaveBeenCalled();
   });
 
@@ -326,7 +368,15 @@ describe("resumePausedSubscription", () => {
   it("still reports resumed when the Convex bookkeeping write fails after creation", async () => {
     mockConvexMutation.mockImplementation((async (name: string) => {
       if (name === "subscriptionPauses.claimResume") {
-        return pauseRecord({ status: "resuming", resumeAttemptCount: 1 });
+        return pauseRecord({
+          status: "resuming",
+          resumeAttemptCount: 1,
+          resumeClaimedAt: NOW,
+          resumeClaimVersion: 2,
+        });
+      }
+      if (name === "subscriptionPauses.authorizeResumeSideEffect") {
+        return true;
       }
       if (name === "subscriptionPauses.markResumeSucceeded") {
         throw new Error("convex write failed");

--- a/lib/billing/pause-resume.ts
+++ b/lib/billing/pause-resume.ts
@@ -149,6 +149,24 @@ export async function resumePausedSubscription(
     return { outcome: "not_claimable" };
   }
 
+  if (claimed.resumeClaimedAt === undefined) {
+    return { outcome: "not_claimable" };
+  }
+
+  const sideEffectAuthorized = await convex.mutation(
+    api.subscriptionPauses.authorizeResumeSideEffect,
+    {
+      serviceKey: key,
+      pauseId: claimed.id,
+      resumeClaimedAt: claimed.resumeClaimedAt,
+      resumeAttemptCount: claimed.resumeAttemptCount,
+      authorizedAt: now,
+    },
+  );
+  if (!sideEffectAuthorized) {
+    return { outcome: "not_claimable" };
+  }
+
   const analytics = pauseAnalyticsProperties(claimed, options.trigger);
 
   try {

--- a/lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts
+++ b/lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("paid daily free allowance", () => {
   const mockCreateRedisClient = jest.fn();
-  const redisStore = new Map<string, number>();
+  const redisStore = new Map<string, number | string>();
   const originalEnv = {
     cost: process.env.PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD,
     nodeEnv: process.env.NODE_ENV,
@@ -17,29 +17,48 @@ describe("paid daily free allowance", () => {
 
   const mockRedis = {
     get: jest.fn(async (key: string) => redisStore.get(key) ?? null),
-    eval: jest.fn(async (_script: string, keys: string[], args: number[]) => {
-      if (keys.length === 2) {
-        // Mirrors the Lua reservation script: only the cost cap blocks, the
-        // request counter is incremented for analytics.
-        const [requestsKey, costKey] = keys;
-        const [costLimit] = args;
-        const requestsUsed = redisStore.get(requestsKey) ?? 0;
-        const costUsed = redisStore.get(costKey) ?? 0;
-        if (costUsed >= costLimit) {
-          return [0, "cost_limit_reached", requestsUsed, costUsed];
+    eval: jest.fn(
+      async (_script: string, keys: string[], args: Array<number | string>) => {
+        if (keys.length === 3) {
+          // Mirrors the atomic tokenized lease shared by Ask and Agent.
+          const [requestsKey, costKey, reservationKey] = keys;
+          const [costLimitRaw, _counterTtlMs, _reservationTtlMs, token] = args;
+          const costLimit = Number(costLimitRaw);
+          const requestsUsed = Number(redisStore.get(requestsKey) ?? 0);
+          const costUsed = Number(redisStore.get(costKey) ?? 0);
+          if (costUsed >= costLimit) {
+            return [0, "cost_limit_reached", requestsUsed, costUsed];
+          }
+          if (redisStore.has(reservationKey)) {
+            return [0, "request_in_progress", requestsUsed, costUsed];
+          }
+          const nextRequests = requestsUsed + 1;
+          redisStore.set(requestsKey, nextRequests);
+          redisStore.set(reservationKey, String(token));
+          return [1, "ok", nextRequests, costUsed];
         }
-        const nextRequests = requestsUsed + 1;
-        redisStore.set(requestsKey, nextRequests);
-        redisStore.set(costKey, costUsed);
-        return [1, "ok", nextRequests, costUsed];
-      }
 
-      const [costKey] = keys;
-      const [costPoints] = args;
-      const nextCost = (redisStore.get(costKey) ?? 0) + costPoints;
-      redisStore.set(costKey, nextCost);
-      return nextCost;
-    }),
+        if (keys.length === 2) {
+          const [costKey, reservationKey] = keys;
+          const [costPointsRaw, _ttlMs, token] = args;
+          const costUsed = Number(redisStore.get(costKey) ?? 0);
+          if (redisStore.get(reservationKey) !== String(token)) {
+            return [0, costUsed];
+          }
+          const nextCost = costUsed + Number(costPointsRaw);
+          redisStore.set(costKey, nextCost);
+          redisStore.delete(reservationKey);
+          return [1, nextCost];
+        }
+
+        const [costKey] = keys;
+        const [costPointsRaw] = args;
+        const costPoints = Number(costPointsRaw);
+        const nextCost = Number(redisStore.get(costKey) ?? 0) + costPoints;
+        redisStore.set(costKey, nextCost);
+        return nextCost;
+      },
+    ),
   };
 
   const getIsolatedModule = () => {
@@ -192,16 +211,94 @@ describe("paid daily free allowance", () => {
   });
 
   it("allows repeated rescues in a day and counts them", async () => {
-    const { reservePaidDailyFreeAllowanceRequest } = getIsolatedModule();
+    const {
+      recordPaidDailyFreeAllowanceCost,
+      reservePaidDailyFreeAllowanceRequest,
+    } = getIsolatedModule();
 
     for (let i = 1; i <= 3; i += 1) {
-      await expect(
-        reservePaidDailyFreeAllowanceRequest(i % 2 ? agentContext : askContext),
-      ).resolves.toMatchObject({
+      const reservation = await reservePaidDailyFreeAllowanceRequest(
+        i % 2 ? agentContext : askContext,
+      );
+      expect(reservation).toMatchObject({
         allowed: true,
         status: { available: true, requestsUsed: i },
       });
+      await expect(
+        recordPaidDailyFreeAllowanceCost("user_123", 0.01, reservation),
+      ).resolves.toMatchObject({ recorded: true });
     }
+  });
+
+  it("admits only one overlapping rescue across Ask and Agent", async () => {
+    const {
+      getPaidDailyFreeAllowanceStatus,
+      recordPaidDailyFreeAllowanceCost,
+      reservePaidDailyFreeAllowanceRequest,
+    } = getIsolatedModule();
+
+    const reservations = await Promise.all([
+      reservePaidDailyFreeAllowanceRequest(askContext),
+      reservePaidDailyFreeAllowanceRequest(agentContext),
+    ]);
+    const admitted = reservations.filter((reservation) => reservation.allowed);
+    const blocked = reservations.filter((reservation) => !reservation.allowed);
+
+    expect(admitted).toHaveLength(1);
+    expect(blocked).toHaveLength(1);
+    expect(blocked[0]).toMatchObject({
+      blockReason: "request_in_progress",
+    });
+    const reservationCall = mockRedis.eval.mock.calls.find(
+      ([, keys]) => keys.length === 3,
+    );
+    expect(reservationCall?.[2][2]).toBe(14_700_000);
+    await expect(
+      getPaidDailyFreeAllowanceStatus(askContext),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "request_in_progress",
+    });
+
+    await expect(
+      recordPaidDailyFreeAllowanceCost("user_123", 0.1, admitted[0]),
+    ).resolves.toMatchObject({ recorded: true, nextCostDollars: 0.1 });
+    await expect(
+      reservePaidDailyFreeAllowanceRequest(agentContext),
+    ).resolves.toMatchObject({ allowed: true });
+  });
+
+  it("releases an unused lease and rejects settlement with the wrong token", async () => {
+    const {
+      recordPaidDailyFreeAllowanceCost,
+      reservePaidDailyFreeAllowanceRequest,
+    } = getIsolatedModule();
+    const reservation = await reservePaidDailyFreeAllowanceRequest(askContext);
+    expect(reservation.allowed).toBe(true);
+
+    const wrongReservation = {
+      ...reservation,
+      redisReservation: {
+        ...reservation.redisReservation!,
+        token: "wrong-token",
+      },
+    };
+    await expect(
+      recordPaidDailyFreeAllowanceCost("user_123", 0, wrongReservation),
+    ).resolves.toMatchObject({
+      recorded: false,
+      unavailableReason: "reservation_unavailable",
+    });
+    await expect(
+      reservePaidDailyFreeAllowanceRequest(agentContext),
+    ).resolves.toMatchObject({ allowed: false });
+
+    await expect(
+      recordPaidDailyFreeAllowanceCost("user_123", 0, reservation),
+    ).resolves.toMatchObject({ recorded: true, nextCostDollars: 0 });
+    await expect(
+      reservePaidDailyFreeAllowanceRequest(agentContext),
+    ).resolves.toMatchObject({ allowed: true });
   });
 
   it("shares one daily cost pool between Ask and Agent and blocks at the cap", async () => {
@@ -289,8 +386,9 @@ describe("paid daily free allowance", () => {
     } = getIsolatedModule();
 
     jest.setSystemTime(new Date("2026-06-11T23:59:00.000Z"));
-    await reservePaidDailyFreeAllowanceRequest(agentContext);
-    await recordPaidDailyFreeAllowanceCost("user_123", 0.25);
+    const reservation =
+      await reservePaidDailyFreeAllowanceRequest(agentContext);
+    await recordPaidDailyFreeAllowanceCost("user_123", 0.25, reservation);
     const june11Keys = getPaidDailyFreeAllowanceKeys("user_123", "2026-06-11");
     expect(redisStore.get(june11Keys.requestsKey)).toBe(1);
     await expect(

--- a/lib/rate-limit/paid-daily-free-allowance.ts
+++ b/lib/rate-limit/paid-daily-free-allowance.ts
@@ -15,17 +15,22 @@ import type { LimitCapReason } from "@/lib/limit-pressure";
  * Ask and Agent share the same daily pool.
  */
 export const PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD_DEFAULT = 0.25;
+const PAID_DAILY_FREE_ALLOWANCE_RESERVATION_TTL_MS =
+  (4 * 60 * 60 + 5 * 60) * 1000;
 
 /**
- * Reserve one rescue request. Only the cost cap is enforced. The request
- * counter is still incremented so analytics can report how many rescue
- * requests a user made in a day.
+ * Reserve the shared per-user allowance for one active rescue request. The
+ * tokenized lease serializes Ask and Agent spending until settlement, while a
+ * bounded TTL recovers a lease if the worker exits without cleanup.
  */
 const RESERVE_PAID_DAILY_FREE_ALLOWANCE_SCRIPT = `
 local requestKey = KEYS[1]
 local costKey = KEYS[2]
+local reservationKey = KEYS[3]
 local costLimit = tonumber(ARGV[1])
-local ttlMs = tonumber(ARGV[2])
+local counterTtlMs = tonumber(ARGV[2])
+local reservationTtlMs = tonumber(ARGV[3])
+local reservationToken = ARGV[4]
 
 local currentRequests = tonumber(redis.call("GET", requestKey) or "0")
 local currentCost = tonumber(redis.call("GET", costKey) or "0")
@@ -34,18 +39,45 @@ if currentCost >= costLimit then
   return {0, "cost_limit_reached", currentRequests, currentCost}
 end
 
-local nextRequests = redis.call("INCRBY", requestKey, 1)
-if nextRequests == 1 then
-  redis.call("PEXPIRE", requestKey, ttlMs)
+local acquired = redis.call(
+  "SET",
+  reservationKey,
+  reservationToken,
+  "PX",
+  reservationTtlMs,
+  "NX"
+)
+if not acquired then
+  return {0, "request_in_progress", currentRequests, currentCost}
 end
 
-if redis.call("EXISTS", costKey) == 0 then
-  redis.call("SET", costKey, currentCost, "PX", ttlMs)
-else
-  redis.call("PEXPIRE", costKey, ttlMs)
+local nextRequests = redis.call("INCRBY", requestKey, 1)
+if nextRequests == 1 then
+  redis.call("PEXPIRE", requestKey, counterTtlMs)
 end
 
 return {1, "ok", nextRequests, currentCost}
+`;
+
+const SETTLE_PAID_DAILY_FREE_ALLOWANCE_RESERVATION_SCRIPT = `
+local costKey = KEYS[1]
+local reservationKey = KEYS[2]
+local costPoints = tonumber(ARGV[1])
+local ttlMs = tonumber(ARGV[2])
+local reservationToken = ARGV[3]
+
+if redis.call("GET", reservationKey) ~= reservationToken then
+  return {0, tonumber(redis.call("GET", costKey) or "0")}
+end
+
+local currentCost = tonumber(redis.call("GET", costKey) or "0")
+local nextCost = currentCost
+if costPoints > 0 then
+  nextCost = redis.call("INCRBY", costKey, costPoints)
+  redis.call("PEXPIRE", costKey, ttlMs)
+end
+redis.call("DEL", reservationKey)
+return {1, nextCost}
 `;
 
 const RECORD_PAID_DAILY_FREE_ALLOWANCE_COST_SCRIPT = `
@@ -68,6 +100,7 @@ export type PaidDailyFreeAllowanceUnavailableReason =
   | "not_monthly_exhausted"
   | "attachments_not_supported"
   | "redis_unavailable"
+  | "request_in_progress"
   | "cost_limit_reached";
 
 export interface PaidDailyFreeAllowanceStatus {
@@ -91,6 +124,11 @@ export interface PaidDailyFreeAllowanceReservation {
   allowed: boolean;
   status: PaidDailyFreeAllowanceStatus;
   blockReason?: PaidDailyFreeAllowanceUnavailableReason;
+  /** Server-only Redis lease identity, present for production reservations. */
+  redisReservation?: {
+    bucket: string;
+    token: string;
+  };
 }
 
 export type PaidDailyFreeAllowanceCostRecordResult =
@@ -105,7 +143,7 @@ export type PaidDailyFreeAllowanceCostRecordResult =
       recorded: false;
       costPoints: number;
       costDollars: number;
-      unavailableReason: "redis_unavailable";
+      unavailableReason: "redis_unavailable" | "reservation_unavailable";
     };
 
 export type PaidDailyFreeAllowanceMetadata = {
@@ -203,6 +241,7 @@ export function getPaidDailyFreeAllowanceKeys(
   return {
     requestsKey: `${prefix}:requests`,
     costKey: `${prefix}:cost`,
+    reservationKey: `${prefix}:reservation`,
   };
 }
 
@@ -272,16 +311,16 @@ export async function getPaidDailyFreeAllowanceStatus(
     return baseStatus("redis_unavailable");
   }
 
-  const { requestsKey, costKey } = getPaidDailyFreeAllowanceKeys(
-    ctx.userId,
-    bucket,
-  );
+  const { requestsKey, costKey, reservationKey } =
+    getPaidDailyFreeAllowanceKeys(ctx.userId, bucket);
   let rawRequestsUsed: unknown;
   let rawCostUsed: unknown;
+  let rawReservation: unknown;
   try {
-    [rawRequestsUsed, rawCostUsed] = await Promise.all([
+    [rawRequestsUsed, rawCostUsed, rawReservation] = await Promise.all([
       redis.get(requestsKey),
       redis.get(costKey),
+      redis.get(reservationKey),
     ]);
   } catch {
     return baseStatus("redis_unavailable");
@@ -290,8 +329,11 @@ export async function getPaidDailyFreeAllowanceStatus(
   const requestsUsed = Math.max(0, Number(rawRequestsUsed ?? 0));
   const costUsedPoints = Math.max(0, Number(rawCostUsed ?? 0));
   const costRemainingPoints = Math.max(0, costLimitPoints - costUsedPoints);
-  const unavailableReason =
-    costRemainingPoints <= 0 ? "cost_limit_reached" : undefined;
+  const unavailableReason = rawReservation
+    ? "request_in_progress"
+    : costRemainingPoints <= 0
+      ? "cost_limit_reached"
+      : undefined;
 
   return {
     type: "paid_daily_free_allowance",
@@ -342,9 +384,12 @@ export async function reservePaidDailyFreeAllowanceRequest(
   }
 
   const { bucket, reset, ttlMs } = getCurrentUtcDayWindow();
-  const { requestsKey, costKey } = getPaidDailyFreeAllowanceKeys(
-    ctx.userId,
-    bucket,
+  const { requestsKey, costKey, reservationKey } =
+    getPaidDailyFreeAllowanceKeys(ctx.userId, bucket);
+  const reservationToken = crypto.randomUUID();
+  const reservationTtlMs = Math.min(
+    ttlMs,
+    PAID_DAILY_FREE_ALLOWANCE_RESERVATION_TTL_MS,
   );
   let result: [
     number,
@@ -355,8 +400,8 @@ export async function reservePaidDailyFreeAllowanceRequest(
   try {
     result = (await redis.eval(
       RESERVE_PAID_DAILY_FREE_ALLOWANCE_SCRIPT,
-      [requestsKey, costKey],
-      [status.costLimitPoints, ttlMs],
+      [requestsKey, costKey, reservationKey],
+      [status.costLimitPoints, ttlMs, reservationTtlMs, reservationToken],
     )) as [
       number,
       PaidDailyFreeAllowanceUnavailableReason | "ok",
@@ -404,15 +449,22 @@ export async function reservePaidDailyFreeAllowanceRequest(
     allowed,
     status: nextStatus,
     ...(blockReason && blockReason !== "ok" && { blockReason }),
+    ...(allowed && {
+      redisReservation: {
+        bucket,
+        token: reservationToken,
+      },
+    }),
   };
 }
 
 export async function recordPaidDailyFreeAllowanceCost(
   userId: string,
   costDollars: number,
+  reservation?: PaidDailyFreeAllowanceReservation,
 ): Promise<PaidDailyFreeAllowanceCostRecordResult> {
   const costPoints = dollarsToPoints(costDollars);
-  if (costPoints <= 0) {
+  if (costPoints <= 0 && !reservation?.redisReservation) {
     return {
       recorded: true,
       costPoints: 0,
@@ -441,15 +493,36 @@ export async function recordPaidDailyFreeAllowanceCost(
     };
   }
 
-  const { bucket, ttlMs } = getCurrentUtcDayWindow();
-  const { costKey } = getPaidDailyFreeAllowanceKeys(userId, bucket);
+  const { bucket: currentBucket, ttlMs } = getCurrentUtcDayWindow();
+  const bucket = reservation?.redisReservation?.bucket ?? currentBucket;
+  const { costKey, reservationKey } = getPaidDailyFreeAllowanceKeys(
+    userId,
+    bucket,
+  );
   let nextCost: unknown;
   try {
-    nextCost = await redis.eval(
-      RECORD_PAID_DAILY_FREE_ALLOWANCE_COST_SCRIPT,
-      [costKey],
-      [costPoints, ttlMs],
-    );
+    if (reservation?.redisReservation) {
+      const [settledRaw, settledCostRaw] = (await redis.eval(
+        SETTLE_PAID_DAILY_FREE_ALLOWANCE_RESERVATION_SCRIPT,
+        [costKey, reservationKey],
+        [costPoints, ttlMs, reservation.redisReservation.token],
+      )) as [number, number];
+      if (settledRaw !== 1) {
+        return {
+          recorded: false,
+          costPoints,
+          costDollars: pointsToDollars(costPoints),
+          unavailableReason: "reservation_unavailable",
+        };
+      }
+      nextCost = settledCostRaw;
+    } else {
+      nextCost = await redis.eval(
+        RECORD_PAID_DAILY_FREE_ALLOWANCE_COST_SCRIPT,
+        [costKey],
+        [costPoints, ttlMs],
+      );
+    }
   } catch {
     return {
       recorded: false,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2139,6 +2139,7 @@ type RunCleanupState = {
   usageRefundTracker: UsageRefundTracker;
   hasObservedUsage: () => boolean;
   releaseFreeRunLock: () => Promise<void>;
+  releasePaidDailyFreeAllowanceReservation: () => Promise<void>;
   chatLogger: ChatLogger | undefined;
   chatId: string;
   userId: string;
@@ -2307,6 +2308,7 @@ export const agentLongTask = task({
     ]);
     if (!cleanup.hasObservedUsage()) {
       await cleanup.usageRefundTracker.refund().catch(() => {});
+      await cleanup.releasePaidDailyFreeAllowanceReservation().catch(() => {});
     }
     await cleanup.releaseFreeRunLock().catch((error) => {
       triggerLogger.warn("[agent-long] canceled run lock release failed", {
@@ -2549,6 +2551,31 @@ export const agentLongTask = task({
     let streamPiped = false;
     let observedUsageTracker: UsageTracker | undefined;
     const hasObservedUsage = () => !!observedUsageTracker?.hasUsage;
+    let paidDailyFreeAllowanceReservation:
+      PaidDailyFreeAllowanceReservation | undefined;
+    let paidDailyFreeAllowanceFinalized = false;
+    const releasePaidDailyFreeAllowanceReservation = async () => {
+      if (
+        !paidDailyFreeAllowanceReservation ||
+        paidDailyFreeAllowanceFinalized
+      ) {
+        return;
+      }
+      const result = await recordPaidDailyFreeAllowanceCost(
+        userId,
+        0,
+        paidDailyFreeAllowanceReservation,
+      );
+      paidDailyFreeAllowanceFinalized = result.recorded;
+      if (!result.recorded) {
+        phLogger.warn("Paid daily free allowance lease release failed", {
+          userId,
+          chatId,
+          endpoint,
+          cost_record_failure_reason: result.unavailableReason,
+        });
+      }
+    };
     let cloudSandboxLifecyclePromise: Promise<void> | undefined;
     let finishE2BIdleLeaseRelease: (() => Promise<void>) | undefined;
     const finishCloudSandboxLifecycle = () => {
@@ -2563,6 +2590,7 @@ export const agentLongTask = task({
       usageRefundTracker,
       hasObservedUsage,
       releaseFreeRunLock: releaseFreeRunLockOnce,
+      releasePaidDailyFreeAllowanceReservation,
       chatLogger,
       chatId,
       userId,
@@ -2872,8 +2900,6 @@ export const agentLongTask = task({
       // before agentUiStream.pipe() registered the stream, and the frontend
       // transport would only see a FAILED status with no error message.
       let rateLimitInfo: RateLimitInfo;
-      let paidDailyFreeAllowanceReservation:
-        PaidDailyFreeAllowanceReservation | undefined;
 
       let streamError: unknown;
       const visionSummaryRecovery = createVisionSummaryRecoveryController({
@@ -3733,7 +3759,15 @@ export const agentLongTask = task({
                   usageTracker.nonModelCost += triggerRunCost;
                   chatLogger?.getBuilder().addToolCost(triggerRunCost);
                 }
-                if (!usageTracker.hasUsage) return;
+                if (!usageTracker.hasUsage) {
+                  // Release an unused rescue lease so a failed provider start
+                  // does not block the user's next sequential rescue.
+                  if (paidDailyFreeAllowanceReservation) {
+                    await releasePaidDailyFreeAllowanceReservation();
+                    hasRecordedUsage = paidDailyFreeAllowanceFinalized;
+                  }
+                  return;
+                }
                 hasRecordedUsage = true;
                 const usageRecordArgs = {
                   selectedModel,
@@ -3758,7 +3792,10 @@ export const agentLongTask = task({
                     await recordPaidDailyFreeAllowanceCost(
                       userId,
                       usageCostRecord.costDollars,
+                      paidDailyFreeAllowanceReservation,
                     );
+                  paidDailyFreeAllowanceFinalized =
+                    allowanceCostRecord.recorded;
                   if (!allowanceCostRecord.recorded) {
                     phLogger.warn(
                       "Paid daily free allowance cost recording failed",
@@ -5739,6 +5776,9 @@ export const agentLongTask = task({
               ),
             );
           } catch (error) {
+            if (!hasObservedUsage()) {
+              await releasePaidDailyFreeAllowanceReservation();
+            }
             await releaseFreeRunLockOnce();
             throw error;
           }
@@ -5829,6 +5869,9 @@ export const agentLongTask = task({
       metadata.set("status", "done");
       await phLogger.flush().catch(() => {});
     } catch (error) {
+      if (!hasObservedUsage()) {
+        await releasePaidDailyFreeAllowanceReservation();
+      }
       await releaseFreeRunLockBestEffort("outer_catch");
       memoryTelemetry.checkpoint({ phase: "run_failed", force: true });
       const chatMissingAfterStream =


### PR DESCRIPTION
## Summary

- serialize paid daily rescue usage across Ask and Agent with a tokenized Redis lease, token-bound settlement, bounded crash recovery, and lifecycle cleanup
- include subscription pause records in account deletion and fence new schedule/resume transitions once deletion starts
- preserve shared-organization resume schedules by anonymizing the departing user while deleting sole-organization records

## Verification

- `corepack pnpm typecheck`
- targeted ESLint and Prettier checks for all changed files
- 199 focused tests across allowance, budget, Agent contracts, account deletion, pause cron/resume, and retention actions
- `corepack pnpm test:ci` (477 suites / 5,123 Jest tests plus 5 research-runner tests)
- commit hook repeated typecheck and all 5,123 Jest tests

Automated validation is sufficient for this backend security fix; no Convex deployment or live environment mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paid daily allowance requests now use reservations to prevent overlapping Ask and Agent requests.
  * Allowance status indicates when another request is in progress.
  * Subscription resume operations now require authorization before billing changes proceed.

* **Bug Fixes**
  * Unused allowance reservations are released when requests fail or are canceled.
  * Account deletion coordinates concurrent billing and membership activity safely.
  * Account deletion preserves data linked to retained organizations while cleaning up personal data.
  * Subscription pauses are safely canceled, anonymized, or removed during account deletion, and new pauses are blocked during deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->