### PR TITLE
Recover Agent response timeouts after completed tools

### DIFF
--- a/docs/provider-error-recovery.md
+++ b/docs/provider-error-recovery.md
@@ -8,6 +8,12 @@ wins. Recovery retains completed tool results and removes only the incomplete
 tail. The existing model selection, billing, authorization, and retry limits
 still apply.
 
+The local provider watchdog distinguishes waiting for a response from waiting
+for a streamed chunk. A response timeout can leave only completed tool results
+in the transcript, with no new step or partial tail to trim. That specific local
+error may retain the completed tail for the existing bounded continuation;
+provider-supplied error wording alone does not enable it.
+
 A rejection delivered through `streamText.onError` before any output can use
 the existing fallback, including an active Abliteration experiment's baseline
 route. This does not enable replay of arbitrary output-bearing 400 failures.

--- a/lib/ai/__tests__/provider-stream-timeout.test.ts
+++ b/lib/ai/__tests__/provider-stream-timeout.test.ts
@@ -1,7 +1,10 @@
 import { stepCountIs, streamText, tool, type LanguageModel } from "ai";
 import { WritableStream } from "node:stream/web";
 import { z } from "zod";
-import { withProviderStreamTimeout } from "../provider-stream-timeout";
+import {
+  withProviderStreamTimeout,
+  isProviderResponseTimeout,
+} from "../provider-stream-timeout";
 import { isRetriableProviderStreamDisconnectError } from "@/lib/utils/error-utils";
 
 const makeModel = (doStream: jest.Mock): LanguageModel => ({
@@ -244,4 +247,16 @@ it("reports a stalled initial request through the SDK error callback rather than
   ).toBe(true);
   expect(onAbort).not.toHaveBeenCalled();
   expect(jest.getTimerCount()).toBe(0);
+});
+
+it("does not mistake provider errors for local response timeouts", () => {
+  expect(
+    isProviderResponseTimeout(
+      Object.assign(new Error("Provider response timed out after 1000ms"), {
+        name: "ProviderStreamTimeoutError",
+        phase: "response",
+      }),
+    ),
+  ).toBe(false);
+  expect(isProviderResponseTimeout(new Error("request timed out"))).toBe(false);
 });

