### PR TITLE
Refund renewal payments received after subscription cancellation

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -25,6 +25,9 @@ const mockListInvoiceLineItems = jest.fn();
 const mockRetrievePaymentIntent = jest.fn();
 const mockRetrieveCharge = jest.fn();
 const mockRetrievePrice = jest.fn();
+const mockListInvoicePayments = jest.fn();
+const mockListRefunds = jest.fn();
+const mockCreateRefund = jest.fn();
 const mockListMemberships = jest.fn();
 const mockConvexMutation = jest.fn();
 const mockFreezeRateLimitBucketForDelinquency = jest.fn();
@@ -77,6 +80,8 @@ jest.mock("@/app/api/stripe", () => ({
     prices: {
       retrieve: mockRetrievePrice,
     },
+    invoicePayments: { list: mockListInvoicePayments },
+    refunds: { list: mockListRefunds, create: mockCreateRefund },
   },
 }));
 
@@ -223,6 +228,110 @@ function subscriptionInvoiceLine(
       price_details: { price: priceId },
     },
   };
+}
+
+function mockLateRenewal() {
+  const endedAt = 1_788_889_078;
+  const paidAt = endedAt + 2050;
+  const price = {
+    id: "price_pro",
+    lookup_key: "pro-monthly-plan",
+    unit_amount: 2500,
+    recurring: { interval: "month", interval_count: 1 },
+    product: { id: "prod_pro", name: "HackerAI Pro", metadata: {} },
+  };
+  const invoice = {
+    id: "in_late",
+    customer: "cus_late",
+    status: "paid",
+    amount_paid: 2500,
+    currency: "usd",
+    livemode: false,
+    billing_reason: "subscription_cycle",
+    collection_method: "charge_automatically",
+    metadata: {},
+    status_transitions: { paid_at: paidAt },
+    parent: { subscription_details: { subscription: "sub_late" } },
+    lines: {
+      data: [subscriptionInvoiceLine("sub_late", "price_pro", 2500)],
+      has_more: false,
+    },
+  };
+  const subscription = {
+    id: "sub_late",
+    customer: "cus_late",
+    status: "canceled",
+    currency: "usd",
+    livemode: false,
+    latest_invoice: invoice.id,
+    ended_at: endedAt,
+    cancellation_details: { reason: "payment_failed" },
+    metadata: {},
+    items: { data: [{ quantity: 1, price }] },
+  };
+  const refund = {
+    id: "re_late",
+    status: "succeeded",
+    amount: 2500,
+    currency: "usd",
+    charge: "ch_late",
+    payment_intent: "pi_late",
+    created: paidAt + 1,
+    metadata: {
+      hackeraiReason: "subscription_payment_after_cancellation",
+      stripeInvoiceId: invoice.id,
+      stripeSubscriptionId: subscription.id,
+    },
+  };
+  mockConstructEvent.mockReturnValue({
+    id: "evt_late",
+    type: "invoice.paid",
+    created: paidAt,
+    data: { object: invoice },
+  });
+  mockRetrieveCustomer.mockResolvedValue({
+    id: "cus_late",
+    metadata: { workOSOrganizationId: "org_late" },
+  } as never);
+  mockListMemberships.mockResolvedValue({
+    autoPagination: jest.fn().mockResolvedValue([{ userId: "user_late" }]),
+  } as never);
+  mockRetrieveSubscription.mockResolvedValue(subscription as never);
+  mockRetrieveInvoice.mockResolvedValue(invoice as never);
+  mockRetrievePrice.mockResolvedValue(price as never);
+  mockListSubscriptions.mockReturnValue([subscription]);
+  mockListInvoicePayments.mockResolvedValue({
+    data: [
+      {
+        invoice: invoice.id,
+        amount_paid: 2500,
+        currency: "usd",
+        status_transitions: { paid_at: paidAt },
+        payment: { type: "payment_intent", payment_intent: "pi_late" },
+      },
+    ],
+    has_more: false,
+  } as never);
+  mockRetrievePaymentIntent.mockResolvedValue({
+    id: "pi_late",
+    status: "succeeded",
+    latest_charge: "ch_late",
+  } as never);
+  mockRetrieveCharge.mockResolvedValue({
+    id: "ch_late",
+    customer: "cus_late",
+    paid: true,
+    captured: true,
+    disputed: false,
+    amount: 2500,
+    amount_captured: 2500,
+    amount_refunded: 0,
+    currency: "usd",
+    livemode: false,
+  } as never);
+  mockListRefunds.mockReturnValue([]);
+  mockCreateRefund.mockResolvedValue(refund as never);
+  return { invoice, subscription, refund };
 }
 
 function mockInvoicePaymentFailedAnalytics({
@@ -542,6 +651,178 @@ describe("POST /api/subscription/webhook", () => {
         charged_amount_dollars: 29,
         stripe_price_id: "price_pro_29",
       }),
+    );
+  });
+
+  it.each(["succeeded", "pending"])(
+    "reconciles a late renewal with a %s refund without granting benefits or recovered MRR",
+    async (status) => {
+      const { refund } = mockLateRenewal();
+      mockCreateRefund.mockResolvedValue({ ...refund, status } as never);
+      const { POST } = await import("../route");
+      expect((await POST(makeWebhookRequest())).status).toBe(200);
+      expect(mockCreateRefund).toHaveBeenCalledTimes(1);
+      expect(mockResetRateLimitBucketAfterPayment).not.toHaveBeenCalled();
+      expect(mockConvexMutation).not.toHaveBeenCalledWith(
+        "referrals.setReferralCodesPaidEligibility",
+        expect.anything(),
+      );
+      expect(mockConvexMutation).toHaveBeenCalledWith(
+        "unitEconomics.recordRevenueEvent",
+        expect.objectContaining({
+          entityId: "user_late",
+          grossRevenueDollars: 25,
+          mrrDollars: undefined,
+          description: "late_payment_after_cancellation",
+        }),
+      );
+      expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+        PAID_FUNNEL_EVENTS.paymentRecovered,
+        expect.anything(),
+      );
+      expect(mockPostHogEvent).toHaveBeenCalledWith(
+        "billing_late_payment_reconciled",
+        expect.objectContaining({
+          reconciliation_status:
+            status === "succeeded" ? "refunded" : "refund_pending",
+          stripe_refund_id: refund.id,
+        }),
+      );
+    },
+  );
+
+  it.each(["customer", "subscription"])(
+    "retries a late renewal after a failed %s lookup",
+    async (lookup) => {
+      mockLateRenewal();
+      if (lookup === "customer")
+        mockRetrieveCustomer.mockRejectedValueOnce(
+          new Error("unavailable") as never,
+        );
+      else
+        mockRetrieveSubscription.mockRejectedValueOnce(
+          new Error("unavailable") as never,
+        );
+      const { POST } = await import("../route");
+      await expect(POST(makeWebhookRequest())).rejects.toThrow();
+      expect(mockCreateRefund).not.toHaveBeenCalled();
+      const marks = mockConvexMutation.mock.calls.filter(
+        ([mutation, args]) =>
+          mutation === "extraUsage.checkAndMarkWebhook" &&
+          !(args as { checkOnly?: boolean }).checkOnly,
+      );
+      expect(marks).toHaveLength(0);
+    },
+  );
+
+  it.each(["failed", "canceled", "requires_action"])(
+    "flags a %s late-payment refund for support",
+    async (status) => {
+      const { refund } = mockLateRenewal();
+      mockConstructEvent.mockReturnValue({
+        id: "evt_refund_update",
+        type: "refund.updated",
+        data: { object: { ...refund, status } },
+      });
+      const { POST } = await import("../route");
+      expect((await POST(makeWebhookRequest())).status).toBe(200);
+      expect(mockPostHogError).toHaveBeenCalledWith(
+        "billing_late_payment_requires_manual_reconciliation",
+        expect.objectContaining({
+          stripe_refund_id: refund.id,
+          reconciliation_reason: `refund_${status}`,
+        }),
+      );
+      expect(mockConvexMutation).not.toHaveBeenCalledWith(
+        "unitEconomics.recordRevenueEvent",
+        expect.anything(),
+      );
+    },
+  );
+
+  it("leaves compensated late payments for manual review", async () => {
+    const { subscription } = mockLateRenewal();
+    mockListSubscriptions.mockReturnValue([
+      subscription,
+      {
+        id: "sub_replacement",
+        status: "trialing",
+        created: subscription.ended_at + 1,
+      },
+    ]);
+    const { POST } = await import("../route");
+    expect((await POST(makeWebhookRequest())).status).toBe(200);
+    expect(mockCreateRefund).not.toHaveBeenCalled();
+    expect(mockResetRateLimitBucketAfterPayment).not.toHaveBeenCalled();
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_late_payment_requires_manual_reconciliation",
+      expect.objectContaining({
+        reconciliation_reason: "replacement_subscription_exists",
+      }),
+    );
+  });
+
+  it("retries an uncertain refund without marking the webhook complete", async () => {
+    const { refund } = mockLateRenewal();
+    mockCreateRefund.mockRejectedValueOnce(
+      new Error("connection reset") as never,
+    );
+    const { POST } = await import("../route");
+    await expect(POST(makeWebhookRequest())).rejects.toThrow(
+      "connection reset",
+    );
+    const marks = mockConvexMutation.mock.calls.filter(
+      ([mutation, args]) =>
+        mutation === "extraUsage.checkAndMarkWebhook" &&
+        !(args as { checkOnly?: boolean }).checkOnly,
+    );
+    expect(marks).toHaveLength(0);
+    // The first request may already have created the refund. A durable lookup
+    // prevents repeating it even after Stripe's idempotency cache expires.
+    mockListRefunds.mockReturnValue([refund]);
+    expect((await POST(makeWebhookRequest())).status).toBe(200);
+    expect(mockCreateRefund).toHaveBeenCalledTimes(1);
+  });
+
+  it("records late-payment refund accounting without legacy Charge.invoice", async () => {
+    const { refund } = mockLateRenewal();
+    mockConstructEvent.mockReturnValue({
+      id: "evt_late_refund",
+      type: "refund.created",
+      data: { object: refund },
+    });
+    const { POST } = await import("../route");
+    expect((await POST(makeWebhookRequest())).status).toBe(200);
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.objectContaining({
+        entityId: "user_late",
+        grossRevenueDollars: -25,
+        stripeInvoiceId: "in_late",
+        stripeSubscriptionId: "sub_late",
+      }),
+    );
+  });
+
+  it("rejects mismatched managed refund attribution", async () => {
+    const { refund } = mockLateRenewal();
+    mockConstructEvent.mockReturnValue({
+      id: "evt_late_refund",
+      type: "refund.created",
+      data: {
+        object: {
+          ...refund,
+          metadata: { ...refund.metadata, stripeSubscriptionId: "sub_other" },
+        },
+      },
+    });
+    const { POST } = await import("../route");
+    await expect(POST(makeWebhookRequest())).rejects.toThrow(
+      "attribution mismatch",
+    );
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.anything(),
     );
   });
 

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -677,7 +677,7 @@ describe("POST /api/subscription/webhook", () => {
         }),
       );
       expect(mockPostHogEvent).not.toHaveBeenCalledWith(
-        PAID_FUNNEL_EVENTS.paymentRecovered,
+        PAID_FUNNEL_EVENTS.billingPaymentRecovered,
         expect.anything(),
       );
       expect(mockPostHogEvent).toHaveBeenCalledWith(
@@ -804,7 +804,7 @@ describe("POST /api/subscription/webhook", () => {
     );
   });
 
