### PR TITLE
Expand Miosa fresh-workspace rollout to Pro+

### DIFF
--- a/docs/miosa-measurement.md
+++ b/docs/miosa-measurement.md
@@ -17,9 +17,9 @@ provider. A Miosa attempt rescued by E2B still belongs to the Miosa arm.
 outage or exposure. Show these separately by reason. Neither flag evaluation
 nor a successful model response proves that a sandbox was used.
 
-For customer comparisons, restrict to Pro parent Cloud Agent runs with actual
-rollout exposure. Split acquisition results by boot path, region and model;
-never compare all legacy E2B workspaces against only fresh Miosa workspaces.
+For customer comparisons, restrict to Pro and Pro+ parent Cloud Agent runs with
+actual rollout exposure. Split acquisition results by boot path, region and
+model; never compare all legacy E2B workspaces against only fresh Miosa workspaces.
 `reuse_existing` currently combines warm reuse and paused restore, so it is
 not a pure resume benchmark. Confirm pause duration and restore mode through
 disposable acceptance tests before making resume-performance claims.

--- a/docs/miosa-pro-pilot.md
+++ b/docs/miosa-pro-pilot.md
@@ -1,4 +1,4 @@
-# MIOSA fresh-workspace Pro pilot
+# MIOSA fresh-workspace Pro and Pro+ pilot
 
 Owner and rollout/readout decisions: [HAC-78](https://linear.app/hackerai/issue/HAC-78/rollout-miosa-as-primary-cloud-agent-sandbox-with-e2b-fallback).
 
@@ -11,10 +11,9 @@ destroyed-name reuse, and a real Preview Agent plus reconnect. Passing a fresh
 creation test alone is insufficient. Follow the release order below before
 enrolling Production users.
 
-- Production: 5% stable user-level candidate assignment.
-- Preview/development: 100% candidate assignment for eligible testing.
-- New enrollment: authenticated Pro Cloud Agent users, outside Europe, with no
-  running or paused E2B workspace in any configured E2B account/cluster.
+- Candidate percentages are managed in HAC-78 and the two PostHog projects.
+- New enrollment: authenticated Pro or Pro+ Cloud Agent users, outside Europe,
+  with no running or paused E2B workspace in any configured E2B account/cluster.
 - No activity event, an idle sandbox, or an old template is **not** proof that
   a workspace has terminated. Read E2B state directly, including all templates.
 - Do not delete, pause, migrate, or reset a workspace to make a user eligible.
@@ -36,7 +35,7 @@ because of an old E2B fallback workspace or a subsequent plan upgrade.
 
 Only a confirmed MIOSA not-found result invokes the new-workspace guard:
 
-1. Require exactly the `pro` plan. Missing plan, Free, Pro+, Ultra, and Team do
+1. Require the `pro` or `pro-plus` plan. Missing plan, Free, Ultra, and Team do
    not create a new MIOSA workspace under this pilot.
 2. Require the configured default E2B account so missing credentials cannot be
    mistaken for an empty inventory.
@@ -54,15 +53,16 @@ run is active. E2B fallback does not copy files or rescue every mid-run failure.
 
 Key: `miosa_cloud_sandbox_rollout_v1` in both independent projects:
 
-| Environment         | Project               | Intended candidate percentage |
-| ------------------- | --------------------- | ----------------------------: |
-| Preview/development | hackerai-dev `401167` |                          100% |
-| Production          | HackerAI `144137`     |                            5% |
+| Environment         | Project               |
+| ------------------- | --------------------- |
+| Preview/development | hackerai-dev `401167` |
+| Production          | HackerAI `144137`     |
 
-Filter by the matching `hackerai_environment`; the server enforces Pro eligibility
-only for new enrollment. Do not add a changing plan condition that inadvertently
-evicts an existing MIOSA assignment after a paid-plan upgrade. Keep the flag key
-and distinct ID stable. An explicit E2B override remains an emergency rollback.
+Filter by the matching `hackerai_environment`; the server enforces Pro and Pro+
+eligibility only for new enrollment. Do not add a changing plan condition that
+inadvertently evicts an existing MIOSA assignment after a paid-plan upgrade.
+Keep the flag key and distinct ID stable. An explicit E2B override remains an
+emergency rollback.
 
 These are approved targets, **not evidence that Production is enabled**. Before
 activation, merge reviewed code, independently verify Vercel/Trigger/Convex and
@@ -79,7 +79,7 @@ Real MIOSA acquisition failures retain existing failure/fallback telemetry.
 
 Keep candidate assignment, enrollment, exposure and final provider distinct.
 Do not use `$feature_flag_called` alone as actual MIOSA exposure. Compare
-completion, latency and cost against comparable fresh Pro E2B workspaces, not
+completion, latency and cost against comparable fresh Pro and Pro+ E2B workspaces, not
 the unfiltered E2B population with older workspaces. Include retry and fallback
 costs; testing credits are not production economics.
 
@@ -89,10 +89,12 @@ failures, or material reliability, latency or cost regression. No automatic ramp
 
 ## Verification
 
-- Pro + confirmed empty E2B inventory: may create MIOSA when assigned treatment.
-- Pro + running/paused E2B (including old templates/later pages/other configured
-  cluster): remains E2B; no workspace is deleted by the enrollment guard.
-- Non-Pro + no MIOSA record: no new MIOSA enrollment.
+- Pro or Pro+ + confirmed empty E2B inventory: may create MIOSA when assigned
+  treatment.
+- Pro or Pro+ + running/paused E2B (including old templates/later pages/other
+  configured cluster): remains E2B; no workspace is deleted by the enrollment
+  guard.
+- Free, Ultra, or Team + no MIOSA record: no new MIOSA enrollment.
 - Existing MIOSA assignment: reuse/resume without applying the new-user gate.
 - Failed inventory lookup: E2B; never interpret the failure as an empty list.
 - After eligible Preview/Production Agent completion, verify final provider,

--- a/lib/ai/tools/utils/__tests__/miosa-enrollment.test.ts
+++ b/lib/ai/tools/utils/__tests__/miosa-enrollment.test.ts
@@ -20,7 +20,7 @@ describe("fresh MIOSA enrollment", () => {
   });
   afterEach(() => jest.restoreAllMocks());
 
-  it.each(["free", "pro-plus", "ultra", "team", undefined] as const)(
+  it.each(["free", "ultra", "team", undefined] as const)(
     "does not enroll %s into a new workspace",
     async (subscription) => {
       await expect(
@@ -30,17 +30,23 @@ describe("fresh MIOSA enrollment", () => {
     },
   );
 
-  it("admits Pro only when no running or paused workspace exists, regardless of template", async () => {
-    await expect(
-      assertFreshMiosaEnrollment({ userId: "user-1", subscription: "pro" }),
-    ).resolves.toBeUndefined();
-    expect(mockList).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: { metadata: { userID: "user-1" }, state: ["running", "paused"] },
-        limit: 1,
-      }),
-    );
-  });
+  it.each(["pro", "pro-plus"] as const)(
+    "admits %s only when no running or paused workspace exists, regardless of template",
+    async (subscription) => {
+      await expect(
+        assertFreshMiosaEnrollment({ userId: "user-1", subscription }),
+      ).resolves.toBeUndefined();
+      expect(mockList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            metadata: { userID: "user-1" },
+            state: ["running", "paused"],
+          },
+          limit: 1,
+        }),
+      );
+    },
+  );
 
   it.each(["running", "paused"])(
     "protects %s E2B workspaces on old templates",

--- a/lib/ai/tools/utils/miosa-enrollment.ts
+++ b/lib/ai/tools/utils/miosa-enrollment.ts
@@ -62,7 +62,7 @@ export class MiosaEnrollmentError extends Error {
 }
 
 /**
- * Admit new Pro workspaces only after authoritative, read-only E2B discovery.
+ * Admit new Pro and Pro+ workspaces only after authoritative, read-only E2B discovery.
  * Paused workspaces and older templates still contain user data. Never delete
  * or resume them to make a user eligible. Metadata checks span configured
  * clusters; execution remains restricted to the request's approved region.
@@ -71,7 +71,7 @@ export async function assertFreshMiosaEnrollment(options: {
   userId: string;
   subscription?: SubscriptionTier;
 }): Promise<void> {
-  if (options.subscription !== "pro") {
+  if (options.subscription !== "pro" && options.subscription !== "pro-plus") {
     throw new MiosaEnrollmentError("not_pro");
   }
   // Without the default E2B account, an empty cluster list proves nothing.


### PR DESCRIPTION
## Summary
- allow fresh Pro+ Cloud Agent workspaces to enroll in Miosa alongside Pro
- preserve existing E2B workspace, non-Europe, discovery-failure, and E2B fallback gates
- update rollout and measurement documentation without embedding live rollout percentages

## Validation
- `corepack pnpm test --runInBand lib/ai/tools/utils/__tests__/miosa-enrollment.test.ts lib/ai/tools/utils/__tests__/cloud-sandbox-routing.test.ts lib/ai/tools/utils/__tests__/cloud-sandbox-provider.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm test --runInBand` (494 suites, 5,465 tests)
- commit hook: typecheck + Jest (494 suites, 5,465 tests)

## Rollout
- production PostHog flag remains 100% for application-approved candidates
- Trigger Production deployment is required after merge
- no workspace migration or deletion
- E2B remains active as fallback

Tracks HAC-78.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pro+ Cloud Agent users are now eligible for MIOSA enrollment alongside Pro users.
  - Customer comparisons and pilot verification now include both Pro and Pro+ experiences.
- **Documentation**
  - Updated pilot guidance to cover Pro+ eligibility, plan gating, measurement comparisons, and verification scenarios.
  - Clarified that candidate percentages are managed externally while Preview and Production mappings remain documented.
- **Tests**
  - Expanded enrollment coverage to verify Pro+ admission and continued exclusion of other subscription tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->