### PR TITLE
Experiment with DeepSeek V4.1 Flash for summarization

### DIFF
--- a/docs/internal/summarization-model-experiment.md
+++ b/docs/internal/summarization-model-experiment.md
@@ -1,0 +1,70 @@
+# Summarization model experiment
+
+[HAC-108](https://linear.app/hackerai/issue/HAC-108) owns the hypothesis,
+rollout decisions, owner, review date, and cleanup plan. This experiment is
+independent of the compaction feedback change in HAC-107.
+
+## Treatment and assignment
+
+`summarization-deepseek-v41-v1` assigns authenticated users consistently to
+`control` (`z-ai/glm-5.3-flash`) or `test`
+(`deepseek/deepseek-v4.1-flash`). Missing, disabled, invalid, or unavailable flags
+retain the existing GLM route. The flag is evaluated only when context actually
+needs summarizing. Ask and Agent share the selection for durable and in-run
+compaction. Prompts, retained history, summary validation, and authorization
+remain the same. Both arms request low reasoning and latency-first routing
+with provider data collection denied.
+
+The separate `agent_startup_compaction_v1` pilot still controls the startup
+30-second primary deadline and fallback. Its existing DeepSeek V4 Flash 0731
+fallback is unchanged. Analyze startup policy separately: otherwise the new
+model effect can be confused with the deadline/fallback policy.
+
+## Measurement contract
+
+Assignment is not exposure. Generation emits
+`summarization_model_experiment_exposed` and an explicit `$feature_flag_called`
+with the assigned variant after cancellation checks. PostHog duplicates flag
+exposures into `$experiment_exposure` on ingestion for its new exposure system;
+read each experiment's `resolved_exposure_event` before validating ingestion.
+Do not emit another `$experiment_exposure` manually.
+
+`summarization_model_experiment_finished` records generation duration (including
+fallback), success/error/aborted outcome, configured and final served models,
+fallback use, mode, scope, startup policy, and a per-attempt ID. Join by that ID
+to find missing outcomes. No prompts, targets, findings, generated summaries, or
+error text are captured. Success here means valid summary generation, not
+successful persistence or completion of the following task.
+
+Use generation duration as a per-compaction ratio (sum of `duration_ms` divided
+by completed outcome event count), alongside p50/p95 diagnostic queries. Do not
+use total latency per user as if it were latency per compaction. Compare failure,
+abandonment, fallback, retained-context correctness, and subsequent continuation
+separately. `final_call_cost_usd` covers only the successful final call; failed
+and cancelled provider costs can be missing. Do not treat missing cost as zero
+or present that field as full attempt cost. Cross-check provider billing before
+making a cost decision.
+
+## Environment and launch checks
+
+Preview uses PostHog project **401167**, experiment **463511**, flag **881105**;
+Production uses project **144137**, experiment **463510**, flag **881102**. Each
+has independent state. Preview enrolls 100% of eligible QA users with a 50/50
+variant split. Production starts disabled with only the existing internal
+allowlist prepared, also split 50/50. Enrollment and variant allocation are
+different percentages. Current rollout state belongs in Linear/PostHog.
+
+Before launch, independently verify the Vercel and Trigger worker PostHog
+project keys against the intended project, plus their designated Convex target.
+A Vercel Preview deployment does not prove its Trigger worker uses Preview
+configuration. Deploy code, start a new Agent run, exercise both variants and
+Ask/Agent compaction, and verify exposure plus outcome ingestion. Existing Agent
+runs can remain pinned to an earlier worker version.
+
+The internal pilot provides functional and directional evidence, not a powered
+population experiment. Review context retention and continuation before any
+public ramp, then choose sample size from observed variance. Keep Production
+disabled if benchmark or acceptance evidence shows a material regression.
+Rollback by disabling the flag in the affected project; subsequent compaction
+lookups return to GLM without a redeploy. In-flight calls finish their selected
+model. Remove the flag and branch only after the recorded readout decision.

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1259,6 +1259,7 @@ const buildProviderMap = (
     "model-glm-5.2": or(GLM_5_2_SLUG),
     "model-glm-5.3": or(GLM_5_3_SLUG),
     "model-glm-5.3-flash": or(GLM_5_3_FLASH_SLUG),
+    "summarization-deepseek-v41": or("deepseek/deepseek-v4.1-flash"),
     "model-glm-5.3-flash-pro": or(GLM_5_3_FLASH_SLUG),
     "model-glm-5.3-flash-agent": or(GLM_5_3_FLASH_SLUG),
     "model-deepseek-v4-flash-vision": or(DEEPSEEK_V4_FLASH_VISION_SLUG),

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -1316,6 +1316,7 @@ export async function createAgentStream(
         ) {
           if (shouldCheckDurableSummary) {
             const result = await runSummarizationStep({
+              userId: ctx.userId,
               messages: state.finalMessages,
               sourceUiMessages: state.sourceUiMessages,
               modelMessages: rawModelMessages,
@@ -1456,6 +1457,7 @@ export async function createAgentStream(
             compactionAttemptCount++;
             lastCompactionRawMessageCount = rawModelMessages.length;
             const inRunResult = await compactModelMessagesInRun({
+              userId: ctx.userId,
               modelMessages: rollingModelMessages,
               sourceUiMessages: state.sourceUiMessages ?? state.finalMessages,
               transcriptModelMessages: rawModelMessages,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -409,6 +409,7 @@ export interface SummarizationStepResult {
 }
 
 export async function runSummarizationStep(options: {
+  userId?: string;
   messages: UIMessage[];
   subscription: SubscriptionTier;
   languageModel: LanguageModel;
@@ -440,6 +441,7 @@ export async function runSummarizationStep(options: {
     summarizedMessages,
     summarizationUsage,
   } = await checkAndSummarizeIfNeeded({
+    userId: options.userId,
     uiMessages: options.messages,
     sourceUiMessages: options.sourceUiMessages,
     subscription: options.subscription,

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -24,9 +24,11 @@ import {
 } from "../constants";
 import { MAX_TOKENS_PAID, safeCountTokens } from "@/lib/token-utils";
 
+const mockExperimentEvent = jest.fn();
 const mockStartupVariant = jest.fn<() => Promise<string | undefined>>();
 jest.doMock("@/lib/posthog/server", () => ({
   getPostHogFeatureFlagVariantForUser: mockStartupVariant,
+  phLogger: { event: mockExperimentEvent },
 }));
 
 const mockGenerateText = jest.fn<() => Promise<any>>();
@@ -553,6 +555,153 @@ describe("checkAndSummarizeIfNeeded", () => {
         }),
       ],
     ]);
+  });
+
+  it.each(["ask", "agent"] as const)(
+    "uses the assigned DeepSeek summarizer for %s in-run compaction and records only metadata",
+    async (mode) => {
+      mockStartupVariant.mockResolvedValue("test");
+      mockGenerateText.mockResolvedValue({
+        finishReason: "stop",
+        text: "PRIVATE SUMMARY",
+        usage: { inputTokens: 100, outputTokens: 20 },
+        response: { modelId: "deepseek/deepseek-v4.1-flash" },
+      });
+      const messages: ModelMessage[] = [
+        { role: "user", content: "PRIVATE USER PROMPT" },
+      ];
+      const result = await compactModelMessagesInRun({
+        userId: "test-user",
+        modelMessages: messages,
+        transcriptModelMessages: messages,
+        subscription: "pro",
+        languageModel: mockLanguageModel,
+        mode,
+        writer: mockWriter,
+        chatId: null,
+        maxTokens: 128_000,
+        compactionIndex: 1,
+        hasExistingSummary: false,
+      });
+      expect(result?.summaryText).toBe("PRIVATE SUMMARY");
+      expect(mockGenerateText).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: { modelId: "summarization-deepseek-v41" },
+          providerOptions: expect.objectContaining({
+            openrouter: expect.objectContaining({
+              reasoning: { enabled: true, effort: "low" },
+            }),
+          }),
+        }),
+      );
+      expect(mockExperimentEvent).toHaveBeenCalledWith(
+        "summarization_model_experiment_finished",
+        expect.objectContaining({
+          experiment_variant: "test",
+          outcome: "success",
+          mode,
+          scope: "in_run",
+          fallback_used: false,
+          served_model: "deepseek/deepseek-v4.1-flash",
+        }),
+      );
+      expect(JSON.stringify(mockExperimentEvent.mock.calls)).not.toMatch(
+        /PRIVATE/,
+      );
+    },
+  );
+
+  it("does not evaluate or expose the model experiment below the compaction threshold", async () => {
+    await checkAndSummarizeIfNeeded({
+      userId: "test-user",
+      uiMessages: [createMessage("short", "user")],
+      subscription: "pro",
+      languageModel: mockLanguageModel,
+      mode: "ask",
+      writer: mockWriter,
+      chatId: null,
+    });
+    expect(mockStartupVariant).not.toHaveBeenCalled();
+    expect(mockExperimentEvent).not.toHaveBeenCalled();
+  });
+
+  it("preserves the independent startup timeout and fallback with the DeepSeek treatment", async () => {
+    mockStartupVariant.mockImplementation(async (...args: unknown[]) =>
+      args[0] === "agent_startup_compaction_v1" ? "bounded_glm_v1" : "test",
+    );
+    mockGenerateText
+      .mockRejectedValueOnce(
+        Object.assign(new Error("timeout"), { name: "TimeoutError" }),
+      )
+      .mockResolvedValueOnce({
+        finishReason: "stop",
+        text: "Fallback summary",
+        usage: { inputTokens: 123, outputTokens: 20 },
+      });
+    const result = await checkAndSummarizeIfNeeded({
+      userId: "test-user",
+      uiMessages: fourMessagesAboveThreshold,
+      subscription: "pro",
+      languageModel: mockLanguageModel,
+      mode: "agent",
+      writer: mockWriter,
+      chatId: null,
+      startupCompaction: { userId: "test-user" },
+    });
+    expect(result.needsSummarization).toBe(true);
+    expect(mockGenerateText).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        model: { modelId: "summarization-deepseek-v41" },
+        timeout: 30_000,
+        maxRetries: 0,
+      }),
+    );
+    expect(mockGenerateText).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        model: { modelId: "model-deepseek-v4-flash-0731" },
+      }),
+    );
+    expect(mockExperimentEvent).toHaveBeenCalledWith(
+      "summarization_model_experiment_finished",
+      expect.objectContaining({
+        outcome: "success",
+        scope: "durable",
+        startup_policy: "bounded_glm_v1",
+        fallback_used: true,
+      }),
+    );
+  });
+
+  it("records an aborted experiment attempt without starting a fallback", async () => {
+    mockStartupVariant.mockResolvedValue("test");
+    const controller = new AbortController();
+    mockGenerateText.mockImplementation(async () => {
+      controller.abort();
+      throw new Error("cancelled");
+    });
+    await expect(
+      compactModelMessagesInRun({
+        userId: "test-user",
+        modelMessages: [{ role: "user", content: "hello" }],
+        transcriptModelMessages: [],
+        subscription: "pro",
+        languageModel: mockLanguageModel,
+        mode: "agent",
+        writer: mockWriter,
+        chatId: null,
+        maxTokens: 128_000,
+        compactionIndex: 1,
+        hasExistingSummary: false,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("cancelled");
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+    expect(mockExperimentEvent).toHaveBeenCalledWith(
+      "summarization_model_experiment_finished",
+      expect.objectContaining({ outcome: "aborted", fallback_used: false }),
+    );
   });
 
   it("clears the transient in-run status when summary generation fails", async () => {

--- a/lib/chat/summarization/__tests__/model-experiment.test.ts
+++ b/lib/chat/summarization/__tests__/model-experiment.test.ts
@@ -1,0 +1,53 @@
+import {
+  getSummarizationModelAssignment,
+  startSummarizationModelMeasurement,
+} from "../model-experiment";
+import {
+  getPostHogFeatureFlagVariantForUser,
+  phLogger,
+} from "@/lib/posthog/server";
+jest.mock("@/lib/posthog/server", () => ({
+  getPostHogFeatureFlagVariantForUser: jest.fn(),
+  phLogger: { event: jest.fn() },
+}));
+const flag = jest.mocked(getPostHogFeatureFlagVariantForUser);
+beforeEach(() => jest.clearAllMocks());
+
+it.each([undefined, "unexpected", "true"])(
+  "does not enroll an unrecognized assignment %s",
+  async (value) => {
+    flag.mockResolvedValue(value);
+    const assignment = await getSummarizationModelAssignment("user");
+    expect(assignment).toBeUndefined();
+    expect(
+      startSummarizationModelMeasurement({
+        userId: "user",
+        assignment,
+        mode: "ask",
+        scope: "durable",
+        startupPolicy: "control",
+      }),
+    ).toBeUndefined();
+    expect(phLogger.event).not.toHaveBeenCalled();
+  },
+);
+it("selects GLM for an enrolled control user without emitting exposure during lookup", async () => {
+  flag.mockResolvedValue("control");
+  expect(await getSummarizationModelAssignment("user")).toEqual({
+    variant: "control",
+    modelKey: "model-glm-5.3-flash",
+  });
+  expect(flag).toHaveBeenCalledWith("summarization-deepseek-v41-v1", "user", {
+    sendFeatureFlagEvents: false,
+  });
+  expect(phLogger.event).not.toHaveBeenCalled();
+});
+it("skips assignment without an authenticated user", async () => {
+  expect(await getSummarizationModelAssignment()).toBeUndefined();
+  expect(flag).not.toHaveBeenCalled();
+});
+
+it("fails open to normal GLM routing when flag evaluation rejects", async () => {
+  flag.mockRejectedValue(new Error("analytics unavailable"));
+  expect(await getSummarizationModelAssignment("user")).toBeUndefined();
+});

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -1,3 +1,7 @@
+import {
+  getSummarizationModelAssignment,
+  startSummarizationModelMeasurement,
+} from "./model-experiment";
 import "server-only";
 
 import {
@@ -275,7 +279,7 @@ const logContextCompactionRetrying = ({
       mode,
       subscription,
       reason,
-      compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
+      default_compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
       summarization_attempt: attempt,
       model_id: getLanguageModelId(languageModel),
       retry_model_name: retryModelName,
@@ -323,6 +327,7 @@ const logContextCompactionFailed = ({
 };
 
 export interface CheckAndSummarizeOptions {
+  userId?: string;
   uiMessages: UIMessage[];
   /** History before injected notes/reminders; falls back to uiMessages for direct callers. */
   sourceUiMessages?: UIMessage[];
@@ -447,7 +452,7 @@ const logContextCompactionStarted = ({
       mode,
       subscription,
       reason,
-      compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
+      default_compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
       total_estimated_tokens: totalEstimatedTokens,
       system_prompt_tokens: systemPromptTokens,
       provider_input_tokens: providerInputTokens,
@@ -472,6 +477,8 @@ const logContextCompactionStarted = ({
 };
 
 const generateSummaryTextWithRetry = async ({
+  userId,
+  scope,
   messagesToSummarize,
   modelMessages,
   mode,
@@ -487,6 +494,8 @@ const generateSummaryTextWithRetry = async ({
   onPhaseDuration,
   startupCompaction,
 }: {
+  userId?: string;
+  scope: "durable" | "in_run";
   messagesToSummarize: UIMessage[];
   modelMessages?: ModelMessage[];
   mode: ChatMode;
@@ -507,20 +516,33 @@ const generateSummaryTextWithRetry = async ({
     attempt: SummarizationAttempt;
   }
 > => {
-  const summaryLanguageModel = myProvider.languageModel(
-    CONTEXT_COMPACTION_MODEL_NAME,
-  );
   const startedAt = Date.now();
   abortSignal?.throwIfAborted();
-  const variant =
+  const [variant, assignment] = await Promise.all([
     startupCompaction && mode === "agent"
-      ? await getStartupCompactionVariant(startupCompaction.userId)
-      : "control";
+      ? getStartupCompactionVariant(startupCompaction.userId)
+      : Promise.resolve("control" as const),
+    getSummarizationModelAssignment(userId),
+  ]);
+  const selectedModel = assignment?.modelKey ?? CONTEXT_COMPACTION_MODEL_NAME;
+  const summaryLanguageModel = myProvider.languageModel(selectedModel);
   const bounded = variant === "bounded_glm_v1";
   abortSignal?.throwIfAborted();
   if (startupCompaction && mode === "agent") {
     startupCompaction.onAttempt?.({ variant, fallbackUsed: false });
   }
+  let fallbackUsed = false;
+  let outcome: "success" | "error" | "aborted" = "error";
+  let finalUsage:
+    Awaited<ReturnType<typeof generateSummaryText>>["usage"] | undefined;
+  const finishMeasurement = startSummarizationModelMeasurement({
+    userId,
+    chatId,
+    assignment,
+    mode,
+    scope,
+    startupPolicy: variant,
+  });
   try {
     let result: Awaited<ReturnType<typeof generateSummaryText>>;
     try {
@@ -531,7 +553,15 @@ const generateSummaryTextWithRetry = async ({
         chatSystemPrompt,
         hasExistingSummary,
         tools,
-        buildContextCompactionProviderOptions(providerOptions),
+        assignment
+          ? {
+              openrouter: {
+                ...buildContextCompactionProviderOptions(providerOptions)
+                  .openrouter,
+                provider: { sort: "latency", data_collection: "deny" },
+              },
+            }
+          : buildContextCompactionProviderOptions(providerOptions),
         abortSignal,
         modelMessages,
         summaryInputMaxTokens,
@@ -553,6 +583,7 @@ const generateSummaryTextWithRetry = async ({
         throw error;
       }
 
+      fallbackUsed = true;
       const retryModelName = bounded
         ? STARTUP_COMPACTION_FALLBACK_MODEL
         : SUMMARIZATION_RETRY_MODEL_BY_MODE[mode];
@@ -596,6 +627,8 @@ const generateSummaryTextWithRetry = async ({
         throw retryError;
       }
 
+      outcome = "success";
+      finalUsage = result.usage;
       return {
         ...result,
         languageModel: retryLanguageModel,
@@ -603,12 +636,20 @@ const generateSummaryTextWithRetry = async ({
       };
     }
 
+    outcome = "success";
+    finalUsage = result.usage;
     return {
       ...result,
       languageModel: summaryLanguageModel,
       attempt: "primary",
     };
+  } catch (error) {
+    outcome = abortSignal?.aborted ? "aborted" : "error";
+    if (!fallbackUsed)
+      markSummarizationAttemptError(error, "primary", selectedModel);
+    throw error;
   } finally {
+    finishMeasurement?.(outcome, fallbackUsed, finalUsage);
     reportPhaseDuration(onPhaseDuration, "summary_generation", startedAt);
   }
 };
@@ -671,6 +712,7 @@ const startTranscriptSave = ({
 };
 
 export interface CompactModelMessagesInRunOptions {
+  userId?: string;
   modelMessages: ModelMessage[];
   /** UI history excludes synthetic SDK continuation/approval messages. */
   sourceUiMessages?: UIMessage[];
@@ -713,6 +755,7 @@ export interface InRunModelCompactionResult {
  * caller keeps the result as a run-scoped rolling checkpoint instead.
  */
 export const compactModelMessagesInRun = async ({
+  userId,
   modelMessages,
   sourceUiMessages = [],
   transcriptModelMessages,
@@ -754,7 +797,7 @@ export const compactModelMessagesInRun = async ({
       reason: compactionReason,
       compaction_index: compactionIndex,
       persistence: "run_scoped",
-      compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
+      default_compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
       model_message_count: modelMessages.length,
       provider_input_tokens: providerInputTokens,
       max_tokens: maxTokens,
@@ -769,6 +812,8 @@ export const compactModelMessagesInRun = async ({
 
   try {
     const summaryPromise = generateSummaryTextWithRetry({
+      userId,
+      scope: "in_run",
       messagesToSummarize: [],
       modelMessages,
       mode,
@@ -816,7 +861,7 @@ export const compactModelMessagesInRun = async ({
         subscription,
         compaction_index: compactionIndex,
         persistence: "run_scoped",
-        compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
+        default_compaction_model: CONTEXT_COMPACTION_MODEL_NAME,
         summary_input_tokens: summaryResult.usage.inputTokens,
         summary_output_tokens: summaryResult.usage.outputTokens,
         estimated_compacted_input_tokens:
@@ -848,7 +893,10 @@ export const compactModelMessagesInRun = async ({
                 ? STARTUP_COMPACTION_FALLBACK_MODEL
                 : SUMMARIZATION_RETRY_MODEL_BY_MODE[mode],
             )
-          : myProvider.languageModel(CONTEXT_COMPACTION_MODEL_NAME),
+          : myProvider.languageModel(
+              (getErrorRecord(error)?.__hackeraiSummarizationModel as string) ??
+                CONTEXT_COMPACTION_MODEL_NAME,
+            ),
       fallbackResult: "no_summarization",
       error,
     });
@@ -928,6 +976,7 @@ const saveTranscriptToSandbox = async (
 
 /** Builds a durable checkpoint when needed, preserving source intent and a bounded tail. */
 export const checkAndSummarizeIfNeeded = async ({
+  userId,
   uiMessages,
   sourceUiMessages,
   subscription,
@@ -1063,6 +1112,8 @@ export const checkAndSummarizeIfNeeded = async ({
     // Run summary generation and transcript saving in parallel — they are
     // independent (transcript is formatted from raw messages, not the summary).
     const summaryPromise = generateSummaryTextWithRetry({
+      userId,
+      scope: "durable",
       messagesToSummarize,
       mode,
       chatSystemPrompt,
@@ -1159,7 +1210,10 @@ export const checkAndSummarizeIfNeeded = async ({
                 ? STARTUP_COMPACTION_FALLBACK_MODEL
                 : SUMMARIZATION_RETRY_MODEL_BY_MODE[mode],
             )
-          : myProvider.languageModel(CONTEXT_COMPACTION_MODEL_NAME),
+          : myProvider.languageModel(
+              (getErrorRecord(error)?.__hackeraiSummarizationModel as string) ??
+                CONTEXT_COMPACTION_MODEL_NAME,
+            ),
       fallbackResult: "no_summarization",
       error,
     });

--- a/lib/chat/summarization/model-experiment.ts
+++ b/lib/chat/summarization/model-experiment.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import {
+  getPostHogFeatureFlagVariantForUser,
+  phLogger,
+} from "@/lib/posthog/server";
+import type { ChatMode } from "@/types";
+import type { SummarizationUsage } from "./helpers";
+
+export const SUMMARIZATION_MODEL_FLAG = "summarization-deepseek-v41-v1";
+export const SUMMARIZATION_MODEL_EXPOSURE =
+  "summarization_model_experiment_exposed";
+export const SUMMARIZATION_MODEL_OUTCOME =
+  "summarization_model_experiment_finished";
+export const DEEPSEEK_SUMMARIZATION_MODEL = "summarization-deepseek-v41";
+
+export async function getSummarizationModelAssignment(userId?: string) {
+  if (!userId) return undefined;
+  try {
+    const variant = await getPostHogFeatureFlagVariantForUser(
+      SUMMARIZATION_MODEL_FLAG,
+      userId,
+      { sendFeatureFlagEvents: false },
+    );
+    if (variant !== "control" && variant !== "test") return undefined;
+    return {
+      variant,
+      modelKey:
+        variant === "test"
+          ? DEEPSEEK_SUMMARIZATION_MODEL
+          : "model-glm-5.3-flash",
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Called only at actual generation, with bounded metadata and no conversation content. */
+export function startSummarizationModelMeasurement({
+  userId,
+  chatId,
+  assignment,
+  mode,
+  scope,
+  startupPolicy,
+}: {
+  userId?: string;
+  chatId?: string | null;
+  assignment: Awaited<ReturnType<typeof getSummarizationModelAssignment>>;
+  mode: ChatMode;
+  scope: "durable" | "in_run";
+  startupPolicy: string;
+}) {
+  if (!userId || !assignment) return undefined;
+  const startedAt = Date.now();
+  const properties = {
+    userId,
+    chat_id: chatId ?? undefined,
+    compaction_attempt_id: randomUUID(),
+    experiment_key: SUMMARIZATION_MODEL_FLAG,
+    experiment_variant: assignment.variant,
+    [`$feature/${SUMMARIZATION_MODEL_FLAG}`]: assignment.variant,
+    configured_model:
+      assignment.variant === "test"
+        ? "deepseek/deepseek-v4.1-flash"
+        : "z-ai/glm-5.3-flash",
+    mode,
+    scope,
+    startup_policy: startupPolicy,
+  };
+  phLogger.event(SUMMARIZATION_MODEL_EXPOSURE, properties);
+  // Explicit exposure at generation, not during the feature-flag lookup.
+  phLogger.event("$feature_flag_called", {
+    userId,
+    $feature_flag: SUMMARIZATION_MODEL_FLAG,
+    $feature_flag_response: assignment.variant,
+    [`$feature/${SUMMARIZATION_MODEL_FLAG}`]: assignment.variant,
+  });
+  return (
+    outcome: "success" | "error" | "aborted",
+    fallbackUsed: boolean,
+    usage?: SummarizationUsage,
+  ) => {
+    phLogger.event(SUMMARIZATION_MODEL_OUTCOME, {
+      ...properties,
+      outcome,
+      duration_ms: Date.now() - startedAt,
+      fallback_used: fallbackUsed,
+      ...(usage && {
+        served_model: usage.model,
+        input_tokens: usage.inputTokens,
+        output_tokens: usage.outputTokens,
+        // Failed/aborted earlier attempts may have unreported cost; this is final-call cost only.
+        ...(usage.cost !== undefined && { final_call_cost_usd: usage.cost }),
+      }),
+    });
+  };
+}

--- a/scripts/benchmark-startup-compaction.ts
+++ b/scripts/benchmark-startup-compaction.ts
@@ -6,7 +6,9 @@ import { AGENT_SUMMARIZATION_PROMPT } from "../lib/chat/summarization/prompts";
 config({ path: ".env.local", quiet: true });
 if (!process.env.OPENROUTER_API_KEY)
   throw new Error("OPENROUTER_API_KEY is required");
-mkdirSync(".artifacts/hac102", { recursive: true });
+const useV41 = process.argv.includes("--deepseek-v41");
+const artifactDir = useV41 ? ".artifacts/hac108" : ".artifacts/hac102";
+mkdirSync(artifactDir, { recursive: true });
 const variants = [
   {
     name: "glm-baseline",
@@ -15,8 +17,10 @@ const variants = [
     prompt: AGENT_SUMMARIZATION_PROMPT,
   },
   {
-    name: "deepseek-low",
-    model: "deepseek/deepseek-v4-flash-0731",
+    name: useV41 ? "deepseek-v41-low" : "deepseek-low",
+    model: useV41
+      ? "deepseek/deepseek-v4.1-flash"
+      : "deepseek/deepseek-v4-flash-0731",
     reasoning: { enabled: true, effort: "low" },
     prompt: AGENT_SUMMARIZATION_PROMPT,
   },
@@ -92,7 +96,7 @@ async function run(variant: (typeof variants)[number], size: number) {
       (h) => !text.includes(h),
     );
     writeFileSync(
-      `.artifacts/hac102/${name}.json`,
+      `${artifactDir}/${name}.json`,
       JSON.stringify(result, null, 2),
     );
     const stats = {
@@ -109,7 +113,7 @@ async function run(variant: (typeof variants)[number], size: number) {
       error: result.error,
     };
     writeFileSync(
-      `.artifacts/hac102/${name}-stats.json`,
+      `${artifactDir}/${name}-stats.json`,
       JSON.stringify(stats, null, 2),
     );
     console.log(JSON.stringify(stats));


### PR DESCRIPTION
## Decision: no rollout

Live benchmarks showed a substantial latency regression. Both Preview and Production flags are disabled, neither experiment was launched, and this PR is retained only as reference. The compaction feedback change continues independently in #1314.

## Change

Adds an independent, stable-user PostHog experiment for context summarization: GLM 5.3 Flash (`control`) versus DeepSeek V4.1 Flash (`test`). Ask and Agent use the assignment only when durable or in-run compaction actually occurs. Disabled/unavailable flags retain GLM. Both arms preserve prompts, context retention, low reasoning, and latency-first/data-collection-denied routing; the existing startup deadline and V4 Flash 0731 fallback stay intact.

Captures content-free exposure and generation outcome metadata (duration, fallback, model, tokens, final-call cost). This is separate from feedback PR #1314 and based directly on main.

## Experiment and evidence

[HAC-108](https://linear.app/hackerai/issue/HAC-108) records the hypothesis, metrics, guardrails, rollout, owner, and readout/cleanup plan. Preview project 401167 has 100% eligible QA enrollment with equal variants; Production 144137 remains disabled with only the internal allowlist prepared. Neither experiment has been launched. New-event metric configuration and runtime ingestion must be verified before launch.

Live synthetic OpenRouter benchmark (one sample per model/size; low reasoning):

| Approximate input | GLM | DeepSeek V4.1 |
| --- | ---: | ---: |
| 15k tokens | 2.4 s | 108.7 s |
| 69k tokens | 4.1 s | 116.5 s |

All four outputs retained all 14 required markers and 10 section headers, including the running-task state. DeepSeek used 3,080 / 1,598 reasoning tokens; these measurements do **not** support a customer rollout or establish population performance. Full-attempt costs can be incomplete after failures; instrumentation names final-call cost explicitly.

## Validation

- Focused assignment/routing/abort/fallback/privacy tests passed.
- Commit hooks passed formatting, lint, typecheck, and the full Jest suite.
- Live synthetic calls confirmed the exact model slug works.

## Manual verification

On this PR Preview, verify Vercel and Trigger independently select PostHog 401167 and the designated Preview Convex deployment. With test users in each variant, trigger compaction in Ask and Agent and verify continuation, abort, fallback, and content retention. Confirm real exposure and outcome events (including missing outcomes) before configuring/launching metrics. Production remains disabled pending this acceptance and the benchmark regression decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an experimental summarization model selection, including DeepSeek and GLM variants.
  * Summarization now records performance outcomes such as completion status, duration, fallback usage, and optional usage metrics.
  * Startup and in-session compaction requests now include user context for more accurate experiment assignment and reporting.

* **Bug Fixes**
  * Improved failure handling so unavailable or invalid experiment assignments safely fall back without interrupting summarization.

* **Documentation**
  * Added guidance covering rollout configuration, measurement, verification, interpretation, and rollback procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->