### PR TITLE
fix: use DeepSeek V4.1 Flash for vision routes

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -142,9 +142,7 @@ describe("provider registry", () => {
     ).toBe("minimax/minimax-m3");
     expect(AUXILIARY_VISION_SLUG).toBe("minimax/minimax-m3");
     expect(GLM_5_3_FLASH_SLUG).toBe("z-ai/glm-5.3-flash");
-    expect(DEEPSEEK_V4_FLASH_VISION_SLUG).toBe(
-      "deepseek/deepseek-v4-flash-vision-exp",
-    );
+    expect(DEEPSEEK_V4_FLASH_VISION_SLUG).toBe("deepseek/deepseek-v4.1-flash");
     expect(
       (myProvider.languageModel("model-glm-5.3-flash") as { modelId: string })
         .modelId,
@@ -1342,6 +1340,9 @@ describe("supportsMultimodalToolResults", () => {
     expect(supportsMultimodalToolResults(DEEPSEEK_V4_FLASH_VISION_SLUG)).toBe(
       true,
     );
+    expect(
+      supportsMultimodalToolResults("deepseek/deepseek-v4.1-flash-20260910"),
+    ).toBe(true);
     expect(supportsMultimodalToolResults("model-grok-4.5")).toBe(true);
     expect(supportsMultimodalToolResults("model-grok-4.5-pro")).toBe(true);
     expect(supportsMultimodalToolResults("model-grok-4.6-pro")).toBe(true);

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1203,8 +1203,8 @@ export const GLM_5_3_SLUG = "z-ai/glm-5.3";
 export const GLM_5_3_FLASH_SLUG = "z-ai/glm-5.3-flash";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
 export const GROK_4_6_SLUG = "x-ai/grok-4.6";
-export const DEEPSEEK_V4_FLASH_VISION_SLUG =
-  "deepseek/deepseek-v4-flash-vision-exp";
+// Preserve the internal vision route keys while upgrading the provider model.
+export const DEEPSEEK_V4_FLASH_VISION_SLUG = "deepseek/deepseek-v4.1-flash";
 export const MINIMAX_M3_SLUG = "minimax/minimax-m3";
 // MiniMax is deliberately isolated to the final text-summary recovery. Normal
 // image turns route the original pixels through GLM Flash and then DeepSeek
@@ -1331,8 +1331,8 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-glm-5.3-flash": "Z.ai GLM 5.3 Flash",
   "model-glm-5.3-flash-pro": "Z.ai GLM 5.3 Flash",
   "model-glm-5.3-flash-agent": "Z.ai GLM 5.3 Flash",
-  "model-deepseek-v4-flash-vision": "DeepSeek V4 Flash Vision",
-  "model-deepseek-v4-flash-vision-pro": "DeepSeek V4 Flash Vision",
+  "model-deepseek-v4-flash-vision": "DeepSeek V4.1 Flash",
+  "model-deepseek-v4-flash-vision-pro": "DeepSeek V4.1 Flash",
   "model-kimi-k3": "Moonshot Kimi K3",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
@@ -1410,6 +1410,8 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
     normalized === "model-deepseek-v4-flash-vision-pro" ||
     normalized.includes("z-ai/glm-5.3-flash") ||
     normalized.includes("deepseek-v4-flash-vision") ||
+    normalized === DEEPSEEK_V4_FLASH_VISION_SLUG ||
+    normalized === "deepseek/deepseek-v4.1-flash-20260910" ||
     isKimiModel(normalized) ||
     isGrokModel(normalized) ||
     isAnthropicModel(normalized) ||

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -33,7 +33,7 @@ const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 const GLM_5_2_SLUG = "z-ai/glm-5.2";
 const GLM_SLUG = "z-ai/glm-5.3";
 const GLM_FLASH_SLUG = "z-ai/glm-5.3-flash";
-const DEEPSEEK_VISION_SLUG = "deepseek/deepseek-v4-flash-vision-exp";
+const DEEPSEEK_VISION_SLUG = "deepseek/deepseek-v4.1-flash";
 const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash-0731";
 const DEEPSEEK_FLASH_CANONICAL_SLUG = "deepseek/deepseek-v4-flash-20260731";
 const DEEPSEEK_FLASH_PREVIOUS_SLUG = "deepseek/deepseek-v4-flash";
@@ -1117,6 +1117,22 @@ describe("getContentFilterRetryModel", () => {
 });
 
 describe("resolveServedModelForCostAccounting", () => {
+  it.each([
+    "deepseek/deepseek-v4.1-flash",
+    "deepseek/deepseek-v4.1-flash-20260910",
+  ])(
+    "maps DeepSeek V4.1 vision response %s to its cost key",
+    (responseModel) => {
+      expect(
+        resolveServedModelForCostAccounting({
+          modelName: "model-glm-5.3-flash",
+          responseModel,
+          mode: "agent",
+        }),
+      ).toBe("model-deepseek-v4-flash-vision");
+    },
+  );
+
   it("preserves the previous DeepSeek Flash slug for legacy route pricing", () => {
     expect(
       resolveServedModelForCostAccounting({

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -929,6 +929,7 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, string> = {
   "z-ai/glm-5.3-20260816": "model-glm-5.3",
   [GLM_5_3_FLASH_SLUG]: "model-glm-5.3-flash",
   [DEEPSEEK_V4_FLASH_VISION_SLUG]: "model-deepseek-v4-flash-vision",
+  "deepseek/deepseek-v4.1-flash-20260910": "model-deepseek-v4-flash-vision",
   "moonshotai/kimi-k3": "model-kimi-k3",
   "moonshotai/kimi-k3-20260715": "model-kimi-k3",
 };

--- a/lib/experiments/__tests__/flash-routing.test.ts
+++ b/lib/experiments/__tests__/flash-routing.test.ts
@@ -141,7 +141,7 @@ describe("Flash routing experiments", () => {
       requestId: "request-1",
     });
     expect(capture).not.toHaveBeenCalled();
-    record("deepseek/deepseek-v4-flash-vision-exp");
+    record("deepseek/deepseek-v4.1-flash");
     expect(capture).not.toHaveBeenCalled();
     record("z-ai/glm-5.3-flash");
     record("z-ai/glm-5.3-flash");

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -581,14 +581,29 @@ describe("token-bucket", () => {
     it.each([
       "model-deepseek-v4-flash-vision",
       "model-deepseek-v4-flash-vision-pro",
-      "deepseek/deepseek-v4-flash-vision-exp",
+      "deepseek/deepseek-v4.1-flash",
+      "deepseek/deepseek-v4.1-flash-20260910",
     ])(
-      "should use the DeepSeek vision peak ceiling for %s ($0.44/$1.32)",
+      "should use the DeepSeek V4.1 Flash peak ceiling for %s ($0.30/$1.20)",
       (modelName) => {
-        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(6600);
-        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(19800);
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(4500);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(18000);
+        expect(
+          calculateRawModelUsageCostDollars({
+            inputTokens: 1_000_000,
+            outputTokens: 1_000_000,
+            cacheReadTokens: 500_000,
+            modelName,
+          }),
+        ).toBeCloseTo(1.353);
       },
     );
+
+    it("preserves historical experimental vision pricing", () => {
+      const modelName = "deepseek/deepseek-v4-flash-vision-exp";
+      expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(6600);
+      expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(19800);
+    });
 
     it.each(["model-kimi-k3", "model-opus-4.6"])(
       "should use Kimi K3 pricing for %s ($3.00/$15.00)",

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -128,6 +128,13 @@ const DEEPSEEK_V4_FLASH_VISION_PRICING: ModelPricing = {
   cacheRead: 0.014,
   cacheWrite: 0.44,
 };
+// Use the weekday peak ceiling from OpenRouter, including cached input.
+const DEEPSEEK_V4_1_FLASH_PRICING: ModelPricing = {
+  input: 0.3,
+  output: 1.2,
+  cacheRead: 0.006,
+  cacheWrite: 0.3,
+};
 const KIMI_K3_PRICING: ModelPricing = {
   input: 3.0,
   output: 15.0,
@@ -162,8 +169,8 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "model-deepseek-v4-flash-0731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "model-deepseek-v4-pro-0813": DEEPSEEK_V4_PRO_PRICING,
-  "model-deepseek-v4-flash-vision": DEEPSEEK_V4_FLASH_VISION_PRICING,
-  "model-deepseek-v4-flash-vision-pro": DEEPSEEK_V4_FLASH_VISION_PRICING,
+  "model-deepseek-v4-flash-vision": DEEPSEEK_V4_1_FLASH_PRICING,
+  "model-deepseek-v4-flash-vision-pro": DEEPSEEK_V4_1_FLASH_PRICING,
   // Persisted Max compatibility key; the active provider route is Kimi K3.
   "model-opus-4.6": KIMI_K3_PRICING,
   // Baseline OpenRouter rates: $0.76 in / $2.42 out per 1M tokens.
@@ -186,6 +193,8 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "deepseek/deepseek-v4-flash-20260731": DEEPSEEK_V4_FLASH_0731_PRICING,
   "deepseek/deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
   "deepseek/deepseek-v4-pro-0813": DEEPSEEK_V4_PRO_PRICING,
+  "deepseek/deepseek-v4.1-flash": DEEPSEEK_V4_1_FLASH_PRICING,
+  "deepseek/deepseek-v4.1-flash-20260910": DEEPSEEK_V4_1_FLASH_PRICING,
   "deepseek/deepseek-v4-flash-vision-exp": DEEPSEEK_V4_FLASH_VISION_PRICING,
   "anthropic/claude-opus-4.6": OPUS_4_6_PRICING,
   "z-ai/glm-5.2": GLM_5_2_PRICING,


### PR DESCRIPTION
DeepSeek vision requests in Ask and Agent now use `deepseek/deepseek-v4.1-flash` instead of the experimental V4 vision model. Existing internal Standard/Pro keys, reasoning settings, routing gates, and recovery paths are preserved.

Update model naming and image-tool capability detection, normalize the dated `20260910` response ID, and use OpenRouter's weekday peak pricing ceiling ($0.30 input / $1.20 output / $0.006 cached input per million tokens). Historical experimental-model responses retain their previous pricing. Model capabilities and pricing were verified against the [OpenRouter model catalog](https://openrouter.ai/api/v1/models).

Validation: commit hooks passed formatting, ESLint, TypeScript, and all 477 Jest suites (5,152 tests), including provider mapping, multimodal support, fallback accounting, cache pricing, and experiment exposure coverage.

Manual verification remaining: on the PR Preview with its matching Trigger Preview worker, create disposable Standard and Pro chats, attach a small image, and ask for its contents. Exercise the DeepSeek vision route in Ask and Agent, confirm a completed visible response and the served V4.1 Flash model, then reload and confirm persistence. Also verify Agent image-tool output and recovery after a failed vision attempt. Live authenticated verification is blocked: the PR branch URL loads, but Chrome sign-in redirects to `hackerai-ofjqwtz9q-hackerai.vercel.app` (toolbar deployment `dpl_HqHxGbTXRCXtqxbAo1tjVrRGeHHM`), different from this PR deployment `GFTJfow8nku1Dd1EZAY4aSuTuHGY`. No test chats were created on that other deployment.

Rollout: deploy the merged change to both Vercel and Trigger for their respective Ask and Agent runtimes. This PR does not change feature flag assignments or environment configuration.