-  it("rejects mismatched managed refund attribution", async () => {
+  it("records mismatched managed refund attribution for manual review", async () => {
     const { refund } = mockLateRenewal();
     mockConstructEvent.mockReturnValue({
       id: "evt_late_refund",
@@ -817,8 +817,18 @@ describe("POST /api/subscription/webhook", () => {
       },
     });
     const { POST } = await import("../route");
-    await expect(POST(makeWebhookRequest())).rejects.toThrow(
-      "attribution mismatch",
+    expect((await POST(makeWebhookRequest())).status).toBe(200);
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_late_payment_requires_manual_reconciliation",
+      expect.objectContaining({
+        stripe_refund_id: refund.id,
+        reconciliation_reason: "refund_attribution_mismatch",
+      }),
+    );
+    expect(mockPostHogFlush).toHaveBeenCalled();
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "extraUsage.checkAndMarkWebhook",
+      { serviceKey: "service_key", eventId: "evt_late_refund" },
     );
     expect(mockConvexMutation).not.toHaveBeenCalledWith(
       "unitEconomics.recordRevenueEvent",

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -41,6 +41,10 @@ import {
 import { includedUsagePointsForStripePrice } from "@/lib/billing/included-usage";
 import { recoverSubscriptionPayment } from "@/lib/billing/payment-method-recovery";
 import {
+  LATE_SUBSCRIPTION_PAYMENT_REFUND_REASON,
+  reconcileLateSubscriptionPayment,
+} from "@/lib/billing/late-subscription-payment";
+import {
   PAUSE_RESUME_CHECKOUT_TYPE,
   subscriptionPauseFromMetadata,
 } from "@/lib/billing/retention-offers";
@@ -1041,6 +1045,9 @@ async function handleInvoicePaid(
   const resetMode = getInvoicePaidBucketResetMode(invoice);
   const customerResult = await resolveUserIdsFromCustomer(customerId);
   const { userIds, orgId } = customerResult;
+  if (customerResult.reason === "lookup_failed") {
+    throw new Error("Paid invoice customer lookup failed");
+  }
 
   if (customerResult.reason === "legacy_user_metadata") {
     console.info(
@@ -1056,7 +1063,7 @@ async function handleInvoicePaid(
     return;
   }
 
-  const resolved = await resolveSubscription(subscriptionId);
+  const resolved = await resolveSubscription(subscriptionId, true);
   if (!resolved) {
     console.error(
       `[Subscription Webhook] Could not resolve subscription ${subscriptionId} for invoice ${invoice.id}`,
@@ -1125,6 +1132,53 @@ async function handleInvoicePaid(
       price: invoicePrice,
       invoicePaidEligible: false,
     });
+    const reconciliation = await reconcileLateSubscriptionPayment(
+      stripe,
+      invoice,
+      subscription,
+    );
+    if (reconciliation.status !== "not_applicable") {
+      const properties = {
+        stripe_event_id: stripeEventId,
+        stripe_invoice_id: invoice.id,
+        stripe_subscription_id: subscription.id,
+        stripe_customer_id: customerId,
+        reconciliation_status: reconciliation.status,
+        ...(reconciliation.status === "manual_review"
+          ? { reconciliation_reason: reconciliation.reason }
+          : { stripe_refund_id: reconciliation.refundId }),
+        amount_paid_dollars: centsToDollars(invoice.amount_paid),
+      };
+      for (const userId of userIds) {
+        phLogger.event("billing_late_payment_reconciled", {
+          userId,
+          ...properties,
+          $insert_id: `billing_late_payment_reconciled:${invoice.id}:${reconciliation.status}:${userId}`,
+        });
+      }
+      if (reconciliation.status === "manual_review") {
+        phLogger.error(
+          "billing_late_payment_requires_manual_reconciliation",
+          properties,
+        );
+      } else {
+        // Record the cash receipt without recovered MRR or paid access, so
+        // the refund webhook's negative revenue has a matching positive entry.
+        await recordSubscriptionRevenue({
+          invoice,
+          invoicePrice,
+          customerId,
+          userIds,
+          orgId: orgId ?? undefined,
+          tier,
+          subscription,
+          invoiceQuantity,
+          reason: "late_payment_after_cancellation",
+        });
+        phLogger.info("billing_late_payment_refund", properties);
+        return;
+      }
+    }
     phLogger.warn("billing_invoice_paid_ineligible_subscription_skipped", {
       event: "billing_invoice_paid_ineligible_subscription_skipped",
       userId: userIds[0],
@@ -1771,30 +1825,65 @@ async function handleSubscriptionRefund(
   stripeEventId: string,
   stripeEventType: "refund.created" | "refund.updated",
 ): Promise<void> {
-  if (refund.status !== "succeeded") return;
+  if (refund.status !== "succeeded") {
+    if (
+      refund.metadata?.hackeraiReason ===
+        LATE_SUBSCRIPTION_PAYMENT_REFUND_REASON &&
+      ["failed", "canceled", "requires_action"].includes(refund.status ?? "")
+    ) {
+      phLogger.error("billing_late_payment_requires_manual_reconciliation", {
+        stripe_event_id: stripeEventId,
+        stripe_refund_id: refund.id,
+        stripe_invoice_id: refund.metadata?.stripeInvoiceId,
+        stripe_subscription_id: refund.metadata?.stripeSubscriptionId,
+        reconciliation_status: "manual_review",
+        reconciliation_reason: `refund_${refund.status}`,
+      });
+    }
+    return;
+  }
 
   const chargeId = stripeObjectId(refund.charge);
   if (!chargeId || refund.amount <= 0) return;
 
   const charge = await stripe.charges.retrieve(chargeId);
-  const invoiceId = stripeObjectId(
+  const chargeInvoiceId = stripeObjectId(
     (charge as Stripe.Charge & { invoice?: string | Stripe.Invoice | null })
       .invoice,
   );
+  // Newer Stripe versions link invoices through Invoice Payments instead of
+  // Charge.invoice. Our late-payment refunds retain that verified allocation.
+  const managedLateRefund =
+    refund.metadata?.hackeraiReason === LATE_SUBSCRIPTION_PAYMENT_REFUND_REASON;
+  const invoiceId =
+    chargeInvoiceId ||
+    (managedLateRefund ? refund.metadata?.stripeInvoiceId : undefined);
   if (!invoiceId) return;
 
   const invoice = await stripe.invoices.retrieve(invoiceId);
   const subscriptionId = invoiceSubscriptionId(invoice);
   if (!subscriptionId) return;
+  if (
+    !chargeInvoiceId &&
+    (subscriptionId !== refund.metadata?.stripeSubscriptionId ||
+      !stripeObjectId(invoice.customer) ||
+      stripeObjectId(invoice.customer) !== stripeObjectId(charge.customer))
+  ) {
+    throw new Error("Late-payment refund invoice attribution mismatch");
+  }
 
-  const resolved = await resolveSubscription(subscriptionId);
+  const resolved = await resolveSubscription(subscriptionId, true);
   if (!resolved || resolved.kind === "legacy_pentestgpt") return;
 
   const customerId =
     stripeObjectId(invoice.customer) ?? stripeObjectId(charge.customer);
   if (!customerId) return;
 
-  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+  const customerResult = await resolveUserIdsFromCustomer(customerId);
+  if (customerResult.reason === "lookup_failed") {
+    throw new Error("Refund customer lookup failed");
+  }
+  const { userIds, orgId } = customerResult;
   if (userIds.length === 0) return;
 
   const refundAttribution = await subscriptionRefundPriceId(

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -1869,7 +1869,15 @@ async function handleSubscriptionRefund(
       !stripeObjectId(invoice.customer) ||
       stripeObjectId(invoice.customer) !== stripeObjectId(charge.customer))
   ) {
-    throw new Error("Late-payment refund invoice attribution mismatch");
+    phLogger.error("billing_late_payment_requires_manual_reconciliation", {
+      stripe_event_id: stripeEventId,
+      stripe_refund_id: refund.id,
+      stripe_invoice_id: invoice.id,
+      stripe_subscription_id: subscriptionId,
+      reconciliation_status: "manual_review",
+      reconciliation_reason: "refund_attribution_mismatch",
+    });
+    return;
   }
 
   const resolved = await resolveSubscription(subscriptionId, true);

--- a/docs/payment-method-recovery.md
+++ b/docs/payment-method-recovery.md
@@ -28,6 +28,36 @@ scan is bounded to 1,000 events and skips collection if history is incomplete or
 the customer event is older than Stripe's 30-day retention. API lookup failures
 retry webhook delivery. Restricted Stripe keys need Events read permission.
 
+## Payments received after cancellation
+
+Paying an old invoice cannot reactivate a canceled Stripe subscription. A renewal
+paid after cancellation for `payment_failed` is refunded automatically only when
+it is the subscription's latest automatic renewal invoice, with one fully paid
+PaymentIntent allocation and a matching, undisputed, fully captured charge.
+The handler checks current Stripe state before refunding. A replacement
+subscription, credit note, support resolution, partial payment, or unrelated
+refund requires manual reconciliation. Payments made before cancellation and
+voluntary cancellations are outside this policy.
+
+Refund creation uses an invoice/charge idempotency key and durable refund metadata
+for retries after Stripe's idempotency cache expires. API failures retry webhook
+delivery. Pending refunds stay pending; failed, canceled, or action-required refund
+updates raise `billing_late_payment_requires_manual_reconciliation`. Monitor this
+event alongside `billing_late_payment_reconciled`. A refund records offsetting cash
+revenue without restored access, recovered MRR, referral eligibility, or fresh
+usage credits. This change handles new webhook deliveries; it does not backfill
+previously processed payments.
+
+For a manual replacement month, first coordinate with any in-flight webhook and
+confirm no refund has been issued. Mark the original invoice's metadata
+`hackeraiLatePaymentResolution` with the chosen resolution before granting service,
+and retain the invoice reference on the replacement subscription. Recheck refunds
+afterward. A zero-dollar trial invoice does **not** refresh a previously frozen
+usage bucket: verify Stripe/WorkOS entitlements and restore the customer's monthly
+allowance separately against the verified production Redis database, preserving
+extra-usage balances and using the new subscription's period end. Verify a bounded
+chat after the customer refreshes their entitlement session.
+
 ## Release requirements
 
 1. Verify the intended account, deployment, custom domain, and environment before
@@ -46,6 +76,9 @@ retry webhook delivery. Restricted Stripe keys need Events read permission.
 4. Deploy the app and complete the sandbox journey below before claiming the
    production recovery behavior is verified. Existing tests mock Stripe, Convex,
    WorkOS, and access state; they are not a substitute for this journey.
+5. The late-payment refund path needs Invoice Payments read and Refunds read/write
+   access. Verify successful `refund.created` and `refund.updated` deliveries,
+   including when the Charge object has no legacy `invoice` field.
 
 ## Manual sandbox journey (required)
 
@@ -79,6 +112,12 @@ detaches existing methods and has no sandbox guard).
 8. Check an attachment-only event, a stale default-card event, and a canceled
    subscription: none initiates collection. Remove disposable test artifacts only
    after recording sanitized outcomes and confirming their exact IDs.
+9. In a separate sandbox case, let renewal failures cancel the subscription, then
+   pay its latest renewal invoice. Confirm exactly one full refund, no paid access
+   or usage reset, and offsetting revenue entries. Replay `invoice.paid` and refund
+   deliveries: no additional refund or accounting entry. Repeat with a credited
+   replacement subscription and with an existing partial refund: both require
+   manual review and must not create another refund.
 
 Measure recovered users/invoices within a fixed window after the first renewal
 failure, joining by subscription and invoice. Separate card selection, actual

--- a/lib/billing/__tests__/late-subscription-payment.test.ts
+++ b/lib/billing/__tests__/late-subscription-payment.test.ts
@@ -1,0 +1,293 @@
+import type Stripe from "stripe";
+import { reconcileLateSubscriptionPayment } from "../late-subscription-payment";
+
+const endedAt = 1_788_889_078;
+const paidAt = endedAt + 2050;
+
+function fixture() {
+  const subscription = {
+    id: "sub_ended",
+    customer: "cus_test",
+    status: "canceled",
+    currency: "usd",
+    livemode: false,
+    ended_at: endedAt,
+    latest_invoice: "in_late",
+    cancellation_details: { reason: "payment_failed" },
+  } as Stripe.Subscription;
+  const invoice = {
+    id: "in_late",
+    customer: "cus_test",
+    status: "paid",
+    billing_reason: "subscription_cycle",
+    collection_method: "charge_automatically",
+    amount_paid: 2500,
+    currency: "usd",
+    livemode: false,
+    metadata: {},
+    status_transitions: { paid_at: paidAt },
+    parent: { subscription_details: { subscription: subscription.id } },
+  } as Stripe.Invoice;
+  const payment = {
+    id: "inpay_late",
+    invoice: invoice.id,
+    amount_paid: 2500,
+    currency: "usd",
+    status_transitions: { paid_at: paidAt },
+    payment: { type: "payment_intent", payment_intent: "pi_late" },
+  } as Stripe.InvoicePayment;
+  const charge = {
+    id: "ch_late",
+    customer: "cus_test",
+    paid: true,
+    captured: true,
+    disputed: false,
+    amount: 2500,
+    amount_captured: 2500,
+    amount_refunded: 0,
+    currency: "usd",
+    livemode: false,
+  } as Stripe.Charge;
+  const refund = {
+    id: "re_late",
+    status: "succeeded",
+    metadata: {
+      hackeraiReason: "subscription_payment_after_cancellation",
+      stripeInvoiceId: invoice.id,
+    },
+  } as Stripe.Refund;
+  const retrieveInvoice = jest.fn().mockResolvedValue(invoice);
+  const listSubscriptions = jest.fn().mockReturnValue([subscription]);
+  const listPayments = jest
+    .fn()
+    .mockResolvedValue({ data: [payment], has_more: false });
+  const retrieveIntent = jest
+    .fn()
+    .mockResolvedValue({ status: "succeeded", latest_charge: charge.id });
+  const retrieveCharge = jest.fn().mockResolvedValue(charge);
+  const listRefunds = jest.fn().mockReturnValue([]);
+  const createRefund = jest.fn().mockResolvedValue(refund);
+  const stripe = {
+    invoices: { retrieve: retrieveInvoice },
+    subscriptions: { list: listSubscriptions },
+    invoicePayments: { list: listPayments },
+    paymentIntents: { retrieve: retrieveIntent },
+    charges: { retrieve: retrieveCharge },
+    refunds: { list: listRefunds, create: createRefund },
+  } as unknown as Stripe;
+  const run = () =>
+    reconcileLateSubscriptionPayment(stripe, invoice, subscription);
+  return {
+    run,
+    stripe,
+    invoice,
+    subscription,
+    payment,
+    charge,
+    refund,
+    retrieveInvoice,
+    listSubscriptions,
+    listPayments,
+    retrieveIntent,
+    retrieveCharge,
+    listRefunds,
+    createRefund,
+  };
+}
+
+describe("late subscription payments", () => {
+  it("refunds the exact renewal paid after automatic cancellation", async () => {
+    const f = fixture();
+    expect(await f.run()).toEqual({ status: "refunded", refundId: "re_late" });
+    expect(f.createRefund).toHaveBeenCalledWith(
+      {
+        charge: "ch_late",
+        amount: 2500,
+        metadata: { ...f.refund.metadata, stripeSubscriptionId: "sub_ended" },
+      },
+      { idempotencyKey: "late-subscription-payment:in_late:ch_late" },
+    );
+  });
+
+  it.each([endedAt - 1, endedAt])(
+    "does not refund a payment made before or at cancellation (%s)",
+    async (paid) => {
+      const f = fixture();
+      f.invoice.status_transitions.paid_at = paid;
+      expect(await f.run()).toEqual({ status: "not_applicable" });
+      expect(f.retrieveInvoice).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["cancellation_requested", "payment_disputed"] as const)(
+    "does not refund %s cancellations",
+    async (reason) => {
+      const f = fixture();
+      f.subscription.cancellation_details!.reason = reason;
+      expect(await f.run()).toEqual({ status: "not_applicable" });
+      expect(f.createRefund).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["active", "trialing", "past_due", "unpaid"] as const)(
+    "does not interfere with %s subscriptions",
+    async (status) => {
+      const f = fixture();
+      f.subscription.status = status;
+      expect(await f.run()).toEqual({ status: "not_applicable" });
+    },
+  );
+
+  it.each(["subscription_create", "subscription_update", "manual"] as const)(
+    "excludes %s invoices",
+    async (reason) => {
+      const f = fixture();
+      f.invoice.billing_reason = reason;
+      expect(await f.run()).toEqual({ status: "not_applicable" });
+    },
+  );
+
+  it("ignores historical invoices and zero-dollar settlements", async () => {
+    const f = fixture();
+    f.subscription.latest_invoice = "in_newer";
+    expect(await f.run()).toEqual({ status: "not_applicable" });
+    f.subscription.latest_invoice = f.invoice.id;
+    f.invoice.amount_paid = 0;
+    expect(await f.run()).toEqual({ status: "not_applicable" });
+  });
+
+  it("honors a support resolution recorded after the webhook snapshot", async () => {
+    const f = fixture();
+    f.retrieveInvoice.mockResolvedValue({
+      ...f.invoice,
+      metadata: { hackeraiLatePaymentResolution: "replacement_subscription" },
+    });
+    expect(await f.run()).toMatchObject({ status: "manual_review" });
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("does not refund a customer's manually replaced plan, even if it later ended", async () => {
+    const f = fixture();
+    f.listSubscriptions.mockReturnValue([
+      f.subscription,
+      { id: "sub_replacement", created: paidAt, status: "canceled" },
+    ]);
+    expect(await f.run()).toEqual({
+      status: "manual_review",
+      reason: "replacement_subscription_exists",
+    });
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("requires matching customer and environment on the refreshed invoice", async () => {
+    const f = fixture();
+    for (const override of [
+      { customer: "cus_other" },
+      { livemode: true },
+      { currency: "eur" },
+    ]) {
+      f.retrieveInvoice.mockResolvedValue({ ...f.invoice, ...override });
+      expect(await f.run()).toMatchObject({ status: "manual_review" });
+    }
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("leaves partial, multiple, external, and pre-cancellation payments for review", async () => {
+    const f = fixture();
+    for (const data of [
+      [],
+      [f.payment, f.payment],
+      [{ ...f.payment, amount_paid: 1000 }],
+      [{ ...f.payment, payment: { type: "payment_record" } }],
+      [{ ...f.payment, status_transitions: { paid_at: endedAt - 1 } }],
+    ]) {
+      f.listPayments.mockResolvedValue({ data, has_more: false });
+      expect(await f.run()).toMatchObject({ status: "manual_review" });
+    }
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("does not refund a charge larger than its invoice allocation or a disputed charge", async () => {
+    const f = fixture();
+    for (const override of [
+      { amount: 5000 },
+      { amount_captured: 1000 },
+      { disputed: true },
+      { customer: "cus_other" },
+    ]) {
+      f.retrieveCharge.mockResolvedValue({ ...f.charge, ...override });
+      expect(await f.run()).toMatchObject({ status: "manual_review" });
+    }
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "succeeded",
+    "pending",
+    "requires_action",
+    "failed",
+    "canceled",
+  ] as const)(
+    "reconciles an existing %s refund without another transfer",
+    async (status) => {
+      const f = fixture();
+      f.listRefunds.mockReturnValue([{ ...f.refund, status }]);
+      expect(await f.run()).toMatchObject({
+        status:
+          status === "succeeded"
+            ? "refunded"
+            : ["pending", "requires_action"].includes(status)
+              ? "refund_pending"
+              : "manual_review",
+      });
+      expect(f.createRefund).not.toHaveBeenCalled();
+    },
+  );
+
+  it("recognizes a completed refund after the customer resubscribes or support adds a note", async () => {
+    const f = fixture();
+    f.listRefunds.mockReturnValue([f.refund]);
+    f.listSubscriptions.mockReturnValue([
+      f.subscription,
+      { id: "sub_new", created: paidAt + 60, status: "active" },
+    ]);
+    f.retrieveInvoice.mockResolvedValue({
+      ...f.invoice,
+      metadata: { hackeraiLatePaymentResolution: "refunded" },
+    });
+    expect(await f.run()).toEqual({
+      status: "refunded",
+      refundId: f.refund.id,
+    });
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("leaves a support refund unchanged", async () => {
+    const f = fixture();
+    f.listRefunds.mockReturnValue([
+      { id: "re_support", metadata: {}, status: "pending" },
+    ]);
+    expect(await f.run()).toEqual({
+      status: "manual_review",
+      reason: "existing_refund",
+    });
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("does not report a pending refund as money returned", async () => {
+    const f = fixture();
+    f.createRefund.mockResolvedValue({ ...f.refund, status: "pending" });
+    expect(await f.run()).toEqual({
+      status: "refund_pending",
+      refundId: "re_late",
+    });
+  });
+
+  it("propagates uncertain failures and retries with identical refund parameters", async () => {
+    const f = fixture();
+    f.createRefund.mockRejectedValueOnce(new Error("connection lost"));
+    await expect(f.run()).rejects.toThrow("connection lost");
+    expect(await f.run()).toMatchObject({ status: "refunded" });
+    expect(f.createRefund.mock.calls[0]).toEqual(f.createRefund.mock.calls[1]);
+  });
+});

--- a/lib/billing/__tests__/late-subscription-payment.test.ts
+++ b/lib/billing/__tests__/late-subscription-payment.test.ts
@@ -262,6 +262,21 @@ describe("late subscription payments", () => {
     expect(f.createRefund).not.toHaveBeenCalled();
   });
 
+  it("finds the managed refund on a later page after a newer support refund", async () => {
+    const f = fixture();
+    f.listRefunds.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { id: "re_support", metadata: {}, status: "failed" };
+        yield f.refund;
+      },
+    });
+    expect(await f.run()).toEqual({
+      status: "refunded",
+      refundId: f.refund.id,
+    });
+    expect(f.createRefund).not.toHaveBeenCalled();
+  });
+
   it("leaves a support refund unchanged", async () => {
     const f = fixture();
     f.listRefunds.mockReturnValue([

--- a/lib/billing/late-subscription-payment.ts
+++ b/lib/billing/late-subscription-payment.ts
@@ -102,6 +102,8 @@ export async function reconcileLateSubscriptionPayment(
 
   // Stripe's idempotency cache expires. The durable refund itself protects
   // replays after that window and records pending/failed refunds explicitly.
+  let managedRefund: Stripe.Refund | undefined;
+  let otherRefundExists = false;
   for await (const refund of stripe.refunds.list({
     charge: chargeId,
     limit: 100,
@@ -111,18 +113,25 @@ export async function reconcileLateSubscriptionPayment(
         LATE_SUBSCRIPTION_PAYMENT_REFUND_REASON &&
       refund.metadata?.stripeInvoiceId === invoice.id
     ) {
-      if (refund.status === "succeeded")
-        return { status: "refunded", refundId: refund.id };
-      if (refund.status === "pending" || refund.status === "requires_action") {
-        return { status: "refund_pending", refundId: refund.id };
-      }
-      return { status: "manual_review", reason: "refund_failed_or_canceled" };
+      managedRefund ??= refund;
+    } else {
+      otherRefundExists = true;
     }
-    // A support refund may be a partial settlement. Do not expand it to a full
-    // refund or race another pending refund.
-    return { status: "manual_review", reason: "existing_refund" };
   }
-  if (charge.amount_refunded !== 0) {
+  if (managedRefund) {
+    if (managedRefund.status === "succeeded")
+      return { status: "refunded", refundId: managedRefund.id };
+    if (
+      managedRefund.status === "pending" ||
+      managedRefund.status === "requires_action"
+    ) {
+      return { status: "refund_pending", refundId: managedRefund.id };
+    }
+    return { status: "manual_review", reason: "refund_failed_or_canceled" };
+  }
+  // A support refund may be a partial settlement. Do not expand it to a full
+  // refund or race another pending refund.
+  if (otherRefundExists || charge.amount_refunded !== 0) {
     return { status: "manual_review", reason: "existing_refund" };
   }
 

--- a/lib/billing/late-subscription-payment.ts
+++ b/lib/billing/late-subscription-payment.ts
@@ -1,0 +1,174 @@
+import type Stripe from "stripe";
+import {
+  invoiceSubscriptionId,
+  stripeObjectId,
+} from "./subscription-payment-failure";
+
+type ReconciliationResult =
+  | { status: "not_applicable" }
+  | { status: "manual_review"; reason: string }
+  | { status: "refunded" | "refund_pending"; refundId: string };
+
+export const LATE_SUBSCRIPTION_PAYMENT_REFUND_REASON =
+  "subscription_payment_after_cancellation";
+
+/**
+ * A late renewal payment cannot reactivate a canceled Stripe subscription.
+ * Return an unambiguously unused payment instead of keeping money without
+ * access. Ambiguous allocations and existing replacement plans need support.
+ */
+export async function reconcileLateSubscriptionPayment(
+  stripe: Stripe,
+  snapshot: Stripe.Invoice,
+  subscription: Stripe.Subscription,
+): Promise<ReconciliationResult> {
+  const endedAt = subscription.ended_at;
+  const paidAt = snapshot.status_transitions?.paid_at;
+  if (
+    subscription.status !== "canceled" ||
+    subscription.cancellation_details?.reason !== "payment_failed" ||
+    !endedAt ||
+    !paidAt ||
+    paidAt <= endedAt ||
+    snapshot.status !== "paid" ||
+    snapshot.billing_reason !== "subscription_cycle" ||
+    snapshot.collection_method !== "charge_automatically" ||
+    snapshot.amount_paid <= 0 ||
+    invoiceSubscriptionId(snapshot) !== subscription.id ||
+    stripeObjectId(subscription.latest_invoice) !== snapshot.id
+  ) {
+    return { status: "not_applicable" };
+  }
+
+  // Webhooks are snapshots. Honor subsequent support adjustments before money
+  // moves, including a replacement month granted outside this handler.
+  const invoice = await stripe.invoices.retrieve(snapshot.id);
+  const customerId = stripeObjectId(subscription.customer);
+  if (
+    !customerId ||
+    stripeObjectId(invoice.customer) !== customerId ||
+    invoiceSubscriptionId(invoice) !== subscription.id ||
+    invoice.status !== "paid" ||
+    invoice.amount_paid !== snapshot.amount_paid ||
+    invoice.status_transitions.paid_at !== paidAt ||
+    invoice.currency !== subscription.currency ||
+    invoice.livemode !== subscription.livemode
+  ) {
+    return { status: "manual_review", reason: "invoice_changed_or_reconciled" };
+  }
+
+  // Never refund an entire charge allocated across multiple invoices, or infer
+  // a cash payment from amount_paid (which can include customer credit).
+  const payments = await stripe.invoicePayments.list({
+    invoice: invoice.id,
+    status: "paid",
+    limit: 2,
+  });
+  const payment = payments.data[0];
+  if (
+    payments.has_more ||
+    payments.data.length !== 1 ||
+    !payment ||
+    stripeObjectId(payment.invoice) !== invoice.id ||
+    payment.amount_paid !== invoice.amount_paid ||
+    payment.currency !== invoice.currency ||
+    !payment.status_transitions.paid_at ||
+    payment.status_transitions.paid_at <= endedAt ||
+    payment.payment.type !== "payment_intent"
+  ) {
+    return { status: "manual_review", reason: "ambiguous_payment_allocation" };
+  }
+  const intentId = stripeObjectId(payment.payment.payment_intent);
+  if (!intentId)
+    return { status: "manual_review", reason: "missing_payment_intent" };
+  const intent = await stripe.paymentIntents.retrieve(intentId);
+  const chargeId = stripeObjectId(intent.latest_charge);
+  if (!chargeId || intent.status !== "succeeded") {
+    return { status: "manual_review", reason: "payment_not_settled" };
+  }
+  const charge = await stripe.charges.retrieve(chargeId);
+  if (
+    !charge.paid ||
+    !charge.captured ||
+    charge.disputed ||
+    charge.amount !== invoice.amount_paid ||
+    charge.amount_captured !== invoice.amount_paid ||
+    charge.currency !== invoice.currency ||
+    charge.livemode !== invoice.livemode ||
+    stripeObjectId(charge.customer) !== customerId
+  ) {
+    return { status: "manual_review", reason: "charge_not_safely_refundable" };
+  }
+
+  // Stripe's idempotency cache expires. The durable refund itself protects
+  // replays after that window and records pending/failed refunds explicitly.
+  for await (const refund of stripe.refunds.list({
+    charge: chargeId,
+    limit: 100,
+  })) {
+    if (
+      refund.metadata?.hackeraiReason ===
+        LATE_SUBSCRIPTION_PAYMENT_REFUND_REASON &&
+      refund.metadata?.stripeInvoiceId === invoice.id
+    ) {
+      if (refund.status === "succeeded")
+        return { status: "refunded", refundId: refund.id };
+      if (refund.status === "pending" || refund.status === "requires_action") {
+        return { status: "refund_pending", refundId: refund.id };
+      }
+      return { status: "manual_review", reason: "refund_failed_or_canceled" };
+    }
+    // A support refund may be a partial settlement. Do not expand it to a full
+    // refund or race another pending refund.
+    return { status: "manual_review", reason: "existing_refund" };
+  }
+  if (charge.amount_refunded !== 0) {
+    return { status: "manual_review", reason: "existing_refund" };
+  }
+
+  // Existing managed refunds above must remain recognizable on retries even
+  // if support or the customer subsequently changes their subscription.
+  if (
+    invoice.metadata?.hackeraiLatePaymentResolution ||
+    invoice.pre_payment_credit_notes_amount > 0 ||
+    invoice.post_payment_credit_notes_amount > 0
+  ) {
+    return { status: "manual_review", reason: "invoice_changed_or_reconciled" };
+  }
+
+  for await (const other of stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 100,
+  })) {
+    if (
+      other.id !== subscription.id &&
+      (other.created >= endedAt ||
+        !["canceled", "incomplete_expired"].includes(other.status))
+    ) {
+      return {
+        status: "manual_review",
+        reason: "replacement_subscription_exists",
+      };
+    }
+  }
+
+  const refund = await stripe.refunds.create(
+    {
+      charge: chargeId,
+      amount: invoice.amount_paid,
+      metadata: {
+        hackeraiReason: LATE_SUBSCRIPTION_PAYMENT_REFUND_REASON,
+        stripeInvoiceId: invoice.id,
+        stripeSubscriptionId: subscription.id,
+      },
+    },
+    { idempotencyKey: `late-subscription-payment:${invoice.id}:${chargeId}` },
+  );
+  if (refund.status === "succeeded")
+    return { status: "refunded", refundId: refund.id };
+  if (refund.status === "pending" || refund.status === "requires_action") {
+    return { status: "refund_pending", refundId: refund.id };
+  }
+  return { status: "manual_review", reason: "refund_failed_or_canceled" };
+}


### PR DESCRIPTION
## Problem

Stripe can accept payment of a renewal invoice after failed retries have already canceled its subscription. The existing webhook correctly withheld paid benefits but left the customer charged without restored access.

## Change

Refund qualifying renewals paid after a `payment_failed` cancellation. Require the latest automatic renewal invoice, one full PaymentIntent allocation, and a matching undisputed captured charge. Support resolutions, replacement subscriptions, credit notes, ambiguous allocations, and unrelated refunds require manual reconciliation.

Use a stable idempotency key plus durable refund metadata to prevent duplicate refunds across retries. Recognize an existing refund even if the customer subsequently resubscribes. Preserve webhook retries on lookup failures, report failed/action-required refunds, and record offsetting revenue without recovered MRR or usage resets. Managed refund accounting also works without the legacy `Charge.invoice` field.

## Validation

- Required pre-commit checks passed: 478 Jest suites / 5,187 tests, TypeScript, and staged formatting/lint.
- Regression coverage includes late versus pre-cancellation payments, voluntary cancellation, manual replacements, partial/disputed charges, pending/failed refunds, duplicate deliveries, lookup failures, and refund attribution.
- Backend-only change; no UI changes. No production deployment or historical webhook replay is included.

## Required manual verification before production rollout

- [ ] In the designated Preview environment with a Stripe sandbox customer, cancel a subscription through failed renewal retries, then pay its latest renewal invoice. Verify one full refund, no restored benefits, and offsetting revenue.
- [ ] Replay invoice/refund deliveries and confirm no duplicate refund, revenue entry, or usage reset. Repeat with a replacement subscription and an existing partial refund; both must require manual review.
- [ ] Verify Invoice Payments read / Refunds read-write permissions and successful `refund.created` and `refund.updated` deliveries, including pending-to-failed status changes.

See `docs/payment-method-recovery.md` for environment boundaries and the full verification procedure. The separate customer remediation is recorded in Stripe and is excluded from automatic refunds by the support-resolution marker and replacement-subscription check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added handling for payments received after a subscription is canceled.
  * Eligible late payments can be safely refunded without restoring subscription access or recurring revenue.
  * Existing, pending, and failed refunds are recognized to prevent duplicate processing.
  * Payment, customer, subscription, and refund mismatches are flagged for manual reconciliation.

* **Documentation**
  * Added guidance for late-payment refunds, retry safety, entitlement handling, and sandbox verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->