### PR TITLE
Add readable Miosa references and account lookup

### DIFF
--- a/docs/miosa-support-lookup.md
+++ b/docs/miosa-support-lookup.md
@@ -1,0 +1,47 @@
+# Identifying Miosa workspaces
+
+New sandboxes carry `userReference`, `environment`, and `identityVersion` metadata
+plus tags such as `hackerai-user-c6c289e49e9c`. The reference is a shortened hash
+of the stable WorkOS user ID. No email, account name, prompt, or scan target is
+sent in these fields. Plan is intentionally omitted because it can change.
+
+Miosa's dashboard must display metadata or tags for these labels to be visible.
+Ask support for the sandbox UUID or complete existing name if labels are hidden.
+The SDK does not update metadata on reuse, so existing sandboxes retain their
+current metadata; the lookup works for their IDs and names immediately.
+
+## Internal lookup
+
+Use the read-only support command from an authorized operator workstation:
+
+```sh
+pnpm exec tsx scripts/miosa-lookup.ts --env-file /absolute/path/to/verified.env --email account@example.com
+pnpm exec tsx scripts/miosa-lookup.ts --env-file /absolute/path/to/verified.env --reference hackerai-user-c6c289e49e9c
+pnpm exec tsx scripts/miosa-lookup.ts --env-file /absolute/path/to/verified.env --sandbox-id SANDBOX_UUID
+```
+
+Before running, verify the file's WorkOS account/client and Miosa tenant both
+belong to the intended HackerAI environment. The command loads only this file,
+never another checkout's configuration or ambient credentials. Required fields
+are `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, and `MIOSA_API_KEY`; `MIOSA_BASE_URL`
+is optional. Do not copy credentials between environments to run the lookup.
+
+Output includes the matching account's name/email, full external user identity,
+reference, sandbox IDs, state, and template. It contains personal information:
+keep it internal and share only the pseudonymous reference/UUID with Miosa.
+Email lookup is direct; reverse lookup paginates through WorkOS accounts and
+can be slower. Zero matches can mean a deleted account or the wrong environment.
+Multiple matches are rejected; use the full existing workspace name or UUID.
+SDK sandbox listing determines which workspaces are returned, including whether
+destroyed workspaces are available.
+
+## Compatibility
+
+The 24-character external user hash, external workspace ID, and `-v2` sandbox
+name remain unchanged. Support references are labels, not authorization keys.
+No sandbox is created, resumed, renamed, or destroyed by the lookup. Environment
+metadata comes from `TRIGGER_ENV` or `VERCEL_ENV`; without a recognized explicit
+value it is `unknown`, since `NODE_ENV=production` can also mean Preview.
+
+Verify a new sandbox's tags/metadata and look it up by UUID. Then use a paused
+existing sandbox's name to confirm its owner resolves while it remains paused.

--- a/lib/ai/tools/utils/__tests__/miosa-identity.test.ts
+++ b/lib/ai/tools/utils/__tests__/miosa-identity.test.ts
@@ -37,6 +37,8 @@ describe("Miosa support identity", () => {
     expect(metadata.environment).toBe("preview");
     expect(metadata.userReference).toMatch(/^hackerai-user-[a-f0-9]{12}$/);
     expect(JSON.stringify(metadata)).not.toContain("private@example.com");
+    process.env = { TRIGGER_ENV: "  ", VERCEL_ENV: " preview " };
+    expect(miosaIdentityMetadata("user-1").environment).toBe("preview");
     process.env = { NODE_ENV: "production" };
     expect(miosaIdentityMetadata("user-1").environment).toBe("unknown");
   });

--- a/lib/ai/tools/utils/__tests__/miosa-identity.test.ts
+++ b/lib/ai/tools/utils/__tests__/miosa-identity.test.ts
@@ -1,0 +1,43 @@
+import {
+  miosaExternalUserId,
+  miosaIdentityMetadata,
+  miosaUserReference,
+  matchesMiosaUserReference,
+} from "../miosa-identity";
+
+describe("Miosa support identity", () => {
+  const original = process.env;
+  afterEach(() => {
+    process.env = original;
+  });
+
+  it("keeps existing provider identities and resolves legacy names", () => {
+    const external = miosaExternalUserId("user-1");
+    expect(external).toBe("hackerai-c6c289e49e9c05b214586038");
+    for (const reference of [
+      external,
+      `${external}-v2`,
+      miosaUserReference("user-1"),
+    ]) {
+      expect(matchesMiosaUserReference("user-1", reference)).toBe(true);
+      expect(matchesMiosaUserReference("user-2", reference)).toBe(false);
+    }
+    expect(matchesMiosaUserReference("user-1", "hackerai-user-c6c2")).toBe(
+      false,
+    );
+  });
+
+  it("uses the worker environment without leaking account details", () => {
+    process.env = {
+      TRIGGER_ENV: "preview",
+      VERCEL_ENV: "production",
+      NODE_ENV: "production",
+    };
+    const metadata = miosaIdentityMetadata("private@example.com");
+    expect(metadata.environment).toBe("preview");
+    expect(metadata.userReference).toMatch(/^hackerai-user-[a-f0-9]{12}$/);
+    expect(JSON.stringify(metadata)).not.toContain("private@example.com");
+    process.env = { NODE_ENV: "production" };
+    expect(miosaIdentityMetadata("user-1").environment).toBe("unknown");
+  });
+});

--- a/lib/ai/tools/utils/__tests__/miosa-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/miosa-sandbox.test.ts
@@ -81,7 +81,13 @@ describe("MIOSA sandbox adapter", () => {
     expect(result.sandbox).toBeInstanceOf(MiosaSandbox);
     expect(mockGetOrCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: expect.stringMatching(/^hackerai-[a-f0-9]{24}-v2$/),
+        name: "hackerai-c6c289e49e9c05b214586038-v2",
+        tags: expect.arrayContaining(["hackerai-user-c6c289e49e9c"]),
+        metadata: expect.objectContaining({
+          provider: "hackerai",
+          sandboxVersion: "v2",
+          userReference: "hackerai-user-c6c289e49e9c",
+        }),
         templateId: "hackerai-kali-promoted",
         cpuCount: 4,
         memoryMb: 4096,

--- a/lib/ai/tools/utils/miosa-identity.ts
+++ b/lib/ai/tools/utils/miosa-identity.ts
@@ -10,9 +10,11 @@ export const miosaUserReference = (userId: string): string =>
 
 export function miosaIdentityMetadata(userId: string) {
   // NODE_ENV is also production in Preview workers; never infer from it.
-  const selected = (process.env.TRIGGER_ENV ?? process.env.VERCEL_ENV ?? "")
-    .trim()
-    .toLowerCase();
+  const selected = (
+    process.env.TRIGGER_ENV?.trim() ||
+    process.env.VERCEL_ENV?.trim() ||
+    ""
+  ).toLowerCase();
   const environment = ["production", "preview", "development"].includes(
     selected,
   )

--- a/lib/ai/tools/utils/miosa-identity.ts
+++ b/lib/ai/tools/utils/miosa-identity.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+
+/** Existing provider identity: changing this would orphan users' workspaces. */
+export const miosaExternalUserId = (userId: string): string =>
+  `hackerai-${createHash("sha256").update(userId).digest("hex").slice(0, 24)}`;
+
+/** A support label, never an authorization or workspace lookup key. */
+export const miosaUserReference = (userId: string): string =>
+  `hackerai-user-${miosaExternalUserId(userId).slice(9, 21)}`;
+
+export function miosaIdentityMetadata(userId: string) {
+  // NODE_ENV is also production in Preview workers; never infer from it.
+  const selected = (process.env.TRIGGER_ENV ?? process.env.VERCEL_ENV ?? "")
+    .trim()
+    .toLowerCase();
+  const environment = ["production", "preview", "development"].includes(
+    selected,
+  )
+    ? selected
+    : "unknown";
+  return {
+    userReference: miosaUserReference(userId),
+    environment,
+    identityVersion: "1",
+  };
+}
+
+/** Accept existing provider names as well as the shorter support reference. */
+export function matchesMiosaUserReference(userId: string, reference: string) {
+  const externalId = miosaExternalUserId(userId);
+  return (
+    reference === miosaUserReference(userId) ||
+    reference === externalId ||
+    reference === `${externalId}-v2`
+  );
+}

--- a/lib/ai/tools/utils/miosa-sandbox.ts
+++ b/lib/ai/tools/utils/miosa-sandbox.ts
@@ -1,4 +1,5 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
+import { miosaExternalUserId, miosaIdentityMetadata } from "./miosa-identity";
 import type {
   Miosa as MiosaClient,
   Sandbox as MiosaSdkSandbox,
@@ -69,11 +70,8 @@ export const miosaCancellationCommand = (processIdPath: string): string =>
     "exit 1",
   ].join("\n");
 
-const externalUserIdForUser = (userId: string): string =>
-  `hackerai-${createHash("sha256").update(userId).digest("hex").slice(0, 24)}`;
-
 const sandboxNameForUser = (userId: string): string =>
-  `${externalUserIdForUser(userId)}-${MIOSA_SANDBOX_VERSION}`;
+  `${miosaExternalUserId(userId)}-${MIOSA_SANDBOX_VERSION}`;
 
 const runtimeInitializationCommand = (runtimeImage: string): string => {
   const image = shellQuote(runtimeImage);
@@ -374,7 +372,8 @@ export async function ensureMiosaSandboxConnection(
     onDiagnostic: options.onDiagnostic,
   });
   const client = await step("client_init", createMiosaClient);
-  const externalUserId = externalUserIdForUser(context.userID);
+  const externalUserId = miosaExternalUserId(context.userID);
+  const identity = miosaIdentityMetadata(context.userID);
   if (options.beforeCreate) {
     const { NotFoundError } = await import("@miosa/sdk");
     try {
@@ -403,9 +402,14 @@ export async function ensureMiosaSandboxConnection(
       externalWorkspaceId: externalUserId,
       externalUserId,
       waitUntilReady: false,
+      tags: [
+        identity.userReference,
+        `hackerai-environment-${identity.environment}`,
+      ],
       metadata: {
         provider: "hackerai",
         sandboxVersion: MIOSA_SANDBOX_VERSION,
+        ...identity,
       },
     }),
   );
@@ -447,7 +451,7 @@ export async function terminateMiosaSandboxesForUser(
 ): Promise<{ total: number; killed: number; alreadyGone: number }> {
   const client = await createMiosaClient();
   const sandboxes = await client.sandboxes.list({
-    externalUserId: externalUserIdForUser(userId),
+    externalUserId: miosaExternalUserId(userId),
   });
   let killed = 0;
   let alreadyGone = 0;

--- a/scripts/__tests__/miosa-lookup.test.ts
+++ b/scripts/__tests__/miosa-lookup.test.ts
@@ -1,0 +1,90 @@
+const mockListUsers = jest.fn();
+const mockGet = jest.fn();
+const mockList = jest.fn();
+jest.mock("node:fs", () => ({
+  ...jest.requireActual("node:fs"),
+  readFileSync: jest.fn(
+    () => "WORKOS_API_KEY=test\nWORKOS_CLIENT_ID=test\nMIOSA_API_KEY=test",
+  ),
+}));
+jest.mock("@workos-inc/node", () => ({
+  WorkOS: jest.fn(() => ({ userManagement: { listUsers: mockListUsers } })),
+}));
+jest.mock("@miosa/sdk", () => ({
+  Miosa: jest.fn(() => ({ sandboxes: { get: mockGet, list: mockList } })),
+}));
+import { main } from "../miosa-lookup";
+import {
+  miosaExternalUserId,
+  miosaUserReference,
+} from "../../lib/ai/tools/utils/miosa-identity";
+
+describe("read-only Miosa support lookup", () => {
+  let log: jest.SpyInstance;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    log = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    log.mockRestore();
+    process.exitCode = 0;
+  });
+  const user = {
+    id: "user-1",
+    email: "test@example.com",
+    firstName: "Test",
+    lastName: "User",
+  };
+  const sandbox = {
+    data: {
+      id: "sandbox-1",
+      name: `${miosaExternalUserId(user.id)}-v2`,
+      state: "paused",
+    },
+  };
+
+  it("finds an existing sandbox owner on a later page without resuming it", async () => {
+    mockGet.mockResolvedValue(sandbox);
+    mockListUsers.mockResolvedValueOnce({
+      data: [{ ...user, id: "other" }],
+      listMetadata: { after: "page-2" },
+    });
+    mockListUsers.mockResolvedValueOnce({ data: [user], listMetadata: {} });
+    await main(["--env-file", "verified.env", "--sandbox-id", "sandbox-1"]);
+    expect(mockListUsers).toHaveBeenLastCalledWith({
+      limit: 100,
+      after: "page-2",
+    });
+    expect(JSON.parse(log.mock.calls[0][0])).toMatchObject({
+      user: { id: user.id, email: user.email, name: "Test User" },
+      sandboxes: [{ id: "sandbox-1", state: "paused" }],
+    });
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("looks up email and lists only that account's immutable provider identity", async () => {
+    mockListUsers.mockResolvedValue({ data: [user], listMetadata: {} });
+    mockList.mockResolvedValue([sandbox]);
+    await main(["--env-file", "verified.env", "--email", user.email]);
+    expect(mockList).toHaveBeenCalledWith({
+      externalUserId: miosaExternalUserId(user.id),
+    });
+    expect(JSON.parse(log.mock.calls[0][0]).userReference).toBe(
+      miosaUserReference(user.id),
+    );
+  });
+
+  it("fails closed on ambiguous references without listing any sandboxes", async () => {
+    mockListUsers.mockResolvedValue({ data: [user, user], listMetadata: {} });
+    await main([
+      "--env-file",
+      "verified.env",
+      "--reference",
+      miosaUserReference(user.id),
+    ]);
+    expect(mockList).not.toHaveBeenCalled();
+    expect(JSON.parse(log.mock.calls[0][0]).result).toBe(
+      "ambiguous_reference_use_full_workspace_name",
+    );
+  });
+});

--- a/scripts/miosa-lookup.ts
+++ b/scripts/miosa-lookup.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { parse } from "dotenv";
+import { WorkOS } from "@workos-inc/node";
+import {
+  matchesMiosaUserReference,
+  miosaExternalUserId,
+  miosaUserReference,
+} from "../lib/ai/tools/utils/miosa-identity";
+
+const usage = `Read-only account/sandbox lookup (prints personal account data locally).
+pnpm exec tsx scripts/miosa-lookup.ts --env-file <verified-environment-file> --email <email>
+pnpm exec tsx scripts/miosa-lookup.ts --env-file <verified-environment-file> --reference <reference-or-existing-name>
+pnpm exec tsx scripts/miosa-lookup.ts --env-file <verified-environment-file> --sandbox-id <id>
+The selected file must contain WORKOS_API_KEY, WORKOS_CLIENT_ID and MIOSA_API_KEY
+for the same intended environment. No values are inherited from other env files.`;
+
+export async function main(args = process.argv.slice(2)) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      "env-file": { type: "string" },
+      email: { type: "string" },
+      reference: { type: "string" },
+      "sandbox-id": { type: "string" },
+      help: { type: "boolean" },
+    },
+  });
+  if (values.help) {
+    console.log(usage);
+    return;
+  }
+  if (
+    !values["env-file"] ||
+    [values.email, values.reference, values["sandbox-id"]].filter(Boolean)
+      .length !== 1
+  ) {
+    console.error(usage);
+    process.exitCode = 1;
+    return;
+  }
+  // Explicit isolated configuration: do not merge Preview/Production credentials.
+  const config = parse(readFileSync(values["env-file"]));
+  if (
+    !config.WORKOS_API_KEY ||
+    !config.WORKOS_CLIENT_ID ||
+    !config.MIOSA_API_KEY
+  ) {
+    throw new Error("configuration");
+  }
+  const workos = new WorkOS(config.WORKOS_API_KEY, {
+    clientId: config.WORKOS_CLIENT_ID,
+  });
+  const { Miosa } = await import("@miosa/sdk");
+  const miosa = new Miosa({
+    apiKey: config.MIOSA_API_KEY,
+    ...(config.MIOSA_BASE_URL ? { baseUrl: config.MIOSA_BASE_URL } : {}),
+  });
+  const sandbox = values["sandbox-id"]
+    ? await miosa.sandboxes.get(values["sandbox-id"])
+    : undefined;
+  // Use the full immutable identity for reverse resolution whenever available.
+  const reference = sandbox
+    ? sandbox.data.external_user_id || sandbox.data.name
+    : values.reference;
+  if (
+    !values.email &&
+    (!reference ||
+      !/^hackerai-(?:user-[a-f0-9]{12}|[a-f0-9]{24}(?:-v2)?)$/.test(reference))
+  ) {
+    throw new Error("identity");
+  }
+  const matches = [];
+  let after: string | undefined;
+  do {
+    const page = await workos.userManagement.listUsers({
+      ...(values.email ? { email: values.email } : {}),
+      limit: 100,
+      ...(after ? { after } : {}),
+    });
+    for (const user of page.data) {
+      if (values.email || matchesMiosaUserReference(user.id, reference!))
+        matches.push(user);
+    }
+    after = page.listMetadata.after ?? undefined;
+  } while (after);
+  // A shortened reference is not guaranteed unique. Never select its first match.
+  if (matches.length !== 1) {
+    console.log(
+      JSON.stringify({
+        matchCount: matches.length,
+        result: matches.length
+          ? "ambiguous_reference_use_full_workspace_name"
+          : "no_account_in_selected_environment",
+      }),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const user = matches[0];
+  const externalUserId = miosaExternalUserId(user.id);
+  const sandboxes = sandbox
+    ? [sandbox]
+    : await miosa.sandboxes.list({ externalUserId });
+  console.log(
+    JSON.stringify(
+      {
+        user: {
+          id: user.id,
+          email: user.email,
+          name: [user.firstName, user.lastName].filter(Boolean).join(" "),
+        },
+        userReference: miosaUserReference(user.id),
+        externalUserId,
+        sandboxes: sandboxes.map(({ data }) => ({
+          id: data.id,
+          name: data.name,
+          state: data.state,
+          template: data.template_id,
+          environment: data.metadata?.environment ?? "unknown",
+          storedUserReference: data.metadata?.userReference ?? null,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (require.main === module)
+  main().catch(() => {
+    // Provider exceptions may contain credentials, headers or personal data.
+    console.error(
+      "Lookup failed. Verify the selected environment file, credentials, reference and service availability. No sandbox was changed.",
+    );
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
Miosa support currently sees opaque sandbox names with no convenient way to identify the corresponding HackerAI account. New sandboxes now receive a stable pseudonymous support reference in tags and metadata, while existing names and external IDs remain unchanged for reconnect and deletion.

A read-only operator CLI resolves email, support reference, legacy workspace name, or sandbox UUID to the account and sandbox status. It uses one explicitly selected environment file, handles account pagination, rejects ambiguous matches, and keeps names/emails in local output. Existing sandboxes work with the lookup without migration; their stored labels are not retroactively updated.

Validation: typecheck, all 496 test suites / 5,485 tests, and CLI help smoke test passed. Tests cover legacy identity compatibility, metadata, pagination, ambiguity and paused-workspace lookup. No runtime sandbox calls were added beyond existing acquisition.

Manual verification after deployment: inspect a newly created sandbox's metadata/tags in Miosa; run the documented lookup against its UUID and an existing paused sandbox name using verified matching WorkOS/Miosa configuration. Both should resolve to the correct account without changing sandbox state. Dashboard rendering of metadata/tags remains provider-dependent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a read-only support lookup tool for finding accounts and sandboxes by email, reference, or sandbox ID.
  - Added stable identity references, environment-aware metadata, and consistent workspace identification.
  - Added safeguards for ambiguous or invalid lookups and protection for sensitive information in results.
  - Added environment tags and metadata to newly created Miosa sandboxes.

- **Documentation**
  - Documented lookup usage, required settings, environment isolation, matching behavior, pagination, privacy requirements, and sandbox listing semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->