--- a/lib/ai/provider-stream-timeout.ts
+++ b/lib/ai/provider-stream-timeout.ts
@@ -29,7 +29,18 @@ export type ProviderStreamTimeoutOptions = {
 
 class ProviderStreamTimeoutError extends Error {
   name = "ProviderStreamTimeoutError";
+
+  constructor(
+    message: string,
+    readonly phase: ProviderStreamTimeoutDetails["phase"],
+  ) {
+    super(message);
+  }
 }
+
+/** Identify a local watchdog failure before a provider response could emit output. */
+export const isProviderResponseTimeout = (error: unknown): boolean =>
+  error instanceof ProviderStreamTimeoutError && error.phase === "response";
 
 /** Bound provider I/O without timing tool execution or durable approval waits. */
 export function withProviderStreamTimeout(
@@ -81,6 +92,7 @@ export function withProviderStreamTimeout(
             const timer = setTimeout(() => {
               const error = new ProviderStreamTimeoutError(
                 `Provider ${phase} timed out after ${options.timeoutMs}ms`,
+                phase,
               );
               fail(error);
               cancelProvider(error);

--- a/lib/chat/__tests__/provider-recovery-stream.test.ts
+++ b/lib/chat/__tests__/provider-recovery-stream.test.ts
@@ -10,7 +10,10 @@ import {
 import { WritableStream } from "node:stream/web";
 import { z } from "zod";
 import { isRetriableProviderStreamDisconnectError } from "@/lib/utils/error-utils";
-import { withProviderStreamTimeout } from "@/lib/ai/provider-stream-timeout";
+import {
+  withProviderStreamTimeout,
+  isProviderResponseTimeout,
+} from "@/lib/ai/provider-stream-timeout";
 import {
   decideProviderRecovery,
   prepareProviderDisconnectContinuation,
@@ -66,10 +69,10 @@ const response = (parts: unknown[]) => ({
 
 afterEach(() => jest.useRealTimers());
 
-it.each(["504", "idle_timeout"])(
+it.each(["504", "idle_timeout", "response_timeout"])(
   "recovers %s after tool execution through real SDK/UI streams without executing the tool twice",
   async (failureMode) => {
-    if (failureMode === "idle_timeout") jest.useFakeTimers();
+    if (failureMode !== "504") jest.useFakeTimers();
     const execute = jest.fn(async () => ({ saved: true }));
     const tools = { save: tool({ inputSchema: z.object({}), execute }) };
     const upstreamError = { code: 504, message: "The operation was aborted" };
@@ -87,24 +90,26 @@ it.each(["504", "idle_timeout"])(
         ]),
       )
       .mockResolvedValueOnce(
-        failureMode === "idle_timeout"
-          ? {
-              stream: new ReadableStream({
-                start(output) {
-                  output.enqueue({ type: "text-start", id: "partial" });
-                  output.enqueue({
-                    type: "text-delta",
-                    id: "partial",
-                    delta: "incomplete",
-                  });
-                },
-              }),
-            }
-          : response([
-              { type: "text-start", id: "partial" },
-              { type: "text-delta", id: "partial", delta: "incomplete" },
-              { type: "error", error: upstreamError },
-            ]),
+        failureMode === "response_timeout"
+          ? new Promise(() => {})
+          : failureMode === "idle_timeout"
+            ? {
+                stream: new ReadableStream({
+                  start(output) {
+                    output.enqueue({ type: "text-start", id: "partial" });
+                    output.enqueue({
+                      type: "text-delta",
+                      id: "partial",
+                      delta: "incomplete",
+                    });
+                  },
+                }),
+              }
+            : response([
+                { type: "text-start", id: "partial" },
+                { type: "text-delta", id: "partial", delta: "incomplete" },
+                { type: "error", error: upstreamError },
+              ]),
       );
     let failure: unknown;
     const initial = streamText({
@@ -125,13 +130,36 @@ it.each(["504", "idle_timeout"])(
       }))
         partial = message;
     })();
-    if (failureMode === "idle_timeout")
-      await jest.advanceTimersByTimeAsync(1100);
+    if (failureMode !== "504") await jest.advanceTimersByTimeAsync(1100);
     await readInitial;
     expect(execute).toHaveBeenCalledTimes(1);
     expect(isRetriableProviderStreamDisconnectError(failure)).toBe(true);
-    const continuation = prepareProviderDisconnectContinuation([partial!]);
+    const continuation = prepareProviderDisconnectContinuation([partial!], {
+      allowCompletedTail: isProviderResponseTimeout(failure),
+    });
+    expect(isProviderResponseTimeout(failure)).toBe(
+      failureMode === "response_timeout",
+    );
     expect(continuation?.preservedCompletedToolCount).toBe(1);
+    if (failureMode === "response_timeout") {
+      expect(continuation?.removedPartCount).toBe(0);
+      const decision = {
+        userCancelled: false,
+        unrecoverableVision: false,
+        alreadyRetried: false,
+        streamAborted: false,
+        loopRecovery: false,
+        hasCandidate: Boolean(continuation),
+        modelEligible: Boolean(continuation),
+      };
+      expect(decideProviderRecovery(decision).attempt).toBe(true);
+      expect(
+        decideProviderRecovery({ ...decision, userCancelled: true }).reason,
+      ).toBe("user_cancelled");
+      expect(
+        decideProviderRecovery({ ...decision, alreadyRetried: true }).reason,
+      ).toBe("retry_budget_exhausted");
+    }
     const messages = await convertToModelMessages(continuation!.messages, {
       tools,
     });

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1,3 +1,4 @@
+import { isProviderResponseTimeout } from "@/lib/ai/provider-stream-timeout";
 import {
   evaluateRegionalFreeLimits,
   captureRegionalFreeLimitsExposure,
@@ -5029,7 +5030,10 @@ export const agentLongTask = task({
                               normalizedFinishedMessages,
                               {
                                 allowCompletedTail:
-                                  shouldRecoverAbliterationStreamError,
+                                  shouldRecoverAbliterationStreamError ||
+                                  isProviderResponseTimeout(
+                                    state.providerError,
+                                  ),
                               },
                             )
                           : undefined;
@@ -5387,6 +5391,12 @@ export const agentLongTask = task({
                                     !retryAborted
                                       ? prepareProviderDisconnectContinuation(
                                           normalizedRetryMessages,
+                                          {
+                                            allowCompletedTail:
+                                              isProviderResponseTimeout(
+                                                state.providerError,
+                                              ),
+                                          },
                                         )
                                       : undefined;
                                   const finalRetryModel = nextContinuation


### PR DESCRIPTION
A local five-minute provider response timeout could end an Agent run even after successful tool work: the SDK had not emitted a new step, so recovery found no incomplete tail to trim and returned `no_safe_recovery`. Preserve the completed transcript for this specific local response-phase timeout and use the existing bounded fallback. Completed tools are not rerun.

Production evidence from the frozen audit window `2026-09-10T20:00:44Z` inclusive–`2026-09-11T20:00:44Z` exclusive:
- Trigger production worker `20260911.5 / eqyw6jib`, deployed `2026-09-11T16:53:17Z`: runs `run_06g93gbqghnss60dpol8f2fue1` and `run_06g93cq1r3643sfj7pg5ht1bw1` failed with `ProviderStreamTimeoutError: Provider response timed out after 300000ms`. Both had completed tools, matched call/result counts, no cancellation, and unused retry budgets, but skipped recovery.
- The audit found 23 provider timeout failures; the two representative response-phase cases establish this defect. Do not attribute all 23 to this cause.
- These runs postdate #1305 (worker `20260910.10`, deployed `2026-09-10T20:26:52Z`). The timer works; continuation eligibility was incomplete. Current Vercel is independently `dpl_8syJ7t6TeY8BoiYZvyoraMLqU5zQ / 65367b1f`, READY `2026-09-11T16:54:53.550Z`.

The watchdog now carries its response/chunk phase. An instance check identifies only locally generated response timeouts and enables the existing completed-tail option at both Agent recovery entry points. Provider error wording, chunk timeout behavior, cancellation, retry budgets, billing, model eligibility, and Ask remain unchanged. No new suppression, feature flag, dependency, configuration, or production change.

Validation: real AI SDK/UI-stream regression failed before the fix and now preserves the completed tool result, executes it once, and completes fallback. Focused 217 tests pass, including cancellation/exhaustion and rejecting provider errors that imitate local timeout fields. Typecheck, changed-file lint/format, dependency isolation, and diff checks pass. Commit hooks passed all 493 suites / 5,458 tests. Adversarial review covered both continuation callers, run-scoped retries, late responses, cancellation, provider wrappers, and deployment skew.

Manual verification: on the PR Preview, use a disposable Agent chat to write/read a marker and report completion; reload and confirm the tool result and answer persist. Cancel another bounded request and confirm no recovery starts after cancellation. Fault injection is covered with synthetic SDK streams; do not replay customer failures. After merge, verify the actual Trigger production worker contains this commit, then inspect the next naturally occurring response timeout for eligible bounded continuation and no repeated completed tools. Existing runs retain their old worker. Docker/desktop release workflows do not match this change; no layout/browser-rendering change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery from local provider response timeouts, allowing completed tool results to be retained when safely continuing a response.
  - Improved retry and cancellation handling for response-timeout scenarios.
  - More accurately distinguishes local response timeouts from provider-reported errors and stream-chunk delays.

- **Documentation**
  - Documented provider watchdog behavior, including response-timeout recovery and the distinction between response waits and stream-chunk waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->