### PR TITLE
Measure Miosa pilot acquisition, fallback and run economics

### DIFF
--- a/docs/miosa-measurement.md
+++ b/docs/miosa-measurement.md
@@ -1,0 +1,62 @@
+# Miosa versus E2B measurement contract
+
+Rollout ownership, current percentages, dashboard links and readout decisions
+belong in [HAC-78](https://linear.app/hackerai/issue/HAC-78/rollout-miosa-as-primary-cloud-agent-sandbox-with-e2b-fallback).
+The [pilot runbook](miosa-pro-pilot.md) defines eligibility and rollback.
+
+## Cohorts and denominators
+
+Keep Production and Preview in separate PostHog projects. Separate internal
+acceptance accounts from customer results. Use stable user assignment and
+`trigger_run_id` to correlate parent Agent events; do not join by chat alone
+because a chat can have many runs. Deduplicate retries before calculating rates.
+
+`miosa_cloud_sandbox_rollout_exposed.variant` is the assigned arm, not the final
+provider. A Miosa attempt rescued by E2B still belongs to the Miosa arm.
+`miosa_cloud_sandbox_enrollment_denied` is an eligibility veto, not a Miosa
+outage or exposure. Show these separately by reason. Neither flag evaluation
+nor a successful model response proves that a sandbox was used.
+
+For customer comparisons, restrict to Pro parent Cloud Agent runs with actual
+rollout exposure. Split acquisition results by boot path, region and model;
+never compare all legacy E2B workspaces against only fresh Miosa workspaces.
+`reuse_existing` currently combines warm reuse and paused restore, so it is
+not a pure resume benchmark. Confirm pause duration and restore mode through
+disposable acceptance tests before making resume-performance claims.
+
+The pilot is operational monitoring, not yet a balanced randomized experiment:
+the fresh-workspace gate is applied to Miosa candidates. A completion or cost
+comparison remains observational unless equivalent enrollment eligibility and
+follow-up cohorts are established for the E2B control. Do not change the boolean
+routing flag into multivariate values: runtime routing requires boolean `true`.
+
+## Scorecard
+
+| Metric                  | Definition / caveat                                                                                                                                                                                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Completion              | Successful parent Agent runs / exposed runs; show error, abort and missing terminal outcome separately. A missing outcome may be in flight or lost telemetry, not success.                                                                                                                                   |
+| Acquisition reliability | Successful `cloud_sandbox_acquisition_completed` / all completed acquisition attempts; deduplicate and aggregate by run for run-level rates. Report enrollment vetoes separately.                                                                                                                            |
+| Fallback                | Runs with `cloud_sandbox_provider_fallback` / Miosa-exposed runs. Show final provider and whether the rescued run completed. Never use model `fallback_served` for sandbox fallback.                                                                                                                         |
+| Startup / reconnect     | Acquisition p50/p95 by arm and boot path, plus request-to-first-model-chunk p50/p95. The acquisition completion event measures the full wait across Miosa and E2B, not just the successful provider.                                                                                                         |
+| Tool / recovery health  | Active terminal and recovery duration, handled tool failure count, and tool count per run. Handled failures include non-sandbox tools; do not label all of them sandbox failures.                                                                                                                            |
+| Persistence             | `terminal_output_persistence_failure`, including recovered versus failed outcomes, correlated by run. This measures output-saving failures, not all filesystem durability. Periodic hash-based pause/restore and deletion/isolation acceptance remain required.                                              |
+| Cost / margin           | Correlate `hackerai-usage_cost.trigger_run_id` with assignment and completion. Include both providers, model and worker costs for failed/fallback runs; divide total observed costs by completed runs. Show cost-event and sandbox-cost coverage. Missing/zero provider cost is not proof of free operation. |
+| Coverage                | Counts, distinct users, run IDs, missing outcome/boot/cost fields, latest event timestamp and sample size. Old events cannot backfill new fields.                                                                                                                                                            |
+
+`hackerai-tool_usage` remains one aggregate event per request. Cost and tool
+events now carry the durable Agent ID; Ask retains its existing behavior.
+Acquisition completion contains only bounded routing/lifecycle metadata, never
+commands, output, filenames, prompts, targets, credentials or provider bodies.
+
+## Decisions
+
+Review completion first, then acquisition/fallback, latency, persistence and
+economics. Include sample counts with percentiles; a handful of internal tests
+cannot establish customer reliability, retention or cost superiority. Measure
+repeat Agent usage and cancellation/feedback only after a meaningful customer
+cohort has accumulated; keep these user-level outcomes separate from run-level
+success. Do not expand on empty charts or credits subsidizing testing.
+
+Stop expansion immediately for confirmed data loss, isolation/deletion defects
+or broken output/cancellation. Apply the existing pilot review window and
+guardrails; dashboard construction does not authorize a rollout increase.

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -50,6 +50,7 @@ import { getSandboxWithFallbackGuard } from "./utils/sandbox-fallback";
 import { createE2BResourcePressureObserver } from "@/lib/analytics/sandbox-resource-pressure";
 import { E2B_COST_PER_MS } from "./utils/e2b-cost";
 import { phLogger } from "@/lib/posthog/server";
+import { MIOSA_NATIVE_TEMPLATE_ID } from "./utils/miosa-runtime";
 import { logger } from "@/lib/logger";
 import { redactSensitiveErrorMessage } from "@/lib/utils/error-redaction";
 import type { TriggerRunRegion } from "@/lib/api/trigger-region";
@@ -266,12 +267,13 @@ export const createTools = (
         subscription,
         subscription_tier: subscription,
         agent_run_kind: cloudSandboxContext.runKind,
+        trigger_region: cloudSandboxContext.triggerRegion,
         sandbox_boot_path: sandboxBootInfo?.path,
         sandbox_acquisition_duration_ms: sandboxBootInfo?.duration_ms,
         sandbox_create_attempts: sandboxBootInfo?.create_attempts,
         image_version:
           provider === "miosa"
-            ? process.env.MIOSA_TEMPLATE_ID
+            ? process.env.MIOSA_TEMPLATE_ID?.trim() || MIOSA_NATIVE_TEMPLATE_ID
             : (process.env.E2B_TEMPLATE ?? "terminal-agent-sandbox"),
         cloud_sandbox_provider_event_version: 8,
       });

