### PR TITLE
Require S3 and document Abliteration setup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -42,11 +42,12 @@ CONVEX_USER_RESEARCH_SERVICE_KEY="replace-with-a-different-32+char-random-secret
 # See: https://docs.convex.dev/cli/local-deployments
 
 # =============================================================================
-# S3 FILE STORAGE (Optional - Feature Flag Controlled)
+# S3 FILE STORAGE (Required)
 # =============================================================================
-# AWS S3 credentials for file storage (only needed if S3 is enabled)
+# AWS S3 credentials for file storage
 # Sign up at: https://aws.amazon.com/s3/
-# ⚠️ IMPORTANT: If using S3, also add these to Convex Dashboard → Environment Variables
+# ⚠️ IMPORTANT: Also add these to Convex Dashboard → Environment Variables
+# and Trigger.dev → Environment Variables.
 AWS_S3_ACCESS_KEY_ID=
 AWS_S3_SECRET_ACCESS_KEY=
 AWS_S3_REGION=us-east-1

--- a/.env.local.example
+++ b/.env.local.example
@@ -65,7 +65,7 @@ AWS_S3_BUCKET_NAME_US_WEST_2=
 # S3_URL_EXPIRATION_BUFFER_SECONDS=300
 
 # =============================================================================
-# AI PROVIDERS (Required)
+# AI PROVIDERS
 # =============================================================================
 # OpenRouter - Get key at: https://openrouter.ai/
 OPENROUTER_API_KEY=
@@ -73,8 +73,9 @@ OPENROUTER_API_KEY=
 # OpenAI - Get key at: https://platform.openai.com/
 OPENAI_API_KEY=
 
-# Optional direct provider for the moderation-gated paid Auto/Standard experiment.
-# Configure independently in Vercel and Trigger; the PostHog flag is also required.
+# Optional abliteration.ai provider for moderation-gated model routing.
+# Create a key at: https://abliteration.ai/console
+# Configure independently in Vercel and Trigger.dev; the PostHog flag is also required.
 ABLITERATION_API_KEY=
 
 # =============================================================================

--- a/.env.local.example
+++ b/.env.local.example
@@ -73,7 +73,8 @@ OPENROUTER_API_KEY=
 # OpenAI - Get key at: https://platform.openai.com/
 OPENAI_API_KEY=
 
