### PR TITLE
Expand Miosa rollout to Team and Ultra

### DIFF
--- a/lib/ai/tools/utils/__tests__/miosa-enrollment.test.ts
+++ b/lib/ai/tools/utils/__tests__/miosa-enrollment.test.ts
@@ -20,7 +20,7 @@ describe("fresh MIOSA enrollment", () => {
   });
   afterEach(() => jest.restoreAllMocks());
 
-  it.each(["free", "ultra", "team", undefined] as const)(
+  it.each(["free", undefined] as const)(
     "does not enroll %s into a new workspace",
     async (subscription) => {
       await expect(
@@ -30,7 +30,7 @@ describe("fresh MIOSA enrollment", () => {
     },
   );
 
-  it.each(["pro", "pro-plus"] as const)(
+  it.each(["pro", "pro-plus", "team", "ultra"] as const)(
     "admits %s only when no running or paused workspace exists, regardless of template",
     async (subscription) => {
       await expect(

--- a/lib/ai/tools/utils/miosa-enrollment.ts
+++ b/lib/ai/tools/utils/miosa-enrollment.ts
@@ -50,6 +50,13 @@ function classifyDiscoveryError(
 export type MiosaEnrollmentReason =
   "not_pro" | "existing_e2b_workspace" | "workspace_discovery_unavailable";
 
+const MIOSA_ELIGIBLE_SUBSCRIPTIONS = new Set<SubscriptionTier>([
+  "pro",
+  "pro-plus",
+  "team",
+  "ultra",
+]);
+
 /** An enrollment veto is not a MIOSA acquisition failure. */
 export class MiosaEnrollmentError extends Error {
   constructor(
@@ -62,7 +69,7 @@ export class MiosaEnrollmentError extends Error {
 }
 
 /**
- * Admit new Pro and Pro+ workspaces only after authoritative, read-only E2B discovery.
+ * Admit new paid-plan workspaces only after authoritative, read-only E2B discovery.
  * Paused workspaces and older templates still contain user data. Never delete
  * or resume them to make a user eligible. Metadata checks span configured
  * clusters; execution remains restricted to the request's approved region.
@@ -71,7 +78,12 @@ export async function assertFreshMiosaEnrollment(options: {
   userId: string;
   subscription?: SubscriptionTier;
 }): Promise<void> {
-  if (options.subscription !== "pro" && options.subscription !== "pro-plus") {
+  if (
+    !options.subscription ||
+    !MIOSA_ELIGIBLE_SUBSCRIPTIONS.has(options.subscription)
+  ) {
+    // Retain the established reason value so rollout dashboards remain
+    // continuous while paid-plan eligibility expands.
     throw new MiosaEnrollmentError("not_pro");
   }
   // Without the default E2B account, an empty cluster list proves nothing.


### PR DESCRIPTION
## Summary
- admit new Team and Ultra workspaces to the existing Miosa rollout
- preserve the read-only E2B discovery gate so existing running or paused workspaces stay on E2B
- preserve the non-Europe region gate and E2B acquisition fallback

## PostHog
- Preview `hackerai-dev` flag already targets preview/development at 100%
- Production flag already targets production at 100%
- application-level eligibility remains the final plan/new-workspace safety gate

## Validation
- `pnpm run typecheck`
- targeted enrollment and routing tests: 38 passed
- full commit hook suite: 494 suites / 5,480 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Eligibility Updates**
  - MIOSA enrollment is now available for all paid subscription tiers: Pro, Pro Plus, Team, and Ultra.
  - Free subscriptions and accounts without a subscription remain ineligible for MIOSA enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->