--- a/lib/ai/tools/utils/__tests__/cloud-sandbox-routing.test.ts
+++ b/lib/ai/tools/utils/__tests__/cloud-sandbox-routing.test.ts
@@ -33,6 +33,101 @@ describe("cloud sandbox provider routing", () => {
     jest.clearAllMocks();
   });
 
+  it("measures the complete fallback wait without attributing it to an E2B assignment", async () => {
+    const clock = jest.spyOn(Date, "now").mockReturnValue(1000);
+    const onBoot = jest.fn();
+    mockEnsureMiosa.mockImplementationOnce(async () => {
+      clock.mockReturnValue(4000);
+      throw new Error("unavailable");
+    });
+    mockEnsureE2B.mockImplementationOnce(async (context) => {
+      clock.mockReturnValue(4500);
+      context.onBoot({
+        path: "create_fresh",
+        duration_ms: 500,
+        create_attempts: 1,
+      });
+      return { sandbox: { sandboxId: "e2b-1" } };
+    });
+    try {
+      await ensureCloudSandboxConnection({
+        userId: "user-1",
+        setSandbox,
+        onBoot,
+        context: {
+          provider: "miosa",
+          selectionReason: "miosa_rollout",
+          triggerRunId: "run-1",
+          subscription: "pro",
+          triggerRegion: "us-east-1",
+        },
+      });
+      const outcomes = mockPostHogEvent.mock.calls.filter(
+        ([event]) => event === "cloud_sandbox_acquisition_completed",
+      );
+      expect(outcomes).toHaveLength(1);
+      expect(outcomes[0][1]).toEqual(
+        expect.objectContaining({
+          trigger_run_id: "run-1",
+          preferred_provider: "miosa",
+          sandbox_provider: "e2b",
+          outcome: "success",
+          fallback_used: true,
+          duration_ms: 3500,
+          sandbox_boot_path: "create_fresh",
+          trigger_region: "us-east-1",
+        }),
+      );
+      expect(onBoot).toHaveBeenCalledTimes(1);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it("records an enrollment veto separately from an infrastructure fallback", async () => {
+    mockEnsureMiosa.mockRejectedValueOnce(
+      new MiosaEnrollmentError("existing_e2b_workspace"),
+    );
+    mockEnsureE2B.mockResolvedValueOnce({ sandbox: { sandboxId: "e2b-1" } });
+    await ensureCloudSandboxConnection({
+      userId: "user-1",
+      setSandbox,
+      context: { provider: "miosa" },
+    });
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "cloud_sandbox_acquisition_completed",
+      expect.objectContaining({
+        outcome: "success",
+        fallback_used: false,
+        enrollment_denied_reason: "existing_e2b_workspace",
+      }),
+    );
+  });
+
+  it("includes total acquisition failure in the denominator without logging raw errors", async () => {
+    mockEnsureMiosa.mockRejectedValueOnce(new Error("private response"));
+    mockEnsureE2B.mockRejectedValueOnce(new Error("private response"));
+    await expect(
+      ensureCloudSandboxConnection({
+        userId: "user-1",
+        setSandbox,
+        context: { provider: "miosa" },
+      }),
+    ).rejects.toThrow();
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "cloud_sandbox_acquisition_completed",
+      expect.objectContaining({
+        outcome: "error",
+        fallback_used: true,
+        preferred_provider: "miosa",
+        sandbox_provider: "e2b",
+      }),
+    );
+    expect(JSON.stringify(mockPostHogEvent.mock.calls)).not.toContain(
+      "private response",
+    );
+  });
+
   it("uses MIOSA for treatment assignments", async () => {
     const sandbox = { sandboxKind: "miosa", sandboxId: "miosa-1" };
     mockEnsureMiosa.mockResolvedValue({ sandbox });
@@ -242,6 +337,7 @@ describe("cloud sandbox provider routing", () => {
       ).resolves.toEqual({ sandbox, provider: "e2b" });
       expect(mockPostHogEvent.mock.calls.map(([event]) => event)).toEqual([
         "miosa_cloud_sandbox_enrollment_denied",
+        "cloud_sandbox_acquisition_completed",
       ]);
       expect(mockPostHogEvent).toHaveBeenCalledWith(
         "miosa_cloud_sandbox_enrollment_denied",
@@ -265,7 +361,7 @@ describe("cloud sandbox provider routing", () => {
       setSandbox,
       context: { provider: "miosa" },
     });
-    expect(mockPostHogEvent).toHaveBeenCalledTimes(1);
+    expect(mockPostHogEvent).toHaveBeenCalledTimes(2);
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "miosa_cloud_sandbox_enrollment_denied",
       expect.objectContaining({

--- a/lib/ai/tools/utils/cloud-sandbox.ts
+++ b/lib/ai/tools/utils/cloud-sandbox.ts
@@ -161,6 +161,45 @@ export async function ensureCloudSandboxConnection(options: {
 }): Promise<{ sandbox: AnySandbox; provider: CloudSandboxProvider }> {
   const startedAt = Date.now();
   const preferredProvider = options.context?.provider ?? "e2b";
+  let bootInfo: SandboxBootInfo | undefined;
+  let fallbackUsed = false;
+  let enrollmentDeniedReason: MiosaEnrollmentError["reason"] | undefined;
+  const onBoot = options.onBoot;
+  options = {
+    ...options,
+    onBoot: (info) => {
+      bootInfo = info;
+      onBoot?.(info);
+    },
+  };
+  // One outcome per acquisition, including failed attempts and the full wait
+  // across providers. Aggregate by run ID, not raw event count, for run metrics.
+  const recordOutcome = (
+    provider: CloudSandboxProvider,
+    outcome: "success" | "error",
+  ) => {
+    phLogger.event("cloud_sandbox_acquisition_completed", {
+      userId: options.userId,
+      chat_id: options.context?.chatId,
+      trigger_run_id: options.context?.triggerRunId,
+      agent_run_kind: options.context?.runKind ?? "parent",
+      subscription_tier: options.context?.subscription,
+      trigger_region: options.context?.triggerRegion,
+      preferred_provider: preferredProvider,
+      provider_selection_reason:
+        options.context?.selectionReason ?? "configured",
+      sandbox_provider: provider,
+      sandbox_type: "cloud",
+      outcome,
+      fallback_used: fallbackUsed,
+      enrollment_denied_reason: enrollmentDeniedReason,
+      duration_ms: Date.now() - startedAt,
+      sandbox_boot_path: bootInfo?.path,
+      image_version: bootInfo?.image_version,
+      sandbox_create_attempts: bootInfo?.create_attempts,
+      cloud_sandbox_acquisition_completed_event_version: 1,
+    });
+  };
 
   if (preferredProvider === "miosa") {
     try {
@@ -169,9 +208,11 @@ export async function ensureCloudSandboxConnection(options: {
       }
       const result = await ensureMiosaCloudSandboxConnection(options);
       recordRolloutExposure(options);
+      recordOutcome("miosa", "success");
       return { ...result, provider: "miosa" };
     } catch (error) {
       if (error instanceof MiosaEnrollmentError) {
+        enrollmentDeniedReason = error.reason;
         phLogger.event("miosa_cloud_sandbox_enrollment_denied", {
           userId: options.userId,
           chat_id: options.context?.chatId,
@@ -187,6 +228,7 @@ export async function ensureCloudSandboxConnection(options: {
           miosa_cloud_sandbox_enrollment_denied_event_version: 2,
         });
       } else {
+        fallbackUsed = true;
         recordRolloutExposure(options);
         recordAcquisitionFailure({
           userId: options.userId,
@@ -215,8 +257,10 @@ export async function ensureCloudSandboxConnection(options: {
 
   try {
     const result = await ensureE2BCloudSandboxConnection(options);
+    recordOutcome("e2b", "success");
     return { ...result, provider: "e2b" };
   } catch (error) {
+    recordOutcome("e2b", "error");
     recordAcquisitionFailure({
       userId: options.userId,
       provider: "e2b",

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -65,6 +65,25 @@ describe("captureToolCalls", () => {
 
     expect(capture).not.toHaveBeenCalled();
   });
+
+  it("correlates aggregate tool counts with the durable Agent run", () => {
+    const capture = jest.fn();
+    captureToolCalls({
+      posthog: { capture },
+      chatLogger: { getToolCalls: () => [{ name: "run_terminal_cmd" }] },
+      userId: "user_123",
+      mode: "agent",
+      triggerRunId: "run_test",
+    });
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          trigger_run_id: "run_test",
+          totalCount: 1,
+        }),
+      }),
+    );
+  });
 });
 
 describe("captureAgentRun", () => {
@@ -85,6 +104,7 @@ describe("captureAgentRun", () => {
       responseModel: "deepseek/deepseek-v4-pro",
       fallbackServed: false,
       triggerRunId: "run_123",
+      handledToolFailureCount: 2,
       triggerUsageDurationMs: 42_000,
       triggerTotalCostUsd: 0.00714,
       startupTimingVersion: 1,
@@ -133,6 +153,7 @@ describe("captureAgentRun", () => {
         configured_model: "deepseek/deepseek-v4-pro",
         agent_permission_mode: "ask_approval",
         trigger_run_id: "run_123",
+        handled_tool_failure_count: 2,
         trigger_usage_duration_ms: 42_000,
         trigger_total_cost_usd: 0.00714,
         startup_timing_version: 1,
@@ -805,6 +826,7 @@ describe("captureUsageCost", () => {
     const capture = jest.fn();
 
     captureUsageCost({
+      triggerRunId: "run_cost_test",
       posthog: { capture } as any,
       userId: "user_123",
       subscription: "pro",
@@ -868,6 +890,7 @@ describe("captureUsageCost", () => {
       event: "hackerai-usage_cost",
       properties: expect.objectContaining({
         user_id: "user_123",
+        trigger_run_id: "run_cost_test",
         subscription: "pro",
         subscription_tier: "pro",
         organization_id: "org_123",

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1184,11 +1184,13 @@ export function captureToolCalls({
   chatLogger,
   userId,
   mode,
+  triggerRunId,
 }: {
   posthog: PostHog | null;
   chatLogger: ChatLogger | undefined;
   userId: string;
   mode: ChatMode;
+  triggerRunId?: string;
 }) {
   if (!posthog || !chatLogger) return;
   const toolCalls = chatLogger.getToolCalls();
@@ -1219,6 +1221,7 @@ export function captureToolCalls({
       ),
       totalCount: toolCalls.length,
       distinctToolCount: tools.length,
+      ...(triggerRunId && { trigger_run_id: triggerRunId }),
       tool_usage_event_version: 2,
       $process_person_profile: false,
     },
@@ -1301,6 +1304,7 @@ type AgentCompletionAnalyticsArgs = {
   activeModelStreamDurationMs?: number;
   activeTerminalWaitDurationMs?: number;
   activeSandboxRecoveryDurationMs?: number;
+  handledToolFailureCount?: number;
   messageCount?: number;
   estimatedInputTokens?: number;
   attachmentCount?: number;
@@ -1357,6 +1361,7 @@ export function captureAgentRun({
   activeModelStreamDurationMs,
   activeTerminalWaitDurationMs,
   activeSandboxRecoveryDurationMs,
+  handledToolFailureCount,
   messageCount,
   estimatedInputTokens,
   attachmentCount,
@@ -1520,6 +1525,9 @@ export function captureAgentRun({
     distinctId: userId,
     event: "hackerai-agent_run",
     properties: {
+      ...(handledToolFailureCount !== undefined && {
+        handled_tool_failure_count: handledToolFailureCount,
+      }),
       mode,
       subscription,
       subscription_tier: subscription,
@@ -1732,6 +1740,7 @@ export function captureAgentCompletionAnalytics(
     budgetAbortDetails: args.budgetAbortDetails,
     agentPermissionMode: args.agentPermissionMode,
     triggerRunId: args.triggerRunId,
+    handledToolFailureCount: args.handledToolFailureCount,
     triggerUsageDurationMs: args.triggerUsageDurationMs,
     triggerTotalCostUsd: args.triggerTotalCostUsd,
     startupTimingVersion: args.startupTimingVersion,
@@ -1799,6 +1808,7 @@ export function captureUsageCost({
   fallbackServed,
   experiment,
   regionalFreeLimits,
+  triggerRunId,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1827,6 +1837,7 @@ export function captureUsageCost({
   fallbackServed?: boolean;
   experiment?: ExperimentAnalyticsContext;
   regionalFreeLimits?: RegionalFreeLimitsAssignment;
+  triggerRunId?: string;
 }) {
   if (!posthog) return;
   const includedUsageValueDollars =
@@ -1845,6 +1856,7 @@ export function captureUsageCost({
     event: "hackerai-usage_cost",
     properties: {
       user_id: userId,
+      ...(triggerRunId && { trigger_run_id: triggerRunId }),
       subscription,
       subscription_tier: subscription,
       ...(organizationId && { organization_id: organizationId }),

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -4010,6 +4010,7 @@ export const agentLongTask = task({
                   });
                 }
                 captureUsageCost({
+                  triggerRunId: ctx.run.id,
                   regionalFreeLimits,
                   posthog,
                   userId,
@@ -4582,7 +4583,13 @@ export const agentLongTask = task({
                 cacheReadTokens: fallbackCacheRead,
                 cacheWriteTokens: fallbackCacheWrite,
               });
-              captureToolCalls({ posthog, chatLogger, userId, mode });
+              captureToolCalls({
+                posthog,
+                chatLogger,
+                userId,
+                mode,
+                triggerRunId: ctx.run.id,
+              });
               await drainBackgroundRunWork();
               // Final reconciliation can change the finish reason to
               // budget-exhausted; do it before analytics and persistence.
@@ -4593,6 +4600,7 @@ export const agentLongTask = task({
                   ? "error"
                   : "success";
               captureAgentCompletionAnalytics({
+                handledToolFailureCount,
                 abliteratedProviderSummary: abliteratedTelemetry?.getSummary(),
                 posthog,
                 userId,
@@ -5550,7 +5558,13 @@ export const agentLongTask = task({
                         cacheReadTokens: usageTracker.cacheReadTokens,
                         cacheWriteTokens: usageTracker.cacheWriteTokens,
                       });
-                      captureToolCalls({ posthog, chatLogger, userId, mode });
+                      captureToolCalls({
+                        posthog,
+                        chatLogger,
+                        userId,
+                        mode,
+                        triggerRunId: ctx.run.id,
+                      });
                       await drainBackgroundRunWork();
                       // Final reconciliation can change the finish reason to
                       // budget-exhausted; do it before analytics and
@@ -5562,6 +5576,7 @@ export const agentLongTask = task({
                           ? "error"
                           : "success";
                       captureAgentCompletionAnalytics({
+                        handledToolFailureCount,
                         abliteratedProviderSummary:
                           abliteratedTelemetry?.getSummary(),
                         posthog,


### PR DESCRIPTION
## Summary
- Record one acquisition outcome including full fallback wait, final provider, eligibility veto and actual boot metadata.
- Correlate aggregate tool and provider cost events with durable Agent run IDs; include handled tool failure counts on run completion.
- Document unbiased cohort boundaries, missing-data coverage and persistence acceptance limits.

## Validation
- 493 suites / 5,456 tests passed; TypeScript and lint passed.
- Production internal account flag evaluates true, but a real Agent run correctly retained its existing E2B workspace (existing_e2b_workspace). No deletion or migration performed.
- Preview verification of new telemetry will follow deployment. General Production rollout remains 0%.

## Manual verification
On Preview, start a Cloud Agent task and run a bounded localhost-only command. Confirm completion and reload, then correlate acquisition outcome, final provider, tool count and usage cost by trigger_run_id. Confirm eligibility veto is not counted as fallback. Preserve existing workspaces; force no production outages.

Owner/readout: HAC-78. No flag percentage or routing logic changes in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cloud sandbox acquisition tracking, including provider outcomes, fallback usage, timing, and boot details.
  * Added durable run correlation and handled tool-failure details to usage and agent activity analytics.
  * Added MIOSA template information to sandbox selection analytics.

* **Documentation**
  * Added measurement guidance covering cohort definitions, metrics, instrumentation, rollout decisions, and review criteria.

* **Tests**
  * Expanded coverage for sandbox acquisition outcomes, fallback behavior, telemetry correlation, and error redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->