-# Optional abliteration.ai provider for moderation-gated model routing.
+# Optional abliteration.ai provider for eligible security requests that
+# standard models may refuse.
 # Create a key at: https://abliteration.ai/console
 # Configure independently in Vercel and Trigger.dev; the PostHog flag is also required.
 ABLITERATION_API_KEY=

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You'll need the following accounts:
 **Required:**
 
 - [OpenRouter](https://openrouter.ai/) - AI model provider
-- [OpenAI](https://platform.openai.com/) - Request classification for detecting when to use [Aliberated.ai](https://aliberated.ai/) models
+- [OpenAI](https://platform.openai.com/) - Request classification for detecting when to use [abliteration.ai](https://abliteration.ai/) models
 - [E2B](https://e2b.dev/) - Isolated cloud execution in Agent mode
 - [Convex](https://www.convex.dev/) - Database and backend
 - [Amazon S3](https://aws.amazon.com/s3/) - File storage
@@ -35,6 +35,7 @@ You'll need the following accounts:
 
 **Optional:**
 
+- [abliteration.ai](https://abliteration.ai/) - Moderation-gated model provider
 - [Perplexity](https://perplexity.ai/) - Web search functionality
 - [Jina AI](https://jina.ai/reader) - Web URL content retrieval
 - [Redis](https://redis.io/) - Stream resumption
@@ -66,6 +67,11 @@ pnpm install
 pnpm run setup
 ```
 
+To enable moderation-gated routing to abliteration.ai models, create an API key
+in the [abliteration.ai console](https://abliteration.ai/console) and set
+`ABLITERATION_API_KEY` in `.env.local`, Vercel, and Trigger.dev. Without this
+optional key, HackerAI continues using its baseline models.
+
 ### Start the development server
 
 This runs both Next.js and Convex dev servers:
@@ -94,7 +100,7 @@ To use the agent locally:
    `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `AWS_S3_ACCESS_KEY_ID`,
    `AWS_S3_SECRET_ACCESS_KEY`, `AWS_S3_REGION`, `AWS_S3_BUCKET_NAME`, and one
    cloud sandbox provider, plus any optional keys you use
-   (`PERPLEXITY_API_KEY`, `JINA_API_KEY`, etc.).
+   (`ABLITERATION_API_KEY`, `PERPLEXITY_API_KEY`, `JINA_API_KEY`, etc.).
 3. Start the worker in a third terminal:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You'll need the following accounts:
 **Required:**
 
 - [OpenRouter](https://openrouter.ai/) - AI model provider
-- [OpenAI](https://platform.openai.com/) - Request classification for detecting when to use [abliteration.ai](https://abliteration.ai/) models
+- [OpenAI](https://platform.openai.com/) - Identifies security requests that should use [abliteration.ai](https://abliteration.ai/) models
 - [E2B](https://e2b.dev/) - Isolated cloud execution in Agent mode
 - [Convex](https://www.convex.dev/) - Database and backend
 - [Amazon S3](https://aws.amazon.com/s3/) - File storage
@@ -35,7 +35,7 @@ You'll need the following accounts:
 
 **Optional:**
 
-- [abliteration.ai](https://abliteration.ai/) - Moderation-gated model provider
+- [abliteration.ai](https://abliteration.ai/) - AI models for security requests that standard models may refuse
 - [Perplexity](https://perplexity.ai/) - Web search functionality
 - [Jina AI](https://jina.ai/reader) - Web URL content retrieval
 - [Redis](https://redis.io/) - Stream resumption
@@ -67,10 +67,10 @@ pnpm install
 pnpm run setup
 ```
 
-To enable moderation-gated routing to abliteration.ai models, create an API key
-in the [abliteration.ai console](https://abliteration.ai/console) and set
+To use abliteration.ai for eligible security requests, create an API key in the
+[abliteration.ai console](https://abliteration.ai/console) and set
 `ABLITERATION_API_KEY` in `.env.local`, Vercel, and Trigger.dev. Without this
-optional key, HackerAI continues using its baseline models.
+optional key, HackerAI continues using its standard models.
 
 ### Start the development server
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You'll need the following accounts:
 **Required:**
 
 - [OpenRouter](https://openrouter.ai/) - AI model provider
-- [OpenAI](https://platform.openai.com/) - Content moderation
+- [OpenAI](https://platform.openai.com/) - Request classification for detecting when to use [Aliberated.ai](https://aliberated.ai/) models
 - [E2B](https://e2b.dev/) - Isolated cloud execution in Agent mode
 - [Convex](https://www.convex.dev/) - Database and backend
 - [Amazon S3](https://aws.amazon.com/s3/) - File storage

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ You'll need the following accounts:
 - [OpenAI](https://platform.openai.com/) - Content moderation
 - [E2B](https://e2b.dev/) - Isolated cloud execution in Agent mode
 - [Convex](https://www.convex.dev/) - Database and backend
+- [Amazon S3](https://aws.amazon.com/s3/) - File storage
 - [WorkOS](https://workos.com/) - Authentication and user management
 - [Trigger.dev](https://trigger.dev/) - Required durable runtime for agent tasks
 
 **Optional:**
 
-- [Amazon S3](https://aws.amazon.com/s3/) - File storage (alternative to Convex storage)
 - [Perplexity](https://perplexity.ai/) - Web search functionality
 - [Jina AI](https://jina.ai/reader) - Web URL content retrieval
 - [Redis](https://redis.io/) - Stream resumption
@@ -91,8 +91,10 @@ To use the agent locally:
 2. In the Trigger.dev dashboard → your project → **Environment Variables**,
    add the env vars the task needs to run (these live on the worker, not on
    Vercel): `NEXT_PUBLIC_CONVEX_URL`, `CONVEX_SERVICE_ROLE_KEY`,
-   `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, one cloud sandbox provider, plus any keys you use
-   (`PERPLEXITY_API_KEY`, `JINA_API_KEY`, S3, etc.).
+   `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `AWS_S3_ACCESS_KEY_ID`,
+   `AWS_S3_SECRET_ACCESS_KEY`, `AWS_S3_REGION`, `AWS_S3_BUCKET_NAME`, and one
+   cloud sandbox provider, plus any optional keys you use
+   (`PERPLEXITY_API_KEY`, `JINA_API_KEY`, etc.).
 3. Start the worker in a third terminal:
 
    ```bash

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -918,7 +918,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
   const handleRemoveFile = async (indexToRemove: number) => {
     const uploadedFile = uploadedFiles[indexToRemove];
 
-    // If the file was uploaded to Convex, delete it from storage
+    // Persisted uploads are stored in S3; local desktop files stay on-device.
     if (uploadedFile?.fileId && uploadedFile.storage !== "local-desktop") {
       try {
         await deleteFile({

--- a/next.config.ts
+++ b/next.config.ts
@@ -71,15 +71,6 @@ const nextConfig: NextConfig = {
         protocol: "http",
         hostname: "127.0.0.1",
       },
-      // Convex storage domains (more specific patterns for better performance)
-      {
-        protocol: "https",
-        hostname: "*.convex.cloud",
-      },
-      {
-        protocol: "https",
-        hostname: "*.convex.dev",
-      },
       // Fallback for other external images
       {
         protocol: "https",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -305,7 +305,8 @@ OPENROUTER_API_KEY=${envVars.OPENROUTER_API_KEY}
 # OpenAI - Get key at: https://platform.openai.com/
 OPENAI_API_KEY=${envVars.OPENAI_API_KEY}
 
-# Optional abliteration.ai provider for moderation-gated model routing.
+# Optional abliteration.ai provider for eligible security requests that
+# standard models may refuse.
 # Create a key at: https://abliteration.ai/console
 # Configure independently in Vercel and Trigger.dev; the PostHog flag is also required.
 ABLITERATION_API_KEY=

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -206,8 +206,8 @@ async function configureConvexDashboard(
   console.log(chalk.bold(`   WORKOS_CLIENT_ID=${workOSClientId}`));
   console.log(chalk.bold(`   WORKOS_AUTH_DOMAIN=${workOSAuthDomain}`));
   console.log(chalk.bold(`   CONVEX_SERVICE_ROLE_KEY=${convexServiceRoleKey}`));
+  console.log("   - AWS_S3_* variables from .env.local");
   console.log("\nOptional variables (add later if using these features):");
-  console.log("   - AWS_S3_* variables (if using S3 storage)");
   console.log("   - REDIS_URL (if using Redis for stream resumption)");
   console.log("   - STRIPE_* variables (if using Stripe payments)");
   return await question(
@@ -251,11 +251,12 @@ NEXT_PUBLIC_CONVEX_URL=${envVars.NEXT_PUBLIC_CONVEX_URL || ""}
 CONVEX_SERVICE_ROLE_KEY=${envVars.CONVEX_SERVICE_ROLE_KEY}
 
 # =============================================================================
-# S3 FILE STORAGE (Optional - Feature Flag Controlled)
+# S3 FILE STORAGE (Required)
 # =============================================================================
-# AWS S3 credentials for file storage (only needed if S3 is enabled)
+# AWS S3 credentials for file storage
 # Sign up at: https://aws.amazon.com/s3/
-# ⚠️ IMPORTANT: If using S3, also add these to Convex Dashboard → Environment Variables
+# ⚠️ IMPORTANT: Also add these to Convex Dashboard → Environment Variables
+# and Trigger.dev → Environment Variables.
 AWS_S3_ACCESS_KEY_ID=
 AWS_S3_SECRET_ACCESS_KEY=
 AWS_S3_REGION=us-east-1

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,5 +1,5 @@
 import readline from "node:readline";
-import { exec } from "node:child_process";
+import { exec, execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
 import crypto from "node:crypto";
@@ -7,6 +7,7 @@ import path from "node:path";
 import chalk from "chalk";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 function question(query: string): Promise<string> {
   const rl = readline.createInterface({
@@ -20,6 +21,17 @@ function question(query: string): Promise<string> {
       resolve(ans);
     }),
   );
+}
+
+async function getRequiredAnswer(
+  prompt: string,
+  defaultValue?: string,
+): Promise<string> {
+  const answer = (await question(prompt)).trim() || defaultValue;
+  if (answer) return answer;
+
+  console.log(chalk.red("This value is required"));
+  return await getRequiredAnswer(prompt, defaultValue);
 }
 
 async function getOpenRouterApiKey(): Promise<string> {
@@ -56,19 +68,30 @@ async function getOpenAiApiKey(): Promise<string> {
   return await getOpenAiApiKey();
 }
 
-async function getXaiApiKey(): Promise<string> {
-  console.log(`\n${chalk.bold("Getting XAI API Key for Agent mode")}`);
-  console.log("You can find your XAI API Key at: https://xai.com/api-keys");
-  const key = await question("Enter your XAI API Key: ");
+async function getS3Config(): Promise<{
+  AWS_S3_ACCESS_KEY_ID: string;
+  AWS_S3_SECRET_ACCESS_KEY: string;
+  AWS_S3_REGION: string;
+  AWS_S3_BUCKET_NAME: string;
+}> {
+  console.log(`\n${chalk.bold("Getting required Amazon S3 configuration")}`);
+  console.log("Create a bucket and credentials at: https://aws.amazon.com/s3/");
 
-  if (key.startsWith("xai-")) {
-    return key;
-  }
-
-  console.log(chalk.red("Invalid XAI API Key format"));
-  console.log('XAI keys should start with "xai-"');
-
-  return await getXaiApiKey();
+  return {
+    AWS_S3_ACCESS_KEY_ID: await getRequiredAnswer(
+      "Enter your AWS S3 access key ID: ",
+    ),
+    AWS_S3_SECRET_ACCESS_KEY: await getRequiredAnswer(
+      "Enter your AWS S3 secret access key: ",
+    ),
+    AWS_S3_REGION: await getRequiredAnswer(
+      "Enter your AWS S3 region [us-east-1]: ",
+      "us-east-1",
+    ),
+    AWS_S3_BUCKET_NAME: await getRequiredAnswer(
+      "Enter your AWS S3 bucket name: ",
+    ),
+  };
 }
 
 async function getE2bApiKey(): Promise<string> {
@@ -257,10 +280,10 @@ CONVEX_SERVICE_ROLE_KEY=${envVars.CONVEX_SERVICE_ROLE_KEY}
 # Sign up at: https://aws.amazon.com/s3/
 # ⚠️ IMPORTANT: Also add these to Convex Dashboard → Environment Variables
 # and Trigger.dev → Environment Variables.
-AWS_S3_ACCESS_KEY_ID=
-AWS_S3_SECRET_ACCESS_KEY=
-AWS_S3_REGION=us-east-1
-AWS_S3_BUCKET_NAME=
+AWS_S3_ACCESS_KEY_ID=${envVars.AWS_S3_ACCESS_KEY_ID}
+AWS_S3_SECRET_ACCESS_KEY=${envVars.AWS_S3_SECRET_ACCESS_KEY}
+AWS_S3_REGION=${envVars.AWS_S3_REGION}
+AWS_S3_BUCKET_NAME=${envVars.AWS_S3_BUCKET_NAME}
 
 # Regional storage rollout. Keep false until the matching bucket names and IAM
 # access are configured in both Convex and Trigger.dev for this environment.
@@ -274,7 +297,7 @@ AWS_S3_BUCKET_NAME_US_WEST_2=
 # S3_URL_EXPIRATION_BUFFER_SECONDS=300
 
 # =============================================================================
-# AI PROVIDERS (Required)
+# AI PROVIDERS
 # =============================================================================
 # OpenRouter - Get key at: https://openrouter.ai/
 OPENROUTER_API_KEY=${envVars.OPENROUTER_API_KEY}
@@ -282,8 +305,10 @@ OPENROUTER_API_KEY=${envVars.OPENROUTER_API_KEY}
 # OpenAI - Get key at: https://platform.openai.com/
 OPENAI_API_KEY=${envVars.OPENAI_API_KEY}
 
-# XAI (Grok) - Get key at: https://x.ai/
-XAI_API_KEY=${envVars.XAI_API_KEY}
+# Optional abliteration.ai provider for moderation-gated model routing.
+# Create a key at: https://abliteration.ai/console
+# Configure independently in Vercel and Trigger.dev; the PostHog flag is also required.
+ABLITERATION_API_KEY=
 
 # =============================================================================
 # CODE EXECUTION - E2B (Required for Agent Mode)
@@ -478,7 +503,12 @@ async function main() {
   // Get required API keys
   const OPENROUTER_API_KEY = await getOpenRouterApiKey();
   const OPENAI_API_KEY = await getOpenAiApiKey();
-  const XAI_API_KEY = await getXaiApiKey();
+  const {
+    AWS_S3_ACCESS_KEY_ID,
+    AWS_S3_SECRET_ACCESS_KEY,
+    AWS_S3_REGION,
+    AWS_S3_BUCKET_NAME,
+  } = await getS3Config();
   const E2B_API_KEY = await getE2bApiKey();
 
   // Get WorkOS configuration
@@ -502,7 +532,10 @@ async function main() {
   await writeEnvFile({
     OPENROUTER_API_KEY,
     OPENAI_API_KEY,
-    XAI_API_KEY,
+    AWS_S3_ACCESS_KEY_ID,
+    AWS_S3_SECRET_ACCESS_KEY,
+    AWS_S3_REGION,
+    AWS_S3_BUCKET_NAME,
     E2B_API_KEY,
     WORKOS_API_KEY,
     WORKOS_CLIENT_ID,
@@ -522,15 +555,25 @@ async function main() {
       `\n${chalk.bold("Setting environment variables on local Convex deployment...")}`,
     );
     try {
-      await execAsync(
-        `npx convex env set WORKOS_CLIENT_ID ${WORKOS_CLIENT_ID} --local`,
-      );
-      await execAsync(
-        `npx convex env set WORKOS_AUTH_DOMAIN ${WORKOS_AUTH_DOMAIN} --local`,
-      );
-      await execAsync(
-        `npx convex env set CONVEX_SERVICE_ROLE_KEY ${CONVEX_SERVICE_ROLE_KEY} --local`,
-      );
+      const requiredLocalConvexEnv = {
+        WORKOS_CLIENT_ID,
+        WORKOS_AUTH_DOMAIN,
+        CONVEX_SERVICE_ROLE_KEY,
+        AWS_S3_ACCESS_KEY_ID,
+        AWS_S3_SECRET_ACCESS_KEY,
+        AWS_S3_REGION,
+        AWS_S3_BUCKET_NAME,
+      };
+      for (const [name, value] of Object.entries(requiredLocalConvexEnv)) {
+        await execFileAsync("npx", [
+          "convex",
+          "env",
+          "set",
+          name,
+          value,
+          "--local",
+        ]);
+      }
       console.log(
         chalk.green("✓ Environment variables set on local Convex deployment"),
       );
@@ -541,13 +584,7 @@ async function main() {
         ),
       );
       console.log(
-        `   npx convex env set WORKOS_CLIENT_ID ${WORKOS_CLIENT_ID} --local`,
-      );
-      console.log(
-        `   npx convex env set WORKOS_AUTH_DOMAIN ${WORKOS_AUTH_DOMAIN} --local`,
-      );
-      console.log(
-        `   npx convex env set CONVEX_SERVICE_ROLE_KEY ${CONVEX_SERVICE_ROLE_KEY} --local`,
+        "   npx convex env set <NAME> <VALUE> --local (for each required WorkOS, service-role, and AWS_S3_* variable)",
       );
     }
   } else {


### PR DESCRIPTION
## Summary
- require Amazon S3 for file storage in prerequisites, environment templates, and setup
- collect required S3 credentials during setup and apply them to local Convex safely
- document optional `ABLITERATION_API_KEY` configuration for abliteration.ai across local, Vercel, and Trigger.dev
- remove the unused XAI setup prompt and stale Convex-storage wording/configuration

## Validation
- `pnpm exec prettier --check README.md scripts/setup.ts app/hooks/useFileUpload.ts next.config.ts`
- `pnpm exec eslint scripts/setup.ts app/hooks/useFileUpload.ts next.config.ts`
- `pnpm typecheck`
- commit hook: 483 test suites / 5,281 tests passed
- repository-wide search confirms no `NEXT_PUBLIC_USE_S3_STORAGE`, `ctx.storage`, `storage_id`, `storageId`, or runtime `XAI_API_KEY` references remain
- GitHub Actions, CodeQL, Vercel preview, Trigger.dev preview, and CodeRabbit passed

## Manual verification
- In a disposable local checkout, run `pnpm setup` with valid AWS and Convex credentials.
- Confirm `.env.local` contains the entered `AWS_S3_*` values and no `XAI_API_KEY`.
- For a local Convex deployment, confirm the required `AWS_S3_*` values appear in `npx convex env list --local`.
- Optionally add `ABLITERATION_API_KEY` and confirm moderated eligible requests can select the configured treatment; without it, baseline routing should remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Setup & Configuration**
  - Amazon S3 is now required for file storage, with guided configuration, validation, and a default region.
  - Setup now supports optional Abliteration AI credentials instead of collecting XAI credentials.
  - Local Convex setup securely passes required WorkOS, service-role, and S3 configuration.

- **Documentation**
  - Updated setup guidance covers S3 requirements, Trigger.dev worker configuration, and optional Abliteration AI usage.
  - Added instructions for identifying eligible security requests and configuring the Abliteration AI provider.

- **Configuration Changes**
  - Removed dedicated Convex image-host allowances; existing general image support remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->