### PR TITLE
Reduce duplicate slow Agent logs while retaining startup telemetry

### DIFF
--- a/docs/agent-startup-compaction.md
+++ b/docs/agent-startup-compaction.md
@@ -57,6 +57,18 @@ completion event. No exposure is emitted for mere flag assignment. Existing
 startup summary and worker timers include the recovery; failed or abandoned
 runs without a completion event are not represented in this event cohort.
 
+Retain the startup timings for the [rolling regression readout](https://us.posthog.com/project/144137/insights/Pt8cDlVX)
+and the tracked pilot review. These are in-memory counters attached to the
+existing completion event, with no per-phase analytics events or user content.
+Reassess retention when the review ends; remove unused fields if the readout
+is retired.
+
+Duplicate `agent_performance_diagnostic` warning logs retain all slow errors
+and a deterministic 1% sample of slow successful or aborted runs, keyed by
+Trigger run ID (chat ID when unavailable). `log_sample_rate` records the
+selection rate. Use the unsampled completion events for percentiles and outcome
+rates; sampled warnings are for individual trace investigation.
+
 Compare timing p50/p95/p99, successful continuation, abort/error rates,
 fallback frequency, and compaction usage cost against control. Include
 summary completeness and retained-context checks. Provider usage from an

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -13,6 +13,7 @@ const {
   captureUsageCost,
   captureUsageSettlement,
   isUsageSettlementSuccessSampled,
+  isAgentPerformanceLogSampled,
   resolveAgentAbortSource,
 } = require("../chat-logger");
 const { ChatSDKError } = require("../../errors");
@@ -251,7 +252,7 @@ describe("captureAgentRun", () => {
         selectedModel: "agent-model",
         configuredModelId: "deepseek/deepseek-v4-pro",
         responseModel: "deepseek/deepseek-v4-pro",
-        triggerRunId: "run_slow",
+        triggerRunId: "run_72",
         triggerUsageDurationMs: 130_000,
         requestToFirstModelStartMs: 2_000,
         requestToFirstModelChunkMs: 20_000,
@@ -274,7 +275,8 @@ describe("captureAgentRun", () => {
           event: "agent_performance_diagnostic",
           service: "agent-long",
           chat_id: "chat_slow",
-          trigger_run_id: "run_slow",
+          trigger_run_id: "run_72",
+          log_sample_rate: 0.01,
           configured_model: "deepseek/deepseek-v4-pro",
           upstream_provider: "DeepInfra",
           trigger_usage_duration_ms: 130_000,
@@ -292,6 +294,60 @@ describe("captureAgentRun", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it.each(["success", "aborted", "error"])(
+    "retains completion analytics while sampling slow %s logs",
+    (outcome) => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const capture = jest.fn();
+      try {
+        captureAgentRun({
+          posthog: { capture } as any,
+          userId: "user_123",
+          chatId: "chat_slow",
+          mode: "agent",
+          subscription: "pro",
+          sandboxInfo: null,
+          outcome,
+          selectedModel: "agent-model",
+          configuredModelId: "deepseek/deepseek-v4-pro",
+          triggerRunId: "run_0",
+          requestToFirstModelStartMs: 2_000,
+          requestToFirstModelChunkMs: 20_000,
+        });
+
+        expect(warnSpy).toHaveBeenCalledTimes(outcome === "error" ? 1 : 0);
+        if (outcome === "error") {
+          expect(JSON.parse(warnSpy.mock.calls[0][0] as string)).toEqual(
+            expect.objectContaining({ log_sample_rate: 1, outcome: "error" }),
+          );
+        }
+        expect(capture).toHaveBeenCalledTimes(1);
+        expect(capture).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: "hackerai-agent_run",
+            properties: expect.objectContaining({
+              outcome,
+              first_output_slow: true,
+              request_to_first_model_chunk_ms: 20_000,
+            }),
+          }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    },
+  );
+
+  it("selects a stable, small sample across representative run IDs", () => {
+    const ids = Array.from({ length: 10_000 }, (_, index) => `run_${index}`);
+    const sampled = ids.filter(isAgentPerformanceLogSampled);
+    expect(sampled.length).toBeGreaterThan(70);
+    expect(sampled.length).toBeLessThan(130);
+    expect(ids.filter(isAgentPerformanceLogSampled)).toEqual(sampled);
+    expect(isAgentPerformanceLogSampled("run_72")).toBe(true);
+    expect(isAgentPerformanceLogSampled("run_0")).toBe(false);
   });
 
   it("captures explicit step-limit and current-run todo measurements", () => {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -75,6 +75,7 @@ import {
 } from "@/lib/limit-pressure";
 
 export const USAGE_SETTLEMENT_SUCCESS_SAMPLE_RATE = 0.005;
+export const AGENT_PERFORMANCE_LOG_SAMPLE_RATE = 0.01;
 export const USAGE_PRICING_VERSION = `request-${NORMAL_USAGE_MULTIPLIER.toFixed(2)}-extra-${EXTRA_USAGE_REQUEST_MULTIPLIER.toFixed(2)}-v2`;
 
 const usagePricingAnalyticsProperties = {
@@ -88,10 +89,10 @@ const usagePricingAnalyticsProperties = {
   ),
 } as const;
 
-const usageSettlementSampleBucket = (usageSettlementId: string): number => {
+const telemetrySampleBucket = (id: string): number => {
   let hash = 2166136261;
-  for (let index = 0; index < usageSettlementId.length; index += 1) {
-    hash ^= usageSettlementId.charCodeAt(index);
+  for (let index = 0; index < id.length; index += 1) {
+    hash ^= id.charCodeAt(index);
     hash = Math.imul(hash, 16777619);
   }
   return (hash >>> 0) % 10_000;
@@ -100,8 +101,12 @@ const usageSettlementSampleBucket = (usageSettlementId: string): number => {
 export const isUsageSettlementSuccessSampled = (
   usageSettlementId: string,
 ): boolean =>
-  usageSettlementSampleBucket(usageSettlementId) <
+  telemetrySampleBucket(usageSettlementId) <
   USAGE_SETTLEMENT_SUCCESS_SAMPLE_RATE * 10_000;
+
+export const isAgentPerformanceLogSampled = (runId: string): boolean =>
+  telemetrySampleBucket(`agent-performance:${runId}`) <
+  AGENT_PERFORMANCE_LOG_SAMPLE_RATE * 10_000;
 
 export interface ChatLoggerConfig {
   chatId: string;
@@ -1414,12 +1419,18 @@ export function captureAgentRun({
       }
     : undefined;
 
+  // Keep complete percentile data on the existing completion event. Duplicate
+  // diagnostic logs retain errors and a stable 1% sample of other slow runs.
   if (
-    performanceDiagnostics?.firstOutputSlow ||
-    performanceDiagnostics?.runtimeSlow
+    (performanceDiagnostics?.firstOutputSlow ||
+      performanceDiagnostics?.runtimeSlow) &&
+    (outcome === "error" ||
+      isAgentPerformanceLogSampled(triggerRunId ?? chatId))
   ) {
     logger.warn("Slow agent run detected", {
       event: "agent_performance_diagnostic",
+      log_sample_rate:
+        outcome === "error" ? 1 : AGENT_PERFORMANCE_LOG_SAMPLE_RATE,
       service: "agent-long",
       chat_id: chatId,
       ...(triggerRunId && { trigger_run_id: triggerRunId }),


### PR DESCRIPTION
Slow Agent diagnostics currently emit a warning for every run with a first chunk after 15 seconds or runtime over two minutes. In the September 3–9 UTC review, 68,698 of 139,388 completion events met that condition, making ordinary long runs a noisy source of duplicate logs.

Keep all slow-error warnings and a deterministic 1% sample of slow successful/aborted runs, keyed by Trigger run ID with chat ID fallback. Retained warnings include `log_sample_rate`. The existing Agent completion event and its startup measurements stay unsampled, preserving percentile and outcome analysis. Expected duplicate warning volume falls about 98.9% at the observed traffic mix; actual error logging is unchanged.

The HAC-75 review still finds startup summaries to be the bottleneck. Its existing PostHog readout now separates actual pilot variants and outcomes and shows missing timing coverage over complete UTC days. The internal pilot has no recorded treatment completions yet, so HAC-75/HAC-102 remain open for the September 15 readout.

Validation: 63 focused logger/timing tests and the full suite (477 suites / 5,138 tests) passed. Required commit-hook formatting, lint and typecheck passed. No UI changed.

Manual verification after deployment: query `agent_performance_diagnostic` logs for `agent-long`; routine slow successes/aborts should be sampled with `log_sample_rate: 0.01`, and slow errors retained with rate 1. Check the [existing regression insight](https://us.posthog.com/project/144137/insights/Pt8cDlVX) still has full completion coverage. Use completion events, not sampled logs, for rates and percentiles.

Related: [HAC-75](https://linear.app/hackerai/issue/HAC-75/review-agent-startup-latency-telemetry-from-pr-1163).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic 1% sampling for slow, successful, and aborted agent runs.
  * Slow error runs continue to generate diagnostics without sampling.
  * Completion events remain available for aggregate performance metrics.
* **Documentation**
  * Added guidance for retaining startup timing counters and removing unused telemetry after pilot review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->