### PR TITLE
Preserve Extra Usage failure causes in PostHog

### DIFF
--- a/lib/__tests__/extra-usage-logging.test.ts
+++ b/lib/__tests__/extra-usage-logging.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockConvexCall = jest.fn<(...args: unknown[]) => Promise<never>>();
+const mockCaptureException = jest.fn();
+const mockEmitPostHogLog = jest.fn<(_record: unknown) => boolean>(() => true);
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: () => ({
+    query: mockConvexCall,
+    mutation: mockConvexCall,
+    action: mockConvexCall,
+  }),
+}));
+jest.mock("@/app/posthog", () => ({
+  __esModule: true,
+  default: () => ({ captureException: mockCaptureException }),
+}));
+jest.mock("@/lib/posthog/logs", () => ({
+  emitPostHogLog: mockEmitPostHogLog,
+}));
+
+const {
+  deductFromBalance,
+  deductFromTeamBalance,
+  getExtraUsageBalance,
+  getTeamExtraUsageState,
+  refundToBalance,
+  refundToTeamBalance,
+} = require("../extra-usage") as typeof import("../extra-usage");
+
+describe("Extra Usage failure capture through phLogger", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConvexCall.mockRejectedValue(new TypeError("fetch failed"));
+  });
+
+  it.each([
+    [
+      "extra_usage_balance_fetch_failed",
+      () => getExtraUsageBalance("user_123"),
+    ],
+    ["extra_usage_deduction_failed", () => deductFromBalance("user_123", 100)],
+    ["extra_usage_refund_failed", () => refundToBalance("user_123", 100)],
+    [
+      "team_extra_usage_state_fetch_failed",
+      () => getTeamExtraUsageState("org_123", "user_123"),
+    ],
+    [
+      "team_extra_usage_deduction_failed",
+      () => deductFromTeamBalance("org_123", "user_123", 100),
+    ],
+    [
+      "team_extra_usage_refund_failed",
+      () => refundToTeamBalance("org_123", "user_123", 100),
+    ],
+  ] as const)("preserves the Convex cause for %s", async (event, call) => {
+    await call();
+
+    expect(mockConvexCall).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    const [exception, distinctId, properties] = mockCaptureException.mock
+      .calls[0] as [Error, string, Record<string, unknown>];
+    const log = mockEmitPostHogLog.mock.calls[0][0] as {
+      body: string;
+      attributes: Record<string, unknown>;
+    };
+    const expectedCause = {
+      event,
+      convex_error_name: "TypeError",
+      convex_error_message: "fetch failed",
+    };
+    expect(properties).toMatchObject(expectedCause);
+    expect(log.attributes).toMatchObject(expectedCause);
+    expect(distinctId).toBe("user_123");
+    expect(properties.error_message).toBe(log.body);
+    expect(exception.message).toBe(log.body);
+    expect(exception.message).not.toBe("fetch failed");
+  });
+
+  it("redacts before bounding the cause without capturing raw Error payloads", async () => {
+    const signedUrl =
+      "https://bucket.s3.amazonaws.com/user-files/private.png?X-Amz-Signature=synthetic-signature";
+    const error = Object.assign(
+      new Error(
+        `fetch failed ${signedUrl} serviceKey=synthetic-key ${"x".repeat(3000)}`,
+      ),
+      {
+        name: `Upstream${"x".repeat(200)}`,
+        responseBody: "PRIVATE_PROVIDER_PAYLOAD",
+        cause: { payload: "PRIVATE_CAUSE_PAYLOAD" },
+      },
+    );
+    mockConvexCall.mockRejectedValue(error);
+
+    await expect(
+      deductFromBalance("user_123", 100, "settlement_123"),
+    ).resolves.toMatchObject({
+      success: false,
+      insufficientFunds: false,
+      monthlyCapExceeded: false,
+    });
+
+    const properties = mockCaptureException.mock.calls[0][2] as Record<
+      string,
+      unknown
+    >;
+    expect(properties.convex_error_name).toHaveLength(128);
+    expect(properties.convex_error_message).toHaveLength(2000);
+    expect(properties.usage_settlement_id).toBe("settlement_123");
+    const captured = JSON.stringify([
+      mockCaptureException.mock.calls,
+      mockEmitPostHogLog.mock.calls,
+    ]);
+    expect(captured).toContain("[Redacted signed URL]");
+    expect(captured).toContain("[Redacted]");
+    for (const secret of [
+      "synthetic-signature",
+      "synthetic-key",
+      "user-files",
+      "PRIVATE_PROVIDER_PAYLOAD",
+      "PRIVATE_CAUSE_PAYLOAD",
+    ]) {
+      expect(captured).not.toContain(secret);
+    }
+  });
+
+  it("preserves string failures without changing the deduction result", async () => {
+    mockConvexCall.mockRejectedValue("upstream unavailable");
+    await expect(
+      deductFromTeamBalance("org_123", "user_123", 100),
+    ).resolves.toMatchObject({
+      success: false,
+      insufficientFunds: false,
+    });
+    expect(mockCaptureException.mock.calls[0][2]).toMatchObject({
+      convex_error_name: "UnknownError",
+      convex_error_message: "upstream unavailable",
+    });
+  });
+});

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -45,8 +45,9 @@ const logExtraUsageConvexFailure = ({
     operation,
     component: "extra_usage",
     duration_ms: Date.now() - startedAt,
-    error_name: errorName(error),
-    error_message: stringifyRedactedError(error),
+    // phLogger reserves error_name/error_message for the captured summary.
+    convex_error_name: stringifyRedactedError(errorName(error)).slice(0, 128),
+    convex_error_message: stringifyRedactedError(error).slice(0, 2_000),
   });
 };
 


