### PR TITLE
Fix stalled provider recovery in long Agent runs

### DIFF
--- a/lib/ai/__tests__/provider-stream-timeout.test.ts
+++ b/lib/ai/__tests__/provider-stream-timeout.test.ts
@@ -1,0 +1,247 @@
+import { stepCountIs, streamText, tool, type LanguageModel } from "ai";
+import { WritableStream } from "node:stream/web";
+import { z } from "zod";
+import { withProviderStreamTimeout } from "../provider-stream-timeout";
+import { isRetriableProviderStreamDisconnectError } from "@/lib/utils/error-utils";
+
+const makeModel = (doStream: jest.Mock): LanguageModel => ({
+  specificationVersion: "v3",
+  provider: "test",
+  modelId: "test-model",
+  supportedUrls: {},
+  doStream,
+  doGenerate: jest.fn(),
+});
+const open = async (model: LanguageModel, abortSignal?: AbortSignal) => {
+  if (typeof model === "string") throw new Error("Expected model object");
+  return model.doStream({ prompt: [], abortSignal });
+};
+const finish = (reason = "stop") => ({
+  type: "finish",
+  finishReason: { unified: reason, raw: reason },
+  usage: {
+    inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 1, text: 1, reasoning: 0 },
+  },
+});
+
+const originalWritableStream = globalThis.WritableStream;
+beforeAll(() => {
+  Object.defineProperty(globalThis, "WritableStream", {
+    configurable: true,
+    value: WritableStream,
+  });
+});
+afterAll(() => {
+  Object.defineProperty(globalThis, "WritableStream", {
+    configurable: true,
+    value: originalWritableStream,
+  });
+});
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
+
+it("bounds a request that never resolves, aborts upstream, and cleans up a late response", async () => {
+  let resolve!: (value: unknown) => void;
+  let signal!: AbortSignal;
+  const onTimeout = jest.fn();
+  const doStream = jest.fn((params) => {
+    signal = params.abortSignal;
+    return new Promise((r) => {
+      resolve = r;
+    });
+  });
+  const pending = open(
+    withProviderStreamTimeout(makeModel(doStream), {
+      timeoutMs: 1000,
+      onTimeout,
+    }),
+  );
+  const rejected = expect(pending).rejects.toThrow(
+    "Provider response timed out",
+  );
+  await jest.advanceTimersByTimeAsync(1000);
+  await rejected;
+  expect(signal.aborted).toBe(true);
+  expect(onTimeout).toHaveBeenCalledWith({
+    phase: "response",
+    timeoutMs: 1000,
+    modelId: "test-model",
+  });
+  const cancel = jest.fn();
+  resolve({ stream: new ReadableStream({ cancel }) });
+  await jest.advanceTimersByTimeAsync(0);
+  expect(cancel).toHaveBeenCalledTimes(1);
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+it("resets the deadline after each chunk and emits a recoverable error without aborting the run", async () => {
+  let source!: ReadableStreamDefaultController;
+  const cancel = jest.fn(() => new Promise<void>(() => {}));
+  const onTimeout = jest.fn(() => {
+    throw new Error("logger offline");
+  });
+  const run = new AbortController();
+  const response = await open(
+    withProviderStreamTimeout(
+      makeModel(
+        jest.fn(async () => ({
+          stream: new ReadableStream({
+            start(c) {
+              source = c;
+            },
+            cancel,
+          }),
+        })),
+      ),
+      { timeoutMs: 1000, onTimeout },
+    ),
+    run.signal,
+  );
+  const reader = response.stream.getReader();
+  for (let index = 0; index < 3; index++) {
+    const next = reader.read();
+    await jest.advanceTimersByTimeAsync(900);
+    source.enqueue({ type: "text-delta", id: "text", delta: "a" });
+    expect((await next).done).toBe(false);
+  }
+  const failed = reader.read();
+  await jest.advanceTimersByTimeAsync(1000);
+  const part = (await failed).value;
+  expect(part.type).toBe("error");
+  const error = part.error;
+  expect(isRetriableProviderStreamDisconnectError(error)).toBe(true);
+  expect(run.signal.aborted).toBe(false);
+  expect(onTimeout).toHaveBeenCalledTimes(1);
+  expect(cancel).toHaveBeenCalledTimes(1);
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+it("does not time downstream pauses, and disposes timers when canceled", async () => {
+  const cancel = jest.fn();
+  const onTimeout = jest.fn();
+  const response = await open(
+    withProviderStreamTimeout(
+      makeModel(
+        jest.fn(async () => ({
+          stream: new ReadableStream({ cancel }),
+        })),
+      ),
+      { timeoutMs: 1000, onTimeout },
+    ),
+  );
+  await jest.advanceTimersByTimeAsync(10000);
+  expect(onTimeout).not.toHaveBeenCalled();
+  const reader = response.stream.getReader();
+  const pending = reader.read();
+  await jest.advanceTimersByTimeAsync(100);
+  await reader.cancel();
+  await pending;
+  await jest.advanceTimersByTimeAsync(2000);
+  expect(cancel).toHaveBeenCalledTimes(1);
+  expect(onTimeout).not.toHaveBeenCalled();
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+it.each(["before_request", "during_request", "during_chunk"])(
+  "preserves user cancellation %s without timeout telemetry",
+  async (phase) => {
+    const run = new AbortController();
+    const reason = new DOMException("Stopped by user", "AbortError");
+    const onTimeout = jest.fn();
+    const doStream = jest.fn(() =>
+      phase === "during_request"
+        ? new Promise(() => {})
+        : Promise.resolve({ stream: new ReadableStream() }),
+    );
+    const model = withProviderStreamTimeout(makeModel(doStream), {
+      timeoutMs: 1000,
+      onTimeout,
+    });
+    if (phase === "before_request") run.abort(reason);
+    const response = open(model, run.signal);
+    const pending =
+      phase === "during_chunk"
+        ? (await response).stream.getReader().read()
+        : response;
+    const rejected = expect(pending).rejects.toBe(reason);
+    await jest.advanceTimersByTimeAsync(0);
+    run.abort(reason);
+    await rejected;
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+    if (phase === "before_request") expect(doStream).not.toHaveBeenCalled();
+  },
+);
+
+it("lets a real SDK tool wait longer than the provider timeout and complete the next step", async () => {
+  const execute = jest.fn(
+    () =>
+      new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 5000)),
+  );
+  const doStream = jest.fn(async () => ({
+    stream: new ReadableStream({
+      start(output) {
+        if (doStream.mock.calls.length === 1) {
+          output.enqueue({
+            type: "tool-call",
+            toolCallId: "once",
+            toolName: "wait",
+            input: "{}",
+          });
+          output.enqueue(finish("tool-calls"));
+        } else {
+          output.enqueue({ type: "text-start", id: "done" });
+          output.enqueue({ type: "text-delta", id: "done", delta: "Finished" });
+          output.enqueue({ type: "text-end", id: "done" });
+          output.enqueue(finish());
+        }
+        output.close();
+      },
+    }),
+  }));
+  const onTimeout = jest.fn();
+  const onError = jest.fn();
+  const result = streamText({
+    model: withProviderStreamTimeout(makeModel(doStream), {
+      timeoutMs: 1000,
+      onTimeout,
+    }),
+    prompt: "Wait, then report",
+    tools: { wait: tool({ inputSchema: z.object({}), execute }) },
+    stopWhen: stepCountIs(3),
+    maxRetries: 0,
+    onError,
+  });
+  const completed = result.consumeStream();
+  await jest.advanceTimersByTimeAsync(6000);
+  await completed;
+  expect(await result.text).toBe("Finished");
+  expect(execute).toHaveBeenCalledTimes(1);
+  expect(onTimeout).not.toHaveBeenCalled();
+  expect(onError).not.toHaveBeenCalled();
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+it("reports a stalled initial request through the SDK error callback rather than user cancellation", async () => {
+  const onError = jest.fn();
+  const onAbort = jest.fn();
+  const doStream = jest.fn(() => new Promise(() => {}));
+  const result = streamText({
+    model: withProviderStreamTimeout(makeModel(doStream), { timeoutMs: 1000 }),
+    prompt: "Respond",
+    maxRetries: 0,
+    onError,
+    onAbort,
+  });
+  const completed = result.consumeStream();
+  await jest.advanceTimersByTimeAsync(1100);
+  await completed;
+  expect(onError).toHaveBeenCalledTimes(1);
+  expect(
+    isRetriableProviderStreamDisconnectError(onError.mock.calls[0][0].error),
+  ).toBe(true);
+  expect(onAbort).not.toHaveBeenCalled();
+  expect(jest.getTimerCount()).toBe(0);
+});

--- a/lib/ai/provider-stream-timeout.ts
+++ b/lib/ai/provider-stream-timeout.ts
@@ -1,0 +1,172 @@
+import {
+  wrapLanguageModel,
+  type LanguageModel,
+  type LanguageModelMiddleware,
+} from "ai";
+
+type StreamResult = Awaited<
+  ReturnType<
+    Parameters<
+      NonNullable<LanguageModelMiddleware["wrapStream"]>
+    >[0]["doStream"]
+  >
+>;
+type StreamPart =
+  StreamResult["stream"] extends ReadableStream<infer T> ? T : never;
+
+export const AGENT_PROVIDER_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type ProviderStreamTimeoutDetails = {
+  phase: "response" | "chunk";
+  timeoutMs: number;
+  modelId: string;
+};
+
+export type ProviderStreamTimeoutOptions = {
+  timeoutMs: number;
+  onTimeout?: (details: ProviderStreamTimeoutDetails) => void;
+};
+
+class ProviderStreamTimeoutError extends Error {
+  name = "ProviderStreamTimeoutError";
+}
+
+/** Bound provider I/O without timing tool execution or durable approval waits. */
+export function withProviderStreamTimeout(
+  model: LanguageModel,
+  options: ProviderStreamTimeoutOptions,
+): LanguageModel {
+  if (typeof model === "string" || model.specificationVersion !== "v3") {
+    return model;
+  }
+
+  return wrapLanguageModel({
+    model,
+    middleware: {
+      specificationVersion: "v3",
+      wrapStream: async ({ model: provider, params }) => {
+        const controller = new AbortController();
+        let pendingReject: ((reason: unknown) => void) | undefined;
+        let reader: ReadableStreamDefaultReader<StreamPart> | undefined;
+        let disposed = false;
+
+        const dispose = () => {
+          disposed = true;
+          params.abortSignal?.removeEventListener("abort", onAbort);
+        };
+        const cancelProvider = (reason: unknown) => {
+          controller.abort(reason);
+          // A broken provider must not block timeout settlement on cancellation.
+          void reader?.cancel(reason).catch(() => undefined);
+        };
+        const onAbort = () => {
+          const reason = params.abortSignal?.reason;
+          pendingReject?.(reason);
+          cancelProvider(reason);
+          dispose();
+        };
+
+        // Each read gets its own timer and rejection handler. Reusing a single
+        // never-settled Promise.race branch retains one handler per streamed chunk.
+        const waitForProvider = <T>(
+          operation: Promise<T>,
+          phase: ProviderStreamTimeoutDetails["phase"],
+        ): Promise<T> =>
+          new Promise((resolve, reject) => {
+            const fail = (reason: unknown) => {
+              clearTimeout(timer);
+              pendingReject = undefined;
+              reject(reason);
+            };
+            const timer = setTimeout(() => {
+              const error = new ProviderStreamTimeoutError(
+                `Provider ${phase} timed out after ${options.timeoutMs}ms`,
+              );
+              fail(error);
+              cancelProvider(error);
+              dispose();
+              try {
+                options.onTimeout?.({
+                  phase,
+                  timeoutMs: options.timeoutMs,
+                  modelId: provider.modelId,
+                });
+              } catch {
+                // Diagnostics must not prevent recovery from a stalled provider.
+              }
+            }, options.timeoutMs);
+            pendingReject = fail;
+            operation.then((value) => {
+              clearTimeout(timer);
+              pendingReject = undefined;
+              resolve(value);
+            }, fail);
+          });
+
+        params.abortSignal?.throwIfAborted();
+        params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+        try {
+          const response = Promise.resolve(
+            provider.doStream({
+              ...params,
+              abortSignal: controller.signal,
+            }),
+          );
+          // Also dispose a response that arrives after its request timed out.
+          void response.then(
+            (result) => {
+              if (disposed) void result.stream.cancel().catch(() => undefined);
+            },
+            () => undefined,
+          );
+          const result = await waitForProvider(response, "response");
+          controller.signal.throwIfAborted();
+          reader = result.stream.getReader();
+          const sourceReader = reader;
+          return {
+            ...result,
+            stream: new ReadableStream<StreamPart>(
+              {
+                async pull(output) {
+                  try {
+                    controller.signal.throwIfAborted();
+                    const next = await waitForProvider(
+                      sourceReader.read(),
+                      "chunk",
+                    );
+                    if (next.done) {
+                      dispose();
+                      sourceReader.releaseLock();
+                      output.close();
+                    } else {
+                      output.enqueue(next.value);
+                    }
+                  } catch (error) {
+                    dispose();
+                    if (error instanceof ProviderStreamTimeoutError) {
+                      // The SDK routes provider error parts through onError and
+                      // UI onFinish. A raw stream rejection skips that recovery.
+                      output.enqueue({ type: "error", error });
+                      output.close();
+                    } else {
+                      output.error(error);
+                    }
+                  }
+                },
+                cancel(reason) {
+                  pendingReject?.(reason);
+                  cancelProvider(reason);
+                  dispose();
+                },
+              },
+              { highWaterMark: 0 },
+            ),
+          };
+        } catch (error) {
+          dispose();
+          throw error;
+        }
+      },
+    },
+  });
+}

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1546,7 +1546,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
 
   test("content-filter finishes retry once on a different model and remain terminal on fallback", () => {
     expect(agentStreamRunnerSrc).toMatch(
-      /const telemetryModel =\s*ctx\.abliteratedTelemetry\?\.wrap\(\s*languageModel,\s*stepIndex,\s*activeStepRouting,?\s*\) \?\? languageModel;\s*const recoveryModel = recoverAbliterationMedia\([\s\S]{0,250}\);[\s\S]{0,150}guardLanguageModelProviderResponse\(recoveryModel/,
+      /const telemetryModel =\s*ctx\.abliteratedTelemetry\?\.wrap\(\s*languageModel,\s*stepIndex,\s*activeStepRouting,?\s*\) \?\? languageModel;\s*const recoveryModel = recoverAbliterationMedia\(\s*ctx\.providerStreamTimeout\s*\?\s*withProviderStreamTimeout\(telemetryModel, ctx\.providerStreamTimeout\)\s*:\s*telemetryModel,?\s*\);[\s\S]{0,150}guardLanguageModelProviderResponse\(recoveryModel/,
     );
     expect(agentStreamRunnerSrc).toMatch(
       /isProviderContentBlockedFinishReasonError\(error\)/,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1546,7 +1546,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
 
   test("content-filter finishes retry once on a different model and remain terminal on fallback", () => {
     expect(agentStreamRunnerSrc).toMatch(
-      /const telemetryModel =\s*ctx\.abliteratedTelemetry\?\.wrap\(\s*languageModel,\s*stepIndex,\s*activeStepRouting,?\s*\) \?\? languageModel;\s*const recoveryModel = recoverAbliterationMedia\(telemetryModel\);[\s\S]{0,150}guardLanguageModelProviderResponse\(recoveryModel/,
+      /const telemetryModel =\s*ctx\.abliteratedTelemetry\?\.wrap\(\s*languageModel,\s*stepIndex,\s*activeStepRouting,?\s*\) \?\? languageModel;\s*const recoveryModel = recoverAbliterationMedia\([\s\S]{0,250}\);[\s\S]{0,150}guardLanguageModelProviderResponse\(recoveryModel/,
     );
     expect(agentStreamRunnerSrc).toMatch(
       /isProviderContentBlockedFinishReasonError\(error\)/,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -148,6 +148,10 @@ import type { ChatMode, SelectedModel, SubscriptionTier } from "@/types";
 import type { AgentStartupPhase } from "@/lib/chat/agent-run-timing";
 import { namespaceLanguageModelToolCalls } from "@/lib/ai/tool-call-id-namespace";
 import {
+  withProviderStreamTimeout,
+  type ProviderStreamTimeoutOptions,
+} from "@/lib/ai/provider-stream-timeout";
+import {
   guardLanguageModelProviderResponse,
   MAX_PROVIDER_TOOL_CALLS_PER_RESPONSE,
 } from "@/lib/ai/provider-response-guard";
@@ -630,6 +634,7 @@ const buildProviderRequestDiagnostics = (args: {
 // ---------------------------------------------------------------------------
 
 export type AgentStreamContext = {
+  providerStreamTimeout?: ProviderStreamTimeoutOptions;
   abliteratedTelemetry?: AbliteratedModelTelemetry;
   abliteratedStepRouting?: {
     baselineModel: string;
@@ -880,7 +885,11 @@ export async function createAgentStream(
         stepIndex,
         activeStepRouting,
       ) ?? languageModel;
-    const recoveryModel = recoverAbliterationMedia(telemetryModel);
+    const recoveryModel = recoverAbliterationMedia(
+      ctx.providerStreamTimeout
+        ? withProviderStreamTimeout(telemetryModel, ctx.providerStreamTimeout)
+        : telemetryModel,
+    );
     const guardedModel = guardLanguageModelProviderResponse(recoveryModel, {
       onToolCallsDropped: ({ droppedToolCallCount, maxToolCalls }) => {
         console.warn("[agent-stream] provider tool calls bounded", {

--- a/lib/chat/__tests__/provider-recovery-stream.test.ts
+++ b/lib/chat/__tests__/provider-recovery-stream.test.ts
@@ -10,6 +10,7 @@ import {
 import { WritableStream } from "node:stream/web";
 import { z } from "zod";
 import { isRetriableProviderStreamDisconnectError } from "@/lib/utils/error-utils";
+import { withProviderStreamTimeout } from "@/lib/ai/provider-stream-timeout";
 import {
   decideProviderRecovery,
   prepareProviderDisconnectContinuation,
@@ -63,95 +64,119 @@ const response = (parts: unknown[]) => ({
   }),
 });
 
-it("recovers a 504 after tool execution through real SDK/UI streams without executing the tool twice", async () => {
-  const execute = jest.fn(async () => ({ saved: true }));
-  const tools = { save: tool({ inputSchema: z.object({}), execute }) };
-  const upstreamError = { code: 504, message: "The operation was aborted" };
-  const primary = jest
-    .fn()
-    .mockResolvedValueOnce(
-      response([
-        {
-          type: "tool-call",
-          toolCallId: "saved-once",
-          toolName: "save",
-          input: "{}",
-        },
-        finish("tool-calls"),
-      ]),
-    )
-    .mockResolvedValueOnce(
-      response([
-        { type: "text-start", id: "partial" },
-        { type: "text-delta", id: "partial", delta: "incomplete" },
-        { type: "error", error: upstreamError },
-      ]),
-    );
-  let failure: unknown;
-  const initial = streamText({
-    model: model(primary),
-    messages: [{ role: "user", content: "save and report" }],
-    tools,
-    stopWhen: stepCountIs(3),
-    maxRetries: 0,
-    onError: ({ error }) => {
-      failure = error;
-    },
-  });
-  let partial: UIMessage | undefined;
-  for await (const message of readUIMessageStream({
-    stream: initial.toUIMessageStream(),
-    onError: () => {},
-  }))
-    partial = message;
-  expect(execute).toHaveBeenCalledTimes(1);
-  expect(isRetriableProviderStreamDisconnectError(failure)).toBe(true);
-  const continuation = prepareProviderDisconnectContinuation([partial!]);
-  expect(continuation?.preservedCompletedToolCount).toBe(1);
-  const messages = await convertToModelMessages(continuation!.messages, {
-    tools,
-  });
-  expect(getProviderToolCallDiagnostics(messages)).toMatchObject({
-    unmatched_tool_call_count: 0,
-    unmatched_tool_result_count: 0,
-  });
-  expect(JSON.stringify(messages)).not.toContain("incomplete");
-  const fallback = jest
-    .fn()
-    .mockResolvedValue(
-      response([
-        { type: "text-start", id: "done" },
-        { type: "text-delta", id: "done", delta: "Saved successfully." },
-        { type: "text-end", id: "done" },
-        finish("stop"),
-      ]),
-    );
-  const recovered = streamText({
-    model: model(fallback),
-    messages,
-    tools,
-    maxRetries: 0,
-  });
-  let final: UIMessage | undefined;
-  const parseErrors: unknown[] = [];
-  for await (const message of readUIMessageStream({
-    stream: recovered.toUIMessageStream(),
-    onError: (e) => parseErrors.push(e),
-  }))
-    final = message;
-  expect(parseErrors).toEqual([]);
-  expect(final?.parts).toContainEqual({
-    type: "text",
-    text: "Saved successfully.",
-    state: "done",
-  });
-  expect(execute).toHaveBeenCalledTimes(1);
-  expect(
-    fallback.mock.calls[0][0].prompt.some(
-      (message: { role: string }) => message.role === "tool",
-    ),
-  ).toBe(true);
-});
+afterEach(() => jest.useRealTimers());
+
+it.each(["504", "idle_timeout"])(
+  "recovers %s after tool execution through real SDK/UI streams without executing the tool twice",
+  async (failureMode) => {
+    if (failureMode === "idle_timeout") jest.useFakeTimers();
+    const execute = jest.fn(async () => ({ saved: true }));
+    const tools = { save: tool({ inputSchema: z.object({}), execute }) };
+    const upstreamError = { code: 504, message: "The operation was aborted" };
+    const primary = jest
+      .fn()
+      .mockResolvedValueOnce(
+        response([
+          {
+            type: "tool-call",
+            toolCallId: "saved-once",
+            toolName: "save",
+            input: "{}",
+          },
+          finish("tool-calls"),
+        ]),
+      )
+      .mockResolvedValueOnce(
+        failureMode === "idle_timeout"
+          ? {
+              stream: new ReadableStream({
+                start(output) {
+                  output.enqueue({ type: "text-start", id: "partial" });
+                  output.enqueue({
+                    type: "text-delta",
+                    id: "partial",
+                    delta: "incomplete",
+                  });
+                },
+              }),
+            }
+          : response([
+              { type: "text-start", id: "partial" },
+              { type: "text-delta", id: "partial", delta: "incomplete" },
+              { type: "error", error: upstreamError },
+            ]),
+      );
+    let failure: unknown;
+    const initial = streamText({
+      model: withProviderStreamTimeout(model(primary), { timeoutMs: 1000 }),
+      messages: [{ role: "user", content: "save and report" }],
+      tools,
+      stopWhen: stepCountIs(3),
+      maxRetries: 0,
+      onError: ({ error }) => {
+        failure = error;
+      },
+    });
+    let partial: UIMessage | undefined;
+    const readInitial = (async () => {
+      for await (const message of readUIMessageStream({
+        stream: initial.toUIMessageStream(),
+        onError: () => {},
+      }))
+        partial = message;
+    })();
+    if (failureMode === "idle_timeout")
+      await jest.advanceTimersByTimeAsync(1100);
+    await readInitial;
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(isRetriableProviderStreamDisconnectError(failure)).toBe(true);
+    const continuation = prepareProviderDisconnectContinuation([partial!]);
+    expect(continuation?.preservedCompletedToolCount).toBe(1);
+    const messages = await convertToModelMessages(continuation!.messages, {
+      tools,
+    });
+    expect(getProviderToolCallDiagnostics(messages)).toMatchObject({
+      unmatched_tool_call_count: 0,
+      unmatched_tool_result_count: 0,
+    });
+    expect(JSON.stringify(messages)).not.toContain("incomplete");
+    const fallback = jest
+      .fn()
+      .mockResolvedValue(
+        response([
+          { type: "text-start", id: "done" },
+          { type: "text-delta", id: "done", delta: "Saved successfully." },
+          { type: "text-end", id: "done" },
+          finish("stop"),
+        ]),
+      );
+    const recovered = streamText({
+      model: model(fallback),
+      messages,
+      tools,
+      maxRetries: 0,
+    });
+    let final: UIMessage | undefined;
+    const parseErrors: unknown[] = [];
+    for await (const message of readUIMessageStream({
+      stream: recovered.toUIMessageStream(),
+      onError: (e) => parseErrors.push(e),
+    }))
+      final = message;
+    expect(parseErrors).toEqual([]);
+    expect(final?.parts).toContainEqual({
+      type: "text",
+      text: "Saved successfully.",
+      state: "done",
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(
+      fallback.mock.calls[0][0].prompt.some(
+        (message: { role: string }) => message.role === "tool",
+      ),
+    ).toBe(true);
+  },
+);
 
 it("recognizes HTTP rejection delivered asynchronously before any content, with cancellation and retry limits intact", async () => {
   let failure: unknown;

--- a/trigger/__tests__/agent-long-setup-cancellation.test.ts
+++ b/trigger/__tests__/agent-long-setup-cancellation.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+// Execute the actual catch block without booting the Trigger worker or its
+// remote services. This keeps cleanup/return ordering covered by behavior.
+const source = ts.createSourceFile(
+  "agent-long.ts",
+  fs.readFileSync(path.resolve(__dirname, "../agent-long.ts"), "utf8"),
+  ts.ScriptTarget.Latest,
+  true,
+);
+let outerCatch: ts.Block | undefined;
+function visit(node: ts.Node) {
+  if (
+    ts.isCatchClause(node) &&
+    node.block
+      .getText(source)
+      .includes('releaseFreeRunLockBestEffort("outer_catch")')
+  ) {
+    outerCatch = node.block;
+  }
+  ts.forEachChild(node, visit);
+}
+visit(source);
+if (!outerCatch) throw new Error("Agent run catch block not found");
+const catchBody = ts.transpileModule(
+  `return (async () => ${outerCatch.getText(source)})();`,
+  { compilerOptions: { target: ts.ScriptTarget.ES2022 } },
+).outputText;
+
+function fixture(
+  triggerSignal: AbortSignal,
+  streamPiped = false,
+  used = false,
+) {
+  const ordinaryFailure = new Error("ordinary failure handler reached");
+  const dependencies = {
+    triggerSignal,
+    streamPiped,
+    hasObservedUsage: () => used,
+    releasePaidDailyFreeAllowanceReservation: jest.fn(async () => {}),
+    releaseFreeRunLockBestEffort: jest.fn(async () => {}),
+    usageRefundTracker: { refund: jest.fn(async () => {}) },
+    metadata: { set: jest.fn() },
+    phLogger: { flush: jest.fn(async () => {}) },
+    memoryTelemetry: { checkpoint: jest.fn() },
+    classifyAgentLongError: jest.fn(() => {
+      throw ordinaryFailure;
+    }),
+    ChatSDKError: class extends Error {},
+    chatId: "test-chat",
+    assistantMessageId: "test-run",
+  };
+  const execute = (error: unknown) =>
+    new Function("error", ...Object.keys(dependencies), catchBody)(
+      error,
+      ...Object.values(dependencies),
+    );
+  return { dependencies, execute, ordinaryFailure };
+}
+
+it.each([false, true])(
+  "handles setup cancellation after cleanup without failure reporting (usage=%s)",
+  async (used) => {
+    const controller = new AbortController();
+    controller.abort(new DOMException("Stopped", "AbortError"));
+    const { dependencies: d, execute } = fixture(
+      controller.signal,
+      false,
+      used,
+    );
+    await expect(execute(controller.signal.reason)).resolves.toEqual({
+      chatId: "test-chat",
+      assistantMessageId: "test-run",
+    });
+    expect(d.releaseFreeRunLockBestEffort).toHaveBeenCalledWith("outer_catch");
+    expect(d.releasePaidDailyFreeAllowanceReservation).toHaveBeenCalledTimes(
+      used ? 0 : 1,
+    );
+    expect(d.usageRefundTracker.refund).toHaveBeenCalledTimes(used ? 0 : 1);
+    expect(d.metadata.set).toHaveBeenCalledWith("status", "canceled");
+    expect(d.memoryTelemetry.checkpoint).not.toHaveBeenCalled();
+    expect(d.classifyAgentLongError).not.toHaveBeenCalled();
+    expect(d.phLogger.flush).toHaveBeenCalled();
+  },
+);
+
+it.each(["not_canceled", "unrelated_error", "streaming"])(
+  "preserves ordinary failure handling for %s",
+  async (scenario) => {
+    const controller = new AbortController();
+    const abortError = new DOMException("Stopped", "AbortError");
+    if (scenario !== "not_canceled") controller.abort(abortError);
+    const error =
+      scenario === "unrelated_error"
+        ? new Error("Database unavailable")
+        : abortError;
+    const {
+      dependencies: d,
+      execute,
+      ordinaryFailure,
+    } = fixture(controller.signal, scenario === "streaming");
+    await expect(execute(error)).rejects.toBe(ordinaryFailure);
+    expect(d.classifyAgentLongError).toHaveBeenCalledWith(error);
+    expect(d.metadata.set).not.toHaveBeenCalledWith("status", "canceled");
+  },
+);

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -36,6 +36,7 @@ import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { createTrackedProvider } from "@/lib/ai/providers";
+import { AGENT_PROVIDER_IDLE_TIMEOUT_MS } from "@/lib/ai/provider-stream-timeout";
 import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
 import { cacheAuxiliaryVisionDescription } from "@/lib/utils/file-transform-utils";
 import {
@@ -2621,8 +2622,18 @@ export const agentLongTask = task({
 
     let activeRuntimeBudget: ActiveRuntimeBudget | undefined;
     let runtimeSettlementWatchdog: RuntimeSettlementWatchdog | undefined;
+    // Register before async setup and handle a signal already canceled while
+    // the task was starting. Abort events are not replayed to late listeners.
+    const userStopSignal = new AbortController();
+    const forwardTriggerAbort = () =>
+      userStopSignal.abort(triggerSignal.reason);
+    triggerSignal.addEventListener("abort", forwardTriggerAbort, {
+      once: true,
+    });
+    if (triggerSignal.aborted) forwardTriggerAbort();
 
     try {
+      userStopSignal.signal.throwIfAborted();
       // Re-fetch from DB so we have fileTokens for summarization.
       // The route already saved the user message; newMessages:[] avoids duplicates.
       const [userCustomization, fetched] = await Promise.all([
@@ -2829,12 +2840,7 @@ export const agentLongTask = task({
 
       chatLogger.getBuilder().setAssistantId(assistantMessageId);
 
-      // Wire trigger.dev's abort signal into a local controller.
-      // Fires on runs.cancel() (UI Stop) and Trigger's maxDuration.
-      const userStopSignal = new AbortController();
-      triggerSignal.addEventListener("abort", () => userStopSignal.abort(), {
-        once: true,
-      });
+      userStopSignal.signal.throwIfAborted();
 
       const summarizationTracker = new SummarizationTracker();
       chatLogger.startStream();
@@ -2856,6 +2862,15 @@ export const agentLongTask = task({
           markAgentLongDurationExceeded();
           runtimeSettlementWatchdog?.arm();
           userStopSignal.abort();
+          triggerLogger.warn("[agent-long] active runtime budget exhausted", {
+            event: "agent_long_runtime_budget_exhausted",
+            run_id: ctx.run.id,
+            chat_id: chatId,
+            active_elapsed_ms: runtimeBudget.getElapsedTimeMs(),
+            runtime_budget_ms: agentLongMaxDurationMs,
+            cleanup_grace_ms: AGENT_LONG_CLEANUP_GRACE_MS,
+            agent_step_count: terminalAgentState?.agentStepCount ?? 0,
+          });
         },
       });
       activeRuntimeBudget = runtimeBudget;
@@ -4281,6 +4296,25 @@ export const agentLongTask = task({
 
             // Shared runner context — immutable deps + platform hook.
             const streamCtx: AgentStreamContext = {
+              providerStreamTimeout: {
+                timeoutMs: AGENT_PROVIDER_IDLE_TIMEOUT_MS,
+                onTimeout: ({ phase, timeoutMs, modelId }) => {
+                  triggerLogger.warn("[agent-long] provider stalled", {
+                    event: "agent_long_provider_idle_timeout",
+                    run_id: ctx.run.id,
+                    chat_id: chatId,
+                    phase,
+                    timeout_ms: timeoutMs,
+                    model: modelId,
+                    agent_step_count: state.agentStepCount,
+                    active_elapsed_ms: runtimeBudget.getElapsedTimeMs(),
+                    remaining_runtime_ms: Math.max(
+                      0,
+                      agentLongMaxDurationMs - runtimeBudget.getElapsedTimeMs(),
+                    ),
+                  });
+                },
+              },
               abliteratedTelemetry,
               ...(activeAbliteratedExperiment?.variant === "test" && {
                 abliteratedStepRouting: {
@@ -5989,6 +6023,7 @@ export const agentLongTask = task({
 
       throw error;
     } finally {
+      triggerSignal.removeEventListener("abort", forwardTriggerAbort);
       await releaseFreeRunLockBestEffort("outer_finally");
       runtimeSettlementWatchdog?.dispose();
       memoryTelemetry.dispose();

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -5928,6 +5928,18 @@ export const agentLongTask = task({
         await releasePaidDailyFreeAllowanceReservation();
       }
       await releaseFreeRunLockBestEffort("outer_catch");
+      if (
+        !streamPiped &&
+        triggerSignal.aborted &&
+        error === triggerSignal.reason
+      ) {
+        metadata.set("status", "canceled");
+        if (!hasObservedUsage()) {
+          await usageRefundTracker.refund().catch(() => {});
+        }
+        await phLogger.flush().catch(() => {});
+        return { chatId, assistantMessageId };
+      }
       memoryTelemetry.checkpoint({ phase: "run_failed", force: true });
       const chatMissingAfterStream =
         streamPiped &&


### PR DESCRIPTION
A model provider that stops returning data can consume most of a long Agent run's four-hour budget. Add a five-minute timeout while waiting for a provider response or the next stream chunk, then route the timeout through the existing bounded recovery path. Completed tool results remain available to continuation, and tool execution, approval waits, and downstream pauses do not consume this timeout.

Also forward cancellation before asynchronous task setup, handle already-canceled runs, and remove the listener during cleanup. Setup cancellation releases reservations and locks and records a canceled outcome without provider-failure reporting. Add content-free diagnostics for provider timeouts and active runtime budget exhaustion, including model, step count, and remaining runtime.

Validation:
- Type checking, ESLint, formatting, and focused runtime/compaction tests passed.
- SDK/UI-stream regression tests cover stalled requests, stalled chunks, cancellation, timer disposal, a tool that outlasts the timeout, and recovery without executing a completed tool twice.
- Required pre-commit hook passed: 479 suites and 5,162 tests.

Manual verification before rollout:
1. In HackerAI Preview, start a disposable Agent chat with a bounded terminal command; reload during execution and confirm the response reconnects and completes.
2. Stop a run during startup and confirm no model/tool work starts afterward.
3. With a controlled provider stall in Preview, verify timeout diagnostics and eligible recovery preserve completed tool results without repeating their actions.

Live Preview verification has not been performed. This changes runtime orchestration and adds no UI layout changes. The timeout is enabled for Trigger Agent runs; the Ask caller retains its existing settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards for stalled AI provider responses, including initial-response and per-chunk timeouts.
  - Added support for canceling active streams when the request or provider becomes unresponsive.
  - Added timeout configuration for long-running agent streams.

- **Bug Fixes**
  - Improved recovery from provider timeouts and temporary stream errors.
  - Preserved valid tool results while excluding incomplete output during stream recovery.
  - Improved cancellation handling during agent setup and execution.

- **Diagnostics**
  - Added structured timeout and runtime telemetry to improve visibility into stalled or canceled runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->