### PR DESCRIPTION
Extra Usage failures lose their underlying Convex cause in PostHog: `phLogger.error` creates a summary exception and its `error_name`/`error_message` properties overwrite the caller's original fields. Record the existing redacted cause as `convex_error_name` and `convex_error_message`, bounded to 128 and 2,000 characters. The captured exception summary and event stay stable; balance operations and failure returns do not change.

### Production evidence
Frozen audit window: **2026-09-09T20:02:17Z inclusive–2026-09-10T20:02:17Z exclusive**. [PostHog issue](https://us.posthog.com/project/144137/error_tracking/019f88d2-c6d8-7ac0-99c8-8777decd7500) contains two new deduction failures affecting two distinct users at 13:32:25.391Z and 15:04:38.004Z on September 10. Events `01a08b85-037e-7bad-8b0d-074612ede4d9` and `01a08bd9-6f6a-7d60-9ab6-87b241c9ef96` both expose only `Error / Extra usage deduction failed`. Resolved frames show server.ts → extra-usage.ts → deductFromBalance → token-bucket → agent-long. The underlying billing/persistence cause remains unknown; this patch makes the next occurrence diagnosable.

Collection production: Vercel `dpl_FT2UggRJq2mYKVMqmKMj4Gc4fWxd` / `e3c728ab`, READY 2026-09-10T19:03:43.520Z; Trigger `20260910.8/s6w8igkt`, deployed 19:01:55Z. Each service must deploy this patch independently before expecting the new fields.

### Validation
- Eight integration regressions exercise all six personal/team fetch, deduct, and refund error paths through the real `phLogger`. Restoring the old field names makes the regression suite fail.
- Verify Error subtype and string failures, signed-URL/service-key redaction before truncation, bounded final fields, stable summary/event, and unchanged failed-deduction returns. Raw Error payloads and nested causes are not captured.
- Focused suites: 36 tests passed. Full configured commit hooks: **481 suites / 5,267 tests passed** on Node 22.23.2, plus typecheck, changed-file ESLint/Prettier, dependency guard, and diff checks.
- Adversarial review covered shared Ask/Agent callers, personal/team paths, final attribute bounds, privacy, and independent Vercel/Trigger versions. No retry, transaction, provider, authorization, settlement, or suppression changes. Docker/desktop release workflows are outside the changed paths.

### Manual verification
After merge, confirm the Vercel and Trigger production deployments each contain this commit. Inspect the next naturally occurring Extra Usage failure: its stable summary should remain, while both `convex_error_*` fields retain a bounded, redacted underlying cause. Check only runs on the updated worker. Do not induce a real payment failure. Automated validation covers the diagnostic-only change; no UI journey was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extra-usage failure logging to preserve relevant Convex error details.
  * Sensitive error information is now redacted and length-limited.
  * Settlement metadata and deduction results are retained for applicable failures.

* **Tests**
  * Added coverage for balance and team-balance failure logging, including error detail handling and data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->